### PR TITLE
fix: 适配 onboard UI 深色模式

### DIFF
--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -70,7 +70,7 @@ export function LoginPage() {
   if (initialized !== true) {
     return (
       <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
-        <div className="text-slate-500 text-sm">加载中...</div>
+        <div className="text-muted-foreground text-sm">加载中...</div>
       </div>
     );
   }
@@ -90,14 +90,14 @@ export function LoginPage() {
           <h1 className="text-2xl font-bold text-foreground text-center mb-2">
             欢迎使用 HappyClaw
           </h1>
-          <p className="text-slate-500 text-center mb-6">
+          <p className="text-muted-foreground text-center mb-6">
             请登录以继续
           </p>
 
           {/* Error Message */}
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="mb-4 p-3 bg-error-bg border border-error/30 rounded-md">
+              <p className="text-sm text-error">{error}</p>
             </div>
           )}
 
@@ -138,7 +138,7 @@ export function LoginPage() {
 
           {/* Register Link — hidden when registration is disabled */}
           {regStatus.allowRegistration && (
-            <p className="text-center text-sm text-slate-500 mt-4">
+            <p className="text-center text-sm text-muted-foreground mt-4">
               {regStatus.requireInviteCode ? '有邀请码？' : '还没有账户？'}
               <Link to="/register" className="text-primary hover:text-primary/80 ml-1">
                 去注册
@@ -148,7 +148,7 @@ export function LoginPage() {
         </div>
 
         {/* Footer */}
-        <p className="text-center text-sm text-slate-500 mt-4">
+        <p className="text-center text-sm text-muted-foreground mt-4">
           HappyClaw - Powered by{' '}
           <a href="https://github.com/riba2534" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary/80">
             riba2534

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -102,7 +102,7 @@ export function RegisterPage() {
   if (initialized !== true || statusLoading) {
     return (
       <div className="h-screen bg-background overflow-y-auto flex items-center justify-center p-4">
-        <div className="text-slate-500 text-sm">加载中...</div>
+        <div className="text-muted-foreground text-sm">加载中...</div>
       </div>
     );
   }
@@ -121,7 +121,7 @@ export function RegisterPage() {
             <h1 className="text-2xl font-bold text-foreground text-center mb-2">
               注册已关闭
             </h1>
-            <p className="text-slate-500 text-center mb-6">
+            <p className="text-muted-foreground text-center mb-6">
               管理员已关闭注册功能，如需账户请联系管理员。
             </p>
             <Link
@@ -150,13 +150,13 @@ export function RegisterPage() {
           <h1 className="text-2xl font-bold text-foreground text-center mb-2">
             注册新账户
           </h1>
-          <p className="text-slate-500 text-center mb-6">
+          <p className="text-muted-foreground text-center mb-6">
             {status.requireInviteCode ? '需要邀请码才能注册' : '创建你的账户'}
           </p>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="mb-4 p-3 bg-error-bg border border-error/30 rounded-md">
+              <p className="text-sm text-error">{error}</p>
             </div>
           )}
 
@@ -196,7 +196,7 @@ export function RegisterPage() {
 
             <div className="mb-4">
               <label htmlFor="reg-display-name" className="block text-sm font-medium text-foreground mb-1">
-                显示名称 <span className="text-slate-400">(可选)</span>
+                显示名称 <span className="text-muted-foreground">(可选)</span>
               </label>
               <Input
                 id="reg-display-name"
@@ -227,14 +227,14 @@ export function RegisterPage() {
             </Button>
           </form>
 
-          <p className="text-center text-sm text-slate-500 mt-4">
+          <p className="text-center text-sm text-muted-foreground mt-4">
             已有账户？
             <Link to="/login" className="text-primary hover:text-primary/80 ml-1">
               去登录
             </Link>
           </p>
 
-          <p className="text-center text-sm text-slate-500 mt-2">
+          <p className="text-center text-sm text-muted-foreground mt-2">
             HappyClaw - Powered by{' '}
             <a href="https://github.com/riba2534" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary/80">
               riba2534

--- a/web/src/pages/SetupChannelsPage.tsx
+++ b/web/src/pages/SetupChannelsPage.tsx
@@ -77,31 +77,31 @@ export function SetupChannelsPage() {
   };
 
   return (
-    <div className="h-screen bg-slate-50 overflow-y-auto p-4">
+    <div className="h-screen bg-background overflow-y-auto p-4">
       <div className="w-full max-w-2xl mx-auto space-y-5">
         <div className="text-center">
           <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center mx-auto mb-4">
             <MessageSquare className="w-6 h-6 text-primary" />
           </div>
           <h1 className="text-2xl font-bold text-foreground mb-2">配置消息通道（可选）</h1>
-          <p className="text-sm text-slate-600">
+          <p className="text-sm text-muted-foreground">
             绑定飞书或 Telegram，即可通过 IM 与 AI 对话。跳过后也可在设置中随时配置。
           </p>
         </div>
 
         {error && (
-          <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">{error}</div>
+          <div className="p-3 rounded-lg bg-error-bg border border-error/30 text-error text-sm">{error}</div>
         )}
 
         {/* Feishu */}
         <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <h2 className="text-base font-semibold text-foreground mb-3">飞书</h2>
-          <p className="text-xs text-slate-500 mb-3">
+          <p className="text-xs text-muted-foreground mb-3">
             填写你的飞书应用凭证，绑定后即可在飞书中与 AI 对话。
           </p>
           <div className="grid md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">App ID</label>
+              <label className="block text-sm font-medium text-foreground mb-1">App ID</label>
               <Input
                 type="text"
                 value={feishuAppId}
@@ -110,7 +110,7 @@ export function SetupChannelsPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">App Secret</label>
+              <label className="block text-sm font-medium text-foreground mb-1">App Secret</label>
               <Input
                 type="password"
                 value={feishuAppSecret}
@@ -124,11 +124,11 @@ export function SetupChannelsPage() {
         {/* Telegram */}
         <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <h2 className="text-base font-semibold text-foreground mb-3">Telegram</h2>
-          <p className="text-xs text-slate-500 mb-3">
+          <p className="text-xs text-muted-foreground mb-3">
             填写 Telegram Bot Token，绑定后即可在 Telegram 中与 AI 对话。
           </p>
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-1">Bot Token</label>
+            <label className="block text-sm font-medium text-foreground mb-1">Bot Token</label>
             <Input
               type="password"
               value={telegramBotToken}

--- a/web/src/pages/SetupPage.tsx
+++ b/web/src/pages/SetupPage.tsx
@@ -61,7 +61,7 @@ export function SetupPage() {
             </div>
           </div>
           <h1 className="text-2xl font-bold text-foreground mb-1">HappyClaw 初始设置</h1>
-          <p className="text-sm text-slate-500">先创建管理员账号，完成后进入后台继续配置飞书 Token 与 Claude Key</p>
+          <p className="text-sm text-muted-foreground">先创建管理员账号，完成后进入后台继续配置飞书 Token 与 Claude Key</p>
         </div>
 
         {/* Step card */}
@@ -139,10 +139,10 @@ function CreateAdminStep({
   return (
     <div>
       <h2 className="text-lg font-semibold text-foreground mb-1">创建管理员账号</h2>
-      <p className="text-sm text-slate-500 mb-4">首次使用请先创建管理员，提交后进入系统接入配置向导。</p>
+      <p className="text-sm text-muted-foreground mb-4">首次使用请先创建管理员，提交后进入系统接入配置向导。</p>
 
       {error && (
-        <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">{error}</div>
+        <div className="mb-4 p-3 rounded-lg bg-error-bg border border-error/30 text-error text-sm">{error}</div>
       )}
 
       <div className="space-y-3">
@@ -169,7 +169,7 @@ function CreateAdminStep({
             <button
               type="button"
               onClick={() => setShowPassword(!showPassword)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </button>
@@ -188,7 +188,7 @@ function CreateAdminStep({
             <button
               type="button"
               onClick={() => setShowConfirm(!showConfirm)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {showConfirm ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </button>

--- a/web/src/pages/SetupProvidersPage.tsx
+++ b/web/src/pages/SetupProvidersPage.tsx
@@ -250,19 +250,19 @@ export function SetupProvidersPage() {
   };
 
   return (
-    <div className="h-screen bg-slate-50 overflow-y-auto p-4">
+    <div className="h-screen bg-background overflow-y-auto p-4">
       <div className="w-full max-w-4xl mx-auto space-y-5">
         <div className="text-center">
           <p className="text-xs font-semibold text-primary tracking-wider mb-2">STEP 2 / 2</p>
           <h1 className="text-2xl font-bold text-foreground mb-2">系统接入初始化</h1>
-          <p className="text-sm text-slate-600">此页面保存的是系统全局默认配置。完成后才进入正式后台。</p>
+          <p className="text-sm text-muted-foreground">此页面保存的是系统全局默认配置。完成后才进入正式后台。</p>
         </div>
 
         {error && (
-          <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">{error}</div>
+          <div className="p-3 rounded-lg bg-error-bg border border-error/30 text-error text-sm">{error}</div>
         )}
         {notice && (
-          <div className="p-3 rounded-lg bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm">{notice}</div>
+          <div className="p-3 rounded-lg bg-success-bg border border-success/30 text-success text-sm">{notice}</div>
         )}
 
         <section className="bg-card rounded-xl border border-border shadow-sm p-5">
@@ -270,10 +270,10 @@ export function SetupProvidersPage() {
             <Link2 className="w-4 h-4 text-primary" />
             <h2 className="text-base font-semibold text-foreground">飞书配置（可选）</h2>
           </div>
-          <p className="text-xs text-slate-500 mb-3">首装不预填任何默认值，全部由你手动输入。</p>
+          <p className="text-xs text-muted-foreground mb-3">首装不预填任何默认值，全部由你手动输入。</p>
           <div className="grid md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">App ID</label>
+              <label className="block text-sm font-medium text-foreground mb-1">App ID</label>
               <Input
                 type="text"
                 value={feishuAppId}
@@ -282,7 +282,7 @@ export function SetupProvidersPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">App Secret</label>
+              <label className="block text-sm font-medium text-foreground mb-1">App Secret</label>
               <Input
                 type="password"
                 value={feishuAppSecret}
@@ -299,12 +299,12 @@ export function SetupProvidersPage() {
             <h2 className="text-base font-semibold text-foreground">Claude Code 配置（二选一）</h2>
           </div>
 
-          <div className="inline-flex rounded-lg border border-slate-200 p-1 bg-slate-50 mb-4">
+          <div className="inline-flex rounded-lg border border-border p-1 bg-muted mb-4">
             <button
               type="button"
               onClick={() => setProviderMode('official')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'official' ? 'bg-background text-primary shadow-sm' : 'text-slate-500'
+                providerMode === 'official' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
               }`}
             >
               官方渠道
@@ -313,7 +313,7 @@ export function SetupProvidersPage() {
               type="button"
               onClick={() => setProviderMode('third_party')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'third_party' ? 'bg-background text-primary shadow-sm' : 'text-slate-500'
+                providerMode === 'third_party' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
               }`}
             >
               第三方渠道
@@ -323,14 +323,14 @@ export function SetupProvidersPage() {
           {providerMode === 'official' ? (
             <div className="space-y-4">
               {/* OAuth one-click login */}
-              <div className="rounded-lg border border-teal-200 bg-teal-50/50 p-4 space-y-3">
-                <div className="text-sm font-medium text-slate-800">一键登录 Claude（推荐）</div>
-                <div className="text-xs text-slate-600">
+              <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3">
+                <div className="text-sm font-medium text-foreground">一键登录 Claude（推荐）</div>
+                <div className="text-xs text-muted-foreground">
                   点击按钮后会打开 claude.ai 授权页面，完成授权后将页面上显示的授权码粘贴回来。
                 </div>
 
                 {oauthDone ? (
-                  <div className="text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-md px-3 py-2">
+                  <div className="text-sm bg-success-bg border border-success/30 text-success rounded-md px-3 py-2">
                     OAuth 登录成功，点击下方按钮完成配置。
                   </div>
                 ) : !oauthState ? (
@@ -340,7 +340,7 @@ export function SetupProvidersPage() {
                   </Button>
                 ) : (
                   <div className="space-y-2">
-                    <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+                    <div className="text-xs bg-warning-bg border border-warning/30 text-warning rounded-md px-3 py-2">
                       授权窗口已打开，请在 claude.ai 完成授权后，将页面上显示的授权码粘贴到下方。
                     </div>
                     <div className="flex gap-2">
@@ -364,15 +364,15 @@ export function SetupProvidersPage() {
                 )}
               </div>
 
-              <div className="relative flex items-center gap-3 text-xs text-slate-400">
-                <div className="flex-1 border-t border-slate-200" />
+              <div className="relative flex items-center gap-3 text-xs text-muted-foreground">
+                <div className="flex-1 border-t border-border" />
                 或手动粘贴 setup-token
-                <div className="flex-1 border-t border-slate-200" />
+                <div className="flex-1 border-t border-border" />
               </div>
 
-              <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+              <div className="rounded-lg border border-border bg-muted p-3 text-sm text-foreground">
                 <div className="font-medium mb-2">获取凭据</div>
-                <ol className="list-decimal ml-5 space-y-1 text-xs">
+                <ol className="list-decimal ml-5 space-y-1 text-xs text-muted-foreground">
                   <li>在目标机器安装 Claude Code CLI（若未安装）。</li>
                   <li>在终端执行 <code>claude login</code> 完成账号登录。</li>
                   <li>
@@ -385,7 +385,7 @@ export function SetupProvidersPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">
+                <label className="block text-sm font-medium text-foreground mb-1">
                   setup-token 或 .credentials.json
                 </label>
                 <Input
@@ -394,21 +394,21 @@ export function SetupProvidersPage() {
                   onChange={(e) => setOfficialToken(e.target.value)}
                   placeholder="粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出"
                 />
-                <p className="text-xs text-slate-400 mt-1">
-                  支持粘贴 <code className="bg-slate-100 px-1 rounded">cat ~/.claude/.credentials.json</code> 的 JSON 内容（含自动续期）
+                <p className="text-xs text-muted-foreground mt-1">
+                  支持粘贴 <code className="bg-muted px-1 rounded">cat ~/.claude/.credentials.json</code> 的 JSON 内容（含自动续期）
                 </p>
               </div>
             </div>
           ) : (
             <div className="space-y-4">
-              <div className="flex items-center gap-2 text-xs text-slate-500">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Server className="w-4 h-4 text-primary" />
                 第三方渠道会写入系统全局默认环境变量。必填项为 ANTHROPIC_BASE_URL 和 ANTHROPIC_AUTH_TOKEN。
               </div>
 
               <div className="grid grid-cols-1 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">ANTHROPIC_BASE_URL（必填）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_BASE_URL（必填）</label>
                   <Input
                     type="text"
                     value={baseUrl}
@@ -418,7 +418,7 @@ export function SetupProvidersPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">ANTHROPIC_AUTH_TOKEN（必填）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_AUTH_TOKEN（必填）</label>
                   <Input
                     type="password"
                     value={authToken}
@@ -428,9 +428,9 @@ export function SetupProvidersPage() {
                 </div>
               </div>
 
-              <div className="border-t border-slate-100 pt-4">
+              <div className="border-t border-border pt-4">
                 <div className="flex items-center justify-between mb-2">
-                  <label className="text-xs text-slate-600">其他自定义环境变量（可选）</label>
+                  <label className="text-xs text-muted-foreground">其他自定义环境变量（可选）</label>
                   <button
                     type="button"
                     onClick={addCustomEnvRow}
@@ -442,7 +442,7 @@ export function SetupProvidersPage() {
                 </div>
 
                 {customEnvRows.length === 0 ? (
-                  <p className="text-xs text-slate-400">暂无</p>
+                  <p className="text-xs text-muted-foreground">暂无</p>
                 ) : (
                   <div className="space-y-2">
                     {customEnvRows.map((row, idx) => (
@@ -464,7 +464,7 @@ export function SetupProvidersPage() {
                         <button
                           type="button"
                           onClick={() => removeCustomEnvRow(idx)}
-                          className="w-8 h-8 rounded-md hover:bg-slate-100 text-slate-400 hover:text-red-500 flex items-center justify-center cursor-pointer"
+                          className="w-8 h-8 rounded-md hover:bg-muted text-muted-foreground hover:text-error flex items-center justify-center cursor-pointer"
                           aria-label="删除环境变量"
                         >
                           <X className="w-4 h-4" />
@@ -479,7 +479,7 @@ export function SetupProvidersPage() {
         </section>
 
         <div className="bg-card rounded-xl border border-border shadow-sm p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
-          <div className="text-sm text-slate-600 flex items-start gap-2">
+          <div className="text-sm text-muted-foreground flex items-start gap-2">
             <ShieldCheck className="w-4 h-4 text-primary mt-0.5 shrink-0" />
             当前页保存的数据会作为系统全局默认配置，后续可在后台设置页继续修改。
           </div>


### PR DESCRIPTION
## 问题描述

Onboard UI 页面（Setup、Login、Register）使用了硬编码的 Tailwind 色值（slate/red/emerald/amber），在深色模式下无法自动适配，导致浅色文字显示在深色背景上（反之亦然）。

## 修改内容

将所有硬编码的浅色模式色类替换为 `globals.css` 中定义的语义化设计 token：

- **背景色**：`bg-slate-50` → `bg-background`；`bg-slate-100` → `bg-muted`
- **文字色**：`text-slate-{400,500,600,700,800}` → `text-muted-foreground` 或 `text-foreground`
- **错误提示**：`bg-red-50 border-red-200 text-red-{600,700}` → `bg-error-bg border-error/30 text-error`
- **成功提示**：`bg-emerald-50 border-emerald-200 text-emerald-700` → `bg-success-bg border-success/30 text-success`
- **警告提示**：`bg-amber-50 border-amber-200 text-amber-700` → `bg-warning-bg border-warning/30 text-warning`
- **切换开关容器**：`border-slate-200 bg-slate-50` → `border-border bg-muted`
- **OAuth 高亮框**：`border-teal-200 bg-teal-50/50` → `border-primary/20 bg-primary/5`
- **Hover 状态**：`hover:bg-slate-100` → `hover:bg-muted`

## 涉及文件

- `web/src/pages/SetupPage.tsx`
- `web/src/pages/SetupProvidersPage.tsx`
- `web/src/pages/SetupChannelsPage.tsx`
- `web/src/pages/LoginPage.tsx`
- `web/src/pages/RegisterPage.tsx`

## 测试说明

所有修改均使用 `globals.css` 主题中已有的语义 token，这些 token 已包含完整的 `:root`（浅色）和 `.dark`（深色）覆盖规则，无需引入新依赖或新 token。

Fixes #89