### PR TITLE
功能: make start/dev 自动检测并安装 Docker 和 Node.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@
 # ─── Development ─────────────────────────────────────────────
 
 dev: ## 启动前后端（首次自动安装依赖和构建容器镜像）
+	@./scripts/ensure-node.sh
 	@if [ ! -d node_modules ] || [ package.json -nt node_modules ] || [ web/package.json -nt web/node_modules ] || [ container/agent-runner/package.json -nt container/agent-runner/node_modules ]; then echo "📦 依赖有更新，安装依赖..."; $(MAKE) install; fi
-	@if command -v docker >/dev/null 2>&1 && ! docker image inspect happyclaw-agent:latest >/dev/null 2>&1; then echo "🐳 构建 Agent 容器镜像..."; ./container/build.sh; fi
+	@./scripts/ensure-docker.sh
+	@if ! docker image inspect happyclaw-agent:latest >/dev/null 2>&1; then echo "🐳 构建 Agent 容器镜像..."; ./container/build.sh; fi
 	@npm --prefix container/agent-runner run build --silent 2>/dev/null || npm --prefix container/agent-runner run build
 	npm run dev:all
 
@@ -32,8 +34,10 @@ build-web: ## 仅编译前端
 # ─── Production ──────────────────────────────────────────────
 
 start: ## 一键启动生产环境（首次自动安装依赖和构建容器镜像）
+	@./scripts/ensure-node.sh
 	@if [ ! -d node_modules ] || [ package.json -nt node_modules ] || [ web/package.json -nt web/node_modules ] || [ container/agent-runner/package.json -nt container/agent-runner/node_modules ]; then echo "📦 依赖有更新，安装依赖..."; $(MAKE) install; fi
-	@if command -v docker >/dev/null 2>&1 && ! docker image inspect happyclaw-agent:latest >/dev/null 2>&1; then echo "🐳 构建 Agent 容器镜像..."; ./container/build.sh; fi
+	@./scripts/ensure-docker.sh
+	@if ! docker image inspect happyclaw-agent:latest >/dev/null 2>&1; then echo "🐳 构建 Agent 容器镜像..."; ./container/build.sh; fi
 	$(MAKE) build
 	npm run start
 

--- a/scripts/ensure-docker.sh
+++ b/scripts/ensure-docker.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# ensure-docker.sh — 确保 Docker 已安装、运行，且当前用户有权限使用
+set -euo pipefail
+
+# 尝试直接执行 docker info，成功则无需任何操作
+try_docker() {
+  docker info >/dev/null 2>&1 && return 0
+  sg docker -c "docker info" >/dev/null 2>&1 && return 0
+  return 1
+}
+
+# 如果 docker 命令存在且可正常执行，直接返回
+if command -v docker >/dev/null 2>&1 && try_docker; then
+  exit 0
+fi
+
+# 如果 docker 命令存在但无权限（用户不在 docker 组）
+if command -v docker >/dev/null 2>&1; then
+  echo "⚠️  Docker 已安装但当前用户无权限，尝试添加到 docker 组..."
+  sudo usermod -aG docker "$USER"
+  if sg docker -c "docker info" >/dev/null 2>&1; then
+    echo "✅ 已将 $USER 加入 docker 组"
+    exit 0
+  fi
+  echo "✅ 已将 $USER 加入 docker 组"
+  echo "⚠️  请重新登录终端或执行 'newgrp docker' 后重试"
+  exit 1
+fi
+
+echo "🐳 Docker 未安装，正在自动安装..."
+
+# 检测发行版
+if [ -f /etc/os-release ]; then
+  . /etc/os-release
+else
+  echo "❌ 无法检测操作系统，请手动安装 Docker"
+  exit 1
+fi
+
+install_docker_rhel() {
+  local repo_url="https://download.docker.com/linux"
+  # RHEL 系（AlmaLinux, Rocky, CentOS Stream, RHEL, Fedora）
+  case "${ID:-}:${ID_LIKE:-}" in
+    fedora:*) repo_url="$repo_url/fedora/docker-ce.repo" ;;
+    *rhel*|*centos*|almalinux:*|rocky:*) repo_url="$repo_url/rhel/docker-ce.repo" ;;
+    *) repo_url="$repo_url/centos/docker-ce.repo" ;;
+  esac
+
+  sudo dnf config-manager --add-repo "$repo_url"
+  sudo dnf install -y docker-ce docker-ce-cli containerd.io
+}
+
+install_docker_debian() {
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl gnupg
+  sudo install -m 0755 -d /etc/apt/keyrings
+  local distro="$ID"
+  # Ubuntu 和 Debian 用各自的源
+  if [ "$distro" != "ubuntu" ] && [ "$distro" != "debian" ]; then
+    distro="debian"
+  fi
+  curl -fsSL "https://download.docker.com/linux/$distro/gpg" | sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$distro $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo apt-get update
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+}
+
+# 根据包管理器选择安装方式
+if command -v dnf >/dev/null 2>&1; then
+  install_docker_rhel
+elif command -v apt-get >/dev/null 2>&1; then
+  install_docker_debian
+else
+  echo "❌ 不支持的包管理器，请手动安装 Docker: https://docs.docker.com/engine/install/"
+  exit 1
+fi
+
+# 启动 Docker 并设置开机自启
+sudo systemctl enable --now docker
+
+# 将当前用户加入 docker 组
+if ! groups "$USER" | grep -q '\bdocker\b'; then
+  sudo usermod -aG docker "$USER"
+  echo "✅ 已将 $USER 加入 docker 组"
+fi
+
+# 验证安装
+if try_docker; then
+  echo "✅ Docker 安装完成"
+else
+  echo "✅ Docker 安装完成，请重新登录终端或执行 'newgrp docker' 使权限生效后重试"
+  exit 1
+fi

