### PR TITLE
功能: 新增脚本注册与监控系统

### DIFF
--- a/src/routes/scripts.ts
+++ b/src/routes/scripts.ts
@@ -1,0 +1,212 @@
+import { Hono } from 'hono';
+import { execSync } from 'child_process';
+import type { Variables } from '../web-context.js';
+import type { AuthUser } from '../types.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { logger } from '../logger.js';
+import { getAllScripts, getScriptById, deleteScript as deleteScriptFromDb, type Script } from '../db.js';
+
+/** Only admin can manage host-level scripts */
+function requireAdmin(c: any): Response | null {
+  const user = c.get('user') as AuthUser;
+  if (user.role !== 'admin') {
+    return c.json({ error: 'Admin access required' }, 403);
+  }
+  return null;
+}
+
+const router = new Hono<{ Variables: Variables }>();
+
+interface PM2Process {
+  name: string;
+  pid: number;
+  pm2_env: {
+    status: string;
+    pm_uptime: number;
+    restart_time: number;
+    pm_exec_path: string;
+  };
+  monit: {
+    cpu: number;
+    memory: number;
+  };
+}
+
+function pm2List(): PM2Process[] {
+  try {
+    const output = execSync('pm2 jlist', {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    return JSON.parse(output);
+  } catch (err) {
+    logger.warn({ err }, 'Failed to run pm2 jlist');
+    return [];
+  }
+}
+
+function pm2Action(action: string, name: string): boolean {
+  try {
+    execSync(`pm2 ${action} ${JSON.stringify(name)}`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    return true;
+  } catch (err) {
+    logger.warn({ err, action, name }, 'PM2 action failed');
+    return false;
+  }
+}
+
+function runShellCommand(command: string): boolean {
+  try {
+    execSync(command, { encoding: 'utf-8', timeout: 10000 });
+    return true;
+  } catch (err) {
+    logger.warn({ err, command }, 'Shell command failed');
+    return false;
+  }
+}
+
+function checkCommandStatus(command: string): 'online' | 'stopped' {
+  try {
+    execSync(command, { timeout: 5000 });
+    return 'online';
+  } catch {
+    return 'stopped';
+  }
+}
+
+function buildScriptResponse(script: Script, pm2Processes: PM2Process[]) {
+  let status: string = 'registered';
+  let pid: number | null = null;
+  let cpu: number | null = null;
+  let memory: number | null = null;
+  let uptime: number | null = null;
+  let restarts: number | null = null;
+
+  if (script.process_manager === 'pm2' && script.pm2_name) {
+    const proc = pm2Processes.find((p) => p.name === script.pm2_name);
+    if (proc) {
+      status = proc.pm2_env.status;
+      pid = proc.pid;
+      cpu = proc.monit.cpu;
+      memory = proc.monit.memory;
+      uptime = proc.pm2_env.pm_uptime;
+      restarts = proc.pm2_env.restart_time;
+    } else {
+      status = 'stopped';
+    }
+  } else if (script.check_command) {
+    status = checkCommandStatus(script.check_command);
+  }
+
+  return {
+    id: script.id,
+    name: script.name,
+    description: script.description,
+    scriptPath: script.script_path,
+    processManager: script.process_manager,
+    pm2Name: script.pm2_name,
+    startCommand: script.start_command,
+    stopCommand: script.stop_command,
+    checkCommand: script.check_command,
+    groupFolder: script.group_folder,
+    createdAt: script.created_at,
+    status,
+    pid,
+    cpu,
+    memory,
+    uptime,
+    restarts,
+  };
+}
+
+// GET /api/scripts — list registered scripts (admin only)
+router.get('/', authMiddleware, async (c) => {
+  const denied = requireAdmin(c);
+  if (denied) return denied;
+
+  const dbScripts = getAllScripts();
+  const pm2Processes = pm2List();
+
+  const scripts = dbScripts.map((s) => buildScriptResponse(s, pm2Processes));
+  return c.json({ scripts });
+});
+
+// POST /api/scripts/:id/start (admin only)
+router.post('/:id/start', authMiddleware, async (c) => {
+  const denied = requireAdmin(c);
+  if (denied) return denied;
+  const script = getScriptById(c.req.param('id'));
+  if (!script) return c.json({ error: 'Script not found' }, 404);
+
+  let ok = false;
+  if (script.process_manager === 'pm2' && script.pm2_name) {
+    ok = pm2Action('start', script.pm2_name);
+  } else if (script.start_command) {
+    ok = runShellCommand(script.start_command);
+  }
+  return c.json({ success: ok });
+});
+
+// POST /api/scripts/:id/stop (admin only)
+router.post('/:id/stop', authMiddleware, async (c) => {
+  const denied = requireAdmin(c);
+  if (denied) return denied;
+  const script = getScriptById(c.req.param('id'));
+  if (!script) return c.json({ error: 'Script not found' }, 404);
+
+  let ok = false;
+  if (script.process_manager === 'pm2' && script.pm2_name) {
+    ok = pm2Action('stop', script.pm2_name);
+  } else if (script.stop_command) {
+    ok = runShellCommand(script.stop_command);
+  }
+  return c.json({ success: ok });
+});
+
+// POST /api/scripts/:id/restart (admin only)
+router.post('/:id/restart', authMiddleware, async (c) => {
+  const denied = requireAdmin(c);
+  if (denied) return denied;
+  const script = getScriptById(c.req.param('id'));
+  if (!script) return c.json({ error: 'Script not found' }, 404);
+
+  let ok = false;
+  if (script.process_manager === 'pm2' && script.pm2_name) {
+    ok = pm2Action('restart', script.pm2_name);
+  } else {
+    // stop + start
+    if (script.stop_command) runShellCommand(script.stop_command);
+    if (script.start_command) {
+      ok = runShellCommand(script.start_command);
+    }
+  }
+  return c.json({ success: ok });
+});
+
+// DELETE /api/scripts/:id (admin only)
+router.delete('/:id', authMiddleware, async (c) => {
+  const denied = requireAdmin(c);
+  if (denied) return denied;
+  const script = getScriptById(c.req.param('id'));
+  if (!script) return c.json({ error: 'Script not found' }, 404);
+
+  // Stop process first
+  try {
+    if (script.process_manager === 'pm2' && script.pm2_name) {
+      pm2Action('stop', script.pm2_name);
+      pm2Action('delete', script.pm2_name);
+    } else if (script.stop_command) {
+      runShellCommand(script.stop_command);
+    }
+  } catch (err) {
+    logger.warn({ err, id: script.id }, 'Failed to stop script during delete');
+  }
+
+  deleteScriptFromDb(script.id);
+  return c.json({ success: true });
+});
+
+export default router;

--- a/src/web.ts
+++ b/src/web.ts
@@ -47,6 +47,7 @@ import skillsRoutes from './routes/skills.js';
 import browseRoutes from './routes/browse.js';
 import agentRoutes from './routes/agents.js';
 import mcpServersRoutes from './routes/mcp-servers.js';
+import scriptsRoutes from './routes/scripts.js';
 
 // Database and types (only for handleWebUserMessage and broadcast)
 import {
@@ -151,6 +152,7 @@ app.route('/api/memory', memoryRoutes);
 app.route('/api/config', configRoutes);
 app.route('/api/tasks', tasksRoutes);
 app.route('/api/skills', skillsRoutes);
+app.route('/api/scripts', scriptsRoutes);
 app.route('/api/admin', adminRoutes);
 app.route('/api/browse', browseRoutes);
 app.route('/api/mcp-servers', mcpServersRoutes);

--- a/web/src/components/tasks/ScriptCard.tsx
+++ b/web/src/components/tasks/ScriptCard.tsx
@@ -1,0 +1,177 @@
+import { Play, Square, RotateCw, FileCode, Trash2 } from 'lucide-react';
+import type { ScriptProcess } from '../../stores/scripts';
+
+interface ScriptCardProps {
+  script: ScriptProcess;
+  actionLoading: string | null;
+  onStart: (id: string) => void;
+  onStop: (id: string) => void;
+  onRestart: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function formatUptime(ms: number): string {
+  if (!ms) return '-';
+  const now = Date.now();
+  const diff = now - ms;
+  if (diff < 0) return '-';
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
+}
+
+function formatMemory(bytes: number): string {
+  if (!bytes) return '-';
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const PM_LABELS: Record<string, string> = {
+  pm2: 'PM2',
+  systemd: 'systemd',
+  manual: '手动',
+};
+
+export function ScriptCard({
+  script,
+  actionLoading,
+  onStart,
+  onStop,
+  onRestart,
+  onDelete,
+}: ScriptCardProps) {
+  const isOnline = script.status === 'online';
+  const isStopped = script.status === 'stopped';
+  const isRegistered = script.status === 'registered';
+  const isActing = actionLoading === script.id;
+
+  const statusColor = isOnline
+    ? 'bg-green-100 text-green-600'
+    : isStopped
+      ? 'bg-slate-100 text-slate-500'
+      : isRegistered
+        ? 'bg-blue-100 text-blue-500'
+        : 'bg-red-100 text-red-600';
+
+  const statusLabel = isOnline
+    ? '运行中'
+    : isStopped
+      ? '已停止'
+      : isRegistered
+        ? '已注册'
+        : script.status === 'errored'
+          ? '异常'
+          : script.status;
+
+  const canStart = script.processManager === 'pm2' || !!script.startCommand;
+  const canStop = script.processManager === 'pm2' || !!script.stopCommand;
+  const canRestart = script.processManager === 'pm2' || (!!script.startCommand && !!script.stopCommand);
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-4">
+      <div className="flex items-start justify-between gap-3">
+        {/* Left: info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <FileCode size={16} className="text-slate-400 shrink-0" />
+            <span className="font-medium text-sm text-slate-800 truncate">
+              {script.name}
+            </span>
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusColor}`}
+            >
+              {statusLabel}
+            </span>
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs text-slate-400 bg-slate-50 border border-slate-100">
+              {PM_LABELS[script.processManager] || script.processManager}
+            </span>
+          </div>
+
+          {script.description && (
+            <p className="text-xs text-slate-500 mb-1.5 line-clamp-1">
+              {script.description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3 text-xs text-slate-400">
+            {script.processManager === 'pm2' && isOnline && script.pid != null && (
+              <>
+                <span>PID {script.pid}</span>
+                {script.uptime != null && <span>{formatUptime(script.uptime)}</span>}
+                {script.memory != null && <span>{formatMemory(script.memory)}</span>}
+                {script.cpu != null && <span>CPU {script.cpu}%</span>}
+              </>
+            )}
+            {script.processManager === 'pm2' && script.restarts != null && script.restarts > 0 && (
+              <span className="text-amber-500">
+                重启 {script.restarts} 次
+              </span>
+            )}
+            {script.processManager !== 'pm2' && script.startCommand && (
+              <span className="truncate text-slate-300" title={script.startCommand}>
+                {script.startCommand.length > 60
+                  ? script.startCommand.slice(0, 60) + '...'
+                  : script.startCommand}
+              </span>
+            )}
+            {script.scriptPath && (
+              <span className="truncate text-slate-300" title={script.scriptPath}>
+                {script.scriptPath.split('/').pop()}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Right: actions */}
+        <div className="flex items-center gap-1 shrink-0">
+          {isOnline ? (
+            <>
+              {canRestart && (
+                <button
+                  onClick={() => onRestart(script.id)}
+                  disabled={isActing}
+                  className="p-1.5 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors disabled:opacity-50"
+                  title="重启"
+                >
+                  <RotateCw size={15} className={isActing ? 'animate-spin' : ''} />
+                </button>
+              )}
+              {canStop && (
+                <button
+                  onClick={() => onStop(script.id)}
+                  disabled={isActing}
+                  className="p-1.5 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                  title="停止"
+                >
+                  <Square size={15} />
+                </button>
+              )}
+            </>
+          ) : canStart ? (
+            <button
+              onClick={() => onStart(script.id)}
+              disabled={isActing}
+              className="p-1.5 text-slate-400 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors disabled:opacity-50"
+              title="启动"
+            >
+              <Play size={15} />
+            </button>
+          ) : null}
+          <button
+            onClick={() => onDelete(script.id)}
+            disabled={isActing}
+            className="p-1.5 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+            title="删除"
+          >
+            <Trash2 size={15} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,23 +1,39 @@
 import { useEffect, useState } from 'react';
 import { useTasksStore } from '../stores/tasks';
+import { useScriptsStore } from '../stores/scripts';
 import { useChatStore } from '../stores/chat';
 import { TaskCard } from '../components/tasks/TaskCard';
+import { ScriptCard } from '../components/tasks/ScriptCard';
 import { CreateTaskForm } from '../components/tasks/CreateTaskForm';
-import { Plus, RefreshCw, Clock, X } from 'lucide-react';
+import { Plus, RefreshCw, Clock, X, FileCode } from 'lucide-react';
 import { PageHeader } from '@/components/common/PageHeader';
 import { SkeletonCardList } from '@/components/common/Skeletons';
 import { EmptyState } from '@/components/common/EmptyState';
 import { Button } from '@/components/ui/button';
+import { useAuthStore } from '../stores/auth';
 
 export function TasksPage() {
   const { tasks, loading, error, loadTasks, createTask, updateTaskStatus, deleteTask } = useTasksStore();
+  const {
+    scripts,
+    loading: scriptsLoading,
+    actionLoading,
+    error: scriptsError,
+    loadScripts,
+    startScript,
+    stopScript,
+    restartScript,
+    deleteScript: deleteScriptAction,
+  } = useScriptsStore();
   const { groups, loadGroups } = useChatStore();
+  const isAdmin = useAuthStore((s) => s.user?.role === 'admin');
   const [showCreateForm, setShowCreateForm] = useState(false);
 
   useEffect(() => {
     loadTasks();
     loadGroups();
-  }, [loadTasks, loadGroups]);
+    if (isAdmin) loadScripts();
+  }, [loadTasks, loadGroups, loadScripts, isAdmin]);
 
   const handleCreateTask = async (data: {
     groupFolder: string;
@@ -56,6 +72,12 @@ export function TasksPage() {
     }
   };
 
+  const handleDeleteScript = async (id: string) => {
+    if (confirm('确定要删除此脚本吗？进程将被终止并从监控面板移除。')) {
+      await deleteScriptAction(id);
+    }
+  };
+
   const groupsList = Object.entries(groups).map(([jid, group]) => ({
     jid,
     name: group.name,
@@ -66,17 +88,24 @@ export function TasksPage() {
   const pausedTasks = tasks.filter((t) => t.status === 'paused');
   const otherTasks = tasks.filter((t) => t.status !== 'active' && t.status !== 'paused');
 
+  const handleRefreshAll = () => {
+    loadTasks();
+    loadScripts();
+  };
+
+  const anyError = error || scriptsError;
+
   return (
     <div className="min-h-full bg-slate-50">
       <div className="max-w-6xl mx-auto p-6">
         <PageHeader
-          title="定时任务管理"
-          subtitle={`共 ${tasks.length} 个任务 · ${activeTasks.length} 运行中 · ${pausedTasks.length} 已暂停`}
+          title="任务管理"
+          subtitle={`${scripts.length} 个脚本 · ${tasks.length} 个定时任务 · ${activeTasks.length} 运行中`}
           className="mb-6"
           actions={
             <div className="flex items-center gap-3">
-              <Button variant="outline" onClick={loadTasks} disabled={loading}>
-                <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+              <Button variant="outline" onClick={handleRefreshAll} disabled={loading || scriptsLoading}>
+                <RefreshCw size={18} className={loading || scriptsLoading ? 'animate-spin' : ''} />
                 刷新
               </Button>
               <Button onClick={() => setShowCreateForm(true)}>
@@ -87,11 +116,14 @@ export function TasksPage() {
           }
         />
 
-        {error && (
+        {anyError && (
           <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 flex items-center justify-between">
-            <span className="text-sm text-red-700">{error}</span>
+            <span className="text-sm text-red-700">{anyError}</span>
             <button
-              onClick={() => useTasksStore.setState({ error: null })}
+              onClick={() => {
+                useTasksStore.setState({ error: null });
+                useScriptsStore.setState({ error: null });
+              }}
               className="p-1 text-red-400 hover:text-red-600 rounded transition-colors"
             >
               <X size={16} />
@@ -99,73 +131,102 @@ export function TasksPage() {
           </div>
         )}
 
-        {loading && tasks.length === 0 ? (
-          <SkeletonCardList count={4} />
-        ) : tasks.length === 0 ? (
-          <EmptyState
-            icon={Clock}
-            title="还没有创建任何定时任务"
-            action={
-              <Button onClick={() => setShowCreateForm(true)}>
-                <Plus size={18} />
-                创建第一个任务
-              </Button>
-            }
-          />
-        ) : (
-          <div className="space-y-6">
-            {activeTasks.length > 0 && (
-              <div>
-                <h2 className="text-sm font-semibold text-slate-700 mb-3">运行中</h2>
-                <div className="space-y-3">
-                  {activeTasks.map((task) => (
-                    <TaskCard
-                      key={task.id}
-                      task={task}
-                      onPause={handlePause}
-                      onResume={handleResume}
-                      onDelete={handleDelete}
-                    />
-                  ))}
-                </div>
+        <div className="space-y-6">
+          {/* Scripts monitoring section */}
+          {scripts.length > 0 && (
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <FileCode size={16} className="text-slate-500" />
+                <h2 className="text-sm font-semibold text-slate-700">脚本监控</h2>
+                <span className="text-xs text-slate-400">
+                  {scripts.filter((s) => s.status === 'online').length}/{scripts.length} 运行中
+                </span>
               </div>
-            )}
+              <div className="space-y-2">
+                {scripts.map((script) => (
+                  <ScriptCard
+                    key={script.id}
+                    script={script}
+                    actionLoading={actionLoading}
+                    onStart={startScript}
+                    onStop={stopScript}
+                    onRestart={restartScript}
+                    onDelete={handleDeleteScript}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
-            {pausedTasks.length > 0 && (
-              <div>
-                <h2 className="text-sm font-semibold text-slate-700 mb-3">已暂停</h2>
-                <div className="space-y-3">
-                  {pausedTasks.map((task) => (
-                    <TaskCard
-                      key={task.id}
-                      task={task}
-                      onPause={handlePause}
-                      onResume={handleResume}
-                      onDelete={handleDelete}
-                    />
-                  ))}
+          {/* Scheduled tasks sections */}
+          {loading && tasks.length === 0 ? (
+            <SkeletonCardList count={4} />
+          ) : tasks.length === 0 && scripts.length === 0 ? (
+            <EmptyState
+              icon={Clock}
+              title="还没有创建任何任务"
+              action={
+                <Button onClick={() => setShowCreateForm(true)}>
+                  <Plus size={18} />
+                  创建第一个任务
+                </Button>
+              }
+            />
+          ) : (
+            <>
+              {activeTasks.length > 0 && (
+                <div>
+                  <h2 className="text-sm font-semibold text-slate-700 mb-3">运行中</h2>
+                  <div className="space-y-3">
+                    {activeTasks.map((task) => (
+                      <TaskCard
+                        key={task.id}
+                        task={task}
+                        onPause={handlePause}
+                        onResume={handleResume}
+                        onDelete={handleDelete}
+                      />
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
-            {otherTasks.length > 0 && (
-              <div>
-                <h2 className="text-sm font-semibold text-slate-700 mb-3">其他</h2>
-                <div className="space-y-3">
-                  {otherTasks.map((task) => (
-                    <TaskCard
-                      key={task.id}
-                      task={task}
-                      onPause={handlePause}
-                      onResume={handleResume}
-                      onDelete={handleDelete}
-                    />
-                  ))}
+              {pausedTasks.length > 0 && (
+                <div>
+                  <h2 className="text-sm font-semibold text-slate-700 mb-3">已暂停</h2>
+                  <div className="space-y-3">
+                    {pausedTasks.map((task) => (
+                      <TaskCard
+                        key={task.id}
+                        task={task}
+                        onPause={handlePause}
+                        onResume={handleResume}
+                        onDelete={handleDelete}
+                      />
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        )}
+              )}
+
+              {otherTasks.length > 0 && (
+                <div>
+                  <h2 className="text-sm font-semibold text-slate-700 mb-3">其他</h2>
+                  <div className="space-y-3">
+                    {otherTasks.map((task) => (
+                      <TaskCard
+                        key={task.id}
+                        task={task}
+                        onPause={handlePause}
+                        onResume={handleResume}
+                        onDelete={handleDelete}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
 
       {showCreateForm && (

--- a/web/src/stores/scripts.ts
+++ b/web/src/stores/scripts.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand';
+import { api } from '../api/client';
+
+export interface ScriptProcess {
+  id: string;
+  name: string;
+  description: string | null;
+  scriptPath: string | null;
+  processManager: 'pm2' | 'systemd' | 'manual';
+  pm2Name: string | null;
+  startCommand: string | null;
+  stopCommand: string | null;
+  checkCommand: string | null;
+  groupFolder: string;
+  createdAt: string;
+  status: 'online' | 'stopped' | 'errored' | 'registered' | 'unknown' | string;
+  pid: number | null;
+  cpu: number | null;
+  memory: number | null;
+  uptime: number | null;
+  restarts: number | null;
+}
+
+interface ScriptsState {
+  scripts: ScriptProcess[];
+  loading: boolean;
+  actionLoading: string | null; // id of script being acted on
+  error: string | null;
+  loadScripts: () => Promise<void>;
+  startScript: (id: string) => Promise<void>;
+  stopScript: (id: string) => Promise<void>;
+  restartScript: (id: string) => Promise<void>;
+  deleteScript: (id: string) => Promise<void>;
+}
+
+export const useScriptsStore = create<ScriptsState>((set, get) => ({
+  scripts: [],
+  loading: false,
+  actionLoading: null,
+  error: null,
+
+  loadScripts: async () => {
+    set({ loading: true, error: null });
+    try {
+      const data = await api.get<{ scripts: ScriptProcess[] }>('/api/scripts');
+      set({ scripts: data.scripts, loading: false });
+    } catch (err) {
+      // Silently ignore 403 (non-admin users)
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('403') || msg.includes('Admin')) {
+        set({ scripts: [], loading: false });
+      } else {
+        set({ error: msg, loading: false });
+      }
+    }
+  },
+
+  startScript: async (id) => {
+    set({ actionLoading: id, error: null });
+    try {
+      await api.post(`/api/scripts/${encodeURIComponent(id)}/start`);
+      await get().loadScripts();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err) });
+    } finally {
+      set({ actionLoading: null });
+    }
+  },
+
+  stopScript: async (id) => {
+    set({ actionLoading: id, error: null });
+    try {
+      await api.post(`/api/scripts/${encodeURIComponent(id)}/stop`);
+      await get().loadScripts();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err) });
+    } finally {
+      set({ actionLoading: null });
+    }
+  },
+
+  restartScript: async (id) => {
+    set({ actionLoading: id, error: null });
+    try {
+      await api.post(`/api/scripts/${encodeURIComponent(id)}/restart`);
+      await get().loadScripts();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err) });
+    } finally {
+      set({ actionLoading: null });
+    }
+  },
+
+  deleteScript: async (id) => {
+    set({ actionLoading: id, error: null });
+    try {
+      await api.delete(`/api/scripts/${encodeURIComponent(id)}`);
+      await get().loadScripts();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err) });
+    } finally {
+      set({ actionLoading: null });
+    }
+  },
+}));


### PR DESCRIPTION
## 背景

AI Agent 可通过 Bash/Write 工具创建并启动长驻脚本（PM2、nohup、后台进程等），但此前系统**没有统一的脚本监控能力**——用户无法在 Web 面板中查看、管理这些 Agent 创建的脚本。

## 为什么不继续用定时任务？—— 脚本优先原则

现有的 `schedule_task` 机制是：每次触发时启动一个完整的 Agent 进程，解析 prompt，调用工具，输出结果。这对于**需要 AI 理解力**的任务（摘要、分析、自然语言判断）是合理的，但对于**逻辑确定、可编码**的周期性任务（余额监控、数据采集、健康检查等），存在明显问题：

| | 定时任务（prompt + Agent） | 常驻脚本 |
|---|---|---|
| 每次执行 | 启动 Agent → 解析 prompt → 推理 → 调用工具 → 输出 | 脚本直接运行逻辑代码 |
| 响应速度 | 10~60 秒（含排队） | 毫秒级 |
| 一致性 | prompt 理解可能有偏差，结果不稳定 | 代码逻辑确定，结果一致 |
| 资源占用 | 占用 Agent 队列槽位，影响其他用户交互 | 独立进程，不占队列 |
| API 成本 | 每次消耗 Claude API tokens | 零 AI 成本 |

**脚本优先原则**：当用户要求创建周期性任务时，Agent 应先评估能否实现为常驻脚本——如果任务逻辑确定且可编码，建议用户采用脚本方案；用户确认后编写脚本、启动并注册到监控面板。只有需要 AI 理解力或对话上下文的任务才使用 `schedule_task`。

适合脚本化的例子：
- 余额低于阈值时告警 → Python/Node 脚本 + setInterval
- 定时采集价格数据写入 DB → cron 脚本
- 健康检查 + 异常通知 → 轮询脚本

仍需 Agent 的例子：
- "每天早上总结昨天的新闻" → 需要 AI 阅读和摘要能力
- "跟进我上次提到的那件事" → 需要对话上下文
- 一次性的、逻辑不确定的任务

此原则已写入 admin Agent 的全局记忆（CLAUDE.md），Agent 在收到定时任务请求时会自动执行判断并向用户建议。

## 功能说明

### 注册制监控

Agent 创建脚本后，通过 MCP 工具 `register_script` 主动注册到 SQLite 数据库，Web 面板从数据库读取并展示。支持三种进程管理方式：

- **PM2**：自动从 `pm2 jlist` 获取 PID、CPU、内存、运行时长等实时指标
- **systemd**：通过 `start_command` / `stop_command` 管理
- **manual**（手动）：nohup、直接后台进程等，可选提供 `check_command`（exit 0 = 运行中）检测状态

### MCP 工具

| 工具 | 作用 |
|------|------|
| `register_script` | 注册脚本到监控面板（参数：name, description, process_manager, pm2_name, start/stop/check_command 等） |
| `unregister_script` | 停止进程并从监控面板移除 |

### Web 面板交互

任务管理页上方新增**脚本监控区**：

- 每个脚本卡片显示：名称、描述、状态徽章、进程管理器类型标签（PM2 / systemd / 手动）
- PM2 类型额外显示：PID、运行时长、内存、CPU、重启次数
- 非 PM2 类型显示：启动命令摘要
- 操作按钮：启动 / 停止 / 重启（根据进程类型和命令可用性条件显示）、删除（终止进程 + 取消注册）
- 仅 admin 可见（非 admin 用户 403 静默处理）

### API 端点

| 方法 | 路径 | 作用 |
|------|------|------|
| GET | `/api/scripts` | 列出所有已注册脚本（含实时状态） |
| POST | `/api/scripts/:id/start` | 启动脚本 |
| POST | `/api/scripts/:id/stop` | 停止脚本 |
| POST | `/api/scripts/:id/restart` | 重启脚本 |
| DELETE | `/api/scripts/:id` | 终止进程并删除注册 |

## 改动文件（8 个）

| 文件 | 改动 |
|------|------|
| `src/db.ts` | 新增 `scripts` 表 + `Script` 接口 + 5 个 CRUD 函数，SCHEMA_VERSION 17→18 |
| `container/agent-runner/src/mcp-tools.ts` | 新增 `register_script` / `unregister_script` MCP 工具 |
| `src/index.ts` | IPC 处理器新增 `register_script` / `unregister_script` 两个 case |
| `src/routes/scripts.ts` | 新增脚本 API（列表/启动/停止/重启/删除） |
| `src/web.ts` | 挂载 `/api/scripts` 路由 |
| `web/src/stores/scripts.ts` | 新增 scripts store |
| `web/src/components/tasks/ScriptCard.tsx` | 新增脚本卡片组件 |
| `web/src/pages/TasksPage.tsx` | 集成脚本监控面板 |

## 数据迁移

现有脚本不会自动出现在新系统中。需通过 admin Agent 调用 `register_script` 或直接在 SQLite 中插入记录来注册已有脚本。

## Test Plan

- [x] `make typecheck` + `make build` 通过
- [x] `pm2 restart happyclaw` + `curl /api/health` 返回 healthy
- [x] admin 登录 → 任务管理页 → 脚本列表为空（尚未注册）
- [x] 通过 admin Agent 调用 `register_script` 注册一个 PM2 脚本（如 `usdc-monitor`）→ 刷新页面 → 显示脚本卡片，状态为「运行中」，有 PID/CPU/内存指标
- [x] 注册一个 manual 类型脚本（带 `check_command`）→ 显示正确的运行状态
- [x] 注册一个无 `check_command` 的 manual 脚本 → 状态显示「已注册」
- [x] 点击「停止」→ 脚本状态变为「已停止」
- [x] 点击「启动」→ 脚本恢复运行
- [x] 点击「重启」→ 脚本重启成功
- [x] 点击「删除」→ confirm 弹窗 → 确认后进程被终止 + 卡片从列表消失
- [x] 调用 `unregister_script` → 进程被终止 + 从数据库移除
- [x] 非 admin 用户 → 任务管理页无脚本区（403 静默）
- [x] 非 admin Agent 注册的脚本 → 其他非 admin Agent 无法更新/删除（权限隔离）

🤖 Generated with [Claude Code](https://claude.com/claude-code)