### PR TITLE
修复: 用户 skills 目录未挂载导致 agent 无法获取 skills

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -165,6 +165,13 @@ function buildVolumeMounts(
   const projectSkillsDir = path.join(projectRoot, 'container', 'skills');
   const userSkillsDir = (mountUserSkills && ownerId) ? path.join(DATA_DIR, 'skills', ownerId) : null;
 
+  // Ensure user skills directory exists so it can always be mounted.
+  // Skills may be installed after the group is created; without pre-creating,
+  // the existsSync check would skip mounting and the container would never see them.
+  if (userSkillsDir) {
+    fs.mkdirSync(userSkillsDir, { recursive: true });
+  }
+
   if (selectedSkills === null) {
     // 全量挂载（默认行为）
     if (fs.existsSync(projectSkillsDir)) {
@@ -174,7 +181,7 @@ function buildVolumeMounts(
         readonly: true,
       });
     }
-    if (userSkillsDir && fs.existsSync(userSkillsDir)) {
+    if (userSkillsDir) {
       mounts.push({
         hostPath: userSkillsDir,
         containerPath: '/workspace/user-skills',
@@ -198,7 +205,7 @@ function buildVolumeMounts(
       }
     }
     // 用户级 skills
-    if (userSkillsDir && fs.existsSync(userSkillsDir)) {
+    if (userSkillsDir) {
       for (const name of selectedSet) {
         const skillPath = path.join(userSkillsDir, name);
         if (fs.existsSync(skillPath) && fs.statSync(skillPath).isDirectory()) {


### PR DESCRIPTION
## Summary

- 修复普通用户自己创建的 skills 无法被 agent 获取的问题
- 根因：`buildVolumeMounts()` 通过 `existsSync` 检查用户 skills 目录，如果用户还没安装 skill（目录不存在），容器不会挂载该目录，导致 agent 始终无法发现用户级 skills
- 修复：提前 `mkdirSync` 确保目录存在，移除 `existsSync` 检查，始终挂载用户 skills 目录

## Changes

文件：`src/container-runner.ts`

1. 在 `buildVolumeMounts()` 函数中，对 `userSkillsDir` 提前调用 `fs.mkdirSync(userSkillsDir, { recursive: true })`，确保目录始终存在
2. 移除两处 `fs.existsSync(userSkillsDir)` 守卫条件（全量挂载模式和选择性挂载模式），改为只要 `userSkillsDir` 非空就执行挂载

## Test plan

- [ ] 新注册用户（尚未安装任何 skill），启动容器后确认 `/workspace/user-skills` 目录已挂载
- [ ] 用户安装 skill 后，无需重启容器即可在下次启动时被 agent 发现
- [ ] 验证 `selectedSkills` 为 null（全量挂载）和非 null（选择性挂载）两种路径均正常工作
- [ ] 验证 admin 和 member 用户的 skills 挂载行为一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)