### PR TITLE
修复: 协作模式下被邀请用户创建文件夹后 AI 无法写入

### DIFF
--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -226,4 +226,7 @@ export function createDirectory(
   }
 
   fs.mkdirSync(absolutePath, { recursive: true });
+  // chmod 0o777 确保容器（node/1000）与宿主机用户均可读写
+  // 与 container-runner.ts 的 mkdirForContainer() 行为一致
+  try { fs.chmodSync(absolutePath, 0o777); } catch { /* 忽略只读文件系统 */ }
 }


### PR DESCRIPTION
## 问题现象

在合作模式（shared workspace）中，被邀请用户通过文件管理界面在 owner 的工作区创建文件夹后，AI 无法向该文件夹写入任何文件，报 `EACCES: permission denied`。

## 根因分析

宿主机用户（`agent`，uid=1002）通过 Web API `POST /api/groups/:jid/directories` 创建目录时，`file-manager.ts` 的 `createDirectory()` 仅调用 `fs.mkdirSync()`，未设置目录权限，继承 umask 默认值 `0o755`（`rwxr-xr-x`）。

容器以 `node`（uid=1000）运行，宿主机以 `agent`（uid=1002）运行，双方 uid 均不是目录属主（uid=1002），容器进程对该目录只有 `r-x`（只读），写入时报 EACCES。

对比：`container-runner.ts` 的 `mkdirForContainer()` 在容器启动时已对工作区**根目录**执行 `chmod 0o777`，但无法覆盖运行时由用户动态创建的子目录。

```
# 修复前
drwxr-xr-x  agent:agent  data/groups/{folder}/user_created_dir/  ← 容器无法写入

# 修复后
drwxrwxrwx  agent:agent  data/groups/{folder}/user_created_dir/  ← 容器可读写
```

## 修复内容

`src/file-manager.ts` 的 `createDirectory()` 在 `fs.mkdirSync()` 后追加 `fs.chmodSync(absolutePath, 0o777)`，与 `mkdirForContainer()` 保持一致：

```typescript
fs.mkdirSync(absolutePath, { recursive: true });
// chmod 0o777 确保容器（node/1000）与宿主机用户均可读写
try { fs.chmodSync(absolutePath, 0o777); } catch { /* 忽略只读文件系统 */ }
```

改动仅 1 行，不影响路径校验、符号链接保护等已有安全逻辑。

## 测试验证

```bash
# 1. 验证 Node.js chmod 0o777 正确生效
Permissions: 777 ✓

# 2. 验证容器（--user node，uid=1000）可写入
container (node/1000) write: OK ✓
```