### PR TITLE
修复: OAuth Token 刷新后优雅重启运行中的容器

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2587,7 +2587,8 @@ async function main(): Promise<void> {
           claudeOAuthCredentials: refreshed,
         });
         updateAllSessionCredentials(saved);
-        logger.info('OAuth token refreshed successfully');
+        const closed = queue.closeAllActiveForCredentialRefresh();
+        logger.info({ closedContainers: closed }, 'OAuth token refreshed successfully');
       } else {
         logger.warn('OAuth token refresh failed');
       }

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -219,6 +219,7 @@ configRoutes.put(
       // Update .credentials.json in all session directories when credentials change
       if (validation.data.claudeOAuthCredentials) {
         updateAllSessionCredentials(saved);
+        deps?.queue?.closeAllActiveForCredentialRefresh();
       }
 
       appendClaudeConfigAudit(actor, 'update_secrets', changedFields);
@@ -408,6 +409,7 @@ configRoutes.post(
       // Write .credentials.json to all session directories
       if (oauthCredentials) {
         updateAllSessionCredentials(saved);
+        deps?.queue?.closeAllActiveForCredentialRefresh();
       }
 
       appendClaudeConfigAudit(actor, 'oauth_login', [


### PR DESCRIPTION
## Summary

- OAuth Token 刷新后，运行中的容器/进程仍使用内存中缓存的旧 Token，旧 Token 被撤销后 Agent 报"无访问权限"错误
- 新增 `GroupQueue.closeAllActiveForCredentialRefresh()` 方法，向所有活跃容器发送 `_close` 信号
- 在三个 Token 更新点（自动刷新、手动更新、OAuth 回调）调用该方法，使容器优雅退出后以新 Token 重启

## 改动

| 文件 | 改动 |
|------|------|
| `src/group-queue.ts` | 新增 `closeAllActiveForCredentialRefresh()` 方法，遍历所有活跃 group 写入 `_close` sentinel |
| `src/index.ts` | 自动刷新 Token 后调用 `queue.closeAllActiveForCredentialRefresh()` |
| `src/routes/config.ts` | 手动更新凭据和 OAuth 回调后调用 `deps.queue.closeAllActiveForCredentialRefresh()` |

## 触发场景

1. OAuth Token 每 5 分钟检查一次，距过期 <30 分钟时自动刷新 → 旧 Token 撤销 → 运行中容器失效
2. 用户在 Web 设置页手动更新凭据
3. OAuth 登录回调更新凭据

## 行为

- 向所有 `active=true` 的容器/进程的 IPC 输入目录写入 `_close` 文件
- 容器收到 `_close` 后优雅退出当前会话
- 如有待处理消息，queue 会自动以新 Token 重启容器

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)