### PR TITLE
功能: 会话绑定飞书群 — 支持将 conversation agent 子对话与 IM 群组双向关联

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,170 @@
+# Changelog: 会话绑定飞书群功能
+
+**版本**: 2026-03-03
+**Commit**: `3a31e87` — 功能: 会话绑定飞书群
+
+## 功能概述
+
+新增 **Conversation Agent 子对话与 IM 群组的双向绑定**能力。用户可以在 Web 端创建 conversation 类型的子对话（agent），并将其绑定到一个飞书群。绑定后：
+
+- 飞书群中的消息 **自动路由** 到该子对话的 agent 处理
+- Agent 的回复 **自动推送** 到飞书群
+- Web 端和飞书群的消息 **共享同一上下文**
+
+这使得用户可以为不同业务场景创建独立的 agent 对话（如"客服助手"、"运维值班"），并将其分别关联到不同的飞书群，实现一个 HappyClaw 工作区服务多个飞书群的能力。
+
+## 飞书 Bot 新增权限要求
+
+为支持在绑定对话框中展示群组信息（头像、名称、成员数），飞书应用需要新增以下 API 权限：
+
+| 权限名称 | 权限标识 | 用途 |
+|---------|---------|------|
+| **获取群信息** | `im:chat:readonly` | 查询群组头像、名称、成员数、聊天模式（群聊/私聊） |
+
+> **如何添加**：飞书开放平台 → 应用管理 → 你的应用 → 权限管理 → 搜索 `im:chat:readonly` → 开通
+
+如果不添加此权限，绑定功能仍可正常使用，但绑定对话框中将无法显示群组头像和成员数。
+
+## 用户操作指南
+
+### 前置条件
+
+1. HappyClaw Web 端已登录
+2. 飞书 Bot 已配置并连接（设置 → IM 通道）
+3. 至少有一个飞书群已向 Bot 发送过消息（群组会自动注册）
+
+### 操作步骤
+
+1. **创建子对话**：在 Web 聊天页面，点击 Tab 栏右侧的 `+` 按钮，创建一个 conversation 类型的子对话并命名
+2. **打开绑定对话框**：鼠标悬停在子对话 Tab 上，点击出现的 🔗 链接图标
+3. **选择飞书群**：在弹出的对话框中，浏览可用的飞书群组（支持搜索），点击「绑定」
+4. **完成**：绑定成功后，Tab 上会显示 💬 图标表示已关联 IM 群组
+5. **解绑**：再次点击 🔗 图标，在对话框中对已绑定的群组点击「解绑」
+
+### 删除子对话
+
+如果子对话已绑定 IM 群组，**必须先解绑所有群组**才能删除：
+
+1. 点击子对话 Tab 上的 ✕ 关闭按钮
+2. 系统检测到有 IM 绑定，弹出提示「该对话已绑定 IM 群组（xxx），请先解绑后再删除」
+3. 自动打开绑定对话框，逐一点击「解绑」
+4. 全部解绑后，再次点击 ✕ 即可删除
+
+### 注意事项
+
+- 每个飞书群 **只能绑定一个** 子对话（一对一关系）
+- 私聊（P2P）不支持绑定，绑定列表中仅显示群聊
+- 删除子对话前 **必须先解绑** 所有关联的 IM 群组（后端返回 409 阻止直接删除）
+- 绑定后，飞书群的消息不再走主对话，而是直接进入子对话上下文
+
+## 绑定流程图
+
+```mermaid
+flowchart TD
+    A[用户在 Web 端创建 Conversation 子对话] --> B[点击子对话 Tab 上的 🔗 图标]
+    B --> C[弹出 IM 绑定对话框]
+    C --> D{飞书群列表是否为空？}
+    D -->|是| E[提示：请先在飞书群中向 Bot 发消息]
+    E --> F[用户在飞书群 @Bot 或发送消息]
+    F --> G[群组自动注册到 HappyClaw]
+    G --> C
+    D -->|否| H[浏览群组列表 / 搜索]
+    H --> I[点击「绑定」按钮]
+    I --> J{群组是否已绑定其他子对话？}
+    J -->|是| K[显示「已绑定到其他对话」，按钮置灰]
+    J -->|否| L[绑定成功 ✅]
+    L --> M[Tab 上显示 💬 图标]
+
+    subgraph 删除子对话
+        DA[点击子对话 Tab 上的 ✕] --> DB{有 IM 绑定？}
+        DB -->|是| DC[弹出提示：请先解绑]
+        DC --> DD[自动打开绑定对话框]
+        DD --> DE[用户逐一解绑]
+        DE --> DA
+        DB -->|否| DF[删除成功 ✅]
+    end
+
+    subgraph 消息流转
+        N[飞书群用户发消息] --> O{该群是否配置了 target_agent_id？}
+        O -->|否| P[消息进入主对话]
+        O -->|是| Q[消息路由到子对话 Agent]
+        Q --> R[Agent 处理并回复]
+        R --> S[回复推送到飞书群]
+        R --> T[回复同步显示在 Web 端子对话]
+    end
+```
+
+## 消息路由架构图
+
+```mermaid
+sequenceDiagram
+    participant U as 飞书群用户
+    participant F as 飞书 WebSocket
+    participant H as HappyClaw 后端
+    participant A as Conversation Agent
+    participant W as Web 前端
+
+    U->>F: 在绑定的飞书群发送消息
+    F->>H: 消息到达 feishu.ts
+    H->>H: resolveEffectiveChatJid()<br/>检查 target_agent_id
+
+    alt 群组已绑定子对话
+        H->>H: 消息存储到虚拟 JID<br/>web:main#agent:xxx
+        H->>W: WebSocket broadcast<br/>(agentId 标识)
+        H->>A: onAgentMessage()<br/>触发 processAgentConversation
+        A->>A: Agent 处理消息
+        A->>H: Agent 输出回复
+        H->>F: imManager.sendMessage()<br/>推送到飞书群
+        H->>W: WebSocket broadcast<br/>同步到 Web 端
+        F->>U: 飞书群收到回复
+    else 群组未绑定
+        H->>H: 消息存储到主 JID
+        H->>W: WebSocket broadcast
+        H->>A: 常规消息处理流程
+    end
+```
+
+## 技术变更详情
+
+### 数据库
+
+| 变更 | 说明 |
+|------|------|
+| Schema 版本 | v18 → v19 |
+| 新增字段 | `registered_groups.target_agent_id TEXT` |
+| 新增查询 | `getGroupsByTargetAgent(agentId)` — 查找路由到指定 agent 的所有 IM 群组 |
+
+### 后端 API
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/groups/:jid/im-groups` | 列出当前 folder 下可绑定的 IM 群组（过滤 Web JID 和私聊） |
+| PUT | `/api/groups/:jid/agents/:agentId/im-binding` | 将 IM 群组绑定到子对话 |
+| DELETE | `/api/groups/:jid/agents/:agentId/im-binding/:imJid` | 解除绑定 |
+
+### 后端核心逻辑（src/index.ts）
+
+- `buildResolveEffectiveChatJid()` — 根据 `target_agent_id` 将 IM chatJid 映射到虚拟 agent JID
+- `buildOnAgentMessage()` — IM 消息触发 `processAgentConversation`
+- `processAgentConversation` 输出时遍历 `getGroupsByTargetAgent()` 向已绑定 IM 群组推送回复
+- DELETE agent 接口：有 IM 绑定时返回 409 + `linked_im_groups`，阻止直接删除
+- 消息循环中跳过有 `target_agent_id` 的群组（避免重复处理）
+
+### 前端
+
+| 文件 | 变更 |
+|------|------|
+| `ImBindingDialog.tsx` | **新增** — 绑定/解绑对话框组件 |
+| `AgentTabBar.tsx` | 绑定状态图标 + 快捷绑定按钮 |
+| `ChatView.tsx` | 集成 ImBindingDialog |
+| `chat.ts` (store) | `loadAvailableImGroups`、`bindImGroup`、`unbindImGroup` actions |
+| `types.ts` | `AvailableImGroup`、`AgentInfo.linked_im_groups` |
+
+### 其他改动
+
+| 变更 | 说明 |
+|------|------|
+| Docker 镜像加速 | `NODE_IMAGE` 构建参数，支持国内镜像源 |
+| Makefile | 合并上游 `maybe-build-image` 宏 + 依赖变更自动检测 |
+| runtime-config | `normalizeSecret()` 清理非 ASCII 字符（如智能引号） |
+| agent-runner | 新增 `@modelcontextprotocol/sdk` 依赖 |

--- a/src/db.ts
+++ b/src/db.ts
@@ -294,6 +294,7 @@ export function initDatabase(): void {
   ensureColumn('registered_groups', 'selected_skills', 'TEXT');
   ensureColumn('sessions', 'agent_id', "TEXT NOT NULL DEFAULT ''");
   ensureColumn('agents', 'kind', "TEXT NOT NULL DEFAULT 'task'");
+  ensureColumn('registered_groups', 'target_agent_id', 'TEXT');
 
   // Migration: remove UNIQUE constraint from registered_groups.folder
   // Multiple groups (web:main + feishu chats) share folder='main' by design.
@@ -371,6 +372,7 @@ export function initDatabase(): void {
       'created_by',
       'is_home',
       'selected_skills',
+      'target_agent_id',
     ],
     ['trigger_pattern', 'requires_trigger'],
   );
@@ -516,7 +518,7 @@ export function initDatabase(): void {
     })();
   }
 
-  const SCHEMA_VERSION = '18';
+  const SCHEMA_VERSION = '19';
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', SCHEMA_VERSION);
@@ -959,6 +961,7 @@ export function getRegisteredGroup(
         created_by: string | null;
         is_home: number;
         selected_skills: string | null;
+        target_agent_id: string | null;
       }
     | undefined;
   if (!row) return undefined;
@@ -978,13 +981,14 @@ export function getRegisteredGroup(
     created_by: row.created_by ?? undefined,
     is_home: row.is_home === 1,
     selected_skills: row.selected_skills ? JSON.parse(row.selected_skills) : null,
+    target_agent_id: row.target_agent_id ?? undefined,
   };
 }
 
 export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, added_at, container_config, execution_mode, custom_cwd, init_source_path, init_git_url, created_by, is_home, selected_skills)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, added_at, container_config, execution_mode, custom_cwd, init_source_path, init_git_url, created_by, is_home, selected_skills, target_agent_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -998,6 +1002,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.created_by ?? null,
     group.is_home ? 1 : 0,
     group.selected_skills ? JSON.stringify(group.selected_skills) : null,
+    group.target_agent_id ?? null,
   );
 }
 
@@ -1026,6 +1031,7 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
     init_git_url: string | null;
     created_by: string | null;
     is_home: number;
+    target_agent_id: string | null;
   }>;
   const result: Record<string, RegisteredGroup> = {};
   for (const row of rows) {
@@ -1042,9 +1048,47 @@ export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
       initGitUrl: row.init_git_url ?? undefined,
       created_by: row.created_by ?? undefined,
       is_home: row.is_home === 1,
+      target_agent_id: row.target_agent_id ?? undefined,
     };
   }
   return result;
+}
+
+/**
+ * Get all registered groups that route to a specific conversation agent.
+ * Returns array of { jid, group } for each IM group targeting the given agentId.
+ */
+export function getGroupsByTargetAgent(agentId: string): Array<{ jid: string; group: RegisteredGroup }> {
+  const rows = db.prepare(
+    'SELECT * FROM registered_groups WHERE target_agent_id = ?',
+  ).all(agentId) as Array<{
+    jid: string;
+    name: string;
+    folder: string;
+    added_at: string;
+    container_config: string | null;
+    execution_mode: string | null;
+    custom_cwd: string | null;
+    init_source_path: string | null;
+    init_git_url: string | null;
+    created_by: string | null;
+    is_home: number;
+    target_agent_id: string | null;
+  }>;
+  return rows.map((row) => ({
+    jid: row.jid,
+    group: {
+      name: row.name,
+      folder: row.folder,
+      added_at: row.added_at,
+      containerConfig: row.container_config ? JSON.parse(row.container_config) : undefined,
+      executionMode: parseExecutionMode(row.execution_mode, `group ${row.jid}`),
+      customCwd: row.custom_cwd ?? undefined,
+      created_by: row.created_by ?? undefined,
+      is_home: row.is_home === 1,
+      target_agent_id: row.target_agent_id ?? undefined,
+    },
+  }));
 }
 
 /**

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -37,6 +37,18 @@ export interface ConnectOptions {
   onCommand?: (chatJid: string, command: string) => Promise<string | null>;
   /** 根据 chatJid 解析群组 folder，用于下载文件/图片到工作区 */
   resolveGroupFolder?: (chatJid: string) => string | undefined;
+  /** 将 IM chatJid 解析为 conversation agent 虚拟 JID */
+  resolveEffectiveChatJid?: (chatJid: string) => { effectiveJid: string; agentId: string } | null;
+  /** 当 IM 消息被路由到 conversation agent 后调用 */
+  onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+}
+
+export interface FeishuChatInfo {
+  avatar?: string;
+  name?: string;
+  user_count?: string;
+  chat_type?: string;
+  chat_mode?: string; // 'p2p' | 'group'
 }
 
 export interface FeishuConnection {
@@ -46,6 +58,7 @@ export interface FeishuConnection {
   sendReaction(chatId: string, isTyping: boolean): Promise<void>;
   isConnected(): boolean;
   syncGroups(): Promise<void>;
+  getChatInfo(chatId: string): Promise<FeishuChatInfo | null>;
 }
 
 // ─── Shared Helpers (pure functions, no instance state) ────────
@@ -504,7 +517,7 @@ export function createFeishuConnection(config: FeishuConnectionConfig): FeishuCo
     payload: IncomingMessagePayload,
     source: 'ws' | 'backfill',
   ): Promise<void> {
-    const { onNewChat, ignoreMessagesBefore, onCommand, resolveGroupFolder } = connectOptions || {};
+    const { onNewChat, ignoreMessagesBefore, onCommand, resolveGroupFolder, resolveEffectiveChatJid, onAgentMessage } = connectOptions || {};
     const {
       chatId,
       messageId,
@@ -624,32 +637,66 @@ export function createFeishuConnection(config: FeishuConnectionConfig): FeishuCo
       return;
     }
 
-    storeChatMetadata(chatJid, timestamp);
-    storeMessageDirect(
-      messageId,
-      chatJid,
-      senderOpenId,
-      resolvedSenderName,
-      text,
-      timestamp,
-      false,
-      attachmentsJson,
-    );
+    // Check if this IM chat should route to a conversation agent
+    const agentRouting = resolveEffectiveChatJid?.(chatJid);
+    if (agentRouting) {
+      const { effectiveJid, agentId } = agentRouting;
+      storeChatMetadata(effectiveJid, timestamp);
+      storeMessageDirect(
+        messageId,
+        effectiveJid,
+        senderOpenId,
+        resolvedSenderName,
+        text,
+        timestamp,
+        false,
+        attachmentsJson,
+      );
 
-    broadcastNewMessage(chatJid, {
-      id: messageId,
-      chat_jid: chatJid,
-      sender: senderOpenId,
-      sender_name: resolvedSenderName,
-      content: text,
-      timestamp,
-      attachments: attachmentsJson,
-    });
+      broadcastNewMessage(effectiveJid, {
+        id: messageId,
+        chat_jid: effectiveJid,
+        sender: senderOpenId,
+        sender_name: resolvedSenderName,
+        content: text,
+        timestamp,
+        attachments: attachmentsJson,
+      }, agentId);
 
-    logger.info(
-      { chatJid, sender: resolvedSenderName, messageId, source },
-      'Feishu message stored',
-    );
+      onAgentMessage?.(chatJid, agentId);
+
+      logger.info(
+        { chatJid, effectiveJid, agentId, sender: resolvedSenderName, messageId, source },
+        'Feishu message routed to conversation agent',
+      );
+    } else {
+      storeChatMetadata(chatJid, timestamp);
+      storeMessageDirect(
+        messageId,
+        chatJid,
+        senderOpenId,
+        resolvedSenderName,
+        text,
+        timestamp,
+        false,
+        attachmentsJson,
+      );
+
+      broadcastNewMessage(chatJid, {
+        id: messageId,
+        chat_jid: chatJid,
+        sender: senderOpenId,
+        sender_name: resolvedSenderName,
+        content: text,
+        timestamp,
+        attachments: attachmentsJson,
+      });
+
+      logger.info(
+        { chatJid, sender: resolvedSenderName, messageId, source },
+        'Feishu message stored',
+      );
+    }
   }
 
   async function backfillChatMessages(chatId: string, sinceMs: number): Promise<void> {
@@ -1030,6 +1077,26 @@ export function createFeishuConnection(config: FeishuConnectionConfig): FeishuCo
 
     isConnected(): boolean {
       return wsClient != null;
+    },
+
+    async getChatInfo(chatId: string): Promise<FeishuChatInfo | null> {
+      if (!client) return null;
+      try {
+        const res = await client.im.v1.chat.get({
+          path: { chat_id: chatId },
+        });
+        if (!res.data) return null;
+        return {
+          avatar: res.data.avatar,
+          name: res.data.name,
+          user_count: res.data.user_count,
+          chat_type: res.data.chat_type,
+          chat_mode: res.data.chat_mode,
+        };
+      } catch (err) {
+        logger.warn({ err, chatId }, 'Failed to get Feishu chat info');
+        return null;
+      }
     },
 
     async syncGroups(): Promise<void> {

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -29,6 +29,10 @@ export interface IMChannelConnectOpts {
   onCommand?: (chatJid: string, command: string) => Promise<string | null>;
   /** 根据 jid 解析群组 folder，用于下载文件/图片到工作区 */
   resolveGroupFolder?: (jid: string) => string | undefined;
+  /** 将 IM chatJid 解析为 conversation agent 虚拟 JID（如果该群组绑定了 target_agent_id） */
+  resolveEffectiveChatJid?: (chatJid: string) => { effectiveJid: string; agentId: string } | null;
+  /** 当 IM 消息被路由到 conversation agent 后调用，触发 agent 处理 */
+  onAgentMessage?: (baseChatJid: string, agentId: string) => void;
 }
 
 export interface IMChannel {
@@ -39,6 +43,7 @@ export interface IMChannel {
   setTyping(chatId: string, isTyping: boolean): Promise<void>;
   isConnected(): boolean;
   syncGroups?(): Promise<void>;
+  getChatInfo?(chatId: string): Promise<{ avatar?: string; name?: string; user_count?: string; chat_type?: string; chat_mode?: string } | null>;
 }
 
 // ─── Channel Registry ───────────────────────────────────────────
@@ -85,6 +90,8 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
         ignoreMessagesBefore: opts.ignoreMessagesBefore,
         onCommand: opts.onCommand,
         resolveGroupFolder: opts.resolveGroupFolder,
+        resolveEffectiveChatJid: opts.resolveEffectiveChatJid,
+        onAgentMessage: opts.onAgentMessage,
       });
       if (!connected) {
         inner = null;
@@ -119,6 +126,11 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
     async syncGroups(): Promise<void> {
       if (!inner) return;
       await inner.syncGroups();
+    },
+
+    async getChatInfo(chatId: string) {
+      if (!inner) return null;
+      return inner.getChatInfo(chatId);
     },
   };
 

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -174,6 +174,8 @@ class IMConnectionManager {
     ignoreMessagesBefore?: number,
     onCommand?: (chatJid: string, command: string) => Promise<string | null>,
     resolveGroupFolder?: (chatJid: string) => string | undefined,
+    resolveEffectiveChatJid?: (chatJid: string) => { effectiveJid: string; agentId: string } | null,
+    onAgentMessage?: (baseChatJid: string, agentId: string) => void,
   ): Promise<boolean> {
     if (!config.appId || !config.appSecret) {
       logger.info({ userId }, 'Feishu config empty, skipping connection');
@@ -193,6 +195,8 @@ class IMConnectionManager {
       ignoreMessagesBefore,
       onCommand,
       resolveGroupFolder,
+      resolveEffectiveChatJid,
+      onAgentMessage,
     });
   }
 
@@ -335,6 +339,13 @@ class IMConnectionManager {
   /** Get the Telegram channel for a user */
   getTelegramConnection(userId: string): IMChannel | undefined {
     return this.connections.get(userId)?.channels.get('telegram');
+  }
+
+  /** Get chat info from the Feishu API for a specific user's connection */
+  async getFeishuChatInfo(userId: string, chatId: string): Promise<{ avatar?: string; name?: string; user_count?: string; chat_type?: string; chat_mode?: string } | null> {
+    const channel = this.getFeishuConnection(userId);
+    if (!channel?.getChatInfo) return null;
+    return channel.getChatInfo(chatId);
   }
 
   /** Get all user IDs with active connections */

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import {
   markAllRunningTaskAgentsAsError,
   getSession,
   listAgentsByJid,
+  getGroupsByTargetAgent,
 } from './db.js';
 // feishu.js deprecated exports are no longer needed; imManager handles all connections
 import { imManager } from './im-manager.js';
@@ -1594,11 +1595,16 @@ async function processTaskIpc(
         break;
       }
       if (data.jid && data.name && data.folder) {
+        // Inherit created_by from the source group so onNewChat won't re-route
+        const sourceEntry = Object.values(registeredGroups).find(
+          (g) => g.folder === sourceGroup,
+        );
         registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
           added_at: new Date().toISOString(),
           containerConfig: data.containerConfig,
+          created_by: sourceEntry?.created_by,
         });
       } else {
         logger.warn(
@@ -1842,6 +1848,18 @@ async function processAgentConversation(chatJid: string, agentId: string): Promi
           timestamp,
           is_from_me: true,
         }, agentId);
+
+        // Send reply to linked IM channels (Feishu/Telegram groups with target_agent_id)
+        const linkedImGroups = getGroupsByTargetAgent(agentId);
+        for (const { jid: imJid } of linkedImGroups) {
+          const channelType = getChannelType(imJid);
+          if (channelType) {
+            imManager.sendMessage(imJid, text).catch((err) => {
+              logger.warn({ imJid, agentId, err }, 'Failed to send agent reply to linked IM channel');
+            });
+          }
+        }
+
         commitCursor();
         resetIdleTimer();
       }
@@ -1980,6 +1998,11 @@ async function startMessageLoop(): Promise<void> {
             }
           }
           if (!group) continue;
+
+          // Skip groups with target_agent_id — their messages are routed
+          // to conversation agents at IM ingestion time (feishu.ts/telegram.ts)
+          if (group.target_agent_id) continue;
+
           if (group.is_home) homeFolders.add(group.folder);
 
           // Handle cold-cache/newly-added groups: detect home folders from DB
@@ -2177,6 +2200,10 @@ function buildOnNewChat(userId: string, homeFolder: string): (chatJid: string, c
       // Already owned by this user — nothing to do
       if (existing.created_by === userId) return;
 
+      // Don't override groups that have target_agent_id configured
+      // (manually bound IM groups routing to conversation agents)
+      if (existing.target_agent_id) return;
+
       // Different user's connection now owns this IM app.
       // Re-route the chat to the current user's home folder.
       // This handles the common case where the same Feishu app credentials
@@ -2225,6 +2252,57 @@ function buildOnPairAttempt(userId: string): (jid: string, chatName: string, cod
 }
 
 /**
+ * Build callback that resolves an IM chatJid to a conversation agent virtual JID.
+ * Returns null if the chatJid has no target_agent_id configured.
+ */
+function buildResolveEffectiveChatJid(): (chatJid: string) => { effectiveJid: string; agentId: string } | null {
+  return (chatJid: string) => {
+    const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+    if (!group?.target_agent_id) return null;
+    // Construct the virtual JID: web:{folder}#agent:{agentId}
+    const effectiveJid = `web:${group.folder}#agent:${group.target_agent_id}`;
+    return { effectiveJid, agentId: group.target_agent_id };
+  };
+}
+
+/**
+ * Build callback that triggers processAgentConversation when an IM message is routed to an agent.
+ */
+function buildOnAgentMessage(): (baseChatJid: string, agentId: string) => void {
+  return (baseChatJid: string, agentId: string) => {
+    const group = registeredGroups[baseChatJid] ?? getRegisteredGroup(baseChatJid);
+    if (!group) return;
+    // The base chatJid for processAgentConversation is the web: JID of the home folder
+    const homeChatJid = `web:${group.folder}`;
+    const virtualChatJid = `${homeChatJid}#agent:${agentId}`;
+
+    // Fetch pending messages and format them for IPC (same as web.ts agent handler)
+    const sinceCursor = lastAgentTimestamp[virtualChatJid] || EMPTY_CURSOR;
+    const missedMessages = getMessagesSince(virtualChatJid, sinceCursor);
+    const formatted = missedMessages.length > 0
+      ? formatMessages(missedMessages, false)
+      : '';
+
+    // Collect images from the messages
+    const images = collectMessageImages(virtualChatJid, missedMessages);
+    const imagesForAgent = images.length > 0 ? images : undefined;
+
+    // Try to pipe into running agent process first
+    const sendResult = formatted
+      ? queue.sendMessage(virtualChatJid, formatted, imagesForAgent, undefined)
+      : 'no_active';
+    if (sendResult === 'no_active') {
+      // No running process (or no messages to pipe) — start one via processAgentConversation
+      const taskId = `agent-conv:${agentId}:${Date.now()}`;
+      queue.enqueueTask(virtualChatJid, taskId, async () => {
+        await processAgentConversation(homeChatJid, agentId);
+      });
+    }
+    logger.info({ baseChatJid, homeChatJid, agentId, messageCount: missedMessages.length }, 'IM message triggered agent conversation processing');
+  };
+}
+
+/**
  * Connect IM channels for a specific user via imManager.
  * Reads the user's IM config and connects if enabled.
  */
