### PR TITLE
修复: MCP 管理支持 HTTP/SSE 类型并修复同步读取路径

### DIFF
--- a/web/src/components/mcp-servers/McpServerCard.tsx
+++ b/web/src/components/mcp-servers/McpServerCard.tsx
@@ -11,7 +11,10 @@ interface McpServerCardProps {
 export function McpServerCard({ server, selected, onSelect }: McpServerCardProps) {
   const toggleServer = useMcpServersStore((s) => s.toggleServer);
 
-  const commandPreview = [server.command, ...(server.args || [])].join(' ');
+  const isHttpType = server.type === 'http' || server.type === 'sse';
+  const preview = isHttpType
+    ? `${server.type?.toUpperCase()} ${server.url || ''}`
+    : [server.command, ...(server.args || [])].join(' ');
 
   return (
     <button
@@ -26,6 +29,11 @@ export function McpServerCard({ server, selected, onSelect }: McpServerCardProps
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
             <h3 className="font-medium text-slate-900 truncate">{server.id}</h3>
+            {isHttpType && (
+              <span className="px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
+                {server.type?.toUpperCase()}
+              </span>
+            )}
             {server.syncedFromHost && (
               <span className="px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-700 inline-flex items-center gap-1">
                 <Download size={10} />
@@ -33,7 +41,7 @@ export function McpServerCard({ server, selected, onSelect }: McpServerCardProps
               </span>
             )}
           </div>
-          <p className="text-sm text-slate-500 truncate font-mono">{commandPreview}</p>
+          <p className="text-sm text-slate-500 truncate font-mono">{preview}</p>
           {server.description && (
             <p className="text-xs text-slate-400 mt-1 line-clamp-1">{server.description}</p>
           )}

--- a/web/src/pages/McpServersPage.tsx
+++ b/web/src/pages/McpServersPage.tsx
@@ -39,7 +39,8 @@ export function McpServersPage() {
       (s) =>
         !q ||
         s.id.toLowerCase().includes(q) ||
-        s.command.toLowerCase().includes(q) ||
+        (s.command && s.command.toLowerCase().includes(q)) ||
+        (s.url && s.url.toLowerCase().includes(q)) ||
         (s.description && s.description.toLowerCase().includes(q)),
     );
   }, [servers, searchQuery]);
@@ -64,13 +65,7 @@ export function McpServersPage() {
     }
   };
 
-  const handleAdd = async (server: {
-    id: string;
-    command: string;
-    args?: string[];
-    env?: Record<string, string>;
-    description?: string;
-  }) => {
+  const handleAdd = async (server: Parameters<typeof addServer>[0]) => {
     await addServer(server);
   };
 
@@ -118,7 +113,7 @@ export function McpServersPage() {
               <SearchInput
                 value={searchQuery}
                 onChange={setSearchQuery}
-                placeholder="搜索 ID 或命令"
+                placeholder="搜索 ID、命令或 URL"
               />
             </div>
 

--- a/web/src/stores/mcp-servers.ts
+++ b/web/src/stores/mcp-servers.ts
@@ -3,9 +3,15 @@ import { api } from '../api/client';
 
 export interface McpServer {
   id: string;
-  command: string;
+  // stdio type
+  command?: string;
   args?: string[];
   env?: Record<string, string>;
+  // http/sse type
+  type?: 'http' | 'sse';
+  url?: string;
+  headers?: Record<string, string>;
+  // metadata
   enabled: boolean;
   syncedFromHost?: boolean;
   description?: string;
@@ -28,9 +34,12 @@ interface McpServersState {
   loadServers: () => Promise<void>;
   addServer: (server: {
     id: string;
-    command: string;
+    command?: string;
     args?: string[];
     env?: Record<string, string>;
+    type?: 'http' | 'sse';
+    url?: string;
+    headers?: Record<string, string>;
     description?: string;
   }) => Promise<void>;
   updateServer: (id: string, updates: Partial<McpServer>) => Promise<void>;


### PR DESCRIPTION
## Summary
- 修复同步宿主机 MCP 配置只读取 `~/.claude/settings.json`，遗漏 `~/.claude.json` 的问题
- 新增 HTTP/SSE 类型 MCP Server 支持（原仅支持 stdio 类型）
- 前端添加对话框、详情面板、卡片列表全面适配 HTTP/SSE 类型

## Test plan
- [ ] 点击"同步宿主机"，验证 `~/.claude.json` 中的 HTTP 类型 MCP Server 能被正确同步
- [ ] 手动添加 HTTP/SSE 类型 MCP Server，验证创建、编辑、启停、删除功能正常
- [ ] 验证已有 stdio 类型 MCP Server 不受影响
- [ ] 验证容器启动后 settings.json 中正确包含 HTTP 类型配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)