### PR TITLE
功能: 定时任务支持脚本执行模式

### DIFF
--- a/src/script-runner.ts
+++ b/src/script-runner.ts
@@ -1,0 +1,93 @@
+import { exec } from 'child_process';
+import path from 'path';
+
+import { GROUPS_DIR } from './config.js';
+import { logger } from './logger.js';
+import { getSystemSettings } from './runtime-config.js';
+
+export interface ScriptRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  timedOut: boolean;
+  durationMs: number;
+}
+
+let activeScriptCount = 0;
+
+export function getActiveScriptCount(): number {
+  return activeScriptCount;
+}
+
+export function hasScriptCapacity(): boolean {
+  const { maxConcurrentScripts } = getSystemSettings();
+  return activeScriptCount < maxConcurrentScripts;
+}
+
+const MAX_BUFFER = 1024 * 1024; // 1MB
+
+export async function runScript(
+  command: string,
+  groupFolder: string,
+): Promise<ScriptRunResult> {
+  const { scriptTimeout } = getSystemSettings();
+  const cwd = path.join(GROUPS_DIR, groupFolder);
+  const startTime = Date.now();
+
+  activeScriptCount++;
+
+  try {
+    return await new Promise<ScriptRunResult>((resolve) => {
+      const child = exec(
+        command,
+        {
+          cwd,
+          timeout: scriptTimeout,
+          maxBuffer: MAX_BUFFER,
+          env: {
+            PATH: process.env.PATH,
+            LANG: process.env.LANG || 'en_US.UTF-8',
+            TZ: process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone,
+            GROUP_FOLDER: groupFolder,
+            HOME: cwd,
+          },
+          shell: '/bin/sh',
+        },
+        (error, stdout, stderr) => {
+          activeScriptCount--;
+          const durationMs = Date.now() - startTime;
+          const timedOut = error?.killed === true;
+
+          if (timedOut) {
+            logger.warn(
+              { command: command.slice(0, 100), groupFolder, durationMs },
+              'Script timed out',
+            );
+          }
+
+          resolve({
+            stdout: stdout.slice(0, MAX_BUFFER),
+            stderr: stderr.slice(0, MAX_BUFFER),
+            exitCode: timedOut ? null : (child.exitCode ?? 0),
+            timedOut,
+            durationMs,
+          });
+        },
+      );
+    });
+  } catch (err) {
+    activeScriptCount--;
+    const durationMs = Date.now() - startTime;
+    logger.error(
+      { command: command.slice(0, 100), groupFolder, err },
+      'Script exec() threw synchronously',
+    );
+    return {
+      stdout: '',
+      stderr: err instanceof Error ? err.message : String(err),
+      exitCode: 1,
+      timedOut: false,
+      durationMs,
+    };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface ScheduledTask {
   schedule_type: 'cron' | 'interval' | 'once';
   schedule_value: string;
   context_mode: 'group' | 'isolated';
+  execution_type: 'agent' | 'script';
+  script_command: string | null;
   next_run: string | null;
   last_run: string | null;
   last_result: string | null;

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -102,6 +102,28 @@ const fields: FieldConfig[] = [
     max: 1440,
     step: 1,
   },
+  {
+    key: 'maxConcurrentScripts',
+    label: '脚本任务最大并发数',
+    description: '同时运行的脚本任务数量上限',
+    unit: '个',
+    toDisplay: (v) => v,
+    toStored: (v) => v,
+    min: 1,
+    max: 50,
+    step: 1,
+  },
+  {
+    key: 'scriptTimeout',
+    label: '脚本执行超时',
+    description: '单个脚本任务的最长执行时间',
+    unit: '秒',
+    toDisplay: (v) => Math.round(v / 1000),
+    toStored: (v) => v * 1000,
+    min: 5,
+    max: 600,
+    step: 5,
+  },
 ];
 
 export function SystemSettingsSection({ setNotice, setError }: SystemSettingsSectionProps) {

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -77,6 +77,8 @@ export interface SystemSettings {
   maxConcurrentHostProcesses: number;
   maxLoginAttempts: number;
   loginLockoutMinutes: number;
+  maxConcurrentScripts: number;
+  scriptTimeout: number;
 }
 
 export type SettingsTab = 'channels' | 'claude' | 'registration' | 'appearance' | 'system' | 'profile' | 'my-channels' | 'security' | 'groups' | 'memory' | 'skills' | 'mcp-servers' | 'users' | 'about';

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -62,13 +62,20 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
       >
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0 mr-4">
-            {/* Prompt (truncated 2 lines) */}
+            {/* Prompt / Script (truncated 2 lines) */}
             <p className="text-slate-900 font-medium line-clamp-2 mb-2">
-              {task.prompt}
+              {task.execution_type === 'script'
+                ? task.script_command || task.prompt
+                : task.prompt}
             </p>
 
             {/* Schedule Info */}
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm mb-2">
+              {task.execution_type === 'script' && (
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                  脚本
+                </span>
+              )}
               <div className="flex items-center gap-2">
                 <span className="text-slate-500">调度:</span>
                 <span className="text-slate-900 font-medium">

--- a/web/src/components/tasks/TaskDetail.tsx
+++ b/web/src/components/tasks/TaskDetail.tsx
@@ -38,16 +38,37 @@ export function TaskDetail({ task }: TaskDetailProps) {
 
   return (
     <div className="p-4 bg-slate-50 space-y-4">
-      {/* Full Prompt */}
-      <div>
-        <div className="text-xs text-slate-500 mb-2">完整 Prompt</div>
-        <div className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap">
-          {task.prompt}
+      {/* Script Command (script mode) */}
+      {task.execution_type === 'script' && task.script_command && (
+        <div>
+          <div className="text-xs text-slate-500 mb-2">脚本命令</div>
+          <pre className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap font-mono">
+            {task.script_command}
+          </pre>
         </div>
-      </div>
+      )}
+
+      {/* Full Prompt / Description */}
+      {task.prompt && (
+        <div>
+          <div className="text-xs text-slate-500 mb-2">
+            {task.execution_type === 'script' ? '任务描述' : '完整 Prompt'}
+          </div>
+          <div className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap">
+            {task.prompt}
+          </div>
+        </div>
+      )}
 
       {/* Schedule Details */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <div className="text-xs text-slate-500 mb-1">执行方式</div>
+          <div className="text-sm text-slate-900">
+            {task.execution_type === 'script' ? '脚本' : 'Agent'}
+          </div>
+        </div>
+
         <div>
           <div className="text-xs text-slate-500 mb-1">调度类型</div>
           <div className="text-sm text-slate-900">
@@ -80,16 +101,18 @@ export function TaskDetail({ task }: TaskDetailProps) {
           </div>
         )}
 
-        <div>
-          <div className="text-xs text-slate-500 mb-1">上下文模式</div>
-          <div className="text-sm text-slate-900">
-            {task.context_mode === 'group'
-              ? '共享群组上下文'
-              : task.context_mode === 'isolated'
-                ? '独立执行'
-                : task.context_mode}
+        {task.execution_type !== 'script' && (
+          <div>
+            <div className="text-xs text-slate-500 mb-1">上下文模式</div>
+            <div className="text-sm text-slate-900">
+              {task.context_mode === 'group'
+                ? '共享群组上下文'
+                : task.context_mode === 'isolated'
+                  ? '独立执行'
+                  : task.context_mode}
+            </div>
           </div>
-        </div>
+        )}
 
         <div>
           <div className="text-xs text-slate-500 mb-1">创建时间</div>

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTasksStore } from '../stores/tasks';
 import { useChatStore } from '../stores/chat';
+import { useAuthStore } from '../stores/auth';
 import { TaskCard } from '../components/tasks/TaskCard';
 import { CreateTaskForm } from '../components/tasks/CreateTaskForm';
 import { Plus, RefreshCw, Clock, X } from 'lucide-react';
@@ -12,7 +13,9 @@ import { Button } from '@/components/ui/button';
 export function TasksPage() {
   const { tasks, loading, error, loadTasks, createTask, updateTaskStatus, deleteTask } = useTasksStore();
   const { groups, loadGroups } = useChatStore();
+  const { user } = useAuthStore();
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const isAdmin = user?.role === 'admin';
 
   useEffect(() => {
     loadTasks();
@@ -26,6 +29,8 @@ export function TasksPage() {
     scheduleType: 'cron' | 'interval' | 'once';
     scheduleValue: string;
     contextMode: 'group' | 'isolated';
+    executionType: 'agent' | 'script';
+    scriptCommand: string;
   }) => {
     await createTask(
       data.groupFolder,
@@ -33,7 +38,9 @@ export function TasksPage() {
       data.prompt,
       data.scheduleType,
       data.scheduleValue,
-      data.contextMode
+      data.contextMode,
+      data.executionType,
+      data.scriptCommand,
     );
     setShowCreateForm(false);
   };
@@ -173,6 +180,7 @@ export function TasksPage() {
           groups={groupsList}
           onSubmit={handleCreateTask}
           onClose={() => setShowCreateForm(false)}
+          isAdmin={isAdmin}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- 新增 `execution_type='script'` 模式，允许管理员创建直接执行 Shell 命令的定时任务，零 API token 消耗
- 全栈实现：数据库 schema v18、后端路由/调度器/脚本运行器、MCP 工具、前端表单/展示/设置
- 安全加固：admin-only 权限、最小化环境变量、PATCH 路由脚本修改权限检查、exec() 异常兜底、script_command 长度限制、防御性空值检查

## Test plan
- [ ] 管理员创建脚本类型定时任务，验证 Shell 命令正确执行
- [ ] 非管理员用户无法看到/创建脚本类型任务
- [ ] 非管理员无法通过 PATCH 修改已有脚本任务的 script_command
- [ ] 脚本超时、并发限制、空命令等边界条件验证
- [ ] 系统设置页面中脚本并发数和超时可正常配置
- [ ] 旧任务（无 execution_type 字段）正常显示为 Agent 模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)