### PR TITLE
优化: Skills 搜索/安装/版本管理全链路改进

### DIFF
--- a/container/skills/install-skill/SKILL.md
+++ b/container/skills/install-skill/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: install-skill
+description: >
+  When a user requests to install a new skill, this skill guides you to identify
+  the package name from various input formats and use the install_skill MCP tool.
+  Supports skills.sh URLs, GitHub URLs, owner/repo, and owner/repo@skill formats.
+user-invocable: false
+---
+
+# Skill Installation Guide
+
+When a user asks to install a skill (e.g., sends a link, mentions a skill name, or says "install xxx skill"), follow this process:
+
+## 1. Identify the Package Name
+
+Parse the user's input to extract the `owner/repo` or `owner/repo@skill` format:
+
+| Input Format | Example | Extract As |
+|---|---|---|
+| skills.sh URL | `https://skills.sh/s/owner/repo` | `owner/repo` |
+| skills.sh skill URL | `https://skills.sh/s/owner/repo/skill-name` | `owner/repo@skill-name` |
+| GitHub URL | `https://github.com/owner/repo` | `owner/repo` |
+| GitHub tree URL | `https://github.com/owner/repo/tree/main/skills/name` | `owner/repo@name` |
+| Direct package | `owner/repo` | `owner/repo` |
+| Package with skill | `owner/repo@skill` | `owner/repo@skill` |
+
+## 2. Install the Skill
+
+Call the `install_skill` MCP tool with the extracted package name:
+
+```
+install_skill({ "package": "owner/repo" })
+```
+
+Or with a specific skill from the repo:
+
+```
+install_skill({ "package": "owner/repo@skill-name" })
+```
+
+## 3. Handle Results
+
+**On success:**
+- Tell the user which skill(s) were installed (use the `installed` array from the response)
+- Briefly describe what the skill does (if you know from context)
+- Mention they can manage it in the Skills page
+
+**On failure:**
+- Check if the package name format is correct
+- Suggest the user verify the URL or package name
+- Common issues:
+  - Package not found: double-check the owner/repo spelling
+  - Network error: ask user to retry
+  - Invalid format: must be `owner/repo` or `owner/repo@skill`
+
+## 4. Uninstalling
+
+If the user wants to uninstall a skill, use the `uninstall_skill` MCP tool:
+
+```
+uninstall_skill({ "skill_id": "skill-name" })
+```
+
+The `skill_id` is the directory name of the installed skill.

--- a/web/src/components/skills/SkillCard.tsx
+++ b/web/src/components/skills/SkillCard.tsx
@@ -51,6 +51,9 @@ export function SkillCard({ skill, selected, onSelect }: SkillCardProps) {
             )}
           </div>
           <p className="text-sm text-slate-500 line-clamp-2">{skill.description}</p>
