### PR TITLE
修复: OAuth 自动续期因 Cloudflare 拦截始终失败

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -267,7 +267,7 @@ const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const OAUTH_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
 const OAUTH_SCOPES = 'org:create_api_key user:profile user:inference';
 const OAUTH_AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
-const OAUTH_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const OAUTH_TOKEN_URL = 'https://api.anthropic.com/v1/oauth/token';
 const OAUTH_FLOW_TTL = 10 * 60 * 1000; // 10 minutes
 
 interface OAuthFlow {

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1124,7 +1124,7 @@ export function buildContainerEnvLines(
 // ─── OAuth credentials file management ────────────────────────────
 
 const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
-const OAUTH_TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const OAUTH_TOKEN_URL = 'https://api.anthropic.com/v1/oauth/token';
 
 /**
  * Write .credentials.json to a Claude session directory.


### PR DESCRIPTION
## 问题现象

OAuth 凭据自动续期功能完全无效。PM2 日志中每 5 分钟循环出现：

```
INFO: OAuth token expiring soon, refreshing... expiresIn: -462
WARN: OAuth token refresh failed  status: 403  body: "<\!DOCTYPE html>...Just a moment..."
```

Token 过期后所有容器凭据失效，AI 无法使用。

## 根因分析

`OAUTH_TOKEN_URL` 指向 `console.anthropic.com/v1/oauth/token`，该域名受 **Cloudflare 反爬虫保护**，服务端 `fetch` 请求返回 HTTP 403 + JS 挑战页面，无法完成 OAuth token 交换。

影响范围：
- `src/routes/config.ts` — OAuth callback 首次换取 token
- `src/runtime-config.ts` — 每 5 分钟自动续期 refresh

## 修复内容

将两处 `OAUTH_TOKEN_URL` 从 `console.anthropic.com` 改为 `api.anthropic.com`。后者不经过 Cloudflare 挑战，正常返回 JSON 响应。

## 测试验证

| 端点 | HTTP 状态 | Content-Type | 结果 |
|------|-----------|-------------|------|
| `console.anthropic.com/v1/oauth/token` | 403 | text/html | Cloudflare 拦截 |
| `api.anthropic.com/v1/oauth/token` | 200 | application/json | 正常返回 token |

端到端验证：
1. 使用真实 refresh_token 调用 `api.anthropic.com` → 成功获取新 access_token + refresh_token（有效期 8h）
2. 加密配置正确更新
3. 15 个 `.credentials.json` 文件（所有容器会话 + sub-agent + `~/.claude/`）同步更新
