### PR TITLE
修复: 中文输入法 Enter 确认候选词时误发消息

### DIFF
--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -76,11 +76,15 @@ export function MessageInput({
   }, [content]);
 
   // IME composition state — prevent Enter from sending while composing (e.g. Chinese input)
+  // On Chrome macOS, compositionEnd fires before the Enter keyDown, so we track
+  // the timestamp and ignore Enter within 100ms after composition ends.
   const composingRef = useRef(false);
+  const compositionEndTimeRef = useRef(0);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (composingRef.current) return;
+    if (composingRef.current || e.nativeEvent.isComposing) return;
     if (e.key === 'Enter' && !e.shiftKey) {
+      if (Date.now() - compositionEndTimeRef.current < 100) return;
       e.preventDefault();
       handleSend();
     }
@@ -450,7 +454,7 @@ export function MessageInput({
               onChange={(e) => setContent(e.target.value)}
               onKeyDown={handleKeyDown}
               onCompositionStart={() => { composingRef.current = true; }}
-              onCompositionEnd={() => { composingRef.current = false; }}
+              onCompositionEnd={() => { composingRef.current = false; compositionEndTimeRef.current = Date.now(); }}
               onPaste={handlePaste}
               placeholder="输入消息..."
               disabled={disabled}


### PR DESCRIPTION
## Summary

- 修复 macOS Chrome 下使用中文输入法时，按 Enter 确认英文候选词会导致消息提前发送的问题
- 原因：Chrome 的 `compositionEnd` 在 `keyDown` 之前触发，导致 composing 状态已清除时 Enter 穿透
- 方案：记录 `compositionEnd` 时间戳，100ms 内的 Enter 事件一律忽略

## Test plan

- [x] macOS Chrome 中文输入法输入英文，按 Enter 确认候选词不会误发
- [x] 纯中文输入，按 Enter 选择候选词不会误发
- [x] 正常按 Enter 发送消息功能不受影响
- [x] Shift+Enter 换行功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)