### PR TITLE
修复: Agent 回复完成后残留"正在思考"幽灵块

### DIFF
--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1212,6 +1212,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // ⑥ 主对话 streaming — 使用 applyStreamEvent 共享函数
     set((s) => {
       const MAX_STREAMING_TEXT = 8000;
+
+      // 防止 "幽灵思考块"：当 streaming 状态已被 handleWsNewMessage 清除后，
+      // 只有表示"Agent 正在活跃处理"的事件才应重新创建 streaming 状态。
+      // usage、tool_use_end、hook_response、task_notification 等后置事件
+      // 如果在 new_message 之后到达，不应重建 streaming 状态和 waiting 标志。
+      if (!s.streaming[chatJid]) {
+        const ACTIVE_EVENTS = new Set([
+          'text_delta', 'thinking_delta', 'tool_use_start',
+          'tool_progress', 'hook_started', 'hook_progress',
+          'status', 'todo_update',
+        ]);
+        if (!ACTIVE_EVENTS.has(event.eventType)) {
+          return s;
+        }
+      }
+
       const prev = s.streaming[chatJid] || { ...DEFAULT_STREAMING_STATE };
       const next = { ...prev };
       applyStreamEvent(event, prev, next, MAX_STREAMING_TEXT);


### PR DESCRIPTION
## Summary

- Agent 回复完成后，`usage`/`tool_use_end` 等后置 `stream_event` 在 `new_message` 之后到达前端，`handleStreamEvent` 无条件设置 `waiting=true` 并重建空的 streaming 状态，导致 StreamingDisplay 渲染"正在思考..."动画且无后续事件清除
- 修复方式：当 streaming 状态已被清除后，仅允许表示活跃处理的事件类型重新创建 streaming 状态，后置事件直接忽略

## Test plan

- [x] 发送消息，等待 Agent 回复完成，确认"正在思考"块不再残留
- [x] 发送需要使用工具的消息，确认流式显示正常工作（工具状态、思考过程、文本输出）
- [ ] 通过 IM（飞书/Telegram）发送消息，确认流式显示仍能正常触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)