### PR TITLE
功能: 实现暗色模式（Dark Mode）

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,7 @@
     <title>HappyClaw</title>
   </head>
   <body>
+    <script>(function(){var s=localStorage.getItem('happyclaw-theme');var dark=s==='dark'||(s!=='light'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(dark)document.documentElement.classList.add('dark');})();</script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/web/src/components/auth/AuthGuard.tsx
+++ b/web/src/components/auth/AuthGuard.tsx
@@ -40,9 +40,9 @@ export function AuthGuard({
   if (checking) {
     if (timedOut) {
       return (
-        <div className="min-h-screen bg-slate-50 flex items-center justify-center p-6">
-          <div className="max-w-md text-center bg-white rounded-xl border border-slate-200 p-6">
-            <h2 className="text-lg font-semibold text-slate-900 mb-2">页面初始化超时</h2>
+        <div className="min-h-screen bg-background flex items-center justify-center p-6">
+          <div className="max-w-md text-center bg-card rounded-xl border border-border p-6">
+            <h2 className="text-lg font-semibold text-foreground mb-2">页面初始化超时</h2>
             <p className="text-sm text-slate-600 mb-4">
               后端可能刚启动或浏览器缓存异常，请先刷新页面；若仍失败，重新登录。
             </p>
@@ -67,7 +67,7 @@ export function AuthGuard({
       );
     }
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-16 h-16 text-primary animate-spin mx-auto mb-4" />
           <p className="text-slate-500">加载中...</p>

--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -7,6 +7,7 @@ interface AgentTabBarProps {
   onSelectTab: (agentId: string | null) => void;
   onDeleteAgent: (agentId: string) => void;
   onCreateConversation?: () => void;
+  sdkTaskIds?: Set<string>; // SDK Task IDs (managed by SDK, no manual delete)
 }
 
 const TASK_STATUS_ICON: Record<string, string> = {
@@ -18,11 +19,11 @@ const TASK_STATUS_ICON: Record<string, string> = {
 const tabClass = (active: boolean) =>
   `flex-shrink-0 px-3 py-1 rounded-md text-xs font-medium transition-colors cursor-pointer ${
     active
-      ? 'bg-teal-100 text-teal-800 shadow-sm'
-      : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
+      ? 'bg-accent text-accent-foreground shadow-sm'
+      : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
   }`;
 
-export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation }: AgentTabBarProps) {
+export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation, sdkTaskIds }: AgentTabBarProps) {
   const conversations = agents.filter(a => a.kind === 'conversation');
   const tasks = agents.filter(a => a.kind === 'task');
 
@@ -30,7 +31,7 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
   if (conversations.length === 0 && tasks.length === 0 && !onCreateConversation) return null;
 
   return (
-    <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 bg-slate-50/80 overflow-x-auto scrollbar-none">
+    <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border bg-background/80 overflow-x-auto scrollbar-none">
       {/* Main conversation tab */}
       <button onClick={() => onSelectTab(null)} className={tabClass(activeTab === null)}>
         主对话
@@ -49,7 +50,7 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
           <span className="truncate max-w-[120px]">{agent.name}</span>
           <button
             onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-            className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-slate-200/80 transition-all cursor-pointer"
+            className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
             title="关闭对话"
           >
             <X className="w-3 h-3" />
@@ -61,7 +62,7 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
       {onCreateConversation && (
         <button
           onClick={onCreateConversation}
-          className="flex-shrink-0 flex items-center gap-0.5 px-2 py-1 rounded-md text-xs font-medium text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors cursor-pointer"
+          className="flex-shrink-0 flex items-center gap-0.5 px-2 py-1 rounded-md text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer"
           title="新建对话"
         >
           <Plus className="w-3.5 h-3.5" />
@@ -71,26 +72,29 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
       {/* Task agent tabs — subordinate style, separated */}
       {tasks.length > 0 && (
         <>
-          <div className="w-px h-4 bg-slate-200 mx-1 flex-shrink-0" />
+          <div className="w-px h-4 bg-border mx-1 flex-shrink-0" />
           {tasks.map((agent) => (
             <div
               key={agent.id}
               className={`flex-shrink-0 flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors cursor-pointer group ${
                 activeTab === agent.id
-                  ? 'bg-slate-200 text-slate-700 shadow-sm'
-                  : 'text-slate-400 hover:bg-slate-100 hover:text-slate-600'
+                  ? 'bg-muted text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
               }`}
               onClick={() => onSelectTab(agent.id)}
             >
               <span>{TASK_STATUS_ICON[agent.status] || ''}</span>
               <span className="truncate max-w-[100px]">{agent.name}</span>
-              <button
-                onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-slate-200 transition-all cursor-pointer"
-                title="关闭"
-              >
-                <X className="w-3 h-3" />
-              </button>
+              {/* SDK Task 由 SDK 管理生命周期，不允许手动删除 */}
+              {!sdkTaskIds?.has(agent.id) && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
+                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-border transition-all cursor-pointer"
+                  title="删除 Agent"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              )}
             </div>
           ))}
         </>

--- a/web/src/components/chat/ChatGroupItem.tsx
+++ b/web/src/components/chat/ChatGroupItem.tsx
@@ -60,7 +60,7 @@ export function ChatGroupItem({
       className={cn(
         'group relative rounded-lg mb-0.5 transition-colors',
         isActive
-          ? 'bg-accent max-lg:bg-white/55 max-lg:backdrop-blur-lg max-lg:saturate-[1.8] max-lg:border max-lg:border-white/35 max-lg:shadow-[0_8px_32px_rgba(0,0,0,0.06),inset_0_1px_1px_rgba(255,255,255,0.6)]'
+          ? 'bg-accent max-lg:bg-background/70 max-lg:backdrop-blur-lg max-lg:saturate-[1.8] max-lg:border max-lg:border-border/40 max-lg:shadow-[0_8px_32px_rgba(0,0,0,0.06)]'
           : 'hover:bg-accent/50',
       )}
     >

--- a/web/src/components/chat/ChatSidebar.tsx
+++ b/web/src/components/chat/ChatSidebar.tsx
@@ -191,7 +191,7 @@ export function ChatSidebar({ className }: ChatSidebarProps) {
           alt={appName}
           className="w-8 h-8 rounded-lg"
         />
-        <span className="text-lg font-bold text-slate-900 truncate">{appName}</span>
+        <span className="text-lg font-bold text-foreground truncate">{appName}</span>
       </div>
 
       {/* New Chat + Search */}
@@ -209,7 +209,7 @@ export function ChatSidebar({ className }: ChatSidebarProps) {
           onChange={setSearchQuery}
           placeholder="搜索工作区..."
           debounce={200}
-          className="max-lg:bg-white/50 max-lg:backdrop-blur-lg max-lg:border-white/30 max-lg:rounded-lg"
+          className="max-lg:bg-background/60 max-lg:backdrop-blur-lg max-lg:border-border/30 max-lg:rounded-lg"
         />
       </div>
 

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -10,8 +10,9 @@ import { FilePanel } from './FilePanel';
 import { ContainerEnvPanel } from './ContainerEnvPanel';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
-import { ArrowLeft, Link, MessageSquare, MoreHorizontal, PanelRightClose, PanelRightOpen, Terminal, Users, X } from 'lucide-react';
+import { ArrowLeft, Link, MessageSquare, Monitor, Moon, MoreHorizontal, PanelRightClose, PanelRightOpen, Sun, Terminal, Users, X } from 'lucide-react';
 import { useDisplayMode } from '../../hooks/useDisplayMode';
+import { useTheme } from '../../hooks/useTheme';
 import { cn } from '@/lib/utils';
 import { wsManager } from '../../api/ws';
 import { api } from '../../api/client';
@@ -52,6 +53,7 @@ interface ChatViewProps {
 
 export function ChatView({ groupJid, onBack }: ChatViewProps) {
   const { mode: displayMode, toggle: toggleDisplayMode } = useDisplayMode();
+  const { theme, toggle: toggleTheme } = useTheme();
   const [mobilePanel, setMobilePanel] = useState<SidebarTab | null>(null);
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('files');
   const [panelOpen, setPanelOpen] = useState(false);
@@ -354,7 +356,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
   return (
     <div ref={containerRef} className="h-full flex flex-col bg-background">
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-2.5 border-b lg:bg-white/80 lg:backdrop-blur-sm lg:border-slate-200/60 max-lg:bg-white/60 max-lg:backdrop-blur-xl max-lg:saturate-[1.8] max-lg:border-white/20 max-lg:shadow-[0_8px_32px_rgba(0,0,0,0.06),inset_0_1px_1px_rgba(255,255,255,0.6)]">
+      <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border lg:bg-background/80 lg:backdrop-blur-sm max-lg:bg-background/60 max-lg:backdrop-blur-xl max-lg:saturate-[1.8] max-lg:border-border/40 max-lg:shadow-[0_8px_32px_rgba(0,0,0,0.06)]">
         {onBack && (
           <button
             onClick={onBack}
@@ -404,6 +406,15 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
             )}
           </div>
         </div>
+        {/* Desktop: toggle theme (light → dark → system) */}
+        <button
+          onClick={toggleTheme}
+          className="hidden lg:flex p-2 rounded-lg hover:bg-accent text-muted-foreground transition-colors cursor-pointer"
+          title={theme === 'light' ? '切换到暗色模式' : theme === 'dark' ? '跟随系统' : '切换到亮色模式'}
+          aria-label={theme === 'light' ? '切换到暗色模式' : theme === 'dark' ? '跟随系统' : '切换到亮色模式'}
+        >
+          {theme === 'light' ? <Moon className="w-5 h-5" /> : theme === 'dark' ? <Monitor className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+        </button>
         {/* Desktop: toggle display mode */}
         <button
           onClick={toggleDisplayMode}
@@ -666,7 +677,7 @@ export function ChatView({ groupJid, onBack }: ChatViewProps) {
 
         {/* Desktop: sidebar with tabs (collapsible) */}
         <div className={cn(
-          "hidden lg:flex lg:flex-col flex-shrink-0 border-l border-border bg-white transition-[width] duration-200",
+          "hidden lg:flex lg:flex-col flex-shrink-0 border-l border-border bg-background transition-[width] duration-200",
           panelOpen ? "w-80" : "w-0 overflow-hidden border-l-0"
         )}>
           {/* Tab bar */}

--- a/web/src/components/chat/FilePanel.tsx
+++ b/web/src/components/chat/FilePanel.tsx
@@ -208,14 +208,14 @@ function TextEditor({
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-xl shadow-xl w-full max-w-4xl h-[85vh] supports-[height:100dvh]:h-[85dvh] flex flex-col animate-in zoom-in-95 duration-200"
+        className="bg-card rounded-xl shadow-xl w-full max-w-4xl h-[85vh] supports-[height:100dvh]:h-[85dvh] flex flex-col animate-in zoom-in-95 duration-200"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
           <div className="flex items-center gap-2 min-w-0">
             <FileIcon name={file.name} />
-            <span className="font-medium text-slate-900 text-sm truncate">{file.name}</span>
+            <span className="font-medium text-foreground text-sm truncate">{file.name}</span>
             {dirty && (
               <span className="text-xs text-amber-500 flex-shrink-0">未保存</span>
             )}
@@ -232,7 +232,7 @@ function TextEditor({
             </Button>
             <button
               onClick={onClose}
-              className="text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-slate-100 cursor-pointer"
+              className="text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-muted cursor-pointer"
               aria-label="关闭编辑器"
             >
               <X className="w-5 h-5" />
@@ -253,7 +253,7 @@ function TextEditor({
                 setContent(e.target.value);
                 setDirty(true);
               }}
-              className="w-full h-full font-mono text-sm text-slate-800 resize-none bg-slate-50"
+              className="w-full h-full font-mono text-sm text-foreground resize-none bg-muted"
               spellCheck={false}
             />
           )}
@@ -434,16 +434,16 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
   };
 
   return (
-    <div className="w-full h-full border-l border-slate-200 bg-white flex flex-col">
+    <div className="w-full h-full border-l border-border bg-background flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200">
-        <h3 className="font-semibold text-slate-900 text-sm">工作区文件管理</h3>
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <h3 className="font-semibold text-foreground text-sm">工作区文件管理</h3>
         <div className="flex items-center gap-1">
           {canOpenLocalFolder && (
             <button
               onClick={handleOpenLocalFolder}
               disabled={openDirLoading}
-              className="hidden md:inline-flex text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-slate-100 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              className="hidden md:inline-flex text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-muted cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               title="打开工作区文件夹"
               aria-label="打开工作区文件夹"
             >
@@ -452,7 +452,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
           )}
           <button
             onClick={handleRefresh}
-            className="text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-slate-100 cursor-pointer"
+            className="text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-muted cursor-pointer"
             title="刷新"
             aria-label="刷新文件列表"
           >
@@ -461,7 +461,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
           {onClose && (
             <button
               onClick={onClose}
-              className="text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-slate-100 cursor-pointer"
+              className="text-slate-400 hover:text-slate-600 transition-colors p-2 rounded-md hover:bg-muted cursor-pointer"
               aria-label="关闭文件面板"
             >
               <X className="w-5 h-5" />
@@ -471,7 +471,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
       </div>
 
       {/* Breadcrumb */}
-      <div className="px-4 py-2 border-b border-slate-200 bg-slate-50">
+      <div className="px-4 py-2 border-b border-border bg-muted">
         <div className="flex items-center gap-1 text-sm overflow-x-auto">
           <button
             onClick={() => handleNavigate(-1)}
@@ -518,10 +518,10 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                   key={item.path}
                   className={`flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors ${
                     clickable
-                      ? 'hover:bg-slate-100 cursor-pointer'
+                      ? 'hover:bg-muted cursor-pointer'
                       : item.isSystem
-                        ? 'bg-slate-50/60'
-                        : 'hover:bg-slate-50'
+                        ? 'bg-muted/60'
+                        : 'hover:bg-muted/50'
                   }`}
                   onClick={() => handleItemClick(item)}
                 >
@@ -620,7 +620,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
       </div>
 
       {/* Footer */}
-      <div className="p-3 border-t border-slate-200 space-y-2">
+      <div className="p-3 border-t border-border space-y-2">
         <Button variant="outline" size="sm" onClick={handleCreateDir} className="w-full">
           <FolderPlus className="w-4 h-4" />
           新建文件夹

--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -65,7 +65,7 @@ function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
       <img
         src={src}
         alt={alt || ''}
-        className="my-3 max-w-full rounded-lg border border-slate-200 cursor-pointer hover:shadow-md transition-shadow"
+        className="my-3 max-w-full rounded-lg border border-border cursor-pointer hover:shadow-md transition-shadow"
         style={{ maxHeight: '400px', objectFit: 'contain' }}
         onClick={() => setExpanded(true)}
         onError={() => setError(true)}
@@ -80,8 +80,8 @@ const sanitizeSchema = {
   ...defaultSchema,
   attributes: {
     ...defaultSchema.attributes,
-    code: [...(defaultSchema.attributes?.code || []), 'className'],
-    span: [...(defaultSchema.attributes?.span || []), 'className'],
+    code: [...(defaultSchema.attributes?.code || []), 'class', 'className'],
+    span: [...(defaultSchema.attributes?.span || []), 'class', 'className'],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -125,7 +125,7 @@ function CodeBlock({
         <div className="absolute right-2 top-2 opacity-70 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
           <button
             onClick={handleCopy}
-            className="p-2 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-700 text-xs flex items-center gap-1"
+            className="p-2 rounded-lg bg-muted hover:bg-muted/80 text-muted-foreground text-xs flex items-center gap-1"
           >
             {copied ? (
               <>
@@ -140,7 +140,7 @@ function CodeBlock({
             )}
           </button>
         </div>
-        <pre className="!bg-[#f6f8fa] rounded-lg p-4 overflow-x-auto">
+        <pre className="!bg-[#f6f8fa] dark:!bg-[#22272e] rounded-lg p-4 overflow-x-auto">
           <code className={className} {...props}>
             {children}
           </code>
@@ -153,8 +153,8 @@ function CodeBlock({
     <code
       className={
         variant === 'chat'
-          ? 'bg-brand-50 text-primary px-1.5 py-0.5 rounded text-[0.9em] leading-relaxed font-mono break-all'
-          : 'bg-brand-50 text-primary px-1.5 py-0.5 rounded text-sm font-mono break-all'
+          ? 'bg-primary/10 dark:bg-primary/20 text-primary px-1.5 py-0.5 rounded text-[0.9em] leading-relaxed font-mono break-all'
+          : 'bg-primary/10 dark:bg-primary/20 text-primary px-1.5 py-0.5 rounded text-sm font-mono break-all'
       }
       {...props}
     >
@@ -165,8 +165,8 @@ function CodeBlock({
 
 export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJid, variant = 'chat' }: MarkdownRendererProps) {
   const textSizeClass = variant === 'chat'
-    ? 'text-[15px] leading-7 text-slate-800'
-    : 'text-sm leading-6 text-slate-800';
+    ? 'text-[15px] leading-7 text-foreground'
+    : 'text-sm leading-6 text-foreground';
   const tableTextClass = variant === 'chat' ? 'text-[0.95em]' : 'text-sm';
 
   return (
@@ -192,27 +192,27 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
               className="my-4 max-w-full overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] [touch-action:pan-x]"
               data-swipe-back-ignore="true"
             >
-              <table className="w-max min-w-full border-collapse border border-slate-200">
+              <table className="w-max min-w-full border-collapse border border-border">
                 {children}
               </table>
             </div>
           ),
           thead: ({ children }) => (
-            <thead className="bg-slate-50">{children}</thead>
+            <thead className="bg-muted">{children}</thead>
           ),
-          tbody: ({ children }) => <tbody className="divide-y divide-slate-200">{children}</tbody>,
+          tbody: ({ children }) => <tbody className="divide-y divide-border">{children}</tbody>,
           tr: ({ children }) => (
-            <tr className="even:bg-white odd:bg-slate-50">
+            <tr className="even:bg-card odd:bg-muted/30">
               {children}
             </tr>
           ),
           th: ({ children }) => (
-            <th className={`px-4 py-2 text-left font-semibold text-slate-900 border border-slate-200 whitespace-nowrap break-normal align-top ${tableTextClass}`}>
+            <th className={`px-4 py-2 text-left font-semibold text-foreground border border-border whitespace-nowrap break-normal align-top ${tableTextClass}`}>
               {children}
             </th>
           ),
           td: ({ children }) => (
-            <td className={`px-4 py-2 text-slate-700 border border-slate-200 whitespace-nowrap break-normal align-top ${tableTextClass}`}>
+            <td className={`px-4 py-2 text-foreground border border-border whitespace-nowrap break-normal align-top ${tableTextClass}`}>
               {children}
             </td>
           ),

--- a/web/src/components/chat/MermaidDiagram.tsx
+++ b/web/src/components/chat/MermaidDiagram.tsx
@@ -106,9 +106,9 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
 
   if (loading) {
     return (
-      <div className="my-4 rounded-lg bg-slate-50 border border-slate-200 p-8 flex items-center justify-center">
+      <div className="my-4 rounded-lg bg-muted border border-border p-8 flex items-center justify-center">
         <div className="animate-pulse flex flex-col items-center gap-2">
-          <div className="h-24 w-48 bg-slate-200 rounded" />
+          <div className="h-24 w-48 bg-muted-foreground/20 rounded" />
           <span className="text-sm text-slate-400">Mermaid 图表渲染中...</span>
         </div>
       </div>
@@ -175,7 +175,7 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
           </button>
         </div>
         <div
-          className="bg-white rounded-lg border border-slate-200 p-4 overflow-x-auto flex justify-center cursor-pointer [&>svg]:!max-w-full [&>svg]:!h-auto"
+          className="bg-card rounded-lg border border-border p-4 overflow-x-auto flex justify-center cursor-pointer [&>svg]:!max-w-full [&>svg]:!h-auto"
           onClick={() => setExpanded(true)}
           dangerouslySetInnerHTML={{ __html: svg! }}
         />
@@ -186,7 +186,7 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
           onClick={() => setExpanded(false)}
         >
           <div
-            className="relative bg-white rounded-xl p-6 w-[95vw] h-[95vh] overflow-auto cursor-default"
+            className="relative bg-card rounded-xl p-6 w-[95vw] h-[95vh] overflow-auto cursor-default"
             onClick={(e) => e.stopPropagation()}
           >
             <button

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -167,10 +167,10 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
       : (isOtherUser ? (message.sender_name || '用户') : (currentUser?.display_name || currentUser?.username || '我'));
 
     return (
-      <div className="group mb-2 border-b border-slate-100 pb-2" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+      <div className="group mb-2 border-b border-border pb-2" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
         {/* Sender line — no avatars in compact mode */}
         <div className="flex items-center gap-1.5 mb-1">
-          <span className={`text-xs font-semibold ${isAI ? 'text-brand-600' : 'text-slate-700'}`}>{senderName}</span>
+          <span className={`text-xs font-semibold ${isAI ? 'text-primary' : 'text-muted-foreground'}`}>{senderName}</span>
           {showTime && <span className="text-[11px] text-slate-400">{time}</span>}
           <button
             onClick={handleCopy}
@@ -205,7 +205,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
             {isAI ? (
               <MarkdownRenderer content={message.content} groupJid={message.chat_jid} variant="chat" />
             ) : (
-              <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words text-slate-800">{message.content}</p>
+              <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words text-foreground">{message.content}</p>
             )}
           </div>
         )}
@@ -262,7 +262,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
                   </div>
                 )}
                 {!hasOnlyImages && (
-                  <div className="bg-white border border-slate-200 text-foreground px-4 py-2.5 rounded-2xl rounded-tl-sm shadow-sm">
+                  <div className="bg-card border border-border text-foreground px-4 py-2.5 rounded-2xl rounded-tl-sm shadow-sm">
                     <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words">{message.content}</p>
                   </div>
                 )}
@@ -324,7 +324,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
               </div>
             )}
             {!hasOnlyImages && (
-              <div className="bg-white border border-slate-200 text-foreground px-4 py-2.5 rounded-2xl rounded-tr-sm shadow-sm">
+              <div className="bg-card border border-border text-foreground px-4 py-2.5 rounded-2xl rounded-tr-sm shadow-sm">
                 <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words">{message.content}</p>
               </div>
             )}
@@ -390,7 +390,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
           </div>
 
           {/* Card */}
-          <div className="relative bg-white rounded-xl border border-slate-100 border-l-[3px] border-l-brand-400 px-5 py-4 max-lg:bg-white/90 max-lg:backdrop-blur-sm overflow-hidden">
+          <div className="relative bg-card rounded-xl border border-border border-l-[3px] border-l-[var(--brand-400)] px-5 py-4 max-lg:bg-card/90 max-lg:backdrop-blur-sm overflow-hidden">
             {/* Copy button — desktop only, mobile uses long-press menu */}
             <button
               onClick={handleCopy}

--- a/web/src/components/chat/MessageContextMenu.tsx
+++ b/web/src/components/chat/MessageContextMenu.tsx
@@ -60,21 +60,21 @@ export function MessageContextMenu({ content, position, onClose }: MessageContex
     <div className="fixed inset-0 z-[60]" onClick={onClose}>
       <div
         ref={menuRef}
-        className="absolute bg-white rounded-xl shadow-lg border border-slate-200 py-1 min-w-[160px] animate-in zoom-in-95 fade-in duration-150"
+        className="absolute bg-card rounded-xl shadow-lg border border-border py-1 min-w-[160px] animate-in zoom-in-95 fade-in duration-150"
         style={{ left: position.x, top: position.y }}
         onClick={(e) => e.stopPropagation()}
       >
         <button
           onClick={handleCopyText}
-          className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 active:bg-slate-100 transition-colors"
+          className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-muted/50 active:bg-muted transition-colors"
         >
           <Copy className="w-4 h-4 text-slate-400" />
           复制文本
         </button>
-        <div className="mx-3 border-t border-slate-100" />
+        <div className="mx-3 border-t border-border" />
         <button
           onClick={handleCopyMarkdown}
-          className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 active:bg-slate-100 transition-colors"
+          className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-muted/50 active:bg-muted transition-colors"
         >
           <FileText className="w-4 h-4 text-slate-400" />
           复制 Markdown

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -309,13 +309,13 @@ export function MessageInput({
 
   return (
     <div
-      className="px-4 pt-2 pb-6 bg-background ios-pwa-bottom-safe max-lg:bg-white/60 max-lg:backdrop-blur-xl max-lg:saturate-[1.8] max-lg:border-t max-lg:border-white/20"
+      className="px-4 pt-2 pb-6 bg-background ios-pwa-bottom-safe max-lg:bg-background/60 max-lg:backdrop-blur-xl max-lg:saturate-[1.8] max-lg:border-t max-lg:border-border/40"
       style={{ paddingBottom: `max(1.5rem, var(--keyboard-height, 0px))` }}
     >
       <div className={isCompact ? 'mx-auto' : 'max-w-3xl mx-auto'}>
         {/* Upload progress bar */}
         {uploading && uploadProgress && (
-          <div className={`mb-2 px-4 py-2.5 ${isCompact ? 'bg-white border border-slate-200' : 'bg-white rounded-xl border border-slate-200 shadow-sm'}`}>
+          <div className={`mb-2 px-4 py-2.5 ${isCompact ? 'bg-card border border-border' : 'bg-card rounded-xl border border-border shadow-sm'}`}>
             <div className="flex items-center justify-between mb-1.5">
               <span className="text-xs text-slate-600 truncate max-w-[65%]">
                 {uploadProgress.currentFile || '完成'}
@@ -334,7 +334,7 @@ export function MessageInput({
         )}
 
         {/* Main input card */}
-        <div className={isCompact ? 'bg-white border border-slate-200 rounded-lg' : 'bg-white rounded-2xl border border-slate-200 shadow-sm'}>
+        <div className={isCompact ? 'bg-card border border-border rounded-lg' : 'bg-card rounded-2xl border border-border shadow-sm'}>
           {/* Send error banner */}
           {sendError && (
             <div className={`px-4 py-2 bg-red-50 text-red-600 text-xs font-medium border-b border-red-100 flex items-center gap-2 ${isCompact ? 'rounded-t-lg' : 'rounded-t-2xl'}`}>
@@ -344,7 +344,7 @@ export function MessageInput({
 
           {/* Pending images preview */}
           {pendingImages.length > 0 && (
-            <div className="px-3 pt-2.5 pb-1 border-b border-slate-100">
+            <div className="px-3 pt-2.5 pb-1 border-b border-border">
               <div className="flex items-center gap-1 mb-1.5">
                 <ImageIcon className="w-3 h-3 text-slate-400" />
                 <span className="text-[11px] text-slate-400">
@@ -380,7 +380,7 @@ export function MessageInput({
 
           {/* Pending files chips */}
           {pendingFiles.length > 0 && (
-            <div className="px-3 pt-2.5 pb-1 border-b border-slate-100">
+            <div className="px-3 pt-2.5 pb-1 border-b border-border">
               <div className="flex items-center gap-1 mb-1">
                 <Paperclip className="w-3 h-3 text-slate-400" />
                 <span className="text-[11px] text-slate-400">

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -261,7 +261,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
                   }}
                 >
                   <div className="flex justify-center my-6">
-                    <span className="bg-white px-4 py-1 rounded-full text-xs text-slate-500 border border-slate-200">
+                    <span className="bg-card px-4 py-1 rounded-full text-xs text-muted-foreground border border-border">
                       {item.content}
                     </span>
                   </div>
@@ -370,7 +370,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
                     <button
                       key={prompt}
                       onClick={() => onSend(prompt)}
-                      className="w-full text-left px-4 py-3 rounded-xl text-sm text-slate-700 transition-all active:scale-[0.98] cursor-pointer bg-white/60 backdrop-blur-sm border border-white/40 shadow-[0_2px_8px_rgba(0,0,0,0.04),inset_0_1px_1px_rgba(255,255,255,0.6)] hover:bg-white/80 hover:shadow-[0_4px_12px_rgba(0,0,0,0.06)]"
+                      className="w-full text-left px-4 py-3 rounded-xl text-sm text-foreground transition-all active:scale-[0.98] cursor-pointer bg-card/60 backdrop-blur-sm border border-border/60 shadow-[0_2px_8px_rgba(0,0,0,0.04)] hover:bg-card/80 hover:shadow-[0_4px_12px_rgba(0,0,0,0.06)]"
                     >
                       {prompt}
                     </button>
@@ -422,7 +422,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
           {!atTop && (
             <button
               onClick={scrollToTop}
-              className="w-10 h-10 rounded-full bg-white border border-slate-200 shadow-sm flex items-center justify-center text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer"
+              className="w-10 h-10 rounded-full bg-card border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
               title="回到顶部"
             >
               <ChevronUp className="w-4 h-4" />
@@ -431,7 +431,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
           {!autoScroll && (
             <button
               onClick={scrollToBottom}
-              className="w-10 h-10 rounded-full bg-white border border-slate-200 shadow-sm flex items-center justify-center text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer"
+              className="w-10 h-10 rounded-full bg-card border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
               title="回到底部"
             >
               <ChevronDown className="w-4 h-4" />

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -94,15 +94,15 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
   if (!hasStreamData) {
     if (isCompact) {
       return (
-        <div className="mb-2 border-b border-slate-100 pb-2">
+        <div className="mb-2 border-b border-border pb-2">
           <div className="flex items-center gap-1.5 mb-1">
-            <span className="text-xs font-semibold text-brand-600">{senderName}</span>
+            <span className="text-xs font-semibold text-primary">{senderName}</span>
           </div>
           <div className="flex items-center gap-1.5">
             <span className="w-1.5 h-1.5 bg-brand-400 rounded-full animate-bounce [animation-delay:-0.3s]" />
             <span className="w-1.5 h-1.5 bg-brand-400 rounded-full animate-bounce [animation-delay:-0.15s]" />
             <span className="w-1.5 h-1.5 bg-brand-400 rounded-full animate-bounce" />
-            <span className="text-sm text-slate-400 ml-1">正在思考...</span>
+            <span className="text-sm text-muted-foreground ml-1">正在思考...</span>
           </div>
         </div>
       );
@@ -123,12 +123,12 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
             <div className="hidden lg:flex items-center gap-2 mb-1">
               <span className="text-xs text-muted-foreground font-medium">{senderName}</span>
             </div>
-            <div className="bg-white rounded-xl border border-slate-100 border-l-[3px] border-l-brand-400 px-5 py-4">
+            <div className="bg-card rounded-xl border border-border border-l-[3px] border-l-[var(--brand-400)] px-5 py-4">
               <div className="flex items-center gap-1.5">
                 <span className="w-2 h-2 bg-brand-400 rounded-full animate-bounce [animation-delay:-0.3s]" />
                 <span className="w-2 h-2 bg-brand-400 rounded-full animate-bounce [animation-delay:-0.15s]" />
                 <span className="w-2 h-2 bg-brand-400 rounded-full animate-bounce" />
-                <span className="text-sm text-slate-400 ml-1">正在思考...</span>
+                <span className="text-sm text-muted-foreground ml-1">正在思考...</span>
               </div>
             </div>
           </div>
@@ -142,10 +142,10 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
   // ── Compact mode streaming ──
   if (isCompact) {
     return (
-      <div className="mb-2 border-b border-slate-100 pb-2">
+      <div className="mb-2 border-b border-border pb-2">
         {/* Sender line */}
         <div className="flex items-center gap-1.5 mb-1">
-          <span className="text-xs font-semibold text-brand-600">{senderName}</span>
+          <span className="text-xs font-semibold text-primary">{senderName}</span>
           {streaming.isThinking && (
             <span className="flex gap-0.5 ml-0.5">
               <span className="w-1 h-1 bg-brand-400 rounded-full animate-bounce [animation-delay:-0.3s]" />
@@ -261,7 +261,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
 
           {/* Recent events timeline */}
           {streaming.recentEvents.length > 0 && (
-            <div className="rounded-lg border border-slate-100 bg-slate-50/50 p-2 mb-2">
+            <div className="rounded-lg border border-border bg-muted/30 p-2 mb-2">
               <div className="text-[11px] font-medium text-slate-500 mb-1">调用轨迹</div>
               <div className="space-y-1 max-h-28 overflow-y-auto">
                 {streaming.recentEvents.map((item) => (
@@ -333,10 +333,10 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
           </div>
 
           {/* Card */}
-          <div className="bg-white rounded-xl border border-slate-100 border-l-[3px] border-l-brand-400 px-5 py-4 overflow-hidden">
+          <div className="bg-card rounded-xl border border-border border-l-[3px] border-l-[var(--brand-400)] px-5 py-4 overflow-hidden">
             {/* System status */}
             {streaming.systemStatus && (
-              <div className="flex items-center gap-2 text-xs text-slate-500 mb-2">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
                 <svg className="w-3.5 h-3.5 animate-spin text-primary" viewBox="0 0 24 24" fill="none">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
@@ -448,7 +448,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
 
             {/* Recent events timeline */}
             {streaming.recentEvents.length > 0 && (
-              <div className="rounded-lg border border-slate-100 bg-slate-50/50 p-2 mb-2">
+              <div className="rounded-lg border border-border bg-muted/30 p-2 mb-2">
                 <div className="text-[11px] font-medium text-slate-500 mb-1">调用轨迹</div>
                 <div className="space-y-1 max-h-28 overflow-y-auto">
                   {streaming.recentEvents.map((item) => (

--- a/web/src/components/chat/TaskInlineCard.tsx
+++ b/web/src/components/chat/TaskInlineCard.tsx
@@ -73,7 +73,7 @@ export function TaskInlineCard({ toolUseId, description, startTime, groupJid }: 
         }`}
       >
         {statusIcon}
-        <span className="text-xs font-medium text-slate-700 truncate flex-1">
+        <span className="text-xs font-medium text-foreground truncate flex-1">
           Task: {description}
         </span>
         {summary && !expanded && (
@@ -97,7 +97,7 @@ export function TaskInlineCard({ toolUseId, description, startTime, groupJid }: 
       {expanded && hasContent && streaming && (
         <div
           ref={contentRef}
-          className="mt-1 rounded-lg border border-slate-200 bg-white max-h-80 overflow-y-auto"
+          className="mt-1 rounded-lg border border-border bg-card max-h-80 overflow-y-auto"
         >
           <div className="px-3 py-2 space-y-2">
             {/* Thinking / Reasoning */}
@@ -137,7 +137,7 @@ export function TaskInlineCard({ toolUseId, description, startTime, groupJid }: 
 
             {/* Recent events timeline */}
             {streaming.recentEvents.length > 0 && (
-              <div className="rounded-md border border-slate-100 bg-slate-50/50 p-1.5">
+              <div className="rounded-md border border-border bg-muted/50 p-1.5">
                 <div className="text-[10px] font-medium text-slate-500 mb-0.5">调用轨迹</div>
                 <div className="space-y-0.5 max-h-20 overflow-y-auto">
                   {streaming.recentEvents.map((item) => (

--- a/web/src/components/common/Skeletons.tsx
+++ b/web/src/components/common/Skeletons.tsx
@@ -9,7 +9,7 @@ export function SkeletonCardGrid() {
       {Array.from({ length: 6 }).map((_, i) => (
         <div
           key={i}
-          className="bg-white rounded-xl border border-slate-200 p-5 space-y-3"
+          className="bg-card rounded-xl border border-border p-5 space-y-3"
         >
           <Skeleton className="h-5 w-2/3 rounded" />
           <Skeleton className="h-4 w-full rounded" />
@@ -29,7 +29,7 @@ export function SkeletonStatCards() {
       {Array.from({ length: 3 }).map((_, i) => (
         <div
           key={i}
-          className="bg-white rounded-xl border border-slate-200 p-5 space-y-3"
+          className="bg-card rounded-xl border border-border p-5 space-y-3"
         >
           <Skeleton className="h-8 w-1/3 rounded" />
           <Skeleton className="h-4 w-1/2 rounded" />
@@ -56,8 +56,8 @@ export function SkeletonCardList({
           key={i}
           className={
             compact
-              ? 'rounded-lg border border-slate-200 bg-white p-3 space-y-2'
-              : 'rounded-xl border border-slate-200 bg-white p-5 space-y-3'
+              ? 'rounded-lg border border-border bg-card p-3 space-y-2'
+              : 'rounded-xl border border-border bg-card p-5 space-y-3'
           }
         >
           <div className="flex items-center gap-3">
@@ -79,9 +79,9 @@ export function SkeletonCardList({
  */
 export function SkeletonTable() {
   return (
-    <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+    <div className="bg-card rounded-xl border border-border overflow-hidden">
       {/* header */}
-      <div className="grid grid-cols-4 gap-4 px-4 py-3 border-b border-slate-200 bg-slate-50">
+      <div className="grid grid-cols-4 gap-4 px-4 py-3 border-b border-border bg-muted">
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} className="h-4 w-3/4 rounded" />
         ))}
@@ -90,7 +90,7 @@ export function SkeletonTable() {
       {Array.from({ length: 5 }).map((_, row) => (
         <div
           key={row}
-          className="grid grid-cols-4 gap-4 px-4 py-3 border-b border-slate-100 last:border-b-0"
+          className="grid grid-cols-4 gap-4 px-4 py-3 border-b border-border last:border-b-0"
         >
           {Array.from({ length: 4 }).map((_, col) => (
             <Skeleton

--- a/web/src/components/groups/GroupCard.tsx
+++ b/web/src/components/groups/GroupCard.tsx
@@ -22,7 +22,7 @@ export function GroupCard({ group }: GroupCardProps) {
   };
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 hover:border-brand-300 transition-colors duration-200">
+    <div className="bg-card rounded-xl border border-border hover:border-brand-300 transition-colors duration-200">
       {/* Card Header - Clickable */}
       <button
         onClick={() => setExpanded(!expanded)}
@@ -32,7 +32,7 @@ export function GroupCard({ group }: GroupCardProps) {
           <div className="flex-1 min-w-0">
             {/* Group Name */}
             <div className="flex items-center gap-2 mb-1">
-              <h3 className="text-lg font-semibold text-slate-900 truncate">
+              <h3 className="text-lg font-semibold text-foreground truncate">
                 {group.name}
               </h3>
               {group.is_shared && (
@@ -52,7 +52,7 @@ export function GroupCard({ group }: GroupCardProps) {
             <div className="space-y-1 text-sm">
               <div className="flex items-center gap-2">
                 <span className="text-slate-500">文件夹:</span>
-                <span className="text-slate-900 font-medium">
+                <span className="text-foreground font-medium">
                   {group.folder}
                 </span>
               </div>
@@ -72,7 +72,7 @@ export function GroupCard({ group }: GroupCardProps) {
 
       {/* Expanded Detail */}
       {expanded && (
-        <div className="border-t border-slate-200">
+        <div className="border-t border-border">
           <GroupDetail group={group} />
         </div>
       )}

--- a/web/src/components/groups/GroupDetail.tsx
+++ b/web/src/components/groups/GroupDetail.tsx
@@ -16,11 +16,11 @@ export function GroupDetail({ group }: GroupDetailProps) {
   };
 
   return (
-    <div className="p-4 bg-slate-50 space-y-3">
+    <div className="p-4 bg-background space-y-3">
       {/* JID */}
       <div>
         <div className="text-xs text-slate-500 mb-1">完整 JID</div>
-        <code className="block text-xs font-mono bg-white px-3 py-2 rounded border border-slate-200 break-all">
+        <code className="block text-xs font-mono bg-card px-3 py-2 rounded border border-border break-all">
           {group.jid}
         </code>
       </div>
@@ -28,13 +28,13 @@ export function GroupDetail({ group }: GroupDetailProps) {
       {/* Folder */}
       <div>
         <div className="text-xs text-slate-500 mb-1">文件夹</div>
-        <div className="text-sm text-slate-900 font-medium">{group.folder}</div>
+        <div className="text-sm text-foreground font-medium">{group.folder}</div>
       </div>
 
       {/* Added At */}
       <div>
         <div className="text-xs text-slate-500 mb-1">添加时间</div>
-        <div className="text-sm text-slate-900">
+        <div className="text-sm text-foreground">
           {formatDate(group.added_at)}
         </div>
       </div>
@@ -43,7 +43,7 @@ export function GroupDetail({ group }: GroupDetailProps) {
       {group.lastMessage && (
         <div>
           <div className="text-xs text-slate-500 mb-1">最后消息</div>
-          <div className="text-sm text-slate-700 bg-white px-3 py-2 rounded border border-slate-200 line-clamp-3 break-words">
+          <div className="text-sm text-foreground bg-card px-3 py-2 rounded border border-border line-clamp-3 break-words">
             {group.lastMessage}
           </div>
           {group.lastMessageTime && (

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -4,10 +4,12 @@ import { NavRail } from './NavRail';
 import { BottomTabBar } from './BottomTabBar';
 import { ConnectionBanner } from '../common/ConnectionBanner';
 import { wsManager } from '../../api/ws';
+import { useTheme } from '../../hooks/useTheme';
 
 export function AppLayout() {
   const location = useLocation();
   const hideMobileTabBar = /^\/chat\/.+/.test(location.pathname);
+  useTheme(); // 应用并同步持久化的主题偏好
 
   // 应用级别建立 WebSocket 连接，确保所有页面（非仅 ChatView）都有连接
   useEffect(() => {

--- a/web/src/components/layout/NavRail.tsx
+++ b/web/src/components/layout/NavRail.tsx
@@ -25,7 +25,7 @@ export function NavRail() {
 
   return (
     <TooltipProvider delayDuration={200}>
-      <nav className="w-16 h-full bg-white border-r border-border flex flex-col items-center py-4 gap-2">
+      <nav className="w-16 h-full bg-background border-r border-border flex flex-col items-center py-4 gap-2">
         {/* Logo */}
         <div className="w-10 h-10 rounded-xl overflow-hidden mb-2 flex-shrink-0">
           <img src={`${import.meta.env.BASE_URL}icons/icon-192.png`} alt="HappyClaw" className="w-full h-full object-cover" />

--- a/web/src/components/mcp-servers/McpServerDetail.tsx
+++ b/web/src/components/mcp-servers/McpServerDetail.tsx
@@ -29,7 +29,7 @@ export function McpServerDetail({ server, onDeleted }: McpServerDetailProps) {
 
   if (!server) {
     return (
-      <div className="bg-white rounded-xl border border-slate-200 p-12 flex items-center justify-center">
+      <div className="bg-card rounded-xl border border-border p-12 flex items-center justify-center">
         <p className="text-slate-400 text-center">选择一个 MCP 服务器查看详情</p>
       </div>
     );
@@ -115,13 +115,13 @@ export function McpServerDetail({ server, onDeleted }: McpServerDetailProps) {
   const headerEntries = server.headers ? Object.entries(server.headers) : [];
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+    <div className="bg-card rounded-xl border border-border overflow-hidden">
       {/* Header */}
       <div className="p-6 border-b border-slate-200">
         <div className="flex items-start justify-between gap-4 mb-3">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-2">
-              <h2 className="text-xl font-bold text-slate-900">{server.id}</h2>
+              <h2 className="text-xl font-bold text-foreground">{server.id}</h2>
               {server.syncedFromHost && (
                 <span className="px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-700 inline-flex items-center gap-1">
                   <Download size={10} />
@@ -352,7 +352,7 @@ export function McpServerDetail({ server, onDeleted }: McpServerDetailProps) {
                 {/* Type */}
                 <div>
                   <span className="text-sm text-slate-500">类型</span>
-                  <p className="font-mono text-sm text-slate-900 mt-1 bg-blue-50 rounded px-3 py-2">
+                  <p className="font-mono text-sm text-foreground mt-1 bg-blue-50 rounded px-3 py-2">
                     {server.type?.toUpperCase()}
                   </p>
                 </div>
@@ -360,7 +360,7 @@ export function McpServerDetail({ server, onDeleted }: McpServerDetailProps) {
                 {/* URL */}
                 <div>
                   <span className="text-sm text-slate-500">URL</span>
-                  <p className="font-mono text-sm text-slate-900 mt-1 bg-slate-50 rounded px-3 py-2 break-all">
+                  <p className="font-mono text-sm text-foreground mt-1 bg-slate-50 rounded px-3 py-2 break-all">
                     {server.url}
                   </p>
                 </div>
@@ -398,7 +398,7 @@ export function McpServerDetail({ server, onDeleted }: McpServerDetailProps) {
                 {/* Command */}
                 <div>
                   <span className="text-sm text-slate-500">命令</span>
-                  <p className="font-mono text-sm text-slate-900 mt-1 bg-slate-50 rounded px-3 py-2">
+                  <p className="font-mono text-sm text-foreground mt-1 bg-slate-50 rounded px-3 py-2">
                     {server.command}
                   </p>
                 </div>

--- a/web/src/components/monitor/ContainerStatus.tsx
+++ b/web/src/components/monitor/ContainerStatus.tsx
@@ -11,21 +11,21 @@ export function ContainerStatus({ status }: ContainerStatusProps) {
   const progressWidth = Math.min(100, percentage);
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-6">
+    <div className="bg-card rounded-xl border border-border p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 bg-brand-100 rounded-lg">
           <Server className="w-6 h-6 text-primary" />
         </div>
         <div>
           <h3 className="text-sm font-medium text-slate-500">活跃工作区</h3>
-          <p className="text-2xl font-bold text-slate-900">
+          <p className="text-2xl font-bold text-foreground">
             {status.activeContainers} / {maxConcurrent}
           </p>
         </div>
       </div>
 
       {/* Progress Bar */}
-      <div className="w-full bg-slate-200 rounded-full h-2">
+      <div className="w-full bg-muted rounded-full h-2">
         <div
           className={`h-2 rounded-full transition-all duration-300 ${
             percentage > 80

--- a/web/src/components/monitor/GroupStatusCard.tsx
+++ b/web/src/components/monitor/GroupStatusCard.tsx
@@ -13,9 +13,9 @@ interface GroupStatusCardProps {
 
 export function GroupStatusCard({ group }: GroupStatusCardProps) {
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-4">
+    <div className="bg-card rounded-xl border border-border p-4">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium text-slate-900 truncate mr-2">
+        <span className="text-sm font-medium text-foreground truncate mr-2">
           {group.jid}
         </span>
         {group.active ? (
@@ -32,13 +32,13 @@ export function GroupStatusCard({ group }: GroupStatusCardProps) {
       <div className="space-y-1.5 text-xs text-slate-500">
         <div className="flex items-center justify-between">
           <span>队列</span>
-          <span className="text-slate-700">
+          <span className="text-foreground">
             {group.pendingTasks} 个任务 / {group.pendingMessages ? '有新消息' : '无新消息'}
           </span>
         </div>
         <div className="flex items-center justify-between">
           <span>进程标识</span>
-          <span className="text-slate-700 font-mono truncate ml-2 max-w-[60%] text-right">
+          <span className="text-foreground font-mono truncate ml-2 max-w-[60%] text-right">
             {group.displayName || group.containerName || '-'}
           </span>
         </div>

--- a/web/src/components/monitor/QueueStatus.tsx
+++ b/web/src/components/monitor/QueueStatus.tsx
@@ -9,14 +9,14 @@ export function QueueStatus({ status }: QueueStatusProps) {
   const groupsWithQueue = status.groups?.filter((g) => g.pendingMessages || g.pendingTasks > 0) || [];
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-6">
+    <div className="bg-card rounded-xl border border-border p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 bg-amber-100 rounded-lg">
           <ListOrdered className="w-6 h-6 text-amber-600" />
         </div>
         <div>
           <h3 className="text-sm font-medium text-slate-500">队列状态</h3>
-          <p className="text-2xl font-bold text-slate-900">
+          <p className="text-2xl font-bold text-foreground">
             {status.queueLength}
           </p>
         </div>
@@ -35,7 +35,7 @@ export function QueueStatus({ status }: QueueStatusProps) {
                 className="flex items-center justify-between text-xs"
               >
                 <span className="text-slate-600 truncate">{group.jid}</span>
-                <span className="text-slate-900 font-medium ml-2">
+                <span className="text-foreground font-medium ml-2">
                   {group.pendingTasks}{group.pendingMessages ? ' + 消息' : ''}
                 </span>
               </div>

--- a/web/src/components/monitor/SystemInfo.tsx
+++ b/web/src/components/monitor/SystemInfo.tsx
@@ -17,21 +17,21 @@ export function SystemInfo({ status }: SystemInfoProps) {
   };
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-6">
+    <div className="bg-card rounded-xl border border-border p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 bg-green-100 rounded-lg">
           <Activity className="w-6 h-6 text-green-600" />
         </div>
         <div>
           <h3 className="text-sm font-medium text-slate-500">系统信息</h3>
-          <p className="text-2xl font-bold text-slate-900">运行中</p>
+          <p className="text-2xl font-bold text-foreground">运行中</p>
         </div>
       </div>
 
       <div className="space-y-2">
         <div className="flex items-center justify-between text-sm">
           <span className="text-slate-500">运行时间</span>
-          <span className="text-slate-900 font-medium">
+          <span className="text-foreground font-medium">
             {formatUptime(status.uptime)}
           </span>
         </div>
@@ -39,7 +39,7 @@ export function SystemInfo({ status }: SystemInfoProps) {
         {status.claudeCodeVersion !== undefined && (
           <div className="flex items-center justify-between text-sm">
             <span className="text-slate-500">Claude Code</span>
-            <span className="text-slate-900 font-medium font-mono text-xs">
+            <span className="text-foreground font-medium font-mono text-xs">
               {status.claudeCodeVersion || '未知'}
             </span>
           </div>

--- a/web/src/components/settings/ClaudeProviderSection.tsx
+++ b/web/src/components/settings/ClaudeProviderSection.tsx
@@ -258,7 +258,7 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
           type="button"
           onClick={() => setProviderMode('official')}
           className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-            providerMode === 'official' ? 'bg-white text-primary shadow-sm' : 'text-slate-500'
+            providerMode === 'official' ? 'bg-background text-primary shadow-sm' : 'text-slate-500'
           }`}
         >
           官方
@@ -267,7 +267,7 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
           type="button"
           onClick={() => setProviderMode('third_party')}
           className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-            providerMode === 'third_party' ? 'bg-white text-primary shadow-sm' : 'text-slate-500'
+            providerMode === 'third_party' ? 'bg-background text-primary shadow-sm' : 'text-slate-500'
           }`}
         >
           第三方

--- a/web/src/components/settings/FeishuConfigForm.tsx
+++ b/web/src/components/settings/FeishuConfigForm.tsx
@@ -80,7 +80,7 @@ export function FeishuConfigForm({ setNotice, setError }: FeishuConfigFormProps)
   const formDisabled = !enabled;
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
       {/* 卡片头部 */}
       <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 bg-slate-50/50">
         <div className="flex items-center gap-2">

--- a/web/src/components/settings/SettingsNav.tsx
+++ b/web/src/components/settings/SettingsNav.tsx
@@ -78,7 +78,7 @@ export function SettingsNav({ activeTab, onTabChange, canManageSystemConfig, can
   return (
     <>
       {/* Desktop: vertical sidebar */}
-      <nav className="hidden lg:block w-56 shrink-0 bg-white border-r border-slate-200 py-6 px-3">
+      <nav className="hidden lg:block w-56 shrink-0 bg-background border-r border-border py-6 px-3">
         {visibleItems.map((section, si) => (
           <div key={section.group} className={si > 0 ? 'mt-6' : ''}>
             <div className="px-3 mb-2 text-xs font-semibold text-slate-400 uppercase tracking-wider">

--- a/web/src/components/settings/TelegramConfigForm.tsx
+++ b/web/src/components/settings/TelegramConfigForm.tsx
@@ -97,7 +97,7 @@ export function TelegramConfigForm({ setNotice, setError }: TelegramConfigFormPr
   const formDisabled = !enabled;
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
       {/* 卡片头部 */}
       <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 bg-slate-50/50">
         <div className="flex items-center gap-2">

--- a/web/src/components/shared/DirectoryBrowser.tsx
+++ b/web/src/components/shared/DirectoryBrowser.tsx
@@ -118,7 +118,7 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
 
   return (
     <div>
-      <label className="block text-sm font-medium text-slate-700 mb-1">
+      <label className="block text-sm font-medium text-foreground mb-1">
         工作目录（可选）
       </label>
       <div className="flex gap-2">
@@ -139,10 +139,10 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
       </div>
 
       {browsing && (
-        <div className="mt-2 border border-slate-200 rounded-lg overflow-hidden bg-white">
+        <div className="mt-2 border border-border rounded-lg overflow-hidden bg-card">
           {/* Breadcrumbs + select current dir */}
           {currentPath && (
-            <div className="flex items-center justify-between px-3 py-2 bg-slate-50 border-b border-slate-200">
+            <div className="flex items-center justify-between px-3 py-2 bg-muted border-b border-border">
               <div className="flex items-center gap-1 text-xs text-slate-500 overflow-x-auto min-w-0">
                 <button
                   onClick={() => fetchDirectories()}
@@ -161,7 +161,7 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
                       }
                       className={`hover:text-primary transition-colors ${
                         i === breadcrumbs.length - 1
-                          ? 'text-slate-700 font-medium'
+                          ? 'text-foreground font-medium'
                           : 'cursor-pointer'
                       }`}
                       disabled={i === breadcrumbs.length - 1}
@@ -195,7 +195,7 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
                 {(parentPath !== null || currentPath !== null) && (
                   <button
                     onClick={handleGoUp}
-                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer border-b border-slate-100"
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-slate-600 hover:bg-muted/50 transition-colors cursor-pointer border-b border-slate-100"
                   >
                     <ArrowLeft className="w-4 h-4" />
                     返回上级
@@ -211,11 +211,11 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
                 {directories.map((dir) => (
                   <div
                     key={dir.path}
-                    className="flex items-center justify-between px-3 py-2 hover:bg-slate-50 transition-colors"
+                    className="flex items-center justify-between px-3 py-2 hover:bg-muted/50 transition-colors"
                   >
                     <button
                       onClick={() => handleNavigate(dir.path)}
-                      className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer flex-1 min-w-0"
+                      className="flex items-center gap-2 text-sm text-foreground cursor-pointer flex-1 min-w-0"
                     >
                       <Folder className="w-4 h-4 text-primary flex-shrink-0" />
                       <span className="truncate">{dir.name}</span>
@@ -237,7 +237,7 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
 
           {/* New folder section */}
           {currentPath && (
-            <div className="border-t border-slate-200 px-3 py-2">
+            <div className="border-t border-border px-3 py-2">
               {creating ? (
                 <div className="flex items-center gap-2">
                   <Input
@@ -271,7 +271,7 @@ export function DirectoryBrowser({ value, onChange, placeholder }: DirectoryBrow
                       setCreating(false);
                       setNewFolderName('');
                     }}
-                    className="px-2 py-1.5 text-xs text-slate-500 hover:text-slate-700 transition-colors cursor-pointer"
+                    className="px-2 py-1.5 text-xs text-slate-500 hover:text-foreground transition-colors cursor-pointer"
                   >
                     取消
                   </button>

--- a/web/src/components/skills/SkillDetail.tsx
+++ b/web/src/components/skills/SkillDetail.tsx
@@ -44,7 +44,7 @@ export function SkillDetail({ skillId, onDeleted }: SkillDetailProps) {
 
   if (!skillId) {
     return (
-      <div className="bg-white rounded-xl border border-slate-200 p-12 flex items-center justify-center">
+      <div className="bg-card rounded-xl border border-border p-12 flex items-center justify-center">
         <p className="text-slate-400 text-center">选择一个技能查看详情</p>
       </div>
     );
@@ -52,7 +52,7 @@ export function SkillDetail({ skillId, onDeleted }: SkillDetailProps) {
 
   if (loading) {
     return (
-      <div className="bg-white rounded-xl border border-slate-200 p-12 flex items-center justify-center">
+      <div className="bg-card rounded-xl border border-border p-12 flex items-center justify-center">
         <Loader2 className="animate-spin text-primary" size={32} />
       </div>
     );
@@ -60,14 +60,14 @@ export function SkillDetail({ skillId, onDeleted }: SkillDetailProps) {
 
   if (error || !detail) {
     return (
-      <div className="bg-white rounded-xl border border-slate-200 p-12 flex items-center justify-center">
+      <div className="bg-card rounded-xl border border-border p-12 flex items-center justify-center">
         <p className="text-red-600 text-center">{error || '加载失败'}</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+    <div className="bg-card rounded-xl border border-border overflow-hidden">
       <div className="p-6 border-b border-slate-200">
         <div className="flex items-start justify-between gap-4 mb-3">
           <div className="flex-1 min-w-0">

--- a/web/src/components/tasks/CreateTaskForm.tsx
+++ b/web/src/components/tasks/CreateTaskForm.tsx
@@ -146,10 +146,10 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+      <div className="bg-card rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-slate-200">
-          <h2 className="text-xl font-bold text-slate-900">创建定时任务</h2>
+        <div className="flex items-center justify-between p-6 border-b border-border">
+          <h2 className="text-xl font-bold text-foreground">创建定时任务</h2>
           <button
             onClick={onClose}
             className="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
@@ -162,7 +162,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
           {/* Group Selection */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
+            <label className="block text-sm font-medium text-foreground mb-2">
               选择群组 <span className="text-red-500">*</span>
             </label>
             <Select value={formData.groupFolder || undefined} onValueChange={handleGroupChange}>
@@ -185,7 +185,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
           {/* Execution Type */}
           {isAdmin && (
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">
+              <label className="block text-sm font-medium text-foreground mb-2">
                 执行方式
               </label>
               <Select
@@ -216,7 +216,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
           {/* Script Command (script mode only) */}
           {isScript && (
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">
+              <label className="block text-sm font-medium text-foreground mb-2">
                 脚本命令 <span className="text-red-500">*</span>
               </label>
               <Textarea
@@ -238,7 +238,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
 
           {/* Prompt / Task Description */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
+            <label className="block text-sm font-medium text-foreground mb-2">
               {isScript ? '任务描述' : '任务 Prompt'}{' '}
               {!isScript && <span className="text-red-500">*</span>}
             </label>
@@ -256,7 +256,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
 
           {/* Schedule Type */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
+            <label className="block text-sm font-medium text-foreground mb-2">
               调度类型 <span className="text-red-500">*</span>
             </label>
             <Select
@@ -284,7 +284,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
 
           {/* Schedule Value */}
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">
+            <label className="block text-sm font-medium text-foreground mb-2">
               调度值 <span className="text-red-500">*</span>
             </label>
 
@@ -357,7 +357,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
           {/* Context Mode (agent mode only) */}
           {!isScript && (
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">
+              <label className="block text-sm font-medium text-foreground mb-2">
                 上下文模式
               </label>
               <Select
@@ -384,7 +384,7 @@ export function CreateTaskForm({ groups, onSubmit, onClose, isAdmin }: CreateTas
           )}
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-slate-200">
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-border">
             <Button type="button" variant="outline" onClick={onClose}>
               取消
             </Button>

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -54,7 +54,7 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
   };
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 hover:border-brand-300 transition-colors duration-200">
+    <div className="bg-card rounded-xl border border-border hover:border-brand-300 transition-colors duration-200">
       {/* Card Header - Clickable */}
       <button
         onClick={() => setExpanded(!expanded)}
@@ -63,7 +63,7 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0 mr-4">
             {/* Prompt / Script (truncated 2 lines) */}
-            <p className="text-slate-900 font-medium line-clamp-2 mb-2">
+            <p className="text-foreground font-medium line-clamp-2 mb-2">
               {task.execution_type === 'script'
                 ? task.script_command || task.prompt
                 : task.prompt}
@@ -78,19 +78,19 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
               )}
               <div className="flex items-center gap-2">
                 <span className="text-slate-500">调度:</span>
-                <span className="text-slate-900 font-medium">
+                <span className="text-foreground font-medium">
                   {task.schedule_type === 'cron' && 'Cron'}
                   {task.schedule_type === 'interval' && '间隔'}
                   {task.schedule_type === 'once' && '单次'}
                 </span>
-                <code className="text-xs bg-slate-100 px-2 py-0.5 rounded">
+                <code className="text-xs bg-muted px-2 py-0.5 rounded">
                   {task.schedule_value}
                 </code>
               </div>
 
               <div className="flex items-center gap-2">
                 <span className="text-slate-500">群组:</span>
-                <span className="text-slate-900 font-medium">
+                <span className="text-foreground font-medium">
                   {task.group_folder}
                 </span>
               </div>
@@ -150,7 +150,7 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
 
       {/* Expanded Detail */}
       {expanded && (
-        <div className="border-t border-slate-200">
+        <div className="border-t border-border">
           <TaskDetail task={task} />
         </div>
       )}

--- a/web/src/components/tasks/TaskDetail.tsx
+++ b/web/src/components/tasks/TaskDetail.tsx
@@ -37,12 +37,12 @@ export function TaskDetail({ task }: TaskDetailProps) {
   };
 
   return (
-    <div className="p-4 bg-slate-50 space-y-4">
+    <div className="p-4 bg-background space-y-4">
       {/* Script Command (script mode) */}
       {task.execution_type === 'script' && task.script_command && (
         <div>
           <div className="text-xs text-slate-500 mb-2">脚本命令</div>
-          <pre className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap font-mono">
+          <pre className="text-sm text-foreground bg-card px-3 py-2 rounded border border-border whitespace-pre-wrap font-mono">
             {task.script_command}
           </pre>
         </div>
@@ -54,7 +54,7 @@ export function TaskDetail({ task }: TaskDetailProps) {
           <div className="text-xs text-slate-500 mb-2">
             {task.execution_type === 'script' ? '任务描述' : '完整 Prompt'}
           </div>
-          <div className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap">
+          <div className="text-sm text-foreground bg-card px-3 py-2 rounded border border-border whitespace-pre-wrap">
             {task.prompt}
           </div>
         </div>
@@ -64,14 +64,14 @@ export function TaskDetail({ task }: TaskDetailProps) {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
           <div className="text-xs text-slate-500 mb-1">执行方式</div>
-          <div className="text-sm text-slate-900">
+          <div className="text-sm text-foreground">
             {task.execution_type === 'script' ? '脚本' : 'Agent'}
           </div>
         </div>
 
         <div>
           <div className="text-xs text-slate-500 mb-1">调度类型</div>
-          <div className="text-sm text-slate-900">
+          <div className="text-sm text-foreground">
             {task.schedule_type === 'cron' && 'Cron 表达式'}
             {task.schedule_type === 'interval' && '间隔执行'}
             {task.schedule_type === 'once' && '单次执行'}
@@ -80,14 +80,14 @@ export function TaskDetail({ task }: TaskDetailProps) {
 
         <div>
           <div className="text-xs text-slate-500 mb-1">调度值</div>
-          <code className="text-sm text-slate-900 bg-white px-2 py-1 rounded border border-slate-200">
+          <code className="text-sm text-foreground bg-card px-2 py-1 rounded border border-border">
             {task.schedule_value}
           </code>
         </div>
 
         <div>
           <div className="text-xs text-slate-500 mb-1">下次运行</div>
-          <div className="text-sm text-slate-900">
+          <div className="text-sm text-foreground">
             {formatDate(task.next_run)}
           </div>
         </div>
@@ -95,7 +95,7 @@ export function TaskDetail({ task }: TaskDetailProps) {
         {task.last_run && (
           <div>
             <div className="text-xs text-slate-500 mb-1">上次运行</div>
-            <div className="text-sm text-slate-900">
+            <div className="text-sm text-foreground">
               {formatDate(task.last_run)}
             </div>
           </div>
@@ -104,7 +104,7 @@ export function TaskDetail({ task }: TaskDetailProps) {
         {task.execution_type !== 'script' && (
           <div>
             <div className="text-xs text-slate-500 mb-1">上下文模式</div>
-            <div className="text-sm text-slate-900">
+            <div className="text-sm text-foreground">
               {task.context_mode === 'group'
                 ? '共享群组上下文'
                 : task.context_mode === 'isolated'
@@ -116,7 +116,7 @@ export function TaskDetail({ task }: TaskDetailProps) {
 
         <div>
           <div className="text-xs text-slate-500 mb-1">创建时间</div>
-          <div className="text-sm text-slate-900">
+          <div className="text-sm text-foreground">
             {formatDate(task.created_at)}
           </div>
         </div>
@@ -124,7 +124,7 @@ export function TaskDetail({ task }: TaskDetailProps) {
         {task.last_result && (
           <div className="col-span-1 md:col-span-2">
             <div className="text-xs text-slate-500 mb-1">最近结果</div>
-            <div className="text-sm text-slate-900 bg-white px-3 py-2 rounded border border-slate-200 whitespace-pre-wrap break-words">
+            <div className="text-sm text-foreground bg-card px-3 py-2 rounded border border-border whitespace-pre-wrap break-words">
               {task.last_result}
             </div>
           </div>
@@ -135,13 +135,13 @@ export function TaskDetail({ task }: TaskDetailProps) {
       <div>
         <div className="text-xs text-slate-500 mb-2">执行日志</div>
         {taskLogs.length === 0 ? (
-          <div className="text-sm text-slate-400 bg-white px-3 py-4 rounded border border-slate-200 text-center">
+          <div className="text-sm text-slate-400 bg-card px-3 py-4 rounded border border-border text-center">
             暂无执行记录
           </div>
         ) : (
-          <div className="overflow-x-auto bg-white rounded border border-slate-200">
-            <table className="min-w-full divide-y divide-slate-200 text-sm">
-              <thead className="bg-slate-50">
+          <div className="overflow-x-auto bg-card rounded border border-border">
+            <table className="min-w-full divide-y divide-border text-sm">
+              <thead className="bg-muted">
                 <tr>
                   <th className="px-3 py-2 text-left text-xs font-medium text-slate-500">
                     运行时间
@@ -157,13 +157,13 @@ export function TaskDetail({ task }: TaskDetailProps) {
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-200">
+              <tbody className="divide-y divide-border">
                 {taskLogs.map((log) => (
-                  <tr key={log.id} className="hover:bg-slate-50">
-                    <td className="px-3 py-2 text-slate-900 whitespace-nowrap">
+                  <tr key={log.id} className="hover:bg-muted/50">
+                    <td className="px-3 py-2 text-foreground whitespace-nowrap">
                       {formatDate(log.run_at)}
                     </td>
-                    <td className="px-3 py-2 text-slate-900 whitespace-nowrap">
+                    <td className="px-3 py-2 text-foreground whitespace-nowrap">
                       {formatDuration(log.duration_ms)}
                     </td>
                     <td className="px-3 py-2 whitespace-nowrap">
@@ -177,7 +177,7 @@ export function TaskDetail({ task }: TaskDetailProps) {
                         {log.status === 'success' ? '成功' : '失败'}
                       </span>
                     </td>
-                    <td className="px-3 py-2 text-slate-900 max-w-xs truncate">
+                    <td className="px-3 py-2 text-foreground max-w-xs truncate">
                       {log.status === 'success'
                         ? log.result || '-'
                         : log.error || '未知错误'}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -60,7 +60,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background max-lg:bg-white/80 max-lg:backdrop-blur-xl max-lg:saturate-200 max-lg:border max-lg:border-white/35 max-lg:shadow-[0_8px_32px_rgba(0,0,0,0.06),inset_0_1px_1px_rgba(255,255,255,0.6)] data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background max-lg:bg-background/80 max-lg:backdrop-blur-xl max-lg:saturate-200 max-lg:border max-lg:border-white/35 max-lg:shadow-[0_8px_32px_rgba(0,0,0,0.06),inset_0_1px_1px_rgba(255,255,255,0.6)] data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/web/src/components/users/AuditLogTab.tsx
+++ b/web/src/components/users/AuditLogTab.tsx
@@ -89,13 +89,13 @@ export function AuditLogTab({ setError }: AuditLogTabProps) {
         </a>
       </div>
 
-      <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 overflow-hidden">
+      <div className="bg-card rounded-xl border border-border divide-y divide-border overflow-hidden">
         {auditLogs.length === 0 ? (
           <div className="p-6 text-center text-sm text-slate-500">暂无记录</div>
         ) : (
           auditLogs.map((log) => (
             <div key={log.id} className="px-5 py-3">
-              <div className="text-sm text-slate-900">
+              <div className="text-sm text-foreground">
                 {log.event_type} · {log.username}
               </div>
               <div className="text-xs text-slate-500 mt-1">

--- a/web/src/components/users/InviteCodesTab.tsx
+++ b/web/src/components/users/InviteCodesTab.tsx
@@ -112,8 +112,8 @@ export function InviteCodesTab({ currentUser, setNotice, setError }: InviteCodes
       </div>
 
       {showCreate && (
-        <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
-          <h3 className="text-sm font-medium text-slate-900">创建邀请码</h3>
+        <div className="bg-card rounded-xl border border-border p-6 space-y-4">
+          <h3 className="text-sm font-medium text-foreground">创建邀请码</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <Select
               value={inviteTemplate}
@@ -198,7 +198,7 @@ export function InviteCodesTab({ currentUser, setNotice, setError }: InviteCodes
             <div className="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg">
               <div className="text-xs text-green-700 mb-1">邀请码已生成（请立即复制）：</div>
               <div className="flex items-center gap-2">
-                <code className="flex-1 text-sm font-mono bg-white px-2 py-1 rounded border border-green-200 select-all">
+                <code className="flex-1 text-sm font-mono bg-card px-2 py-1 rounded border border-green-200 select-all">
                   {generatedCode}
                 </code>
                 <button
@@ -213,7 +213,7 @@ export function InviteCodesTab({ currentUser, setNotice, setError }: InviteCodes
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 overflow-hidden">
+      <div className="bg-card rounded-xl border border-border divide-y divide-border overflow-hidden">
         {invites.length === 0 ? (
           <div className="p-6 text-center text-sm text-slate-500">暂无邀请码</div>
         ) : (
@@ -224,14 +224,14 @@ export function InviteCodesTab({ currentUser, setNotice, setError }: InviteCodes
               <div key={invite.code} className="flex items-center justify-between px-6 py-4">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <code className="text-sm font-mono text-slate-700">{invite.code.slice(0, 12)}...</code>
+                    <code className="text-sm font-mono text-foreground">{invite.code.slice(0, 12)}...</code>
                     <button
                       onClick={() => copyToClipboard(invite.code)}
-                      className="p-1 hover:bg-slate-100 rounded cursor-pointer"
+                      className="p-1 hover:bg-muted rounded cursor-pointer"
                     >
                       <Copy className="w-3.5 h-3.5 text-slate-400" />
                     </button>
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-slate-100 text-slate-700">
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-foreground">
                       {invite.role}
                     </span>
                     {invite.permission_template && (
@@ -261,7 +261,7 @@ export function InviteCodesTab({ currentUser, setNotice, setError }: InviteCodes
                       setError(getErrorMessage(err, '删除失败'));
                     }
                   }}
-                  className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-red-600 cursor-pointer"
+                  className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-red-600 cursor-pointer"
                   title="删除邀请码"
                 >
                   <Trash2 className="w-4 h-4" />

--- a/web/src/components/users/UserListTab.tsx
+++ b/web/src/components/users/UserListTab.tsx
@@ -298,8 +298,8 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
       </div>
 
       {showCreate && (
-        <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
-          <h3 className="text-sm font-medium text-slate-900">创建新用户</h3>
+        <div className="bg-card rounded-xl border border-border p-6 space-y-4">
+          <h3 className="text-sm font-medium text-foreground">创建新用户</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <Input
               type="text"
@@ -376,7 +376,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
               <div className="text-xs text-slate-500 mb-1">权限明细</div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                 {assignablePermissions.map((perm) => (
-                  <label key={perm} className="inline-flex items-center gap-2 text-xs text-slate-700">
+                  <label key={perm} className="inline-flex items-center gap-2 text-xs text-foreground">
                     <input
                       type="checkbox"
                       checked={newPermissions.includes(perm)}
@@ -399,7 +399,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 overflow-hidden">
+      <div className="bg-card rounded-xl border border-border divide-y divide-border overflow-hidden">
         {users.length === 0 ? (
           <div className="p-6 text-center text-sm text-slate-500">暂无用户</div>
         ) : (
@@ -408,10 +408,10 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className="text-sm font-medium text-slate-900">{user.display_name || user.username}</span>
+                    <span className="text-sm font-medium text-foreground">{user.display_name || user.username}</span>
                     <span className="text-xs text-slate-500">@{user.username}</span>
                     <span className={`text-xs px-1.5 py-0.5 rounded ${
-                      user.role === 'admin' ? 'bg-brand-100 text-primary' : 'bg-slate-100 text-slate-700'
+                      user.role === 'admin' ? 'bg-brand-100 text-primary' : 'bg-muted text-foreground'
                     }`}>
                       {user.role}
                     </span>
@@ -445,7 +445,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                           setChangePasswordValue('');
                           if (opening) setEditingId(null);
                         }}
-                        className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-indigo-700 cursor-pointer"
+                        className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-indigo-700 cursor-pointer"
                         title="修改密码"
                       >
                         <KeyRound className="w-4 h-4" />
@@ -455,7 +455,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                       <>
                         <button
                           onClick={() => startEdit(user)}
-                          className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-slate-700 cursor-pointer"
+                          className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-foreground cursor-pointer"
                           title="编辑"
                         >
                           <Edit3 className="w-4 h-4" />
@@ -463,7 +463,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                         {user.status === 'active' ? (
                           <button
                             onClick={() => changeStatus(user, 'disabled')}
-                            className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-amber-700 cursor-pointer"
+                            className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-amber-700 cursor-pointer"
                             title="禁用"
                           >
                             <ShieldOff className="w-4 h-4" />
@@ -471,7 +471,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                         ) : user.status === 'disabled' ? (
                           <button
                             onClick={() => changeStatus(user, 'active')}
-                            className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-primary cursor-pointer"
+                            className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-primary cursor-pointer"
                             title="启用"
                           >
                             <ShieldCheck className="w-4 h-4" />
@@ -479,7 +479,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                         ) : (
                           <button
                             onClick={() => handleRestore(user)}
-                            className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-primary cursor-pointer"
+                            className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-primary cursor-pointer"
                             title="恢复"
                           >
                             <Undo2 className="w-4 h-4" />
@@ -487,14 +487,14 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                         )}
                         <button
                           onClick={() => handleRevokeAll(user)}
-                          className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-orange-600 cursor-pointer"
+                          className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-orange-600 cursor-pointer"
                           title="撤销全部会话"
                         >
                           <LogOut className="w-4 h-4" />
                         </button>
                         <button
                           onClick={() => handleDelete(user)}
-                          className="p-2 hover:bg-slate-100 rounded-lg text-slate-500 hover:text-red-600 cursor-pointer"
+                          className="p-2 hover:bg-muted rounded-lg text-slate-500 hover:text-red-600 cursor-pointer"
                           title="删除"
                         >
                           <Trash2 className="w-4 h-4" />
@@ -535,7 +535,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
               )}
 
               {editingId === user.id && (
-                <div className="rounded-lg border border-slate-200 p-3 space-y-3 bg-slate-50">
+                <div className="rounded-lg border border-border p-3 space-y-3 bg-muted/30">
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
                     <Input
                       type="text"
@@ -559,7 +559,7 @@ export function UserListTab({ currentUser, setNotice, setError }: UserListTabPro
                         type="text"
                         value={user.role}
                         disabled
-                        className="bg-slate-100 px-2.5 py-1.5 text-sm text-slate-500 h-auto"
+                        className="bg-muted px-2.5 py-1.5 text-sm text-slate-500 h-auto"
                       />
                     )}
                     <Input

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'happyclaw-theme';
+const listeners = new Set<() => void>();
+
+function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function readTheme(): Theme {
+  if (typeof window === 'undefined') return 'system';
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark' || stored === 'system') return stored;
+  return 'system'; // default: follow system
+}
+
+function resolveTheme(theme: Theme): 'light' | 'dark' {
+  return theme === 'system' ? getSystemTheme() : theme;
+}
+
+export function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle('dark', resolveTheme(theme) === 'dark');
+}
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+export function useTheme() {
+  const getSnapshot = useCallback(() => readTheme(), []);
+  const theme = useSyncExternalStore(subscribe, getSnapshot, () => 'system' as Theme);
+
+  // Apply theme whenever it changes
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // Listen to system preference changes — only matters when theme === 'system'
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      if (readTheme() === 'system') {
+        applyTheme('system');
+        listeners.forEach((cb) => cb());
+      }
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const setTheme = useCallback((t: Theme) => {
+    if (typeof window !== 'undefined') {
+      if (t === 'system') {
+        window.localStorage.removeItem(STORAGE_KEY); // no storage = follow system
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, t);
+      }
+    }
+    applyTheme(t);
+    listeners.forEach((cb) => cb());
+  }, []);
+
+  // Cycle: light → dark → system → light
+  const toggle = useCallback(() => {
+    const next: Theme = theme === 'light' ? 'dark' : theme === 'dark' ? 'system' : 'light';
+    setTheme(next);
+  }, [theme, setTheme]);
+
+  return { theme, resolvedTheme: resolveTheme(theme), toggle, setTheme };
+}

--- a/web/src/pages/GroupsPage.tsx
+++ b/web/src/pages/GroupsPage.tsx
@@ -19,7 +19,7 @@ export function GroupsPage() {
   }));
 
   return (
-    <div className="min-h-full bg-slate-50 p-4 lg:p-8">
+    <div className="min-h-full bg-background p-4 lg:p-8">
       <div className="max-w-7xl mx-auto">
         <PageHeader
           title="群组管理"

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -69,16 +69,16 @@ export function LoginPage() {
 
   if (initialized !== true) {
     return (
-      <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
+      <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
         <div className="text-slate-500 text-sm">加载中...</div>
       </div>
     );
   }
 
   return (
-    <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
+    <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        <div className="bg-white rounded-lg border border-slate-200 p-8">
+        <div className="bg-card rounded-lg border border-border p-8">
           {/* Logo */}
           <div className="flex justify-center mb-6">
             <div className="w-16 h-16 rounded-2xl overflow-hidden mx-auto">
@@ -87,7 +87,7 @@ export function LoginPage() {
           </div>
 
           {/* Title */}
-          <h1 className="text-2xl font-bold text-slate-900 text-center mb-2">
+          <h1 className="text-2xl font-bold text-foreground text-center mb-2">
             欢迎使用 HappyClaw
           </h1>
           <p className="text-slate-500 text-center mb-6">
@@ -104,7 +104,7 @@ export function LoginPage() {
           {/* Login Form */}
           <form onSubmit={handleSubmit}>
             <div className="mb-4">
-              <label htmlFor="username" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="username" className="block text-sm font-medium text-foreground mb-1">
                 用户名
               </label>
               <Input
@@ -118,7 +118,7 @@ export function LoginPage() {
             </div>
 
             <div className="mb-6">
-              <label htmlFor="password" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="password" className="block text-sm font-medium text-foreground mb-1">
                 密码
               </label>
               <Input

--- a/web/src/pages/McpServersPage.tsx
+++ b/web/src/pages/McpServersPage.tsx
@@ -73,7 +73,7 @@ export function McpServersPage() {
     <div className="min-h-full bg-slate-50">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="bg-white border-b border-slate-200 px-6 py-4">
+        <div className="bg-background border-b border-border px-6 py-4">
           <PageHeader
             title="MCP 服务器"
             subtitle={`共 ${servers.length} 个${syncedServers.length > 0 ? `（含同步 ${syncedServers.length}）` : ''} · 启用 ${enabledCount}`}
@@ -121,7 +121,7 @@ export function McpServersPage() {
               {loading && servers.length === 0 ? (
                 <SkeletonCardList count={3} />
               ) : error ? (
-                <div className="bg-white rounded-xl border border-red-200 p-6 text-center">
+                <div className="bg-card rounded-xl border border-red-200 p-6 text-center">
                   <p className="text-red-600">{error}</p>
                 </div>
               ) : filtered.length === 0 ? (

--- a/web/src/pages/MemoryPage.tsx
+++ b/web/src/pages/MemoryPage.tsx
@@ -237,15 +237,15 @@ export function MemoryPage() {
     : '未记录';
 
   return (
-    <div className="min-h-full bg-slate-50 p-4 lg:p-8">
+    <div className="min-h-full bg-background p-4 lg:p-8">
       <div className="max-w-7xl mx-auto space-y-4">
-        <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <div className="bg-card rounded-xl border border-border p-6">
           <div className="flex items-center gap-3 mb-3">
             <div className="p-2 bg-brand-100 rounded-lg">
               <BookOpen className="w-5 h-5 text-primary" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-slate-900">记忆管理</h1>
+              <h1 className="text-2xl font-bold text-foreground">记忆管理</h1>
               <p className="text-sm text-slate-500 mt-0.5">
                 管理个人全局记忆、主会话记忆、各会话流记忆，以及可读取的自动记忆文件。
               </p>
@@ -259,7 +259,7 @@ export function MemoryPage() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-4">
           {(!isMobile || !showContent) && (
-          <div className="bg-white rounded-xl border border-slate-200 p-4">
+          <div className="bg-card rounded-xl border border-border p-4">
             <div className="mb-3">
               <Input
                 type="text"
@@ -296,10 +296,10 @@ export function MemoryPage() {
                             className={`w-full text-left rounded-lg border px-3 py-2 transition-colors ${
                               active
                                 ? 'border-primary bg-brand-50'
-                                : 'border-slate-200 hover:bg-slate-50'
+                                : 'border-border hover:bg-muted/50'
                             }`}
                           >
-                            <div className="text-sm font-medium text-slate-900 truncate">
+                            <div className="text-sm font-medium text-foreground truncate">
                               {source.label}
                             </div>
                             <div className="text-[11px] text-slate-500 truncate mt-0.5">
@@ -329,7 +329,7 @@ export function MemoryPage() {
           )}
 
           {(!isMobile || showContent) && (
-          <div className="bg-white rounded-xl border border-slate-200 p-4 lg:p-6">
+          <div className="bg-card rounded-xl border border-border p-4 lg:p-6">
             {selectedPath ? (
               <>
                 {isMobile && (
@@ -342,7 +342,7 @@ export function MemoryPage() {
                   </button>
                 )}
                 <div className="mb-3">
-                  <div className="text-sm font-semibold text-slate-900 break-all">{selectedPath}</div>
+                  <div className="text-sm font-semibold text-foreground break-all">{selectedPath}</div>
                   <div className="text-xs text-slate-500 mt-1">
                     最近更新时间: {updatedText} · 字节数: {new TextEncoder().encode(content).length} · {fileMeta?.writable ? '可编辑' : '只读'}
                   </div>
@@ -351,7 +351,7 @@ export function MemoryPage() {
                 <Textarea
                   value={content}
                   onChange={(e) => setContent(e.target.value)}
-                  className="min-h-[calc(100dvh-380px)] lg:min-h-[460px] resize-y p-4 font-mono text-sm leading-6 disabled:bg-slate-50"
+                  className="min-h-[calc(100dvh-380px)] lg:min-h-[460px] resize-y p-4 font-mono text-sm leading-6 disabled:bg-muted"
                   placeholder={loadingFile ? '正在加载...' : '此记忆源暂无内容'}
                   disabled={loadingFile || saving || !fileMeta?.writable}
                 />

--- a/web/src/pages/MonitorPage.tsx
+++ b/web/src/pages/MonitorPage.tsx
@@ -58,7 +58,7 @@ export function MonitorPage() {
   };
 
   return (
-    <div className="min-h-full bg-slate-50 p-4 lg:p-8">
+    <div className="min-h-full bg-background p-4 lg:p-8">
       <div className="max-w-7xl mx-auto">
         <PageHeader
           title="系统监控"
@@ -79,8 +79,8 @@ export function MonitorPage() {
         {status && (
           <div className="space-y-6">
             {/* Docker 镜像状态 */}
-            <div className="bg-white rounded-xl border border-slate-200 p-6">
-              <h2 className="text-lg font-semibold text-slate-900 mb-4">
+            <div className="bg-card rounded-xl border border-border p-6">
+              <h2 className="text-lg font-semibold text-foreground mb-4">
                 Docker 镜像
               </h2>
               <div className="flex items-center justify-between">
@@ -158,8 +158,8 @@ export function MonitorPage() {
 
             {/* 群组详情 */}
             {status.groups && status.groups.length > 0 && (
-              <div className="bg-white rounded-xl border border-slate-200 p-4 lg:p-6">
-                <h2 className="text-lg font-semibold text-slate-900 mb-4">
+              <div className="bg-card rounded-xl border border-border p-4 lg:p-6">
+                <h2 className="text-lg font-semibold text-foreground mb-4">
                   群组状态
                 </h2>
 
@@ -172,7 +172,7 @@ export function MonitorPage() {
 
                 {/* 桌面端：表格 */}
                 <div className="hidden lg:block overflow-x-auto">
-                  <table className="min-w-full divide-y divide-slate-200">
+                  <table className="min-w-full divide-y divide-border">
                     <thead>
                       <tr>
                         <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase">
@@ -189,10 +189,10 @@ export function MonitorPage() {
                         </th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-slate-200">
+                    <tbody className="divide-y divide-border">
                       {status.groups.map((group) => (
-                        <tr key={group.jid} className="hover:bg-slate-50">
-                          <td className="px-4 py-3 text-sm font-medium text-slate-900">
+                        <tr key={group.jid} className="hover:bg-muted/50">
+                          <td className="px-4 py-3 text-sm font-medium text-foreground">
                             {group.jid}
                           </td>
                           <td className="px-4 py-3 text-sm text-slate-600">

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -101,7 +101,7 @@ export function RegisterPage() {
 
   if (initialized !== true || statusLoading) {
     return (
-      <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
+      <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
         <div className="text-slate-500 text-sm">加载中...</div>
       </div>
     );
@@ -110,15 +110,15 @@ export function RegisterPage() {
   // Registration disabled
   if (!status.allowRegistration) {
     return (
-      <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
+      <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
         <div className="w-full max-w-md">
-          <div className="bg-white rounded-lg border border-slate-200 p-8">
+          <div className="bg-card rounded-lg border border-border p-8">
             <div className="flex justify-center mb-6">
               <div className="w-16 h-16 rounded-2xl overflow-hidden mx-auto">
                 <img src={`${import.meta.env.BASE_URL}icons/icon-192.png`} alt="HappyClaw" className="w-full h-full object-cover" />
               </div>
             </div>
-            <h1 className="text-2xl font-bold text-slate-900 text-center mb-2">
+            <h1 className="text-2xl font-bold text-foreground text-center mb-2">
               注册已关闭
             </h1>
             <p className="text-slate-500 text-center mb-6">
@@ -137,9 +137,9 @@ export function RegisterPage() {
   }
 
   return (
-    <div className="h-screen bg-slate-50 overflow-y-auto flex items-center justify-center p-4">
+    <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        <div className="bg-white rounded-lg border border-slate-200 p-8">
+        <div className="bg-card rounded-lg border border-border p-8">
           {/* Logo */}
           <div className="flex justify-center mb-6">
             <div className="w-16 h-16 rounded-2xl overflow-hidden mx-auto">
@@ -147,7 +147,7 @@ export function RegisterPage() {
             </div>
           </div>
 
-          <h1 className="text-2xl font-bold text-slate-900 text-center mb-2">
+          <h1 className="text-2xl font-bold text-foreground text-center mb-2">
             注册新账户
           </h1>
           <p className="text-slate-500 text-center mb-6">
@@ -163,7 +163,7 @@ export function RegisterPage() {
           <form onSubmit={handleSubmit}>
             {status.requireInviteCode && (
               <div className="mb-4">
-                <label htmlFor="invite_code" className="block text-sm font-medium text-slate-700 mb-1">
+                <label htmlFor="invite_code" className="block text-sm font-medium text-foreground mb-1">
                   邀请码
                 </label>
                 <Input
@@ -180,7 +180,7 @@ export function RegisterPage() {
             )}
 
             <div className="mb-4">
-              <label htmlFor="reg-username" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="reg-username" className="block text-sm font-medium text-foreground mb-1">
                 用户名
               </label>
               <Input
@@ -195,7 +195,7 @@ export function RegisterPage() {
             </div>
 
             <div className="mb-4">
-              <label htmlFor="reg-display-name" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="reg-display-name" className="block text-sm font-medium text-foreground mb-1">
                 显示名称 <span className="text-slate-400">(可选)</span>
               </label>
               <Input
@@ -208,7 +208,7 @@ export function RegisterPage() {
             </div>
 
             <div className="mb-6">
-              <label htmlFor="reg-password" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="reg-password" className="block text-sm font-medium text-foreground mb-1">
                 密码
               </label>
               <Input

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -111,9 +111,9 @@ export function SettingsPage() {
   };
 
   return (
-    <div className="min-h-full bg-slate-50 flex flex-col lg:flex-row">
+    <div className="min-h-full bg-background flex flex-col lg:flex-row">
       {/* Mobile header */}
-      <div className="lg:hidden sticky top-0 z-10 flex items-center bg-white border-b border-slate-200 px-4 h-12">
+      <div className="lg:hidden sticky top-0 z-10 flex items-center bg-background border-b border-border px-4 h-12">
         <button
           onClick={() => setNavOpen(true)}
           className="p-1.5 -ml-1.5 rounded-lg hover:bg-slate-100 transition-colors"
@@ -127,7 +127,7 @@ export function SettingsPage() {
       {/* Mobile horizontal tab bar */}
       <div
         ref={tabBarRef}
-        className="lg:hidden flex items-center gap-1 px-3 py-2 overflow-x-auto bg-white border-b border-slate-200 [&::-webkit-scrollbar]:hidden"
+        className="lg:hidden flex items-center gap-1 px-3 py-2 overflow-x-auto bg-background border-b border-border [&::-webkit-scrollbar]:hidden"
         style={{ scrollbarWidth: 'none', WebkitOverflowScrolling: 'touch' } as React.CSSProperties}
       >
         {mobileTabs.map((tab) => {
@@ -192,13 +192,13 @@ export function SettingsPage() {
               )}
 
               {(notice || error) && (
-                <div className="bg-white rounded-xl border border-slate-200 p-4 space-y-1">
+                <div className="bg-card rounded-xl border border-border p-4 space-y-1">
                   {notice && <div className="text-sm text-green-600">{notice}</div>}
                   {error && <div className="text-sm text-red-600">{error}</div>}
                 </div>
               )}
 
-              <div className="bg-white rounded-xl border border-slate-200 p-6">
+              <div className="bg-card rounded-xl border border-border p-6">
                 {activeTab === 'channels' && <ChannelsSection setNotice={setNotice} setError={setError} />}
                 {activeTab === 'claude' && <ClaudeProviderSection setNotice={setNotice} setError={setError} />}
                 {activeTab === 'registration' && <RegistrationSection setNotice={setNotice} setError={setError} />}

--- a/web/src/pages/SetupChannelsPage.tsx
+++ b/web/src/pages/SetupChannelsPage.tsx
@@ -83,7 +83,7 @@ export function SetupChannelsPage() {
           <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center mx-auto mb-4">
             <MessageSquare className="w-6 h-6 text-primary" />
           </div>
-          <h1 className="text-2xl font-bold text-slate-900 mb-2">配置消息通道（可选）</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-2">配置消息通道（可选）</h1>
           <p className="text-sm text-slate-600">
             绑定飞书或 Telegram，即可通过 IM 与 AI 对话。跳过后也可在设置中随时配置。
           </p>
@@ -94,8 +94,8 @@ export function SetupChannelsPage() {
         )}
 
         {/* Feishu */}
-        <section className="bg-white rounded-xl border border-slate-200 shadow-sm p-5">
-          <h2 className="text-base font-semibold text-slate-900 mb-3">飞书</h2>
+        <section className="bg-card rounded-xl border border-border shadow-sm p-5">
+          <h2 className="text-base font-semibold text-foreground mb-3">飞书</h2>
           <p className="text-xs text-slate-500 mb-3">
             填写你的飞书应用凭证，绑定后即可在飞书中与 AI 对话。
           </p>
@@ -122,8 +122,8 @@ export function SetupChannelsPage() {
         </section>
 
         {/* Telegram */}
-        <section className="bg-white rounded-xl border border-slate-200 shadow-sm p-5">
-          <h2 className="text-base font-semibold text-slate-900 mb-3">Telegram</h2>
+        <section className="bg-card rounded-xl border border-border shadow-sm p-5">
+          <h2 className="text-base font-semibold text-foreground mb-3">Telegram</h2>
           <p className="text-xs text-slate-500 mb-3">
             填写 Telegram Bot Token，绑定后即可在 Telegram 中与 AI 对话。
           </p>

--- a/web/src/pages/SetupPage.tsx
+++ b/web/src/pages/SetupPage.tsx
@@ -44,14 +44,14 @@ export function SetupPage() {
   // Loading or redirecting
   if (initialized !== false) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center">
         <Loader2 className="w-16 h-16 text-primary animate-spin" />
       </div>
     );
   }
 
   return (
-    <div className="h-screen bg-slate-50 overflow-y-auto p-4 flex flex-col items-center justify-center">
+    <div className="h-screen bg-background overflow-y-auto p-4 flex flex-col items-center justify-center">
       <div className="w-full max-w-lg">
         {/* Header */}
         <div className="text-center mb-8">
@@ -60,12 +60,12 @@ export function SetupPage() {
               <img src={`${import.meta.env.BASE_URL}icons/icon-192.png`} alt="HappyClaw" className="w-full h-full object-cover" />
             </div>
           </div>
-          <h1 className="text-2xl font-bold text-slate-900 mb-1">HappyClaw 初始设置</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-1">HappyClaw 初始设置</h1>
           <p className="text-sm text-slate-500">先创建管理员账号，完成后进入后台继续配置飞书 Token 与 Claude Key</p>
         </div>
 
         {/* Step card */}
-        <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+        <div className="bg-card rounded-xl border border-border shadow-sm p-6">
           <CreateAdminStep
             onDone={() => navigate('/setup/providers', { replace: true })}
             setupAdmin={setupAdmin}
@@ -138,7 +138,7 @@ function CreateAdminStep({
 
   return (
     <div>
-      <h2 className="text-lg font-semibold text-slate-900 mb-1">创建管理员账号</h2>
+      <h2 className="text-lg font-semibold text-foreground mb-1">创建管理员账号</h2>
       <p className="text-sm text-slate-500 mb-4">首次使用请先创建管理员，提交后进入系统接入配置向导。</p>
 
       {error && (
@@ -147,7 +147,7 @@ function CreateAdminStep({
 
       <div className="space-y-3">
         <div>
-          <label className="block text-sm font-medium text-slate-700 mb-1">用户名</label>
+          <label className="block text-sm font-medium text-foreground mb-1">用户名</label>
           <Input
             type="text"
             value={username}
@@ -157,7 +157,7 @@ function CreateAdminStep({
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-slate-700 mb-1">密码</label>
+          <label className="block text-sm font-medium text-foreground mb-1">密码</label>
           <div className="relative">
             <Input
               type={showPassword ? 'text' : 'password'}
@@ -176,7 +176,7 @@ function CreateAdminStep({
           </div>
         </div>
         <div>
-          <label className="block text-sm font-medium text-slate-700 mb-1">确认密码</label>
+          <label className="block text-sm font-medium text-foreground mb-1">确认密码</label>
           <div className="relative">
             <Input
               type={showConfirm ? 'text' : 'password'}

--- a/web/src/pages/SetupProvidersPage.tsx
+++ b/web/src/pages/SetupProvidersPage.tsx
@@ -254,7 +254,7 @@ export function SetupProvidersPage() {
       <div className="w-full max-w-4xl mx-auto space-y-5">
         <div className="text-center">
           <p className="text-xs font-semibold text-primary tracking-wider mb-2">STEP 2 / 2</p>
-          <h1 className="text-2xl font-bold text-slate-900 mb-2">系统接入初始化</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-2">系统接入初始化</h1>
           <p className="text-sm text-slate-600">此页面保存的是系统全局默认配置。完成后才进入正式后台。</p>
         </div>
 
@@ -265,10 +265,10 @@ export function SetupProvidersPage() {
           <div className="p-3 rounded-lg bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm">{notice}</div>
         )}
 
-        <section className="bg-white rounded-xl border border-slate-200 shadow-sm p-5">
+        <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <div className="flex items-center gap-2 mb-3">
             <Link2 className="w-4 h-4 text-primary" />
-            <h2 className="text-base font-semibold text-slate-900">飞书配置（可选）</h2>
+            <h2 className="text-base font-semibold text-foreground">飞书配置（可选）</h2>
           </div>
           <p className="text-xs text-slate-500 mb-3">首装不预填任何默认值，全部由你手动输入。</p>
           <div className="grid md:grid-cols-2 gap-3">
@@ -293,10 +293,10 @@ export function SetupProvidersPage() {
           </div>
         </section>
 
-        <section className="bg-white rounded-xl border border-slate-200 shadow-sm p-5">
+        <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <div className="flex items-center gap-2 mb-3">
             <KeyRound className="w-4 h-4 text-primary" />
-            <h2 className="text-base font-semibold text-slate-900">Claude Code 配置（二选一）</h2>
+            <h2 className="text-base font-semibold text-foreground">Claude Code 配置（二选一）</h2>
           </div>
 
           <div className="inline-flex rounded-lg border border-slate-200 p-1 bg-slate-50 mb-4">
@@ -304,7 +304,7 @@ export function SetupProvidersPage() {
               type="button"
               onClick={() => setProviderMode('official')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'official' ? 'bg-white text-primary shadow-sm' : 'text-slate-500'
+                providerMode === 'official' ? 'bg-background text-primary shadow-sm' : 'text-slate-500'
               }`}
             >
               官方渠道
@@ -313,7 +313,7 @@ export function SetupProvidersPage() {
               type="button"
               onClick={() => setProviderMode('third_party')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'third_party' ? 'bg-white text-primary shadow-sm' : 'text-slate-500'
+                providerMode === 'third_party' ? 'bg-background text-primary shadow-sm' : 'text-slate-500'
               }`}
             >
               第三方渠道
@@ -478,7 +478,7 @@ export function SetupProvidersPage() {
           )}
         </section>
 
-        <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div className="bg-card rounded-xl border border-border shadow-sm p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
           <div className="text-sm text-slate-600 flex items-start gap-2">
             <ShieldCheck className="w-4 h-4 text-primary mt-0.5 shrink-0" />
             当前页保存的数据会作为系统全局默认配置，后续可在后台设置页继续修改。

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -72,7 +72,7 @@ export function SkillsPage() {
     <div className="min-h-full bg-slate-50">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
-        <div className="bg-white border-b border-slate-200 px-6 py-4">
+        <div className="bg-background border-b border-border px-6 py-4">
           <PageHeader
             title="技能管理"
             subtitle={`用户级 ${manualUserSkills.length + syncedUserSkills.length}${syncedUserSkills.length > 0 ? `（含同步 ${syncedUserSkills.length}）` : ''} · 项目级 ${projectSkills.length} · 启用 ${enabledCount}`}
@@ -120,7 +120,7 @@ export function SkillsPage() {
               {loading && skills.length === 0 ? (
                 <SkeletonCardList count={3} />
               ) : error ? (
-                <div className="bg-white rounded-xl border border-red-200 p-6 text-center">
+                <div className="bg-card rounded-xl border border-red-200 p-6 text-center">
                   <p className="text-red-600">{error}</p>
                 </div>
               ) : filtered.length === 0 ? (

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -74,7 +74,7 @@ export function TasksPage() {
   const otherTasks = tasks.filter((t) => t.status !== 'active' && t.status !== 'paused');
 
   return (
-    <div className="min-h-full bg-slate-50">
+    <div className="min-h-full bg-background">
       <div className="max-w-6xl mx-auto p-6">
         <PageHeader
           title="定时任务管理"

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -39,8 +39,8 @@ export function UsersPage() {
 
   if (tabs.length === 0) {
     return (
-      <div className="min-h-full bg-slate-50 p-4 lg:p-8">
-        <div className="max-w-3xl mx-auto bg-white rounded-xl border border-slate-200 p-8 text-sm text-slate-600">
+      <div className="min-h-full bg-background p-4 lg:p-8">
+        <div className="max-w-3xl mx-auto bg-card rounded-xl border border-border p-8 text-sm text-slate-600">
           当前账户无用户管理权限。
         </div>
       </div>
@@ -48,7 +48,7 @@ export function UsersPage() {
   }
 
   return (
-    <div className="min-h-full bg-slate-50 p-4 lg:p-8">
+    <div className="min-h-full bg-background p-4 lg:p-8">
       <div className="max-w-5xl mx-auto space-y-6">
         <PageHeader
           title="用户管理"
@@ -56,7 +56,7 @@ export function UsersPage() {
         />
 
         {(notice || error) && (
-          <div className="bg-white rounded-xl border border-slate-200 p-4 space-y-1">
+          <div className="bg-card rounded-xl border border-border p-4 space-y-1">
             {notice && <div className="text-sm text-green-600">{notice}</div>}
             {error && <div className="text-sm text-red-600">{error}</div>}
           </div>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -144,6 +144,54 @@
 }
 
 /* =====================================================
+   Dark mode token overrides
+   ===================================================== */
+.dark {
+  --background: #0f172a;
+  --foreground: #e2e8f0;
+  --card: #1e293b;
+  --card-foreground: #e2e8f0;
+  --popover: #1e293b;
+  --popover-foreground: #e2e8f0;
+  --primary: #2dd4bf;
+  --primary-foreground: #0f172a;
+  --secondary: #1e293b;
+  --secondary-foreground: #e2e8f0;
+  --muted: #1e293b;
+  --muted-foreground: #94a3b8;
+  --accent: #134e4a;
+  --accent-foreground: #99f6e4;
+  --destructive: #f87171;
+  --destructive-foreground: #ffffff;
+  --border: #334155;
+  --input: #334155;
+  --ring: #2dd4bf;
+
+  --sidebar-background: #0f172a;
+  --sidebar-foreground: #cbd5e1;
+  --sidebar-primary: #2dd4bf;
+  --sidebar-primary-foreground: #0f172a;
+  --sidebar-accent: #1e293b;
+  --sidebar-accent-foreground: #cbd5e1;
+  --sidebar-border: #1e293b;
+  --sidebar-ring: #2dd4bf;
+
+  --success: #4ade80;
+  --success-bg: #14532d;
+  --warning: #fbbf24;
+  --warning-bg: #451a03;
+  --error: #f87171;
+  --error-bg: #450a0a;
+
+  --glass-bg: rgba(15, 23, 42, 0.55);
+  --glass-bg-heavy: rgba(15, 23, 42, 0.80);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  --glass-highlight: linear-gradient(135deg, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0) 60%);
+  --glass-inner-shadow: inset 0 1px 1px rgba(255,255,255,0.06);
+}
+
+/* =====================================================
    Base styles
    ===================================================== */
 
@@ -183,6 +231,52 @@ pre code.hljs {
   border-radius: 8px;
   padding: 16px !important;
 }
+
+/* Dark mode syntax highlighting — GitHub Dark Dimmed */
+.dark pre code.hljs {
+  background: #22272e !important;
+  color: #adbac7 !important;
+}
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-template-tag,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-variable.language_ { color: #f47067 !important; }
+.dark .hljs-title,
+.dark .hljs-title.class_,
+.dark .hljs-title.class_.inherited__,
+.dark .hljs-title\.function_ { color: #dcbdfb !important; }
+.dark .hljs-attr,
+.dark .hljs-attribute,
+.dark .hljs-literal,
+.dark .hljs-meta,
+.dark .hljs-number,
+.dark .hljs-operator,
+.dark .hljs-variable,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-class,
+.dark .hljs-selector-id { color: #6cb6ff !important; }
+.dark .hljs-regexp,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-string { color: #96d0ff !important; }
+.dark .hljs-built_in,
+.dark .hljs-symbol { color: #f69d50 !important; }
+.dark .hljs-comment,
+.dark .hljs-code,
+.dark .hljs-formula { color: #768390 !important; }
+.dark .hljs-name,
+.dark .hljs-quote,
+.dark .hljs-selector-tag,
+.dark .hljs-selector-pseudo { color: #8ddb8c !important; }
+.dark .hljs-subst { color: #adbac7 !important; }
+.dark .hljs-section { color: #316dca !important; font-weight: bold; }
+.dark .hljs-bullet { color: #eac55f !important; }
+.dark .hljs-emphasis { color: #adbac7 !important; font-style: italic; }
+.dark .hljs-strong { color: #adbac7 !important; font-weight: bold; }
+.dark .hljs-addition { color: #b4f1b4 !important; background-color: #1b4721 !important; }
+.dark .hljs-deletion { color: #ffd8d3 !important; background-color: #78191b !important; }
 
 /* Reduced motion preference */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Closes #67

## 概述

为 HappyClaw Web 前端实现完整的暗色模式（Dark Mode）支持，包含主题系统设计、防闪烁、语法高亮适配，以及全量组件颜色迁移。

<img width="3024" height="1786" alt="dark-mode" src="https://github.com/user-attachments/assets/e97107bd-3e76-4508-b803-ddd1b14ac3e2" />

<img width="3024" height="1786" alt="darkmode2" src="https://github.com/user-attachments/assets/1822ee35-f240-40fa-a221-7347182bbc6f" />


## 架构实现

### 主题系统（`web/src/hooks/useTheme.ts`）

新增 `useTheme` Hook，核心设计：

- **三档主题**：`'light' | 'dark' | 'system'`，默认 `'system'`（跟随系统）
- **持久化**：仅 `light`/`dark` 写入 `localStorage`；`system` 模式调用 `removeItem`（key 不存在 = 跟随系统），避免 `'system'` 字符串污染存储
- **跨组件同步**：通过模块级 `listeners: Set<() => void>` + React `useSyncExternalStore` 实现，无需 Context/Provider
- **系统偏好响应**：`matchMedia('(prefers-color-scheme: dark)')` 的 `change` 事件监听，仅在 `theme === 'system'` 时触发 re-render
- **Toggle 循环**：`light → dark → system → light`

```typescript
export type Theme = 'light' | 'dark' | 'system';

// localStorage 无 key = system（跟随系统）
const setTheme = (t: Theme) => {
  if (t === 'system') localStorage.removeItem(STORAGE_KEY);
  else localStorage.setItem(STORAGE_KEY, t);
  applyTheme(t);
  listeners.forEach(cb => cb());
};
```

### 防闪烁（Anti-FOUC，`web/index.html`）

在 React 挂载前，通过内联脚本读取偏好并提前设置 `.dark` class，避免白屏闪烁：

```html
<script>(function(){
  var s = localStorage.getItem('happyclaw-theme');
  var dark = s === 'dark' || (s !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
  if (dark) document.documentElement.classList.add('dark');
})();</script>
```

### CSS 变量体系（`web/src/styles/globals.css`）

Tailwind CSS v4 暗色模式通过 `@custom-variant dark (&:is(.dark *))` 激活，`.dark` class 加在 `<html>` 上。新增完整的 CSS 变量 override block：

```css
.dark {
  --background: 15 23 42;    /* #0f172a */
  --card: 30 41 59;           /* #1e293b */
  --border: 51 65 85;         /* #334155 */
  --foreground: 226 232 240;  /* #e2e8f0 */
  /* ... */
}
```

### 暗色语法高亮

采用 GitHub Dark Dimmed 配色，通过 CSS 覆盖 highlight.js token class（`.dark .hljs-keyword`、`.dark .hljs-string` 等），无需引入额外主题包。

### Bug 修复：rehype-sanitize `class` vs `className`

`MarkdownRenderer.tsx` 中的 `sanitizeSchema` 误用了 React prop 名 `'className'`，而 `rehype-sanitize` 处理的是 HTML 属性名 `'class'`，导致所有代码块的 `.hljs` class 被剥离，语法高亮完全失效（颜色退回父级继承色）：

```typescript
// 修复前（错误）
attributes: { code: ['className'] }

// 修复后（正确）
attributes: { code: ['class', 'className'] }
```

### 全量组件颜色迁移

将 50+ 个组件/页面中的硬编码 Tailwind 颜色替换为语义 CSS 变量类：

| 旧（固定颜色） | 新（自适应语义类） |
|---|---|
| `bg-white` | `bg-background` / `bg-card` |
| `border-slate-200` | `border-border` |
| `text-slate-800` / `text-slate-900` | `text-foreground` |
| `text-slate-500` | `text-muted-foreground` |
| `bg-slate-50` | `bg-muted` / `bg-background` |
| `hover:bg-slate-100` | `hover:bg-accent` |

### 主题切换按钮（`ChatView.tsx`）

三档切换，图标随当前状态变化：
- 浅色模式 → 显示 Moon（点击切深色）
- 深色模式 → 显示 Monitor（点击切跟随系统）
- 系统模式 → 显示 Sun（点击切浅色）

## 涉及文件

- `web/src/hooks/useTheme.ts`（新增）
- `web/index.html`（Anti-FOUC）
- `web/src/styles/globals.css`（暗色变量 + 语法高亮）
- `web/src/components/chat/MarkdownRenderer.tsx`（sanitize bug fix + 暗色适配）
- `web/src/components/chat/ChatView.tsx`（三档切换按钮）
- `web/src/components/chat/AgentTabBar.tsx`
- `web/src/components/chat/StreamingDisplay.tsx`
- `web/src/components/chat/MessageInput.tsx`
- `web/src/components/chat/MessageList.tsx`
- `web/src/components/chat/MessageBubble.tsx`
- `web/src/components/layout/NavRail.tsx`
- 其他 40+ 页面与子组件（卡片、弹窗、表单、骨架屏等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)