### PR TITLE
修复: Agent 子对话中断按钮无法正常工作

### DIFF
--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -727,8 +727,12 @@ groupRoutes.post('/:jid/interrupt', authMiddleware, async (c) => {
   const deps = getWebDeps();
   if (!deps) return c.json({ error: 'Server not initialized' }, 500);
 
-  const jid = c.req.param('jid');
-  const group = getRegisteredGroup(jid);
+  const rawJid = c.req.param('jid');
+  const jid = decodeURIComponent(rawJid);
+  // Support virtual JIDs for conversation agents: {jid}#agent:{agentId}
+  const agentSep = jid.indexOf('#agent:');
+  const baseJid = agentSep >= 0 ? jid.slice(0, agentSep) : jid;
+  const group = getRegisteredGroup(baseJid);
   if (!group) return c.json({ error: 'Group not found' }, 404);
   const authUser = c.get('user') as AuthUser;
   if (!canAccessGroup({ id: authUser.id, role: authUser.role }, group)) {

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -482,7 +482,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
                 scrollTrigger={scrollTrigger}
                 groupJid={groupJid}
                 isWaiting={!!agentWaiting[activeAgentTab] || !!agentStreaming[activeAgentTab]}
-                onInterrupt={() => {}}
+                onInterrupt={() => interruptQuery(`${groupJid}#agent:${activeAgentTab}`)}
                 agentId={activeAgentTab}
               />
               <MessageInput
@@ -592,7 +592,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
                   scrollTrigger={scrollTrigger}
                   groupJid={groupJid}
                   isWaiting={!!agentStreaming[activeAgentTab]}
-                  onInterrupt={() => {}}
+                  onInterrupt={() => interruptQuery(groupJid)}
                   agentId={activeAgentTab}
                 />
               )}


### PR DESCRIPTION
## Summary

修复 Agent 子对话（测试分区）中点击中断按钮无法停止思考的问题。涉及三层 bug：

- **后端 404**：`@hono/node-server` 不会自动将 URL 路径中的 `%23` 解码为 `#`，导致包含 `#agent:` 的虚拟 JID 查找不到对应群组。添加 `decodeURIComponent()` 解决。
- **前端空函数**：`ChatView.tsx` 中 Agent 分栏的 `onInterrupt` 绑定为 `() => {}`，改为实际调用 `interruptQuery` 并传入含 `#agent:` 的虚拟 JID。
- **前端状态未清除**：`interruptQuery` 未识别 `#agent:` 虚拟 JID，无法正确清除 `agentStreaming`/`agentWaiting` 状态；`handleStreamEvent` 收到 `interrupted` 事件时仅清除 `agentStreaming` 未清除 `agentWaiting`。

## 改动文件

- `src/routes/groups.ts` — interrupt 路由添加 `decodeURIComponent` + 虚拟 JID 解析
- `web/src/components/chat/ChatView.tsx` — Agent 分栏 `onInterrupt` 接入实际中断逻辑
- `web/src/stores/chat.ts` — `interruptQuery` 和 `handleStreamEvent` 正确处理 agent 状态

## Test plan

- [x] 在 Agent 子对话中发送消息，等待思考中，点击中断按钮
- [x] 验证 API 返回 200（非 404）
- [x] 验证 UI 正确停止流式显示和等待状态
- [x] 验证主对话的中断功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)