### PR TITLE
修复: 配置第三方 Claude 后无法切换回官方渠道

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -119,10 +119,14 @@ configRoutes.put(
     const actor = (c.get('user') as AuthUser).username;
     const current = getClaudeProviderConfig();
 
+    // When clearing baseUrl, also clear anthropicAuthToken since it requires a baseUrl
+    const newBaseUrl = validation.data.anthropicBaseUrl;
+    const keepAuthToken = newBaseUrl ? current.anthropicAuthToken : '';
+
     try {
       const saved = saveClaudeProviderConfig({
-        anthropicBaseUrl: validation.data.anthropicBaseUrl,
-        anthropicAuthToken: current.anthropicAuthToken,
+        anthropicBaseUrl: newBaseUrl,
+        anthropicAuthToken: keepAuthToken,
         anthropicApiKey: current.anthropicApiKey,
         claudeCodeOauthToken: current.claudeCodeOauthToken,
         claudeOAuthCredentials: current.claudeOAuthCredentials,

--- a/web/src/components/settings/ClaudeProviderSection.tsx
+++ b/web/src/components/settings/ClaudeProviderSection.tsx
@@ -110,6 +110,30 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
     return new Date(config.updatedAt).toLocaleString('zh-CN');
   }, [config?.updatedAt]);
 
+  // Switch back to official using existing OAuth credentials (no re-auth needed)
+  const handleUseExistingOAuth = async () => {
+    setSaving(true);
+    setNotice(null);
+    setError(null);
+    try {
+      await api.put<ClaudeConfigPublic>('/api/config/claude', {
+        anthropicBaseUrl: '',
+      });
+      const saved = await api.put<ClaudeConfigPublic>('/api/config/claude/secrets', {
+        clearAnthropicAuthToken: true,
+        clearAnthropicApiKey: true,
+      });
+      setConfig(saved);
+      setProviderMode('official');
+      setNotice('已切换回官方渠道，使用已有 OAuth 凭据。');
+      await loadConfig();
+    } catch (err) {
+      setError(getErrorMessage(err, '切换失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const handleSaveOfficial = async () => {
     if (!officialCode.trim()) {
       setError('请填写官方 setup-token 或粘贴 .credentials.json 内容');
@@ -360,6 +384,16 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
                 </div>
               )}
               <div className="text-xs text-emerald-600">系统每 5 分钟检查一次，过期前 2 小时内自动刷新。</div>
+              {/* Show switch button when third-party config is still active */}
+              {(config.anthropicBaseUrl || config.hasAnthropicAuthToken) && (
+                <div className="pt-2 border-t border-emerald-200">
+                  <div className="text-xs text-slate-600 mb-2">当前正在使用第三方渠道，可直接切换回官方。</div>
+                  <Button size="sm" onClick={handleUseExistingOAuth} disabled={loading || saving}>
+                    {saving && <Loader2 className="size-4 animate-spin" />}
+                    使用此凭据切换回官方
+                  </Button>
+                </div>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- 修复配置第三方 Claude 提供商后无法切换回官方渠道的 bug
- 后端：`PUT /api/config/claude` 清空 `baseUrl` 时自动清空 `anthropicAuthToken`，避免验证冲突
- 前端：已有 OAuth 凭据时在凭据卡片中显示「使用此凭据切换回官方」按钮，无需重新认证

## Test plan
- [x] 配置第三方 Claude 提供商（填写 baseUrl 和 authToken）
- [x] 切换到「官方」标签，确认 OAuth 凭据卡片中显示「使用此凭据切换回官方」按钮
- [x] 点击按钮，确认成功切换回官方渠道
- [x] 确认切换后 OAuth 凭据正常工作，定时刷新正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)