### PR TITLE
修复: Skills 手动安装支持 GitHub URL 输入

### DIFF
--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -333,7 +333,7 @@ Example packages: "anthropic/memory", "anthropic/think", "owner/repo", "owner/re
       },
       async (args) => {
         const pkg = args.package.trim();
-        if (!/^[\w\-]+\/[\w\-.]+(?:[@#][\w\-.\/]+)?$/.test(pkg)) {
+        if (!/^[\w\-]+\/[\w\-.]+(?:[@#][\w\-.\/]+)?$/.test(pkg) && !/^https?:\/\//.test(pkg)) {
           return {
             content: [{ type: 'text' as const, text: `Invalid package format: "${pkg}". Expected format: owner/repo or owner/repo@skill` }],
             isError: true,

--- a/src/routes/skills.ts
+++ b/src/routes/skills.ts
@@ -823,7 +823,7 @@ async function installSkillForUser(
   userId: string,
   pkg: string,
 ): Promise<{ success: boolean; installed?: string[]; error?: string }> {
-  if (!/^[\w\-]+\/[\w\-.]+(?:[@#][\w\-.\/]+)?$/.test(pkg)) {
+  if (!/^[\w\-]+\/[\w\-.]+(?:[@#][\w\-.\/]+)?$/.test(pkg) && !/^https?:\/\//.test(pkg)) {
     return { success: false, error: 'Invalid package name format' };
   }
 

--- a/web/src/components/skills/InstallSkillDialog.tsx
+++ b/web/src/components/skills/InstallSkillDialog.tsx
@@ -310,11 +310,11 @@ export function InstallSkillDialog({
                 type="text"
                 value={pkg}
                 onChange={(e) => setPkg(e.target.value)}
-                placeholder="owner/repo 或 owner/repo@skill"
+                placeholder="owner/repo、owner/repo@skill 或 GitHub URL"
                 disabled={isInstalling}
               />
               <p className="mt-1 text-xs text-muted-foreground">
-                支持格式：owner/repo 或 owner/repo@skill
+                支持格式：owner/repo、owner/repo@skill 或 GitHub URL
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- 放宽后端 `installSkillForUser()` 和 MCP 工具 `install_skill` 的正则校验，允许 `https://` 开头的 GitHub URL 通过
- 更新前端 `InstallSkillDialog` 的 placeholder 和提示文字

## Test plan
- [ ] 输入 `https://github.com/Alph-ai-official/Skills` → 通过校验
- [ ] 输入 `owner/repo` / `owner/repo@skill` → 行为不变
- [ ] 输入空字符串 / 随机垃圾 → 仍被拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)