### PR TITLE
功能: 4 项功能增强 — 智能中断、每日汇总、心跳上下文、IM 标准化

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -675,8 +675,19 @@ async function runQuery(
     '且 agent-browser 可用，立即改用 agent-browser 通过真实浏览器访问。不要反复重试 WebFetch。',
   ].join('\n');
 
+  // Read HEARTBEAT.md (recent work summary) for context injection
+  let heartbeatContent = '';
+  const heartbeatPath = path.join(WORKSPACE_GLOBAL, 'HEARTBEAT.md');
+  if (fs.existsSync(heartbeatPath)) {
+    try {
+      const raw = fs.readFileSync(heartbeatPath, 'utf-8');
+      heartbeatContent = raw.length > 4096 ? raw.slice(0, 4096) + '\n\n[...截断]' : raw;
+    } catch { /* skip */ }
+  }
+
   const systemPromptAppend = [
     globalClaudeMd,
+    heartbeatContent,
     memoryRecall,
     outputGuidelines,
     webFetchGuidelines,

--- a/src/daily-summary.ts
+++ b/src/daily-summary.ts
@@ -1,0 +1,246 @@
+import fs from 'fs';
+import path from 'path';
+import type { Logger } from 'pino';
+
+import { TIMEZONE } from './config.js';
+import { getGroupsByOwner, getMessagesByTimeRange, listUsers } from './db.js';
+
+export interface DailySummaryDeps {
+  logger: Logger;
+  dataDir: string;
+}
+
+let lastCheckTime = 0;
+const CHECK_INTERVAL_MS = 55 * 60 * 1000; // 55 minutes
+
+/**
+ * Run daily summary generation if conditions are met.
+ * Called from the scheduler loop every 60s.
+ * Actually executes only once per hour, and only between 2:00-3:00 AM local time.
+ */
+export function runDailySummaryIfNeeded(deps: DailySummaryDeps): void {
+  const now = Date.now();
+
+  // Throttle: skip if checked less than 55 minutes ago
+  if (now - lastCheckTime < CHECK_INTERVAL_MS) return;
+  lastCheckTime = now;
+
+  // Only run between 2:00-3:00 AM in the configured timezone
+  const localHour = getLocalHour(now);
+  if (localHour < 2 || localHour >= 3) return;
+
+  deps.logger.info('Daily summary: starting generation');
+
+  try {
+    generateSummaries(deps, now);
+  } catch (err) {
+    deps.logger.error({ err }, 'Daily summary: generation failed');
+  }
+}
+
+function getLocalHour(timestampMs: number): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    hour12: false,
+    timeZone: TIMEZONE,
+  });
+  return parseInt(formatter.format(new Date(timestampMs)), 10);
+}
+
+function getLocalDateString(timestampMs: number): string {
+  const formatter = new Intl.DateTimeFormat('sv-SE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: TIMEZONE,
+  });
+  // sv-SE locale gives YYYY-MM-DD format
+  return formatter.format(new Date(timestampMs));
+}
+
+/**
+ * Get start and end timestamps (ms) for a given local date string (YYYY-MM-DD).
+ */
+function getDayBounds(dateStr: string): { startTs: number; endTs: number } {
+  // Parse date components and create timestamps in the configured timezone
+  const [year, month, day] = dateStr.split('-').map(Number);
+
+  // Use a trick: format a known date to find the offset, then compute bounds
+  // Create date at midnight UTC, then adjust for timezone
+  const midnightUtc = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
+
+  // Find the timezone offset by comparing UTC and local representations
+  const localStr = midnightUtc.toLocaleString('en-US', { timeZone: TIMEZONE });
+  const localDate = new Date(localStr);
+  const offsetMs = midnightUtc.getTime() - localDate.getTime();
+
+  const startTs = midnightUtc.getTime() + offsetMs;
+  const endTs = startTs + 24 * 60 * 60 * 1000;
+
+  return { startTs, endTs };
+}
+
+function generateSummaries(deps: DailySummaryDeps, nowMs: number): void {
+  // Yesterday's date in local timezone
+  const yesterdayMs = nowMs - 24 * 60 * 60 * 1000;
+  const dateStr = getLocalDateString(yesterdayMs);
+  const { startTs, endTs } = getDayBounds(dateStr);
+
+  // Get all active users
+  let page = 1;
+  let processedUsers = 0;
+  while (true) {
+    const result = listUsers({ status: 'active', page, pageSize: 200 });
+    for (const user of result.users) {
+      try {
+        const generated = generateUserSummary(deps, user.id, user.username, dateStr, startTs, endTs);
+        if (generated) processedUsers++;
+      } catch (err) {
+        deps.logger.error({ err, userId: user.id }, 'Daily summary: failed for user');
+      }
+    }
+    if (result.users.length < result.pageSize || page * result.pageSize >= result.total) break;
+    page++;
+  }
+
+  deps.logger.info({ date: dateStr, processedUsers }, 'Daily summary: generation complete');
+}
+
+function generateUserSummary(
+  deps: DailySummaryDeps,
+  userId: string,
+  username: string,
+  dateStr: string,
+  startTs: number,
+  endTs: number,
+): boolean {
+  // Output path: data/groups/user-global/{userId}/daily-summary/YYYY-MM-DD.md
+  const summaryDir = path.join(deps.dataDir, 'groups', 'user-global', userId, 'daily-summary');
+  const summaryPath = path.join(summaryDir, `${dateStr}.md`);
+
+  // Idempotent: skip if already exists
+  if (fs.existsSync(summaryPath)) {
+    deps.logger.debug({ userId, date: dateStr }, 'Daily summary: already exists, skipping');
+    return false;
+  }
+
+  // Get all groups owned by this user
+  const groups = getGroupsByOwner(userId);
+  if (groups.length === 0) return false;
+
+  // Collect all chat_jids for the user's groups
+  const chatJids = groups.map((g) => g.jid);
+
+  // Fetch messages for all jids in the time range
+  const sections: string[] = [];
+  let totalCount = 0;
+
+  for (const jid of chatJids) {
+    const messages = getMessagesByTimeRange(jid, startTs, endTs);
+    if (messages.length === 0) continue;
+
+    totalCount += messages.length;
+    const lines: string[] = [];
+
+    let prevWasAgent = false;
+    for (const msg of messages) {
+      const isAgent = msg.is_from_me;
+      const sender = isAgent ? 'Agent' : (msg.sender_name || msg.sender || 'User');
+      const content = truncate(msg.content || '', 200);
+
+      // Merge consecutive Agent replies
+      if (isAgent && prevWasAgent) continue;
+
+      lines.push(`- **${sender}**: ${content}`);
+      prevWasAgent = isAgent;
+    }
+
+    sections.push(`## ${jid}\n${lines.join('\n')}`);
+  }
+
+  if (totalCount === 0) return false;
+
+  // Build markdown content
+  const md = `# ${dateStr} 对话汇总\n\n用户: ${username} | 消息数: ${totalCount}\n\n${sections.join('\n\n')}\n`;
+
+  // Write file
+  fs.mkdirSync(summaryDir, { recursive: true });
+  fs.writeFileSync(summaryPath, md, 'utf-8');
+  deps.logger.info({ userId, date: dateStr, messageCount: totalCount }, 'Daily summary: generated');
+
+  // Update HEARTBEAT.md with latest summaries
+  const userGlobalDir = path.join(deps.dataDir, 'groups', 'user-global', userId);
+  updateHeartbeat(userGlobalDir, username, deps.logger);
+
+  return true;
+}
+
+function truncate(text: string, maxLen: number): string {
+  // Replace newlines with spaces for single-line display
+  const singleLine = text.replace(/\n/g, ' ').trim();
+  if (singleLine.length <= maxLen) return singleLine;
+  return singleLine.slice(0, maxLen) + '...';
+}
+
+const HEARTBEAT_MAX_CHARS = 4096;
+const HEARTBEAT_PER_DAY_MAX_CHARS = 1024;
+const HEARTBEAT_DAYS = 3;
+
+/**
+ * Update HEARTBEAT.md with the most recent daily summaries.
+ * Called after a daily summary is generated for a user.
+ */
+function updateHeartbeat(userGlobalDir: string, username: string, logger: Logger): void {
+  const summaryDir = path.join(userGlobalDir, 'daily-summary');
+  if (!fs.existsSync(summaryDir)) return;
+
+  // Read all .md files sorted by name (YYYY-MM-DD.md) descending, take latest 3
+  let files: string[];
+  try {
+    files = fs.readdirSync(summaryDir)
+      .filter(f => f.endsWith('.md'))
+      .sort()
+      .reverse()
+      .slice(0, HEARTBEAT_DAYS);
+  } catch {
+    return;
+  }
+
+  if (files.length === 0) return;
+
+  // Reverse back to chronological order (oldest first)
+  files.reverse();
+
+  const now = new Date();
+  const timestamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+
+  const sections: string[] = [];
+  for (const file of files) {
+    const dateLabel = file.replace(/\.md$/, '');
+    try {
+      let content = fs.readFileSync(path.join(summaryDir, file), 'utf-8');
+      if (content.length > HEARTBEAT_PER_DAY_MAX_CHARS) {
+        content = content.slice(0, HEARTBEAT_PER_DAY_MAX_CHARS) + '\n\n[...截断]';
+      }
+      sections.push(`### ${dateLabel}\n${content}`);
+    } catch {
+      continue;
+    }
+  }
+
+  if (sections.length === 0) return;
+
+  let md = `# 近期工作摘要\n\n> 自动生成，最近更新：${timestamp}\n\n## 最近 ${files.length} 天对话汇总\n\n${sections.join('\n\n')}\n`;
+
+  if (md.length > HEARTBEAT_MAX_CHARS) {
+    md = md.slice(0, HEARTBEAT_MAX_CHARS) + '\n\n[...截断]';
+  }
+
+  const heartbeatPath = path.join(userGlobalDir, 'HEARTBEAT.md');
+  try {
+    fs.writeFileSync(heartbeatPath, md, 'utf-8');
+    logger.info({ username }, 'Daily summary: updated HEARTBEAT.md');
+  } catch (err) {
+    logger.error({ err, username }, 'Daily summary: failed to write HEARTBEAT.md');
+  }
+}

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -1,0 +1,193 @@
+/**
+ * Unified IM Channel Interface
+ *
+ * Defines a standard interface for all IM integrations (Feishu, Telegram, etc.)
+ * and provides adapter factories that wrap existing connection implementations.
+ */
+import {
+  createFeishuConnection,
+  type FeishuConnection,
+  type FeishuConnectionConfig,
+} from './feishu.js';
+import {
+  createTelegramConnection,
+  type TelegramConnection,
+  type TelegramConnectionConfig,
+} from './telegram.js';
+import { logger } from './logger.js';
+
+// ─── Unified Interface ──────────────────────────────────────────
+
+export interface IMChannelConnectOpts {
+  onReady: () => void;
+  onNewChat: (chatJid: string, chatName: string) => void;
+  onMessage?: (chatJid: string, text: string, senderName: string) => void;
+  ignoreMessagesBefore?: number;
+  isChatAuthorized?: (jid: string) => boolean;
+  onPairAttempt?: (jid: string, chatName: string, code: string) => Promise<boolean>;
+}
+
+export interface IMChannel {
+  readonly channelType: string;
+  connect(opts: IMChannelConnectOpts): Promise<boolean>;
+  disconnect(): Promise<void>;
+  sendMessage(chatId: string, text: string): Promise<void>;
+  setTyping(chatId: string, isTyping: boolean): Promise<void>;
+  isConnected(): boolean;
+  syncGroups?(): Promise<void>;
+}
+
+// ─── Channel Registry ───────────────────────────────────────────
+
+export const CHANNEL_REGISTRY: Record<string, { prefix: string }> = {
+  feishu: { prefix: 'feishu:' },
+  telegram: { prefix: 'telegram:' },
+};
+
+/**
+ * Determine the channel type from a JID string.
+ * Returns the matching channelType key or null if no prefix matches.
+ */
+export function getChannelType(jid: string): string | null {
+  for (const [type, { prefix }] of Object.entries(CHANNEL_REGISTRY)) {
+    if (jid.startsWith(prefix)) return type;
+  }
+  return null;
+}
+
+/**
+ * Strip the channel prefix from a JID, returning the raw chat ID.
+ */
+export function extractChatId(jid: string): string {
+  for (const { prefix } of Object.values(CHANNEL_REGISTRY)) {
+    if (jid.startsWith(prefix)) return jid.slice(prefix.length);
+  }
+  return jid;
+}
+
+// ─── Feishu Adapter ─────────────────────────────────────────────
+
+export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
+  let inner: FeishuConnection | null = null;
+
+  const channel: IMChannel = {
+    channelType: 'feishu',
+
+    async connect(opts: IMChannelConnectOpts): Promise<boolean> {
+      inner = createFeishuConnection(config);
+      const connected = await inner.connect({
+        onReady: opts.onReady,
+        onNewChat: opts.onNewChat,
+        ignoreMessagesBefore: opts.ignoreMessagesBefore,
+      });
+      if (!connected) {
+        inner = null;
+      }
+      return connected;
+    },
+
+    async disconnect(): Promise<void> {
+      if (inner) {
+        await inner.stop();
+        inner = null;
+      }
+    },
+
+    async sendMessage(chatId: string, text: string): Promise<void> {
+      if (!inner) {
+        logger.warn({ chatId }, 'Feishu channel not connected, skip sending message');
+        return;
+      }
+      await inner.sendMessage(chatId, text);
+    },
+
+    async setTyping(chatId: string, isTyping: boolean): Promise<void> {
+      if (!inner) return;
+      await inner.sendReaction(chatId, isTyping);
+    },
+
+    isConnected(): boolean {
+      return inner?.isConnected() ?? false;
+    },
+
+    async syncGroups(): Promise<void> {
+      if (!inner) return;
+      await inner.syncGroups();
+    },
+  };
+
+  return channel;
+}
+
+// ─── Telegram Adapter ───────────────────────────────────────────
+
+export function createTelegramChannel(config: TelegramConnectionConfig): IMChannel {
+  let inner: TelegramConnection | null = null;
+  // Telegram typing indicator expires after ~5s; resend every 4s while active.
+  let typingTimer: NodeJS.Timeout | null = null;
+
+  function clearTypingTimer(): void {
+    if (typingTimer) {
+      clearInterval(typingTimer);
+      typingTimer = null;
+    }
+  }
+
+  const channel: IMChannel = {
+    channelType: 'telegram',
+
+    async connect(opts: IMChannelConnectOpts): Promise<boolean> {
+      inner = createTelegramConnection(config);
+      try {
+        await inner.connect({
+          onReady: opts.onReady,
+          onNewChat: opts.onNewChat,
+          isChatAuthorized: opts.isChatAuthorized ?? (() => true),
+          onPairAttempt: opts.onPairAttempt,
+        });
+        return inner.isConnected();
+      } catch (err) {
+        logger.error({ err }, 'Telegram channel connect failed');
+        inner = null;
+        return false;
+      }
+    },
+
+    async disconnect(): Promise<void> {
+      clearTypingTimer();
+      if (inner) {
+        await inner.disconnect();
+        inner = null;
+      }
+    },
+
+    async sendMessage(chatId: string, text: string): Promise<void> {
+      if (!inner) {
+        logger.warn({ chatId }, 'Telegram channel not connected, skip sending message');
+        return;
+      }
+      await inner.sendMessage(chatId, text);
+    },
+
+    async setTyping(chatId: string, isTyping: boolean): Promise<void> {
+      // Always clear existing timer first
+      clearTypingTimer();
+      if (!isTyping || !inner) return;
+
+      const sendAction = async (): Promise<void> => {
+        if (!inner) return;
+        await inner.sendChatAction(chatId, 'typing');
+      };
+
+      // Send immediately, then repeat every 4s to keep indicator alive
+      void sendAction();
+      typingTimer = setInterval(() => { void sendAction(); }, 4000);
+    },
+
+    isConnected(): boolean {
+      return inner?.isConnected() ?? false;
+    },
+  };
+
+  return channel;
+}

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -1,19 +1,26 @@
 /**
  * IM Connection Pool Manager
  *
- * Manages per-user IM connections (Feishu, Telegram).
+ * Manages per-user IM connections using the unified IMChannel interface.
  * Each user can have independent IM connections that route messages
  * to their home container.
  */