--- a/scripts/ensure-node.sh
+++ b/scripts/ensure-node.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ensure-node.sh — 确保 Node.js >= 20 已安装
+set -euo pipefail
+
+REQUIRED_MAJOR=20
+
+# 检查原生模块编译工具链（node-pty 等需要 g++ 和 make）
+ensure_build_tools() {
+  if command -v g++ >/dev/null 2>&1 && command -v make >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "🔧 安装原生模块编译工具链（g++、make、python3）..."
+  if command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y gcc-c++ make python3
+  elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y build-essential python3
+  fi
+}
+
+# 检查 node 是否已安装且版本满足要求
+if command -v node >/dev/null 2>&1; then
+  NODE_VERSION=$(node -v | sed 's/^v//')
+  NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+  if [ "$NODE_MAJOR" -ge "$REQUIRED_MAJOR" ]; then
+    ensure_build_tools
+    exit 0
+  fi
+  echo "⚠️  当前 Node.js 版本为 v$NODE_VERSION，需要 >= v$REQUIRED_MAJOR"
+fi
+
+echo "📦 Node.js >= $REQUIRED_MAJOR 未安装，正在自动安装..."
+
+# 优先使用 fnm（快速 Node 版本管理器）
+if command -v fnm >/dev/null 2>&1; then
+  fnm install "$REQUIRED_MAJOR"
+  fnm use "$REQUIRED_MAJOR"
+  echo "✅ Node.js $(node -v) 已通过 fnm 安装"
+  exit 0
+fi
+
+# 检测发行版并安装
+if [ -f /etc/os-release ]; then
+  . /etc/os-release
+fi
+
+install_node_rhel() {
+  # 尝试 dnf module（RHEL/AlmaLinux/Rocky 自带 AppStream）
+  if sudo dnf module list nodejs 2>/dev/null | grep -q "$REQUIRED_MAJOR"; then
+    sudo dnf module enable -y "nodejs:$REQUIRED_MAJOR"
+    sudo dnf install -y nodejs
+  else
+    # 回退到 NodeSource
+    curl -fsSL "https://rpm.nodesource.com/setup_${REQUIRED_MAJOR}.x" | sudo bash -
+    sudo dnf install -y nodejs
+  fi
+}
+
+install_node_debian() {
+  curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_MAJOR}.x" | sudo bash -
+  sudo apt-get install -y nodejs
+}
+
+if command -v dnf >/dev/null 2>&1; then
+  install_node_rhel
+elif command -v apt-get >/dev/null 2>&1; then
+  install_node_debian
+else
+  echo "❌ 不支持的包管理器，请手动安装 Node.js >= $REQUIRED_MAJOR: https://nodejs.org/"
+  exit 1
+fi
+
+# 验证安装
+if command -v node >/dev/null 2>&1; then
+  ensure_build_tools
+  echo "✅ Node.js $(node -v) 安装完成"
+else
+  echo "❌ Node.js 安装失败，请手动安装: https://nodejs.org/"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- 新增 `scripts/ensure-docker.sh`：自动检测/安装 Docker，支持 RHEL/Debian 系
- 新增 `scripts/ensure-node.sh`：自动检测/安装 Node.js >= 20，含原生模块编译工具链
- Makefile `dev`/`start` 目标前自动调用检测脚本，缺失依赖直接安装，无需交互确认

## Test plan
- [x] 在已安装 Docker + Node.js 的环境运行 `make dev`，确认跳过安装直接启动
- [ ] 在缺少 Docker 的 Debian/Ubuntu 环境运行 `make start`，确认自动安装 Docker
- [x] 在缺少 Node.js 的 RHEL/AlmaLinux 环境运行 `make dev`，确认自动安装 Node.js >= 20
- [x] 确认安装过程全程无交互提示（无 y/N 确认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)