### PR TITLE
修复: 记忆管理页面因权限不足目录导致 500 错误

### DIFF
--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -273,7 +273,12 @@ function walkFiles(
 ): void {
   if (out.length >= limit || currentDepth > maxDepth || !fs.existsSync(baseDir))
     return;
-  const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
   for (const entry of entries) {
     if (out.length >= limit) break;
     const fullPath = path.join(baseDir, entry.name);


### PR DESCRIPTION
## Summary

- 记忆管理页面 `/api/memory/sources` 返回 500，前端显示为空
- 根因：`walkFiles` 递归扫描 `data/sessions/` 时遇到无读权限的子目录（如 `projects.old`），`readdirSync` 抛出 `EACCES` 异常未捕获
- 修复：添加 try-catch，静默跳过不可读目录

## 变更文件

| 文件 | 变更 | 说明 |
|------|------|------|
| `src/routes/memory.ts` | 修改 | `walkFiles` 添加 try-catch 包裹 `readdirSync` |

## Test plan

- [ ] 访问记忆管理页面，确认正常加载
- [ ] `make build && make typecheck` 通过