### PR TITLE
修复: SDK Task 标签页卡在 running 状态无法关闭

### DIFF
--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -7,7 +7,6 @@ interface AgentTabBarProps {
   onSelectTab: (agentId: string | null) => void;
   onDeleteAgent: (agentId: string) => void;
   onCreateConversation?: () => void;
-  sdkTaskIds?: Set<string>; // SDK Task IDs (managed by SDK, no manual delete)
 }
 
 const TASK_STATUS_ICON: Record<string, string> = {
@@ -23,7 +22,7 @@ const tabClass = (active: boolean) =>
       : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
   }`;
 
-export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation, sdkTaskIds }: AgentTabBarProps) {
+export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation }: AgentTabBarProps) {
   const conversations = agents.filter(a => a.kind === 'conversation');
   const tasks = agents.filter(a => a.kind === 'task');
 
@@ -85,16 +84,13 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
             >
               <span>{TASK_STATUS_ICON[agent.status] || ''}</span>
               <span className="truncate max-w-[100px]">{agent.name}</span>
-              {/* SDK Task 由 SDK 管理生命周期，不允许手动删除 */}
-              {!sdkTaskIds?.has(agent.id) && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-slate-200 transition-all cursor-pointer"
-                  title="删除 Agent"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
+                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-slate-200 transition-all cursor-pointer"
+                title="关闭"
+              >
+                <X className="w-3 h-3" />
+              </button>
             </div>
           ))}
         </>

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useChatStore } from '../../stores/chat';
 import { useAuthStore } from '../../stores/auth';
@@ -190,7 +190,6 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
   const activeAgent = activeAgentTab ? agents.find(a => a.id === activeAgentTab) : null;
   const isConversationTab = activeAgent?.kind === 'conversation';
   const isSdkTask = !!activeAgentTab && !!sdkTasks[activeAgentTab];
-  const sdkTaskIds = useMemo(() => new Set(Object.keys(sdkTasks)), [sdkTasks]);
 
   // Load sub-agents for this group
   useEffect(() => {
@@ -466,7 +465,6 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
         activeTab={activeAgentTab}
         onSelectTab={(id) => setActiveAgentTab(groupJid, id)}
         onDeleteAgent={(id) => deleteAgentAction(groupJid, id)}
-        sdkTaskIds={sdkTaskIds}
         onCreateConversation={() => {
           const name = prompt('对话名称：');
           if (name?.trim()) {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -166,7 +166,9 @@ const DEFAULT_STREAMING_STATE: StreamingState = {
 const MAX_EVENT_LOG = 30;
 const SDK_TASK_AUTO_CLOSE_MS = 3000;
 const SDK_TASK_TOOL_END_FALLBACK_CLOSE_MS = 1200;
+const SDK_TASK_STALE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes stale timeout for non-teammate tasks
 const sdkTaskCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const sdkTaskStaleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 // 兜底路由支持的事件类型（模块级常量，避免热路径上重复创建 Set）
 const FALLBACK_EVENT_TYPES: Set<StreamEventType> = new Set([
@@ -221,6 +223,47 @@ function clearSdkTaskCleanupTimer(taskId: string): void {
   }
 }
 
+function clearSdkTaskStaleTimer(taskId: string): void {
+  const timer = sdkTaskStaleTimers.get(taskId);
+  if (timer) {
+    clearTimeout(timer);
+    sdkTaskStaleTimers.delete(taskId);
+  }
+}
+
+/**
+ * Reset the stale timer for a non-teammate SDK task.
+ * If no events are received within SDK_TASK_STALE_TIMEOUT_MS, auto-finalize it.
+ */
+function resetSdkTaskStaleTimer(
+  set: (fn: (s: ChatState) => Partial<ChatState>) => void,
+  get: () => ChatState,
+  taskId: string,
+  chatJid: string,
+): void {
+  clearSdkTaskStaleTimer(taskId);
+  const timer = setTimeout(() => {
+    sdkTaskStaleTimers.delete(taskId);
+    const state = get();
+    const task = state.sdkTasks[taskId];
+    if (task && task.status === 'running' && !task.isTeammate) {
+      // Auto-finalize stale task
+      set((s) => {
+        const existingTask = s.sdkTasks[taskId];
+        if (!existingTask || existingTask.status !== 'running') return {};
+        return {
+          sdkTasks: {
+            ...s.sdkTasks,
+            [taskId]: { ...existingTask, status: 'completed' as const },
+          },
+        };
+      });
+      scheduleSdkTaskCleanup(set, taskId, chatJid, SDK_TASK_AUTO_CLOSE_MS, get);
+    }
+  }, SDK_TASK_STALE_TIMEOUT_MS);
+  sdkTaskStaleTimers.set(taskId, timer);
+}
+
 const SDK_TASK_VIEWING_CLOSE_MS = 8000; // 用户正在查看标签页时延长关闭延迟
 
 function doSdkTaskCleanup(
@@ -229,6 +272,7 @@ function doSdkTaskCleanup(
   chatJid: string,
 ): void {
   sdkTaskCleanupTimers.delete(taskId);
+  clearSdkTaskStaleTimer(taskId);
   set((s) => {
     const isTeammate = s.sdkTasks[taskId]?.isTeammate || false;
     const nextSdkTasks = { ...s.sdkTasks };
@@ -928,6 +972,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
           agents: { ...s.agents, [chatJid]: updatedAgents },
         };
       });
+      // Start stale timer for non-teammate tasks
+      if (!isTeammate) {
+        resetSdkTaskStaleTimer(set, get, taskId, chatJid);
+      }
     };
 
     const resolveOrBindTaskId = (rawId: string): string => {
@@ -948,6 +996,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       summary?: string,
       closeAfterMs = SDK_TASK_AUTO_CLOSE_MS,
     ) => {
+      clearSdkTaskStaleTimer(taskId);
       let targetChatJid: string | null = null;
       set((s) => {
         const existingTask = s.sdkTasks[taskId];
@@ -1057,6 +1106,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
         if (!state.sdkTasks[tid]) {
           ensureSdkTask(tid, taskFromDb?.prompt || taskFromDb?.name);
         }
+        // Reset stale timer — task is still active
+        const task = state.sdkTasks[tid];
+        if (task && !task.isTeammate) {
+          resetSdkTaskStaleTimer(set, get, tid, chatJid);
+        }
         set((s) => {
           const prev = s.agentStreaming[tid] || { ...DEFAULT_STREAMING_STATE };
           const next = { ...prev };
@@ -1079,6 +1133,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
           .map(([id]) => id);
         if (runningNonTeammateTaskIds.length === 1) {
           const tid = runningNonTeammateTaskIds[0];
+          // Reset stale timer — task is still active (fallback-routed events)
+          resetSdkTaskStaleTimer(set, get, tid, chatJid);
           set((s) => {
             const prev = s.agentStreaming[tid] || { ...DEFAULT_STREAMING_STATE };
             const next = { ...prev };
@@ -1221,6 +1277,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // '__removed__' signal: agent has been cleaned up, remove from list
       if (resultSummary === '__removed__') {
         clearSdkTaskCleanupTimer(agentId);
+        clearSdkTaskStaleTimer(agentId);
         const filtered = existing.filter((a) => a.id !== agentId);
         const nextAgentStreaming = { ...s.agentStreaming };
         delete nextAgentStreaming[agentId];
@@ -1274,6 +1331,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       if (resolvedKind === 'task') {
         if (status !== 'running') {
           clearSdkTaskCleanupTimer(agentId);
+          clearSdkTaskStaleTimer(agentId);
           delete nextSdkTasks[agentId];
           nextSdkTaskAliases = removeSdkTaskAliases(nextSdkTaskAliases, agentId);
         } else if (nextSdkTasks[agentId]) {
@@ -1323,6 +1381,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             };
           } else {
             clearSdkTaskCleanupTimer(id);
+            clearSdkTaskStaleTimer(id);
           }
         }
 
@@ -1376,6 +1435,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     try {
       await api.delete(`/api/groups/${encodeURIComponent(jid)}/agents/${agentId}`);
       clearSdkTaskCleanupTimer(agentId);
+      clearSdkTaskStaleTimer(agentId);
       set((s) => {
         const updated = (s.agents[jid] || []).filter((a) => a.id !== agentId);
         const nextAgentStreaming = { ...s.agentStreaming };


### PR DESCRIPTION
## Summary

- SDK Task 标签页在 host 模式下偶尔因 `task_notification` 事件丢失而永远卡在 running 状态，且没有关闭按钮
- 移除 SDK Task 标签页关闭按钮的条件限制，所有 task 标签均可手动关闭
- 增加 5 分钟 stale 超时保护：非 teammate SDK Task 无事件更新超过 5 分钟自动标记为 completed 并清理
- 兜底路由（无 parentToolUseId）也重置 stale timer，防止活跃 task 被误判
- 所有清理路径同步清理 stale timer，防止 handle 泄漏

## 改动

| 文件 | 改动 |
|------|------|
| `web/src/components/chat/AgentTabBar.tsx` | 移除 `sdkTaskIds` prop 和关闭按钮条件限制 |
| `web/src/components/chat/ChatView.tsx` | 移除不再需要的 `sdkTaskIds` 计算和传递 |
| `web/src/stores/chat.ts` | 新增 stale timer 机制（`resetSdkTaskStaleTimer`/`clearSdkTaskStaleTimer`），在 7 处清理路径同步清理 |

## 触发场景

1. Host 模式下 Agent 调用 Task 工具启动 sub-agent
2. Sub-agent 执行完毕但 `task_notification` 事件丢失（agent-runner 被 kill 或 WebSocket 断连等）
3. 前端标签页卡在 🔄 running 状态，无法关闭

## Test plan

- [x] TypeScript 全量类型检查通过（后端 + 前端 + agent-runner）
- [x] 完整构建通过
- [x] 代码审查通过（审查后修复了 stale timer 覆盖度问题）
- [x] StreamEvent 类型同步校验通过
- [x] 手动测试：在 host 模式主对话中触发 Task 工具，验证标签页正常显示和关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)