### PR TITLE
功能: 新增 Claude OAuth 一键登录 + 修复全屏页面滚动

### DIFF
--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -69,14 +69,14 @@ export function LoginPage() {
 
   if (initialized !== true) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+      <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
         <div className="text-slate-500 text-sm">加载中...</div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+    <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <div className="bg-white rounded-lg border border-slate-200 p-8">
           {/* Logo */}

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -101,7 +101,7 @@ export function RegisterPage() {
 
   if (initialized !== true || statusLoading) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+      <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
         <div className="text-slate-500 text-sm">加载中...</div>
       </div>
     );
@@ -110,7 +110,7 @@ export function RegisterPage() {
   // Registration disabled
   if (!status.allowRegistration) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+      <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
         <div className="w-full max-w-md">
           <div className="bg-white rounded-lg border border-slate-200 p-8">
             <div className="flex justify-center mb-6">
@@ -137,7 +137,7 @@ export function RegisterPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+    <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
       <div className="w-full max-w-md">
         <div className="bg-white rounded-lg border border-slate-200 p-8">
           {/* Logo */}

--- a/web/src/pages/SetupChannelsPage.tsx
+++ b/web/src/pages/SetupChannelsPage.tsx
@@ -77,8 +77,8 @@ export function SetupChannelsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
-      <div className="w-full max-w-2xl space-y-5">
+    <div className="h-screen bg-slate-50 overflow-y-auto p-4">
+      <div className="w-full max-w-2xl mx-auto space-y-5">
         <div className="text-center">
           <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center mx-auto mb-4">
             <MessageSquare className="w-6 h-6 text-primary" />

--- a/web/src/pages/SetupPage.tsx
+++ b/web/src/pages/SetupPage.tsx
@@ -51,7 +51,7 @@ export function SetupPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-4">
+    <div className="h-screen bg-slate-50 overflow-y-auto p-4 flex flex-col items-center justify-center">
       <div className="w-full max-w-lg">
         {/* Header */}
         <div className="text-center mb-8">


### PR DESCRIPTION
## Summary

- 后端新增 Claude OAuth PKCE 流程（`POST /api/config/claude/oauth/start` 和 `POST /api/config/claude/oauth/callback`），支持通过 claude.ai 授权页面一键获取 OAuth token，替代手动执行 CLI 命令的繁琐流程
- 前端设置页（`ClaudeProviderSection`）和初始化向导（`SetupProvidersPage`）增加 OAuth 一键登录 UI，作为推荐方式展示，同时保留手动粘贴 setup-token 的备选方案
- 修复 SetupPage、SetupProvidersPage、SetupChannelsPage、LoginPage、RegisterPage 等全屏页面在内容超出视口时无法滚动的问题（`min-h-screen` -> `h-screen overflow-y-auto`）

## 变更文件

| 文件 | 变更说明 |
|------|---------|
| `src/routes/config.ts` | 新增 OAuth start/callback 两个 API 端点，PKCE 流程实现 |
| `web/src/components/settings/ClaudeProviderSection.tsx` | 设置页增加 OAuth 一键登录 UI |
| `web/src/pages/SetupProvidersPage.tsx` | 初始化向导增加 OAuth 一键登录 UI + 布局滚动修复 |
| `web/src/pages/LoginPage.tsx` | 滚动修复 |
| `web/src/pages/RegisterPage.tsx` | 滚动修复 |
| `web/src/pages/SetupChannelsPage.tsx` | 滚动修复 |
| `web/src/pages/SetupPage.tsx` | 滚动修复 |

## Test plan

- [ ] 验证 OAuth 一键登录流程：点击按钮 -> 打开 claude.ai 授权页 -> 粘贴授权码 -> token 保存成功
- [ ] 验证手动 setup-token 方式仍然正常工作
- [ ] 验证初始化向导中 OAuth 登录后可正常完成配置流程
- [ ] 验证各全屏页面在小屏幕/内容溢出时可正常滚动
- [ ] 验证 OAuth flow 10 分钟过期清理机制

🤖 Generated with [Claude Code](https://claude.com/claude-code)