-import { createFeishuConnection, FeishuConnection } from './feishu.js';
-import { createTelegramConnection, TelegramConnection } from './telegram.js';
+import {
+  type IMChannel,
+  type IMChannelConnectOpts,
+  getChannelType,
+  extractChatId,
+  createFeishuChannel,
+  createTelegramChannel,
+} from './im-channel.js';
+import type { FeishuConnectionConfig } from './feishu.js';
+import type { TelegramConnectionConfig } from './telegram.js';
 import { getRegisteredGroup, getJidsByFolder } from './db.js';
 import { logger } from './logger.js';
 
 export interface UserIMConnection {
   userId: string;
-  feishu?: FeishuConnection;
-  telegram?: TelegramConnection;
+  channels: Map<string, IMChannel>;
 }
 
 export interface FeishuConnectConfig {
@@ -30,8 +37,6 @@ export interface TelegramConnectConfig {
 class IMConnectionManager {
   private connections = new Map<string, UserIMConnection>();
   private adminUserIds = new Set<string>();
-  // Telegram typing indicator timers keyed by chatJid
-  private telegramTypingTimers = new Map<string, NodeJS.Timeout>();
 
   /** Register a user ID as admin (for fallback routing) */
   registerAdminUser(userId: string): void {
@@ -41,18 +46,125 @@ class IMConnectionManager {
   private getOrCreate(userId: string): UserIMConnection {
     let conn = this.connections.get(userId);
     if (!conn) {
-      conn = { userId };
+      conn = { userId, channels: new Map() };
       this.connections.set(userId, conn);
     }
     return conn;
   }
 
+  // ─── Generic Channel Methods ────────────────────────────────
+
+  /**
+   * Connect any IMChannel for a user.
+   */
+  async connectChannel(
+    userId: string,
+    channelType: string,
+    channel: IMChannel,
+    opts: IMChannelConnectOpts,
+  ): Promise<boolean> {
+    // Disconnect existing channel of same type
+    await this.disconnectChannel(userId, channelType);
+
+    const conn = this.getOrCreate(userId);
+    const connected = await channel.connect(opts);
+    if (connected) {
+      conn.channels.set(channelType, channel);
+      logger.info({ userId, channelType }, 'IM channel connected');
+    }
+    return connected;
+  }
+
+  /**
+   * Disconnect a specific channel type for a user.
+   */
+  async disconnectChannel(userId: string, channelType: string): Promise<void> {
+    const conn = this.connections.get(userId);
+    const channel = conn?.channels.get(channelType);
+    if (channel) {
+      await channel.disconnect();
+      conn!.channels.delete(channelType);
+      logger.info({ userId, channelType }, 'IM channel disconnected');
+    }
+  }
+
+  /**
+   * Send a message to an IM chat, auto-routing via JID prefix.
+   * Resolves the user by looking up chatJid -> registered_groups.created_by.
+   * Falls back to iterating sibling groups if no created_by is set.
+   */
+  async sendMessage(jid: string, text: string): Promise<void> {
+    const channelType = getChannelType(jid);
+    if (!channelType) {
+      logger.debug({ jid }, 'Unknown channel type for JID, skip sending');
+      return;
+    }
+
+    const chatId = extractChatId(jid);
+    const channel = this.findChannelForJid(jid, channelType);
+    if (channel) {
+      await channel.sendMessage(chatId, text);
+      return;
+    }
+
+    logger.warn({ jid, channelType }, 'No IM channel available to send message');
+  }
+
+  /**
+   * Set typing indicator on an IM chat, auto-routing via JID prefix.
+   */
+  async setTyping(jid: string, isTyping: boolean): Promise<void> {
+    const channelType = getChannelType(jid);
+    if (!channelType) return;
+
+    const chatId = extractChatId(jid);
+    const channel = this.findChannelForJid(jid, channelType);
+    if (channel) {
+      await channel.setTyping(chatId, isTyping);
+    }
+    // No fallback for typing — silently ignore if owner's connection is unavailable
+  }
+
+  /**
+   * Find the appropriate IMChannel for a given JID, using group ownership lookup
+   * and sibling fallback.
+   */
+  private findChannelForJid(jid: string, channelType: string): IMChannel | undefined {
+    // Direct lookup via group ownership
+    const group = getRegisteredGroup(jid);
+    if (group?.created_by) {
+      const conn = this.connections.get(group.created_by);
+      const ch = conn?.channels.get(channelType);
+      if (ch?.isConnected()) return ch;
+    }
+
+    // Fallback: find owner via sibling groups sharing the same folder
+    if (group) {
+      const siblingJids = getJidsByFolder(group.folder);
+      for (const sibJid of siblingJids) {
+        if (sibJid === jid) continue;
+        const sibling = getRegisteredGroup(sibJid);
+        if (sibling?.created_by) {
+          const conn = this.connections.get(sibling.created_by);
+          const ch = conn?.channels.get(channelType);
+          if (ch?.isConnected()) {
+            logger.warn(
+              { jid, fallbackUserId: sibling.created_by, folder: group.folder },
+              'IM message routed via sibling group owner connection',
+            );
+            return ch;
+          }
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  // ─── Convenience Methods (API-compatible wrappers) ──────────
+
   /**
    * Connect a Feishu instance for a specific user.
-   * @param userId - The user ID to associate the connection with
-   * @param config - Feishu app credentials
-   * @param onNewChat - Callback when a new chat is discovered
-   * @param ignoreMessagesBefore - Optional timestamp to ignore stale messages
    */
   async connectUserFeishu(
     userId: string,
@@ -65,29 +177,18 @@ class IMConnectionManager {
       return false;
     }
 
-    // Stop existing connection if any
-    await this.disconnectUserFeishu(userId);
-
-    const conn = this.getOrCreate(userId);
-    const feishu = createFeishuConnection({
+    const channel = createFeishuChannel({
       appId: config.appId,
       appSecret: config.appSecret,
     });
 
-    const connected = await feishu.connect({
+    return this.connectChannel(userId, 'feishu', channel, {
       onReady: () => {
         logger.info({ userId }, 'User Feishu WebSocket connected');
       },
       onNewChat,
       ignoreMessagesBefore,
     });
-
-    if (connected) {
-      conn.feishu = feishu;
-      logger.info({ userId }, 'User Feishu connection established');
-    }
-
-    return connected;
   }
 
   /**
@@ -105,189 +206,78 @@ class IMConnectionManager {
       return false;
     }
 
-    // Stop existing connection if any
-    await this.disconnectUserTelegram(userId);
-
-    const conn = this.getOrCreate(userId);
-    const telegram = createTelegramConnection({
+    const channel = createTelegramChannel({
       botToken: config.botToken,
     });
 
-    try {
-      await telegram.connect({
-        onReady: () => {
-          logger.info({ userId }, 'User Telegram bot connected');
-        },
-        onNewChat,
-        isChatAuthorized: isChatAuthorized ?? (() => true),
-        onPairAttempt,
-      });
-
-      if (telegram.isConnected()) {
-        conn.telegram = telegram;
-        logger.info({ userId }, 'User Telegram connection established');
-        return true;
-      }
-      return false;
-    } catch (err) {
-      logger.error({ userId, err }, 'Failed to connect user Telegram');
-      return false;
-    }
+    return this.connectChannel(userId, 'telegram', channel, {
+      onReady: () => {
+        logger.info({ userId }, 'User Telegram bot connected');
+      },
+      onNewChat,
+      isChatAuthorized,
+      onPairAttempt,
+    });
   }
 
   async disconnectUserFeishu(userId: string): Promise<void> {
-    const conn = this.connections.get(userId);
-    if (conn?.feishu) {
-      await conn.feishu.stop();
-      conn.feishu = undefined;
-      logger.info({ userId }, 'User Feishu connection disconnected');
-    }
+    await this.disconnectChannel(userId, 'feishu');
   }
 
   async disconnectUserTelegram(userId: string): Promise<void> {
-    const conn = this.connections.get(userId);
-    if (conn?.telegram) {
-      await conn.telegram.disconnect();
-      conn.telegram = undefined;
-      logger.info({ userId }, 'User Telegram connection disconnected');
-    }
+    await this.disconnectChannel(userId, 'telegram');
   }
 
   /**
-   * Send a message to a Feishu chat, routing through the correct user's connection.
-   * Resolves the user by looking up chatJid → registered_groups.created_by.
-   * Falls back to iterating all connections if no created_by is set.
+   * Send a message to a Feishu chat.
+   * @deprecated Use sendMessage(jid, text) which auto-routes.
    */
   async sendFeishuMessage(chatJid: string, text: string): Promise<void> {
-    const chatId = chatJid.replace(/^feishu:/, '');
-
-    // Find the appropriate connection by group ownership
-    const group = getRegisteredGroup(chatJid);
-    if (group?.created_by) {
-      const conn = this.connections.get(group.created_by);
-      if (conn?.feishu?.isConnected()) {
-        await conn.feishu.sendMessage(chatId, text);
-        return;
-      }
+    const chatId = extractChatId(chatJid);
+    const channel = this.findChannelForJid(chatJid, 'feishu');
+    if (channel) {
+      await channel.sendMessage(chatId, text);
+      return;
     }
-
-    // Fallback: find owner via sibling groups sharing the same folder
-    if (group) {
-      const siblingJids = getJidsByFolder(group.folder);
-      for (const sibJid of siblingJids) {
-        if (sibJid === chatJid) continue;
-        const sibling = getRegisteredGroup(sibJid);
-        if (sibling?.created_by) {
-          const conn = this.connections.get(sibling.created_by);
-          if (conn?.feishu?.isConnected()) {
-            logger.warn(
-              { chatJid, fallbackUserId: sibling.created_by, folder: group.folder },
-              'Feishu message routed via sibling group owner connection',
-            );
-            await conn.feishu.sendMessage(chatId, text);
-            return;
-          }
-        }
-      }
-    }
-
     logger.warn({ chatJid }, 'No Feishu connection available to send message');
   }
 
   /**
-   * Send a message to a Telegram chat, routing through the correct user's connection.
+   * Send a message to a Telegram chat.
+   * @deprecated Use sendMessage(jid, text) which auto-routes.
    */
   async sendTelegramMessage(chatJid: string, text: string): Promise<void> {
-    const chatId = chatJid.replace(/^telegram:/, '');
-
-    // Find the appropriate connection by group ownership
-    const group = getRegisteredGroup(chatJid);
-    if (group?.created_by) {
-      const conn = this.connections.get(group.created_by);
-      if (conn?.telegram?.isConnected()) {
-        await conn.telegram.sendMessage(chatId, text);
-        return;
-      }
+    const chatId = extractChatId(chatJid);
+    const channel = this.findChannelForJid(chatJid, 'telegram');
+    if (channel) {
+      await channel.sendMessage(chatId, text);
+      return;
     }
-
-    // Fallback: find owner via sibling groups sharing the same folder
-    if (group) {
-      const siblingJids = getJidsByFolder(group.folder);
-      for (const sibJid of siblingJids) {
-        if (sibJid === chatJid) continue;
-        const sibling = getRegisteredGroup(sibJid);
-        if (sibling?.created_by) {
-          const conn = this.connections.get(sibling.created_by);
-          if (conn?.telegram?.isConnected()) {
-            logger.warn(
-              { chatJid, fallbackUserId: sibling.created_by, folder: group.folder },
-              'Telegram message routed via sibling group owner connection',
-            );
-            await conn.telegram.sendMessage(chatId, text);
-            return;
-          }
-        }
-      }
-    }
-
     logger.warn({ chatJid }, 'No Telegram connection available to send message');
   }
 
   /**
    * Set typing reaction on a Feishu chat.
+   * @deprecated Use setTyping(jid, isTyping) which auto-routes.
    */
   async setFeishuTyping(chatJid: string, isTyping: boolean): Promise<void> {
-    const chatId = chatJid.replace(/^feishu:/, '');
-
-    const group = getRegisteredGroup(chatJid);
-    if (group?.created_by) {
-      const conn = this.connections.get(group.created_by);
-      if (conn?.feishu?.isConnected()) {
-        await conn.feishu.sendReaction(chatId, isTyping);
-        return;
-      }
+    const chatId = extractChatId(chatJid);
+    const channel = this.findChannelForJid(chatJid, 'feishu');
+    if (channel) {
+      await channel.setTyping(chatId, isTyping);
     }
-
-    // No fallback for typing — silently ignore if owner's connection is unavailable
   }
 
   /**
    * Set Telegram typing chat action for a chat.
-   * Telegram's typing indicator expires after ~5s, so we resend every 4s while active.
+   * @deprecated Use setTyping(jid, isTyping) which auto-routes.
    */
   async setTelegramTyping(chatJid: string, isTyping: boolean): Promise<void> {
-    // Clear any existing timer regardless of direction
-    const existing = this.telegramTypingTimers.get(chatJid);
-    if (existing) {
-      clearInterval(existing);
-      this.telegramTypingTimers.delete(chatJid);
+    const chatId = extractChatId(chatJid);
+    const channel = this.findChannelForJid(chatJid, 'telegram');
+    if (channel) {
+      await channel.setTyping(chatId, isTyping);
     }
-
-    if (!isTyping) return;
-
-    const chatId = chatJid.replace(/^telegram:/, '');
-
-    // Helper: find the right TelegramConnection for this chatJid
-    const findConn = (): TelegramConnection | undefined => {
-      const group = getRegisteredGroup(chatJid);
-      if (group?.created_by) {
-        const conn = this.connections.get(group.created_by);
-        if (conn?.telegram?.isConnected()) return conn.telegram;
-      }
-      return undefined;
-    };
-
-    const sendAction = async (): Promise<void> => {
-      const conn = findConn();
-      if (!conn) return;
-      await conn.sendChatAction(chatId, 'typing');
-    };
-
-    // Send immediately, then repeat every 4s to keep indicator alive
-    void sendAction();
-    const timer = setInterval(() => { void sendAction(); }, 4000);
-    this.telegramTypingTimers.set(chatJid, timer);
-    logger.debug({ chatJid }, 'Telegram typing indicator started');
   }
 
   /**
@@ -295,25 +285,26 @@ class IMConnectionManager {
    */
   async syncFeishuGroups(userId: string): Promise<void> {
     const conn = this.connections.get(userId);
-    if (conn?.feishu?.isConnected()) {
-      await conn.feishu.syncGroups();
+    const channel = conn?.channels.get('feishu');
+    if (channel?.isConnected() && channel.syncGroups) {
+      await channel.syncGroups();
     }
   }
 
   isFeishuConnected(userId: string): boolean {
     const conn = this.connections.get(userId);
-    return conn?.feishu?.isConnected() ?? false;
+    return conn?.channels.get('feishu')?.isConnected() ?? false;
   }
 
   isTelegramConnected(userId: string): boolean {
     const conn = this.connections.get(userId);
-    return conn?.telegram?.isConnected() ?? false;
+    return conn?.channels.get('telegram')?.isConnected() ?? false;
   }
 
   /** Check if any user has an active Feishu connection */
   isAnyFeishuConnected(): boolean {
     for (const conn of this.connections.values()) {
-      if (conn.feishu?.isConnected()) return true;
+      if (conn.channels.get('feishu')?.isConnected()) return true;
     }
     return false;
   }
@@ -321,27 +312,30 @@ class IMConnectionManager {
   /** Check if any user has an active Telegram connection */
   isAnyTelegramConnected(): boolean {
     for (const conn of this.connections.values()) {
-      if (conn.telegram?.isConnected()) return true;
+      if (conn.channels.get('telegram')?.isConnected()) return true;
     }
     return false;
   }
 
-  /** Get the Feishu connection for a user (for direct access like syncGroups) */
-  getFeishuConnection(userId: string): FeishuConnection | undefined {
-    return this.connections.get(userId)?.feishu;
+  /** Get the Feishu channel for a user (for direct access like syncGroups) */
+  getFeishuConnection(userId: string): IMChannel | undefined {
+    return this.connections.get(userId)?.channels.get('feishu');
   }
 
-  /** Get the Telegram connection for a user */
-  getTelegramConnection(userId: string): TelegramConnection | undefined {
-    return this.connections.get(userId)?.telegram;
+  /** Get the Telegram channel for a user */
+  getTelegramConnection(userId: string): IMChannel | undefined {
+    return this.connections.get(userId)?.channels.get('telegram');
   }
 
   /** Get all user IDs with active connections */
   getConnectedUserIds(): string[] {
     const ids: string[] = [];
     for (const [userId, conn] of this.connections.entries()) {
-      if (conn.feishu?.isConnected() || conn.telegram?.isConnected()) {
-        ids.push(userId);
+      for (const ch of conn.channels.values()) {
+        if (ch.isConnected()) {
+          ids.push(userId);
+          break;
+        }
       }
     }
     return ids;
@@ -355,26 +349,16 @@ class IMConnectionManager {
     const promises: Promise<void>[] = [];
 
     for (const [userId, conn] of this.connections.entries()) {
-      if (conn.feishu) {
+      for (const [channelType, channel] of conn.channels.entries()) {
         promises.push(
-          conn.feishu.stop().catch((err) => {
-            logger.warn({ userId, err }, 'Error stopping Feishu connection');
-          }),
-        );
-      }
-      if (conn.telegram) {
-        promises.push(
-          conn.telegram.disconnect().catch((err) => {
-            logger.warn({ userId, err }, 'Error stopping Telegram connection');
+          channel.disconnect().catch((err) => {
+            logger.warn({ userId, channelType, err }, 'Error stopping IM channel');
           }),
         );
       }
     }
 
     await Promise.allSettled(promises);
-    // Clear all Telegram typing timers
-    for (const timer of this.telegramTypingTimers.values()) clearInterval(timer);
-    this.telegramTypingTimers.clear();
     this.connections.clear();
     logger.info('All IM connections disconnected');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,8 @@ import {
 } from './db.js';
 // feishu.js deprecated exports are no longer needed; imManager handles all connections
 import { imManager } from './im-manager.js';
+import { getChannelType } from './im-channel.js';
+import { analyzeIntent } from './intent-analyzer.js';
 import {
   getClaudeProviderConfig as getClaudeProviderConfigForRefresh,
   getFeishuProviderConfigWithSource,
@@ -158,17 +160,13 @@ function sendSystemMessage(jid: string, type: string, detail: string): void {
 }
 
 async function setTyping(jid: string, isTyping: boolean): Promise<void> {
-  if (jid.startsWith('feishu:')) {
-    await imManager.setFeishuTyping(jid, isTyping);
-  }
-  if (jid.startsWith('telegram:')) {
-    await imManager.setTelegramTyping(jid, isTyping);
-  }
+  await imManager.setTyping(jid, isTyping);
   broadcastTyping(jid, isTyping);
 }
 
 interface SendMessageOptions {
-  sendToFeishu?: boolean;
+  /** Whether to forward the reply to the IM channel (Feishu/Telegram). Defaults to true for IM JIDs. */
+  sendToIM?: boolean;
 }
 
 function loadState(): void {
@@ -508,10 +506,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     }
   }
 
-  // Reply routing: feishu JIDs reply to feishu, telegram JIDs reply to telegram.
+  // Reply routing: IM JIDs reply to their respective IM channel.
   // With the home-folder forced restart in the message loop, each JID gets its
   // own processGroupMessages call, so JID-based routing is always correct.
-  const shouldReplyToFeishu = chatJid.startsWith('feishu:');
+  const shouldReplyToIM = getChannelType(chatJid) !== null;
 
   const shared = isGroupShared(group.folder);
   const prompt = formatMessages(missedMessages, shared);
@@ -523,7 +521,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     {
       group: group.name,
       messageCount: missedMessages.length,
-      shouldReplyToFeishu,
+      shouldReplyToIM,
       imageCount: images.length,
       shared,
     },
@@ -691,7 +689,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             // so it doesn't keep firing while the agent stays alive in idle state.
             await setTyping(chatJid, false);
             await sendMessage(chatJid, text, {
-              sendToFeishu: shouldReplyToFeishu,
+              sendToIM: shouldReplyToIM,
             });
             sentReply = true;
             // Persist cursor as soon as a visible reply is emitted.
@@ -1058,21 +1056,14 @@ async function sendMessage(
   text: string,
   options: SendMessageOptions = {},
 ): Promise<void> {
-  const sendToFeishu = options.sendToFeishu ?? jid.startsWith('feishu:');
+  const isIMChannel = getChannelType(jid) !== null;
+  const sendToIM = options.sendToIM ?? isIMChannel;
   try {
-    if (sendToFeishu && jid.startsWith('feishu:')) {
+    if (sendToIM && isIMChannel) {
       try {
-        await imManager.sendFeishuMessage(jid, text);
+        await imManager.sendMessage(jid, text);
       } catch (err) {
-        logger.error({ jid, err }, 'Failed to send message to Feishu');
-      }
-    }
-
-    if (jid.startsWith('telegram:')) {
-      try {
-        await imManager.sendTelegramMessage(jid, text);
-      } catch (err) {
-        logger.error({ jid, err }, 'Failed to send message to Telegram');
+        logger.error({ jid, err }, 'Failed to send message to IM channel');
       }
     }
 
@@ -1099,7 +1090,7 @@ async function sendMessage(
       timestamp,
       is_from_me: true,
     });
-    logger.info({ jid, length: text.length, sendToFeishu }, 'Message sent');
+    logger.info({ jid, length: text.length, sendToIM }, 'Message sent');
     broadcastToWebClients(jid, text);
   } catch (err) {
     logger.error({ jid, err }, 'Failed to send message');
@@ -1908,7 +1899,10 @@ async function startMessageLoop(): Promise<void> {
           const images = collectMessageImages(chatJid, messagesToSend);
           const imagesForAgent = images.length > 0 ? images : undefined;
 
-          if (queue.sendMessage(chatJid, formatted, imagesForAgent)) {
+          const lastRawText = messagesToSend[messagesToSend.length - 1].content;
+          const intent = analyzeIntent(lastRawText);
+          const sendResult = queue.sendMessage(chatJid, formatted, imagesForAgent, intent);
+          if (sendResult === 'sent') {
             logger.debug(
               { chatJid, count: messagesToSend.length, imageCount: images.length },
               'Piped messages to active container',
@@ -1919,8 +1913,26 @@ async function startMessageLoop(): Promise<void> {
               id: lastProcessed.id,
             };
             saveState();
+          } else if (sendResult === 'interrupted_stop') {
+            // Stop intent: update cursor, don't enqueue (agent stops)
+            const lastProcessed = messagesToSend[messagesToSend.length - 1];
+            lastAgentTimestamp[chatJid] = {
+              timestamp: lastProcessed.timestamp,
+              id: lastProcessed.id,
+            };
+            saveState();
+          } else if (sendResult === 'interrupted_correction') {
+            // Correction intent: update cursor; the IPC message was written so the
+            // interrupted agent will pick it up in its session loop after the abort.
+            // No enqueueMessageCheck needed — the existing agent handles it.
+            const lastProcessed = messagesToSend[messagesToSend.length - 1];
+            lastAgentTimestamp[chatJid] = {
+              timestamp: lastProcessed.timestamp,
+              id: lastProcessed.id,
+            };
+            saveState();
           } else {
-            // No active container — enqueue for a new one
+            // no_active — enqueue for a new one
             queue.enqueueMessageCheck(chatJid);
           }
         }
@@ -2551,6 +2563,10 @@ async function main(): Promise<void> {
       queue.registerProcess(groupJid, proc, containerName, groupFolder, displayName),
     sendMessage,
     assistantName: ASSISTANT_NAME,
+    dailySummaryDeps: {
+      logger,
+      dataDir: DATA_DIR,
+    },
   });
   startIpcWatcher();
   recoverPendingMessages();

--- a/src/intent-analyzer.ts
+++ b/src/intent-analyzer.ts
@@ -1,0 +1,34 @@
+export type MessageIntent = 'stop' | 'correction' | 'continue';
+
+const STOP_KEYWORDS = ['停', '算了', '取消', '不用了', 'stop', 'cancel', 'abort'];
+const CORRECTION_KEYWORDS = ['不对', '错了', '等等', '重来', 'wrong', 'redo'];
+
+const MAX_SHORT_MESSAGE_LENGTH = 50;
+
+export function analyzeIntent(text: string): MessageIntent {
+  const trimmed = text.trim();
+
+  if (trimmed.length === 0 || trimmed.length > MAX_SHORT_MESSAGE_LENGTH) {
+    return 'continue';
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  // Exact match first
+  for (const kw of STOP_KEYWORDS) {
+    if (lower === kw) return 'stop';
+  }
+  for (const kw of CORRECTION_KEYWORDS) {
+    if (lower === kw) return 'correction';
+  }
+
+  // Substring match
+  for (const kw of STOP_KEYWORDS) {
+    if (lower.includes(kw)) return 'stop';
+  }
+  for (const kw of CORRECTION_KEYWORDS) {
+    if (lower.includes(kw)) return 'correction';
+  }
+
+  return 'continue';
+}


### PR DESCRIPTION
## Summary

- **智能中断与意图识别**：Agent 执行中发送"停/算了/取消"自动中断，发送"不对/错了/重来"中断后重新处理纠正消息，纯关键词匹配无 LLM 开销
- **每日对话汇总**：凌晨 2-3 点自动生成前一天对话摘要，按用户维度汇总所有群组，输出到 `user-global/{userId}/daily-summary/`
- **心跳上下文**：Agent 启动时注入最近 3 天工作摘要（HEARTBEAT.md），所有会话均可读取，快速恢复上下文
- **IM 渠道接口标准化**：统一 `IMChannel` 接口抽象飞书/Telegram，`im-manager.ts` 基于 `Map<string, IMChannel>` 重构，降低新增渠道成本

## 文件变更

| 文件 | 变更 |
|------|------|
| `src/intent-analyzer.ts` | 新增：关键词意图分析模块 |
| `src/daily-summary.ts` | 新增：每日汇总 + HEARTBEAT.md 更新 |
| `src/im-channel.ts` | 新增：统一 IMChannel 接口 + adapter |
| `src/group-queue.ts` | 修改：sendMessage 支持 intent 参数 |
| `src/index.ts` | 修改：意图判断 + 汇总依赖 + IM 路由简化 |
| `src/web.ts` | 修改：Web 端意图判断 |
| `src/db.ts` | 修改：新增复合索引 + 时间范围查询 |
| `src/task-scheduler.ts` | 修改：嵌入每日汇总检查 |
| `src/im-manager.ts` | 重构：基于 Map\<string, IMChannel\> |
| `container/agent-runner/src/index.ts` | 修改：注入 HEARTBEAT.md |

## Test plan

- [ ] Agent 执行中发送"停" → Agent 立即中断
- [ ] Agent 执行中发送"不对，应该用 xxx" → Agent 中断后重启并处理纠正消息
- [ ] Agent 执行中发送正常长消息 → 通过 IPC 注入（不中断）
- [ ] 飞书消息收发正常
- [ ] Telegram 消息收发正常 + typing 刷新
- [ ] `make typecheck` 通过
- [ ] `make build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)