### PR TITLE
fix: add missing 'code' parameter to OAuth authorize URL

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -277,6 +277,7 @@ configRoutes.post(
     });
 
     const params = new URLSearchParams({
+      code: 'true',
       response_type: 'code',
       client_id: OAUTH_CLIENT_ID,
       redirect_uri: OAUTH_REDIRECT_URI,


### PR DESCRIPTION
## 问题描述

在新加坡服务器上，Claude OAuth 登录返回 403 错误。

## 根本原因

对比 openclaw (clawdbot) 的实现，发现授权 URL 缺少关键参数 `code: 'true'`。

openclaw 的实现：
```javascript
const authParams = new URLSearchParams({
    code: "true",  // ← 关键参数
    client_id: CLIENT_ID,
    response_type: "code,