### PR TITLE
fix: 代码块复制内容出现 [object Object]

### DIFF
--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -2,7 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
-import { useState, memo } from 'react';
+import React, { useState, memo } from 'react';
 import { createPortal } from 'react-dom';
 import { Copy, Check } from 'lucide-react';
 import { MermaidDiagram } from './MermaidDiagram';
@@ -89,6 +89,13 @@ const sanitizeSchema = {
   },
 };
 
+function extractText(node: React.ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join('');
+  if (React.isValidElement(node)) return extractText((node.props as { children?: React.ReactNode }).children);
+  return '';
+}
+
 /** Code block / inline code renderer extracted from MarkdownRenderer */
 function CodeBlock({
   className,
@@ -100,7 +107,7 @@ function CodeBlock({
   const match = /language-(\w+)/.exec(className || '');
   const lang = match?.[1];
   const isBlock = Boolean(match);
-  const codeString = String(children).replace(/\n$/, '');
+  const codeString = extractText(children).replace(/\n$/, '');
 
   if (lang === 'mermaid') {
     return <MermaidDiagram code={codeString} />;


### PR DESCRIPTION
## 问题

`rehype-highlight` 将代码中的关键词、字符串等包裹成 `<span class="hljs-*">` React 元素树，原来的 `String(children)` 对 React 元素调用 `.toString()` 返回 `[object Object]`，导致复制结果出现乱码。

例如 `--rm` 变成 `--[object Object]`，双引号字符串变成 `[object Object]`。

## 修复

新增 `extractText()` 递归函数，遍历 React 节点树提取纯文本字符串，替换原来的 `String(children)`：

```ts
function extractText(node: React.ReactNode): string {
  if (typeof node === 'string' || typeof node === 'number') return String(node);
  if (Array.isArray(node)) return node.map(extractText).join('');
  if (React.isValidElement(node)) return extractText((node.props as { children?: React.ReactNode }).children);
  return '';
}
```

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)