@@ -2240,11 +2318,13 @@ async function connectUserIMChannels(
     const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
     return group?.folder;
   };
+  const resolveEffectiveChatJid = buildResolveEffectiveChatJid();
+  const onAgentMessage = buildOnAgentMessage();
   let feishu = false;
   let telegram = false;
 
   if (feishuConfig && feishuConfig.enabled !== false && feishuConfig.appId && feishuConfig.appSecret) {
-    feishu = await imManager.connectUserFeishu(userId, feishuConfig, onNewChat, ignoreMessagesBefore, handleCommand, resolveGroupFolder);
+    feishu = await imManager.connectUserFeishu(userId, feishuConfig, onNewChat, ignoreMessagesBefore, handleCommand, resolveGroupFolder, resolveEffectiveChatJid, onAgentMessage);
   }
 
   if (telegramConfig && telegramConfig.enabled !== false && telegramConfig.botToken) {
@@ -2600,6 +2680,7 @@ async function main(): Promise<void> {
     isUserFeishuConnected: (userId: string) => imManager.isFeishuConnected(userId),
     isUserTelegramConnected: (userId: string) => imManager.isTelegramConnected(userId),
     processAgentConversation,
+    getFeishuChatInfo: (userId: string, chatId: string) => imManager.getFeishuChatInfo(userId, chatId),
   });
 
   // Clean expired sessions every hour

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -16,6 +16,9 @@ import {
   ensureChatExists,
   deleteMessagesForChatJid,
   deleteSession,
+  getGroupsByTargetAgent,
+  getJidsByFolder,
+  setRegisteredGroup,
 } from '../db.js';
 import { DATA_DIR } from '../config.js';
 import type { SubAgent } from '../types.js';
