### PR TITLE
feat: 新增 make backup / restore 迁移命令

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: dev dev-backend dev-web build build-backend build-web start \
        typecheck typecheck-backend typecheck-web typecheck-agent-runner \
-       format format-check install clean reset-init update-sdk sync-types help
+       format format-check install clean reset-init update-sdk sync-types \
+       backup restore help
 
 # ─── Development ─────────────────────────────────────────────
 
@@ -83,6 +84,56 @@ clean: ## 清理构建产物
 reset-init: ## 完全重置为首装状态（清空所有运行时数据）
 	rm -rf data store groups
 	@echo "✅ 已完全重置为首装状态（数据库、配置、工作区、记忆、会话全部清除）"
+
+# ─── Backup / Restore ────────────────────────────────────────
+
+backup: ## 备份运行时数据到 happyclaw-backup-{date}.tar.gz
+	@DATE=$$(date +%Y%m%d-%H%M%S); \
+	FILE="happyclaw-backup-$$DATE.tar.gz"; \
+	echo "📦 正在打包备份到 $$FILE ..."; \
+	tar -czf "$$FILE" \
+	  --exclude='data/ipc' \
+	  --exclude='data/env' \
+	  --exclude='data/happyclaw.log' \
+	  --exclude='data/db/messages.db-shm' \
+	  --exclude='data/db/messages.db-wal' \
+	  --exclude='data/groups/*/logs' \
+	  data/db \
+	  data/config \
+	  data/groups \
+	  data/sessions \
+	  $$([ -d data/skills ] && echo data/skills) \
+	  2>/dev/null; \
+	echo "✅ 备份完成：$$FILE ($$(du -sh $$FILE | cut -f1))"
+
+restore: ## 从 happyclaw-backup-*.tar.gz 恢复数据（用法：make restore 或 make restore FILE=xxx.tar.gz）
+	@if [ -n "$(FILE)" ]; then \
+	  BACKUP="$(FILE)"; \
+	elif [ $$(ls happyclaw-backup-*.tar.gz 2>/dev/null | wc -l) -eq 1 ]; then \
+	  BACKUP=$$(ls happyclaw-backup-*.tar.gz); \
+	elif [ $$(ls happyclaw-backup-*.tar.gz 2>/dev/null | wc -l) -gt 1 ]; then \
+	  echo "❌ 发现多个备份文件，请用 make restore FILE=xxx.tar.gz 指定："; \
+	  ls happyclaw-backup-*.tar.gz; \
+	  exit 1; \
+	else \
+	  echo "❌ 未找到备份文件，请将 happyclaw-backup-*.tar.gz 放到当前目录"; \
+	  exit 1; \
+	fi; \
+	echo "📂 正在从 $$BACKUP 恢复..."; \
+	if [ -d data ] && [ "$$(ls -A data 2>/dev/null)" ]; then \
+	  echo "⚠️  data/ 目录已存在数据，继续将覆盖。是否继续？[y/N] "; \
+	  read CONFIRM; \
+	  [ "$$CONFIRM" = "y" ] || [ "$$CONFIRM" = "Y" ] || { echo "已取消"; exit 1; }; \
+	fi; \
+	tar -xzf "$$BACKUP"; \
+	if [ ! -f data/config/session-secret.key ]; then \
+	  echo "⚠️  警告：备份中缺少 session-secret.key，用户登录 cookie 将失效，需重新登录"; \
+	fi; \
+	echo "✅ 数据恢复完成"; \
+	echo ""; \
+	echo "后续步骤："; \
+	echo "  1. 如需 Docker 容器支持：./container/build.sh"; \
+	echo "  2. 启动服务：make start"
 
 # ─── Help ────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ make typecheck        # TypeScript 全量类型检查
 make format           # 代码格式化（Prettier）
 make clean            # 清理构建产物
 make reset-init       # 重置为首装状态（清空数据库、配置、工作区、记忆、会话）
+make backup           # 备份运行时数据到 happyclaw-backup-{date}.tar.gz
+make restore          # 从备份恢复数据（make restore 或 make restore FILE=xxx.tar.gz）
 ```
 
 | 服务 | 默认端口 | 说明 |


### PR DESCRIPTION
## Summary
- `make backup`：打包 `data/{db,config,groups,sessions,skills}` 为带时间戳的 tar.gz，排除 `ipc`、`env`、`logs` 等运行时临时目录
- `make restore`：自动检测或手动指定备份文件（`make restore FILE=xxx.tar.gz`），覆盖前二次确认，并检查 `session-secret.key` 完整性
- README 补充两条命令说明

## 迁移流程
旧机器：`make backup` → 拷贝 tar.gz 到新机器 repo 目录 → `make restore` → `make start`

## Test plan
- [x] `make backup` 生成正确的 tar.gz，排除 ipc/env/logs
- [x] `make restore` 自动检测单个备份文件
- [x] `make restore FILE=xxx.tar.gz` 手动指定
- [x] 多个备份文件时报错提示
- [x] data/ 已存在时二次确认
- [x] 缺少 session-secret.key 时给出警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)