### PR TITLE
功能: Agent 网页访问策略 — WebFetch 失败时 fallback 到 agent-browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ Thumbs.db
 *.swp
 *.swo
 
-log
+/log/

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -702,7 +702,7 @@ async function runQuery(
     '',
     '访问外部网页时优先使用 WebFetch（速度快）。',
     '如果 WebFetch 失败（403、被拦截、内容为空或需要 JavaScript 渲染），',
-    '立即改用 agent-browser 通过真实浏览器访问。不要反复重试 WebFetch。',
+    '且 agent-browser 可用，立即改用 agent-browser 通过真实浏览器访问。不要反复重试 WebFetch。',
   ].join('\n');
 
   const systemPromptAppend = [


### PR DESCRIPTION
## Summary

- 在 agent-runner 的 system prompt 中新增"网页访问策略"段落，引导 Agent 在 WebFetch 遭遇 403、拦截、空内容或需要 JS 渲染时，立即 fallback 到 agent-browser（真实浏览器），避免无效重试
- .gitignore 中添加 `log` 目录的忽略规则

## 变更文件

- `container/agent-runner/src/index.ts` — 新增 `webFetchGuidelines` 并追加到 `systemPromptAppend`
- `.gitignore` — 添加 `log` 忽略项

## Test plan

- [ ] 验证 Agent 在 WebFetch 返回 403 时是否自动切换到 agent-browser
- [ ] 验证正常 WebFetch 请求不受影响
- [ ] 确认 system prompt 中新增段落格式正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)