### PR TITLE
功能: Telegram 对话中显示 AI 思考中的 typing 状态

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,9 @@ async function setTyping(jid: string, isTyping: boolean): Promise<void> {
   if (jid.startsWith('feishu:')) {
     await imManager.setFeishuTyping(jid, isTyping);
   }
+  if (jid.startsWith('telegram:')) {
+    await imManager.setTelegramTyping(jid, isTyping);
+  }
   broadcastTyping(jid, isTyping);
 }
 
@@ -712,6 +715,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             `Agent output: ${raw.slice(0, 200)}`,
           );
           if (text) {
+            // Stop typing indicator before sending — clears the 4s refresh timer
+            // so it doesn't keep firing while the agent stays alive in idle state.
+            await setTyping(chatJid, false);
             await sendMessage(chatJid, text, {
               sendToFeishu: shouldReplyToFeishu,
             });

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -30,6 +30,7 @@ export interface TelegramConnection {
   connect(opts: TelegramConnectOpts): Promise<void>;
   disconnect(): Promise<void>;
   sendMessage(chatId: string, text: string): Promise<void>;
+  sendChatAction(chatId: string, action: 'typing'): Promise<void>;
   isConnected(): boolean;
 }
 
@@ -392,6 +393,17 @@ export function createTelegramConnection(config: TelegramConnectionConfig): Tele
       } catch (err) {
         logger.error({ err, chatId }, 'Failed to send Telegram message');
         throw err;
+      }
+    },
+
+    async sendChatAction(chatId: string, action: 'typing'): Promise<void> {
+      if (!bot) return;
+      const chatIdNum = Number(chatId);
+      if (isNaN(chatIdNum)) return;
+      try {
+        await bot.api.sendChatAction(chatIdNum, action);
+      } catch (err) {
+        logger.debug({ err, chatId }, 'Failed to send Telegram chat action');
       }
     },
 


### PR DESCRIPTION
## 问题现象

Telegram 用户发送消息后，若 AI 正在执行工具调用或进行复杂推理，对话界面将长时间没有任何反馈。用户无法区分以下两种情况：

- AI 正在正常思考/处理中（需要等待）
- 系统已无响应/容器卡死（需要介入）

这在思考时间较长的任务中会造成明显困惑，影响使用体验。

## 根因分析

HappyClaw 已有 `setTyping()` 机制，在消息开始/结束处理时分别调用 `setTyping(true/false)`，并已对飞书实现了 👀 reaction 反馈。但 `setTyping()` 中缺少对 `telegram:` JID 的处理分支，Telegram 通道始终没有任何状态指示。

此外，Telegram 原生的 typing 指示器有约 5 秒的过期机制，若不持续刷新会自动消失，需要定时重发。

还存在一个隐患：`setTyping(false)` 原本在 `runAgent()` 返回后调用，但 host 模式 agent 进程在回复后会保持 idle 状态长达 30 分钟（`IDLE_TIMEOUT`），会导致 typing 指示器持续刷新直到进程退出。

## 修复内容

### `src/telegram.ts`

`TelegramConnection` 接口新增 `sendChatAction(chatId, action)` 方法，调用 grammy 的 `bot.api.sendChatAction()`，静默处理失败（debug 日志）。

### `src/im-manager.ts`

新增 `setTelegramTyping(chatJid, isTyping)` 方法，与已有的 `setFeishuTyping` 对称：

- `isTyping=true`：立即发送一次 typing action，并启动 4s 刷新定时器，持续保活指示器
- `isTyping=false`：清除定时器，停止刷新
- `disconnectAll()` 时统一清理所有定时器，防止泄漏

### `src/index.ts`

两处修改：

1. `setTyping()` 加入 `telegram:` 分支，路由到 `imManager.setTelegramTyping()`
2. `onOutput` 回调中，在产生实际文字并调用 `sendMessage` **之前**先调用 `setTyping(false)`，确保 typing 指示器在回复发出时立即停止，而不是等到 agent 进程退出（最长 30 分钟后）

## 测试验证

通过日志确认完整生命周期：

```
22:02:56.191  Processing messages
22:02:56.192  Telegram typing indicator started    ← setTyping(true) 触发，立即发送
22:03:00.xxx  Telegram chat action sent            ← 4s 定时刷新
22:03:05.507  Telegram message sent               ← AI 回复发出
             （无更多 typing 日志）                 ← 定时器已清除
```

回复发出后不再有 typing action 产生，指示器在 Telegram 客户端立即消失。