@@ -39,16 +42,26 @@ router.get('/:jid/agents', authMiddleware, async (c) => {
 
   const agents = listAgentsByJid(jid);
   return c.json({
-    agents: agents.map((a) => ({
-      id: a.id,
-      name: a.name,
-      prompt: a.prompt,
-      status: a.status,
-      kind: a.kind,
-      created_at: a.created_at,
-      completed_at: a.completed_at,
-      result_summary: a.result_summary,
-    })),
+    agents: agents.map((a) => {
+      const base = {
+        id: a.id,
+        name: a.name,
+        prompt: a.prompt,
+        status: a.status,
+        kind: a.kind,
+        created_at: a.created_at,
+        completed_at: a.completed_at,
+        result_summary: a.result_summary,
+      };
+      if (a.kind === 'conversation') {
+        const linked = getGroupsByTargetAgent(a.id);
+        return {
+          ...base,
+          linked_im_groups: linked.map((l) => ({ jid: l.jid, name: l.group.name })),
+        };
+      }
+      return base;
+    }),
   });
 });
 
@@ -145,6 +158,20 @@ router.delete('/:jid/agents/:agentId', authMiddleware, async (c) => {
     return c.json({ error: 'Agent not found' }, 404);
   }
 
+  // Block deletion if conversation agent has active IM bindings
+  if (agent.kind === 'conversation') {
+    const linkedImGroups = getGroupsByTargetAgent(agentId);
+    if (linkedImGroups.length > 0) {
+      return c.json({
+        error: 'Agent has active IM bindings. Unbind all IM groups before deleting.',
+        linked_im_groups: linkedImGroups.map(({ jid: imJid, group: imGroup }) => ({
+          jid: imJid,
+          name: imGroup.name,
+        })),
+      }, 409);
+    }
+  }
+
   // If the agent is still running or idle, stop the process
   if (agent.status === 'running' || agent.status === 'idle') {
     updateAgentStatus(agentId, 'error', '用户手动停止');
@@ -166,6 +193,9 @@ router.delete('/:jid/agents/:agentId', authMiddleware, async (c) => {
   if (agent.kind === 'conversation') {
     const virtualChatJid = `${jid}#agent:${agentId}`;
     deleteMessagesForChatJid(virtualChatJid);
+
+    // Note: IM bindings are checked above and block deletion if present.
+    // No auto-clear here — user must unbind explicitly before deleting.
   }
 
   // Delete session records
@@ -178,6 +208,188 @@ router.delete('/:jid/agents/:agentId', authMiddleware, async (c) => {
   broadcastAgentStatus(jid, agentId, 'error', agent.name, agent.prompt, '__removed__');
 
   logger.info({ agentId, jid, userId: user.id }, 'Agent deleted by user');
+  return c.json({ success: true });
+});
+
+// Helper: check if a Telegram JID is a private/P2P chat
+function isTelegramPrivateChat(jid: string): boolean {
+  if (!jid.startsWith('telegram:')) return false;
+  const id = jid.slice('telegram:'.length);
+  return !id.startsWith('-');
+}
+
+// GET /api/groups/:jid/im-groups — list available IM group chats for this folder
+router.get('/:jid/im-groups', authMiddleware, async (c) => {
+  const jid = decodeURIComponent(c.req.param('jid'));
+  const user = c.get('user');
+
+  const group = getRegisteredGroup(jid);
+  if (!group) {
+    return c.json({ error: 'Group not found' }, 404);
+  }
+  if (!canAccessGroup(user, { ...group, jid })) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const siblingJids = getJidsByFolder(group.folder);
+  // Pre-filter: exclude web JIDs and Telegram private chats
+  const imJids = siblingJids.filter((j) => !j.startsWith('web:') && !isTelegramPrivateChat(j));
+
+  // Build candidate list
+  interface ImGroupCandidate {
+    jid: string;
+    name: string;
+    bound_agent_id: string | null;
+    avatar?: string;
+    member_count?: number;
+    channel_type: string;
+    chat_mode?: string; // 'p2p' | 'group' — from Feishu API (distinguishes P2P vs group chat)
+  }
+
+  const candidates: ImGroupCandidate[] = [];
+  for (const j of imJids) {
+    const g = getRegisteredGroup(j);
+    if (!g) continue;
+    candidates.push({
+      jid: j,
+      name: g.name,
+      bound_agent_id: g.target_agent_id ?? null,
+      channel_type: j.startsWith('feishu:') ? 'feishu' : j.startsWith('telegram:') ? 'telegram' : 'unknown',
+    });
+  }
+
+  // Enrich Feishu groups with avatar, member count, and chat_mode
+  const deps = getWebDeps();
+  if (deps?.getFeishuChatInfo) {
+    const feishuCandidates = candidates.filter((g) => g.channel_type === 'feishu');
+    const chatInfoPromises = feishuCandidates.map(async (g) => {
+      const chatId = g.jid.slice('feishu:'.length);
+      const info = await deps.getFeishuChatInfo!(user.id, chatId);
+      if (info) {
+        g.avatar = info.avatar;
+        g.chat_mode = info.chat_mode;
+        if (info.user_count) g.member_count = parseInt(info.user_count, 10) || undefined;
+        if (info.name && info.name !== g.name) g.name = info.name;
+      }
+    });
+    await Promise.allSettled(chatInfoPromises);
+  }
+
+  // Feishu chat_mode: 'group' = group chat, 'p2p' = private chat
+  // If chat_mode is available, use it directly. If API returned partial data
+  // (has name/avatar but no chat_mode), still include it (likely a group chat
+  // with limited API permissions). Filter out entries with no useful data (P2P).
+  const imGroups = candidates
+    .filter((g) => {
+      if (g.channel_type === 'feishu') {
+        if (g.chat_mode === 'p2p') return false;
+        if (g.chat_mode === 'group') return true;
+        // chat_mode missing: keep if API returned a name (group chats have names, P2P don't)
+        return !!g.avatar || g.member_count !== undefined;
+      }
+      return true;
+    })
+    .map(({ chat_mode: _, ...rest }) => rest);
+
+  return c.json({ imGroups });
+});
+
+// PUT /api/groups/:jid/agents/:agentId/im-binding — bind an IM group to this agent
+router.put('/:jid/agents/:agentId/im-binding', authMiddleware, async (c) => {
+  const jid = decodeURIComponent(c.req.param('jid'));
+  const agentId = c.req.param('agentId');
+  const user = c.get('user');
+
+  const group = getRegisteredGroup(jid);
+  if (!group) {
+    return c.json({ error: 'Group not found' }, 404);
+  }
+  if (!canAccessGroup(user, { ...group, jid })) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const agent = getAgent(agentId);
+  if (!agent || agent.chat_jid !== jid) {
+    return c.json({ error: 'Agent not found' }, 404);
+  }
+  if (agent.kind !== 'conversation') {
+    return c.json({ error: 'Only conversation agents can bind IM groups' }, 400);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const imJid = typeof body.im_jid === 'string' ? body.im_jid.trim() : '';
+  if (!imJid) {
+    return c.json({ error: 'im_jid is required' }, 400);
+  }
+
+  const imGroup = getRegisteredGroup(imJid);
+  if (!imGroup) {
+    return c.json({ error: 'IM group not found' }, 404);
+  }
+  if (imGroup.folder !== group.folder) {
+    return c.json({ error: 'IM group must be in the same folder' }, 400);
+  }
+  if (imGroup.target_agent_id && imGroup.target_agent_id !== agentId) {
+    return c.json({ error: 'IM group is already bound to another agent' }, 409);
+  }
+
+  // Update DB
+  setRegisteredGroup(imJid, { ...imGroup, target_agent_id: agentId });
+
+  // Update in-memory cache
+  const deps = getWebDeps();
+  if (deps) {
+    const groups = deps.getRegisteredGroups();
+    if (groups[imJid]) {
+      groups[imJid].target_agent_id = agentId;
+    }
+  }
+
+  logger.info({ imJid, agentId, userId: user.id }, 'IM group bound to agent');
+  return c.json({ success: true });
+});
+
+// DELETE /api/groups/:jid/agents/:agentId/im-binding/:imJid — unbind an IM group
+router.delete('/:jid/agents/:agentId/im-binding/:imJid', authMiddleware, async (c) => {
+  const jid = decodeURIComponent(c.req.param('jid'));
+  const agentId = c.req.param('agentId');
+  const imJid = decodeURIComponent(c.req.param('imJid'));
+  const user = c.get('user');
+
+  const group = getRegisteredGroup(jid);
+  if (!group) {
+    return c.json({ error: 'Group not found' }, 404);
+  }
+  if (!canAccessGroup(user, { ...group, jid })) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const agent = getAgent(agentId);
+  if (!agent || agent.chat_jid !== jid) {
+    return c.json({ error: 'Agent not found' }, 404);
+  }
+
+  const imGroup = getRegisteredGroup(imJid);
+  if (!imGroup) {
+    return c.json({ error: 'IM group not found' }, 404);
+  }
+  if (imGroup.target_agent_id !== agentId) {
+    return c.json({ error: 'IM group is not bound to this agent' }, 400);
+  }
+
+  // Update DB
+  setRegisteredGroup(imJid, { ...imGroup, target_agent_id: undefined });
+
+  // Update in-memory cache
+  const deps = getWebDeps();
+  if (deps) {
+    const groups = deps.getRegisteredGroups();
+    if (groups[imJid]) {
+      groups[imJid].target_agent_id = undefined;
+    }
+  }
+
+  logger.info({ imJid, agentId, userId: user.id }, 'IM group unbound from agent');
   return c.json({ success: true });
 });
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -206,9 +206,10 @@ function normalizeSecret(input: unknown, fieldName: string): string {
   if (typeof input !== 'string') {
     throw new Error(`Invalid field: ${fieldName}`);
   }
-  // Strip ALL whitespace — API keys/tokens never contain spaces;
-  // users often paste with accidental spaces or line breaks.
-  const value = input.replace(/\s+/g, '');
+  // Strip ALL whitespace and non-ASCII characters — API keys/tokens are always ASCII;
+  // users often paste with accidental spaces, line breaks, or smart quotes (e.g. U+2019).
+  // eslint-disable-next-line no-control-regex
+  const value = input.replace(/\s+/g, '').replace(/[^\x00-\x7F]/g, '');
   if (value.length > MAX_FIELD_LENGTH) {
     throw new Error(`Field too long: ${fieldName}`);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface RegisteredGroup {
   created_by?: string;
   is_home?: boolean; // 用户主容器标记
   selected_skills?: string[] | null; // null = 全部启用
+  target_agent_id?: string; // IM 消息路由到指定 conversation agent
 }
 
 export interface GroupMember {

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -30,6 +30,7 @@ export interface WebDeps {
   isUserFeishuConnected?: (userId: string) => boolean;
   isUserTelegramConnected?: (userId: string) => boolean;
   processAgentConversation?: (chatJid: string, agentId: string) => Promise<void>;
+  getFeishuChatInfo?: (userId: string, chatId: string) => Promise<{ avatar?: string; name?: string; user_count?: string; chat_type?: string; chat_mode?: string } | null>;
 }
 
 export type Variables = {

--- a/src/web.ts
+++ b/src/web.ts
@@ -1173,17 +1173,21 @@ export function broadcastNewMessage(
   msg: NewMessage & { is_from_me?: boolean },
   agentId?: string,
 ): void {
-  // For virtual JIDs like "web:xxx#agent:yyy", extract base JID for broadcast
-  const baseChatJid = chatJid.includes('#agent:')
-    ? chatJid.split('#agent:')[0]
-    : chatJid;
+  // For virtual JIDs like "web:xxx#agent:yyy", extract base JID and agentId
+  let baseChatJid = chatJid;
+  let effectiveAgentId = agentId;
+  if (chatJid.includes('#agent:')) {
+    const parts = chatJid.split('#agent:');
+    baseChatJid = parts[0];
+    if (!effectiveAgentId) effectiveAgentId = parts[1];
+  }
   const jid = normalizeHomeJid(baseChatJid);
   const allowedUserIds = getGroupAllowedUserIds(baseChatJid);
   const wsMsg: WsMessageOut = {
     type: 'new_message',
     chatJid: jid,
     message: { ...msg, is_from_me: msg.is_from_me ?? false },
-    ...(agentId ? { agentId } : {}),
+    ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
   };
   safeBroadcast(wsMsg, isHostGroupJid(baseChatJid), allowedUserIds);
 }

--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -1,4 +1,4 @@
-import { Plus, X } from 'lucide-react';
+import { Plus, X, Link, MessageSquare } from 'lucide-react';
 import type { AgentInfo } from '../../types';
 
 interface AgentTabBarProps {
@@ -7,6 +7,7 @@ interface AgentTabBarProps {
   onSelectTab: (agentId: string | null) => void;
   onDeleteAgent: (agentId: string) => void;
   onCreateConversation?: () => void;
+  onBindIm?: (agentId: string) => void;
 }
 
 const TASK_STATUS_ICON: Record<string, string> = {
@@ -22,7 +23,7 @@ const tabClass = (active: boolean) =>
       : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
   }`;
 
-export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation }: AgentTabBarProps) {
+export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation, onBindIm }: AgentTabBarProps) {
   const conversations = agents.filter(a => a.kind === 'conversation');
   const tasks = agents.filter(a => a.kind === 'task');
 
@@ -37,25 +38,42 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
       </button>
 
       {/* Conversation tabs — same visual level as main */}
-      {conversations.map((agent) => (
-        <div
-          key={agent.id}
-          className={`${tabClass(activeTab === agent.id)} flex items-center gap-1.5 group`}
-          onClick={() => onSelectTab(agent.id)}
-        >
-          {agent.status === 'running' && (
-            <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
-          )}
-          <span className="truncate max-w-[120px]">{agent.name}</span>
-          <button
-            onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-            className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-            title="关闭对话"
+      {conversations.map((agent) => {
+        const hasLinked = agent.linked_im_groups && agent.linked_im_groups.length > 0;
+        return (
+          <div
+            key={agent.id}
+            className={`${tabClass(activeTab === agent.id)} flex items-center gap-1.5 group`}
+            onClick={() => onSelectTab(agent.id)}
           >
-            <X className="w-3 h-3" />
-          </button>
-        </div>
-      ))}
+            {agent.status === 'running' && (
+              <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
+            )}
+            {hasLinked && (
+              <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
+                <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />
+              </span>
+            )}
+            <span className="truncate max-w-[120px]">{agent.name}</span>
+            {onBindIm && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
+                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+                title="绑定 IM 群组"
+              >
+                <Link className="w-3 h-3" />
+              </button>
+            )}
+            <button
+              onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
+              className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+              title="关闭对话"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </div>
+        );
+      })}
 
       {/* Create conversation button */}
       {onCreateConversation && (

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -20,6 +20,7 @@ import { TerminalPanel } from './TerminalPanel';
 import { GroupSkillsPanel } from './GroupSkillsPanel';
 import { GroupMembersPanel } from './GroupMembersPanel';
 import { AgentTabBar } from './AgentTabBar';
+import { ImBindingDialog } from './ImBindingDialog';
 
 /** Inline elapsed-time counter for running tasks */
 function ElapsedTimer({ startTime }: { startTime: number }) {
@@ -66,6 +67,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const [terminalHeight, setTerminalHeight] = useState(TERMINAL_DEFAULT_HEIGHT);
   const [mobileTerminal, setMobileTerminal] = useState(false);
   const [mobileActionsOpen, setMobileActionsOpen] = useState(false);
+  const [bindingAgentId, setBindingAgentId] = useState<string | null>(null);
   const [imStatus, setImStatus] = useState<{ feishu: boolean; telegram: boolean } | null>(null);
   const [imBannerDismissed, setImBannerDismissed] = useState(() =>
     localStorage.getItem('im-banner-dismissed') === '1',
@@ -477,7 +479,16 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
         agents={agents}
         activeTab={activeAgentTab}
         onSelectTab={(id) => setActiveAgentTab(groupJid, id)}
-        onDeleteAgent={(id) => deleteAgentAction(groupJid, id)}
+        onDeleteAgent={(id) => {
+          const agent = agents.find((a) => a.id === id);
+          if (agent?.linked_im_groups && agent.linked_im_groups.length > 0) {
+            const names = agent.linked_im_groups.map((g) => g.name).join('、');
+            alert(`该对话已绑定 IM 群组（${names}），请先解绑后再删除。`);
+            setBindingAgentId(id);
+            return;
+          }
+          deleteAgentAction(groupJid, id);
+        }}
         onCreateConversation={() => {
           const name = prompt('对话名称：');
           if (name?.trim()) {
@@ -486,6 +497,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
             });
           }
         }}
+        onBindIm={setBindingAgentId}
       />
 
       {/* Main Content: Messages + Sidebar */}
@@ -908,6 +920,17 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
         confirmVariant="danger"
         loading={resetLoading}
       />
+
+      {/* IM binding dialog */}
+      {bindingAgentId && (
+        <ImBindingDialog
+          open={!!bindingAgentId}
+          groupJid={groupJid}
+          agentId={bindingAgentId}
+          agent={agents.find((a) => a.id === bindingAgentId)}
+          onClose={() => setBindingAgentId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/chat/ImBindingDialog.tsx
+++ b/web/src/components/chat/ImBindingDialog.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Loader2, Link2, Unlink, MessageSquare, Users } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { SearchInput } from '@/components/common/SearchInput';
+import { useChatStore } from '../../stores/chat';
+import type { AgentInfo, AvailableImGroup } from '../../types';
+
+interface ImBindingDialogProps {
+  open: boolean;
+  groupJid: string;
+  agentId: string;
+  agent?: AgentInfo;
+  onClose: () => void;
+}
+
+const CHANNEL_LABEL: Record<string, string> = {
+  feishu: '飞书群聊',
+  telegram: 'Telegram',
+};
+
+export function ImBindingDialog({ open, groupJid, agentId, agent, onClose }: ImBindingDialogProps) {
+  const [imGroups, setImGroups] = useState<AvailableImGroup[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+
+  const loadAvailableImGroups = useChatStore((s) => s.loadAvailableImGroups);
+  const bindImGroup = useChatStore((s) => s.bindImGroup);
+  const unbindImGroup = useChatStore((s) => s.unbindImGroup);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setFilter('');
+    loadAvailableImGroups(groupJid).then((groups) => {
+      setImGroups(groups);
+      setLoading(false);
+    });
+  }, [open, groupJid, loadAvailableImGroups]);
+
+  const filteredGroups = useMemo(() => {
+    if (!filter.trim()) return imGroups;
+    const q = filter.trim().toLowerCase();
+    return imGroups.filter(
+      (g) => g.name.toLowerCase().includes(q) || g.jid.toLowerCase().includes(q),
+    );
+  }, [imGroups, filter]);
+
+  const handleBind = async (imJid: string) => {
+    setActionLoading(imJid);
+    const ok = await bindImGroup(groupJid, agentId, imJid);
+    if (ok) {
+      setImGroups((prev) =>
+        prev.map((g) => (g.jid === imJid ? { ...g, bound_agent_id: agentId } : g)),
+      );
+    }
+    setActionLoading(null);
+  };
+
+  const handleUnbind = async (imJid: string) => {
+    setActionLoading(imJid);
+    const ok = await unbindImGroup(groupJid, agentId, imJid);
+    if (ok) {
+      setImGroups((prev) =>
+        prev.map((g) => (g.jid === imJid ? { ...g, bound_agent_id: null } : g)),
+      );
+    }
+    setActionLoading(null);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <MessageSquare className="w-4 h-4" />
+            绑定 IM 群组{agent ? ` — ${agent.name}` : ''}
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Filter input — only show when there are groups */}
+        {!loading && imGroups.length > 0 && (
+          <SearchInput
+            value={filter}
+            onChange={setFilter}
+            placeholder="搜索群组..."
+            debounce={150}
+          />
+        )}
+
+        <div className="space-y-2 max-h-72 overflow-y-auto">
+          {loading && (
+            <div className="flex items-center justify-center py-8 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin mr-2" />
+              加载中...
+            </div>
+          )}
+
+          {!loading && imGroups.length === 0 && (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              暂无群聊可绑定。请先在飞书/Telegram 群中向 Bot 发送消息，群聊会自动出现在此列表中。
+              <br />
+              <span className="text-xs opacity-70">私聊不支持绑定到子对话。</span>
+            </div>
+          )}
+
+          {!loading && imGroups.length > 0 && filteredGroups.length === 0 && (
+            <div className="text-center py-6 text-muted-foreground text-sm">
+              没有匹配的群组
+            </div>
+          )}
+
+          {!loading &&
+            filteredGroups.map((group) => {
+              const isBoundToThis = group.bound_agent_id === agentId;
+              const isBoundToOther = !!group.bound_agent_id && !isBoundToThis;
+              const isActioning = actionLoading === group.jid;
+
+              return (
+                <div
+                  key={group.jid}
+                  className={`flex items-center gap-3 p-3 rounded-lg border ${
+                    isBoundToThis
+                      ? 'border-teal-500/30 bg-teal-50/50 dark:bg-teal-950/20'
+                      : isBoundToOther
+                        ? 'border-border opacity-50'
+                        : 'border-border hover:border-border/80'
+                  }`}
+                >
+                  {/* Group avatar */}
+                  {group.avatar ? (
+                    <img
+                      src={group.avatar}
+                      alt=""
+                      className="w-10 h-10 rounded-lg flex-shrink-0 object-cover"
+                    />
+                  ) : (
+                    <div className="w-10 h-10 rounded-lg flex-shrink-0 bg-muted flex items-center justify-center">
+                      <MessageSquare className="w-5 h-5 text-muted-foreground" />
+                    </div>
+                  )}
+
+                  {/* Group info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate">{group.name}</div>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>{CHANNEL_LABEL[group.channel_type] || group.channel_type}</span>
+                      {group.member_count != null && (
+                        <span className="flex items-center gap-0.5">
+                          <Users className="w-3 h-3" />
+                          {group.member_count}
+                        </span>
+                      )}
+                      {isBoundToOther && <span className="text-amber-500">已绑定到其他对话</span>}
+                    </div>
+                  </div>
+
+                  {/* Action button */}
+                  {isBoundToThis ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleUnbind(group.jid)}
+                      disabled={isActioning}
+                      className="flex-shrink-0"
+                    >
+                      {isActioning ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <Unlink className="w-3 h-3 mr-1" />
+                      )}
+                      解绑
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      onClick={() => handleBind(group.jid)}
+                      disabled={isActioning || isBoundToOther}
+                      className="flex-shrink-0"
+                    >
+                      {isActioning ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <Link2 className="w-3 h-3 mr-1" />
+                      )}
+                      绑定
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -4,7 +4,7 @@ import { wsManager } from '../api/ws';
 import { useFileStore } from './files';
 import { useAuthStore } from './auth';
 import { showToast, notifyIfHidden, shouldEmitBackgroundTaskNotice } from '../utils/toast';
-import type { GroupInfo, AgentInfo } from '../types';
+import type { GroupInfo, AgentInfo, AvailableImGroup } from '../types';
 
 export type { GroupInfo, AgentInfo };
 
@@ -157,6 +157,10 @@ interface ChatState {
   loadAgentMessages: (jid: string, agentId: string, loadMore?: boolean) => Promise<void>;
   sendAgentMessage: (jid: string, agentId: string, content: string) => void;
   refreshAgentMessages: (jid: string, agentId: string) => Promise<void>;
+  // IM binding actions
+  loadAvailableImGroups: (jid: string) => Promise<AvailableImGroup[]>;
+  bindImGroup: (jid: string, agentId: string, imJid: string) => Promise<boolean>;
+  unbindImGroup: (jid: string, agentId: string, imJid: string) => Promise<boolean>;
 }
 
 const DEFAULT_STREAMING_STATE: StreamingState = {
@@ -1589,6 +1593,44 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
+    }
+  },
+
+  // IM binding actions
+  loadAvailableImGroups: async (jid) => {
+    try {
+      const data = await api.get<{ imGroups: AvailableImGroup[] }>(
+        `/api/groups/${encodeURIComponent(jid)}/im-groups`,
+      );
+      return data.imGroups;
+    } catch {
+      return [];
+    }
+  },
+
+  bindImGroup: async (jid, agentId, imJid) => {
+    try {
+      await api.put(
+        `/api/groups/${encodeURIComponent(jid)}/agents/${agentId}/im-binding`,
+        { im_jid: imJid },
+      );
+      // Refresh agents to get updated linked_im_groups
+      get().loadAgents(jid);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  unbindImGroup: async (jid, agentId, imJid) => {
+    try {
+      await api.delete(
+        `/api/groups/${encodeURIComponent(jid)}/agents/${agentId}/im-binding/${encodeURIComponent(imJid)}`,
+      );
+      get().loadAgents(jid);
+      return true;
+    } catch {
+      return false;
     }
   },
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -27,6 +27,16 @@ export interface AgentInfo {
   created_at: string;
   completed_at?: string;
   result_summary?: string;
+  linked_im_groups?: Array<{ jid: string; name: string }>;
+}
+
+export interface AvailableImGroup {
+  jid: string;
+  name: string;
+  bound_agent_id: string | null;
+  avatar?: string;
+  member_count?: number;
+  channel_type: string;
 }
 
 export interface GroupMember {


### PR DESCRIPTION
- 新增 registered_groups.target_agent_id 字段（DB schema v19），实现 IM 群组到 conversation agent 的路由映射
- 后端 API：GET /im-groups（列出可绑定群组）、PUT/DELETE /im-binding（绑定/解绑）
- 飞书消息路由：当 IM 群组配置了 target_agent_id，消息自动写入 agent 虚拟 JID 并触发 agent 处理
- Agent 回复自动推送到已绑定的 IM 群组
- 删除子对话时检查 IM 绑定：有绑定返回 409，前端提示先解绑再删除并自动打开绑定对话框
- 前端 ImBindingDialog 组件：支持搜索、绑定/解绑操作，显示群组头像和成员数
- AgentTabBar 显示绑定状态图标和快捷绑定按钮
- 使用飞书 chat_mode 字段过滤私聊（P2P），仅展示群聊
- runtime-config: normalizeSecret 清理非 ASCII 字符