### PR TITLE
修复: 容器创建的文件用户无法通过 Web 删除

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Set permissive umask so files created by the container (node user, uid 1000)
+# are writable by the host backend (agent user, uid 1002).
+# Without this, the host cannot delete/modify files created by the container.
+umask 0000
+
 # Fix ownership on mounted volumes.
 # Host uid may differ from container node user (uid 1000), especially in
 # rootless podman where uid remapping causes EACCES on bind mounts.


### PR DESCRIPTION
## Summary

- 容器内 `node` 用户（uid 1000）创建文件默认 umask 0022，权限为 644/755
- 宿主机后端以 `agent` 用户（uid 1002）运行，只有只读权限，`fs.unlinkSync()` 抛出 EACCES
- 在 `entrypoint.sh` 中设置 `umask 0000`，使容器创建的文件/目录对所有用户可写
- 已有文件通过 Docker 批量 `chmod -R a+rwX` 修复

## Test plan

- [x] 容器通过真实 entrypoint.sh 创建文件 → 权限 `rw-rw-rw-`（666）
- [x] 后端 agent 用户通过 API 删除容器创建的文件 → 成功
- [x] 容器镜像已重建并验证 umask 生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)