### PR TITLE
功能: 新增 install_skill/uninstall_skill MCP 工具，优化技能管理页面

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -389,6 +389,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
             hasMore={hasMoreMessages}
             onLoadMore={handleLoadMore}
             scrollTrigger={scrollTrigger}
+            groupJid={groupJid}
           />
           <StreamingDisplay groupJid={groupJid} isWaiting={isWaiting} senderName={currentUser?.ai_name || appearance?.aiName || group?.name || 'AI'} />
           {isWaiting && (
@@ -446,7 +447,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
                   : 'text-slate-400 hover:text-slate-600'
               }`}
             >
-              Skills
+              技能
             </button>
           </div>
 
@@ -530,7 +531,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
       <Sheet open={mobilePanel === 'skills'} onOpenChange={(v) => !v && setMobilePanel(null)}>
         <SheetContent side="bottom" className="h-[80dvh] p-0">
           <SheetHeader className="px-4 pt-4 pb-2">
-            <SheetTitle>Skills 管理</SheetTitle>
+            <SheetTitle>技能管理</SheetTitle>
           </SheetHeader>
           <div className="flex-1 overflow-hidden h-[calc(80dvh-56px)]">
             <GroupSkillsPanel

--- a/web/src/components/chat/GroupSkillsPanel.tsx
+++ b/web/src/components/chat/GroupSkillsPanel.tsx
@@ -148,7 +148,7 @@ export function GroupSkillsPanel({ groupJid }: GroupSkillsPanelProps) {
       <div className="flex-1 overflow-y-auto">
         {allSkills.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-            暂无可用 Skills
+            暂无可用技能
           </div>
         ) : (
           <div className="divide-y divide-border">

--- a/web/src/components/skills/SkillCard.tsx
+++ b/web/src/components/skills/SkillCard.tsx
@@ -39,21 +39,34 @@ export function SkillCard({ skill, selected, onSelect }: SkillCardProps) {
           <p className="text-sm text-slate-500 line-clamp-2">{skill.description}</p>
         </div>
 
-        <div className="flex items-center gap-2">
-          <Lock size={16} className="text-slate-400" />
-          <button
-            disabled
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              skill.enabled ? 'bg-primary' : 'bg-slate-300'
-            } opacity-50 cursor-not-allowed`}
-          >
+        {skill.source === 'project' && (
+          <div className="flex items-center gap-2">
+            <Lock size={16} className="text-slate-400" />
+            <div
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                skill.enabled ? 'bg-primary' : 'bg-slate-300'
+              } opacity-50`}
+            >
+              <span
+                className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                  skill.enabled ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </div>
+          </div>
+        )}
+
+        {skill.source === 'user' && (
+          <div className="flex items-center">
             <span
-              className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
-                skill.enabled ? 'translate-x-6' : 'translate-x-1'
+              className={`inline-flex h-5 px-2 items-center rounded text-xs font-medium ${
+                skill.enabled ? 'bg-green-100 text-green-700' : 'bg-slate-100 text-slate-500'
               }`}
-            />
-          </button>
-        </div>
+            >
+              {skill.enabled ? '已启用' : '已禁用'}
+            </span>
+          </div>
+        )}
       </div>
     </button>
   );

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -138,14 +138,14 @@ export function SkillsPage() {
 
           {/* 右侧详情（桌面端） */}
           <div className="hidden lg:block lg:w-1/2 xl:w-3/5">
-            <SkillDetail skillId={selectedId} />
+            <SkillDetail skillId={selectedId} onDeleted={() => setSelectedId(null)} />
           </div>
         </div>
 
         {/* 移动端详情 */}
         {selectedId && (
           <div className="lg:hidden p-4">
-            <SkillDetail skillId={selectedId} />
+            <SkillDetail skillId={selectedId} onDeleted={() => setSelectedId(null)} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- 新增 `install_skill` / `uninstall_skill` MCP 工具，agent 可在对话中直接安装/卸载 skill，通过 IPC 与主进程通信完成操作
- 提取 `installSkillForUser` / `deleteSkillForUser` 公共函数，供 HTTP 路由和 IPC 处理共用，消除重复逻辑
- 修复技能管理页面用户级技能显示上锁图标的问题，改为显示状态标签和删除按钮
- 聊天界面 "Skills" 文案汉化为"技能"
- MessageList 支持跨群组切换时保存/恢复滚动位置

## 涉及文件

- `container/agent-runner/src/ipc-mcp-stdio.ts` — 新增 install_skill / uninstall_skill MCP 工具定义
- `src/index.ts` — IPC 处理器新增 install_skill / uninstall_skill 分支
- `src/routes/skills.ts` — 提取 installSkillForUser / deleteSkillForUser 公共函数
- `web/src/components/skills/SkillCard.tsx` — 用户级技能卡片显示优化
- `web/src/components/skills/SkillDetail.tsx` — 技能详情页显示优化
- `web/src/pages/SkillsPage.tsx` — 技能管理页面逻辑调整
- `web/src/components/chat/ChatView.tsx` — 文案汉化 + 传递 groupJid
- `web/src/components/chat/GroupSkillsPanel.tsx` — 文案汉化
- `web/src/components/chat/MessageList.tsx` — 滚动位置缓存

## Test plan

- [ ] 在对话中调用 install_skill 安装一个 skill，验证安装成功
- [ ] 在对话中调用 uninstall_skill 卸载已安装的 skill，验证卸载成功
- [ ] 技能管理页面确认用户级技能显示状态标签和删除按钮（非上锁图标）
- [ ] 切换群组后返回，验证消息列表滚动位置恢复正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)