### PR TITLE
优化: 定时任务系统多项修复与体验改进

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -841,6 +841,14 @@ export function logTaskRun(log: TaskRunLog): void {
   );
 }
 
+export function cleanupOldTaskRunLogs(retentionDays = 30): number {
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+  const result = db.prepare(
+    `DELETE FROM task_run_logs WHERE run_at < ?`,
+  ).run(cutoff);
+  return result.changes;
+}
+
 // --- Router state accessors ---
 
 export function getRouterState(key: string): string | undefined {

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -20,7 +20,6 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
       case 'paused':
         return 'bg-amber-100 text-amber-600';
       case 'completed':
-      case 'failed':
         return 'bg-slate-100 text-slate-500';
       default:
         return 'bg-slate-100 text-slate-600';
@@ -35,8 +34,6 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
         return '已暂停';
       case 'completed':
         return '已完成';
-      case 'failed':
-        return '失败';
       default:
         return status;
     }

--- a/web/src/components/tasks/TaskDetail.tsx
+++ b/web/src/components/tasks/TaskDetail.tsx
@@ -97,6 +97,15 @@ export function TaskDetail({ task }: TaskDetailProps) {
             {formatDate(task.created_at)}
           </div>
         </div>
+
+        {task.last_result && (
+          <div className="col-span-1 md:col-span-2">
+            <div className="text-xs text-slate-500 mb-1">最近结果</div>
+            <div className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap break-words">
+              {task.last_result}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Execution Logs */}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -3,14 +3,14 @@ import { useTasksStore } from '../stores/tasks';
 import { useChatStore } from '../stores/chat';
 import { TaskCard } from '../components/tasks/TaskCard';
 import { CreateTaskForm } from '../components/tasks/CreateTaskForm';
-import { Plus, RefreshCw, Clock } from 'lucide-react';
+import { Plus, RefreshCw, Clock, X } from 'lucide-react';
 import { PageHeader } from '@/components/common/PageHeader';
 import { SkeletonCardList } from '@/components/common/Skeletons';
 import { EmptyState } from '@/components/common/EmptyState';
 import { Button } from '@/components/ui/button';
 
 export function TasksPage() {
-  const { tasks, loading, loadTasks, createTask, updateTaskStatus, deleteTask } = useTasksStore();
+  const { tasks, loading, error, loadTasks, createTask, updateTaskStatus, deleteTask } = useTasksStore();
   const { groups, loadGroups } = useChatStore();
   const [showCreateForm, setShowCreateForm] = useState(false);
 
@@ -86,6 +86,18 @@ export function TasksPage() {
             </div>
           }
         />
+
+        {error && (
+          <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 flex items-center justify-between">
+            <span className="text-sm text-red-700">{error}</span>
+            <button
+              onClick={() => useTasksStore.setState({ error: null })}
+              className="p-1 text-red-400 hover:text-red-600 rounded transition-colors"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        )}
 
         {loading && tasks.length === 0 ? (
           <SkeletonCardList count={4} />

--- a/web/src/stores/tasks.ts
+++ b/web/src/stores/tasks.ts
@@ -11,7 +11,8 @@ export interface ScheduledTask {
   context_mode: 'group' | 'isolated';
   next_run: string | null;
   last_run?: string | null;
-  status: 'active' | 'paused' | 'completed' | 'failed';
+  last_result?: string | null;
+  status: 'active' | 'paused' | 'completed';
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

- **P0**: 修复 Web API 创建 once 任务 `next_run` 硬编码为当前时间导致立即触发的 bug，改为根据 `schedule_type` 正确计算
- **P1**: 修复 interval 模式时间漂移；新增 `runningTaskIds` 防重入；移除前端 `failed` 死状态；修正 cron 帮助文本为 5 段格式
- **P2**: 新增 `task_run_logs` 30 天自动清理；TaskDetail 展示 `last_result`；interval 改为数值+单位选择器；once 改为 datetime-local 选择器；TasksPage 新增可关闭错误 banner

## Test plan

- [ ] Web API 创建 once 任务，确认 `next_run` 等于 `schedule_value` 而非当前时间
- [ ] 创建 interval 任务，观察多次执行后 `next_run` 不累积漂移
- [ ] 创建短间隔 cron 任务配合长 prompt，确认不会并发执行同一任务
- [ ] 前端 typecheck 通过，无 `'failed'` 引用残留
- [ ] 前端 interval 单位选择器、once datetime-local 选择器交互正常
- [ ] TaskDetail 展开后可见 `last_result` 字段
- [ ] TasksPage 操作失败时显示可关闭的错误 banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)