### PR TITLE
修复: 使用 --env-file 确保 .env 在 ESM 模块初始化前加载

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
-    "dev": "tsx src/index.ts",
+    "start": "node --env-file=.env dist/index.js",
+    "dev": "tsx --env-file=.env src/index.ts",
     "reset:admin": "tsx src/reset-admin.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
## 问题

在 ESM（ES Modules）中，所有 `import` 语句会被提升（hoisted）并在模块体代码执行之前运行。因此，即使 `.env` 加载器代码写在文件顶部，`config.ts` 中对 `process.env.WEB_PORT` 等变量的读取仍会发生在加载器之前，导致 `.env` 中的配置完全无效。

**复现**：在 `.env` 中设置 `WEB_PORT=23456`，启动后服务仍监听 `3000`。

## 修复

将 `start` 和 `dev` 脚本改为使用 Node.js 原生 `--env-file` 标志，该标志由 Node.js 运行时在任何模块被求值之前注入环境变量，从根本上解决加载时序问题。

```
node --env-file=.env dist/index.js
tsx --env-file=.env src/index.ts
```

`--env-file` 在 Node.js v20.6.0 起可用，与项目 `engines.node >= 20` 要求一致。

## 测试

- 在 `.env` 中设置 `WEB_PORT=23456`，运行 `make start`，确认日志输出 `port: 23456`

🤖 Generated with [Claude Code](https://claude.com/claude-code)