+          {skill.packageName && (
+            <p className="text-xs text-slate-400 mt-1 font-mono truncate">{skill.packageName}</p>
+          )}
         </div>
 
         {isReadonly && (

--- a/web/src/stores/skills.ts
+++ b/web/src/stores/skills.ts
@@ -8,6 +8,8 @@ export interface Skill {
   source: 'user' | 'project';
   enabled: boolean;
   syncedFromHost?: boolean;
+  packageName?: string;
+  installedAt?: string;
   userInvocable: boolean;
   allowedTools: string[];
   argumentHint: string | null;
@@ -22,10 +24,16 @@ export interface SkillDetail extends Skill {
 export interface SearchResult {
   package: string;
   url: string;
+  description?: string;
+  installs?: number;
+  skillId?: string;
+  source?: string;
 }
 
 export interface SearchResultDetail {
   description: string;
+  skillName?: string;
+  readme?: string;
   installs: string;
   age: string;
   features: string[];
@@ -51,10 +59,11 @@ interface SkillsState {
   toggleSkill: (id: string, enabled: boolean) => Promise<void>;
   deleteSkill: (id: string) => Promise<void>;
   installSkill: (pkg: string) => Promise<void>;
+  reinstallSkill: (id: string) => Promise<void>;
   syncHostSkills: () => Promise<SyncHostResult>;
   getSkillDetail: (id: string) => Promise<SkillDetail>;
   searchSkills: (query: string) => Promise<void>;
-  fetchSearchDetail: (url: string) => Promise<void>;
+  fetchSearchDetail: (result: SearchResult) => Promise<void>;
 }
 
 export const useSkillsStore = create<SkillsState>((set, get) => ({
@@ -112,6 +121,19 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
     }
   },
 
+  reinstallSkill: async (id: string) => {
+    set({ installing: true, error: null });
+    try {
+      await api.post(`/api/skills/${id}/reinstall`, {}, 60_000);
+      await get().loadSkills();
+    } catch (err: any) {
+      set({ error: err?.message || '重新安装失败，请稍后重试' });
+      throw err;
+    } finally {
+      set({ installing: false });
+    }
+  },
+
   syncHostSkills: async () => {
     set({ syncing: true, error: null });
     try {
@@ -138,29 +160,44 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
         `/api/skills/search?q=${encodeURIComponent(query)}`,
       );
       set({ searching: false, searchResults: data.results });
-    } catch (err) {
+    } catch {
       set({ searching: false, searchResults: [] });
     }
   },
 
-  fetchSearchDetail: async (url: string) => {
+  fetchSearchDetail: async (result: SearchResult) => {
+    const key = result.package;
     const { searchDetails, searchDetailLoading } = get();
-    // Already fetched or in-flight
-    if (url in searchDetails || searchDetailLoading[url]) return;
+    if (key in searchDetails || searchDetailLoading[key]) return;
 
-    set({ searchDetailLoading: { ...get().searchDetailLoading, [url]: true } });
+    set({ searchDetailLoading: { ...get().searchDetailLoading, [key]: true } });
     try {
+      // Use source/skillId params if available (new API), fallback to url
+      const params = result.source && result.skillId
+        ? `source=${encodeURIComponent(result.source)}&skillId=${encodeURIComponent(result.skillId)}`
+        : result.url
+          ? `url=${encodeURIComponent(result.url)}`
+          : '';
+
+      if (!params) {
+        set({
+          searchDetails: { ...get().searchDetails, [key]: null },
+          searchDetailLoading: { ...get().searchDetailLoading, [key]: false },
+        });
+        return;
+      }
+
       const data = await api.get<{ detail: SearchResultDetail | null }>(
-        `/api/skills/search/detail?url=${encodeURIComponent(url)}`,
+        `/api/skills/search/detail?${params}`,
       );
       set({
-        searchDetails: { ...get().searchDetails, [url]: data.detail },
-        searchDetailLoading: { ...get().searchDetailLoading, [url]: false },
+        searchDetails: { ...get().searchDetails, [key]: data.detail },
+        searchDetailLoading: { ...get().searchDetailLoading, [key]: false },
       });
     } catch {
       set({
-        searchDetails: { ...get().searchDetails, [url]: null },
-        searchDetailLoading: { ...get().searchDetailLoading, [url]: false },
+        searchDetails: { ...get().searchDetails, [key]: null },
+        searchDetailLoading: { ...get().searchDetailLoading, [key]: false },
       });
     }
   },


### PR DESCRIPTION
## Summary
- 搜索: 替换 npx CLI 为 skills.sh API 直接调用，增加 LRU 缓存（5min/100条），失败降级到 npx fallback
- 详情: 从 GitHub Raw URL 拉取 SKILL.md 全文预览，替代原来抓取 HTML `<h1>` 标签
- 安装: 使用临时 HOME 目录隔离 `npx skills add`，彻底消除多用户并发竞态
- 元数据: 新增 `.skills-manifest.json` 记录安装来源/时间，列表和详情页展示
- 重装: 新增 `POST /api/skills/:id/reinstall` 路由和前端重新安装按钮
- Agent: 新增 `install-skill` 项目级 Skill，引导 Agent 自动处理技能安装请求

## Test plan
- [ ] 搜索市场中搜索关键词，验证结果有安装次数
- [ ] 展开搜索结果，验证能看到 SKILL.md 内容预览
- [ ] 安装技能包，验证安装成功且出现在列表
- [ ] 两个用户同时安装不同技能，验证不互相干扰
- [ ] 对有 packageName 的技能执行重新安装，验证更新成功
- [ ] `make typecheck` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)