### PR TITLE
修复: 定时任务不再泄露 agent 中间输出给用户

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -184,17 +184,10 @@ async function runTask(
       async (streamedOutput: ContainerOutput) => {
         if (streamedOutput.result) {
           result = streamedOutput.result;
-          // Forward result to user (strip <internal> tags)
-          const text = streamedOutput.result
-            .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-            .trim();
-          if (text) {
-            await deps.sendMessage(
-              groupJid,
-              `${deps.assistantName}: ${text}`,
-            );
-          }
-          // Only reset idle timer on actual results, not session-update markers
+          // Scheduled tasks should only produce user-visible output via the
+          // send_message MCP tool (IPC messages/*.json → index.ts polling).
+          // Do NOT forward raw agent text here — it contains intermediate
+          // reasoning / status updates that leak to the user as noise.
           resetIdleTimer();
         }
         if (streamedOutput.status === 'error') {


### PR DESCRIPTION
## 背景

定时任务（`task-scheduler.ts`）的 `onOutput` 回调在收到 agent 输出时，会将文本（去除 `<internal>` 标签后）直接通过 IM/Web 转发给用户。这导致 agent 的中间推理过程、状态更新等内部文本作为噪音消息发送给用户（如 "All 12 tickers scanned. Let me convert..."）。

### 原因

`onOutput` 回调中存在一段自动转发逻辑：

```typescript
// 修复前 — 所有 agent 输出都被转发
const text = streamedOutput.result
  .replace(/<internal>[\s\S]*?<\/internal>/g, '')
  .trim();
if (text) {
  await deps.sendMessage(groupJid, `${deps.assistantName}: ${text}`);
}
```

`<internal>` 标签机制要求 agent 主动包裹内部文本，但实际执行中 agent 的中间输出（工具调用状态、思考过程等）不一定被 `<internal>` 包裹，导致泄露。

### 修复方式

- 移除 `onOutput` 中的自动转发逻辑
- 定时任务的用户可见输出统一通过 `send_message` MCP 工具（IPC `messages/*.json` → `index.ts` 轮询）产出，由 agent 自主控制输出内容

## 涉及文件

| 文件 | 变更 |
|------|------|
| `src/task-scheduler.ts` | 移除 `onOutput` 回调中的 `sendMessage` 转发逻辑（-11 行，+4 行注释） |

## Test plan

- [ ] 创建定时任务，确认 agent 中间处理文本不再发送给用户
- [ ] 确认 agent 通过 `send_message` MCP 工具发送的消息仍正常到达
- [ ] 确认任务执行错误仍能正常上报（`status === 'error'` 分支未受影响）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
