### PR TITLE
fix: prevent web messages from broadcasting to IM channels (#99)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1063,9 +1063,25 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   // Direct IM chats reply to themselves. Routed IM messages keep their original
   // source_jid so workspace-bound conversations can reply back to the sender
   // without mirroring every Web reply into IM.
-  const latestSourceJid = missedMessages[missedMessages.length - 1]?.source_jid || chatJid;
+  //
+  // When messages from multiple sources (web + IM) are batched together, only
+  // route replies to IM if ALL messages came from the same IM source. If any
+  // message originated from web, the web user expects replies on web only — do
+  // not broadcast to IM (#99).
   const directImReply = getChannelType(chatJid) !== null;
-  const replySourceImJid = getChannelType(latestSourceJid) ? latestSourceJid : null;
+  let replySourceImJid: string | null = null;
+  if (!directImReply) {
+    // chatJid is a web channel — check if ALL messages share the same IM source
+    const firstSourceJid = missedMessages[0]?.source_jid || chatJid;
+    const allSameImSource = getChannelType(firstSourceJid) !== null &&
+      missedMessages.every((m) => (m.source_jid || chatJid) === firstSourceJid);
+    if (allSameImSource) {
+      replySourceImJid = firstSourceJid;
+    }
+  } else {
+    // chatJid is an IM channel — reply directly
+    replySourceImJid = chatJid;
+  }
 
   const shared = isGroupShared(group.folder);
   const prompt = formatMessages(missedMessages, shared);
@@ -2414,8 +2430,17 @@ async function processAgentConversation(chatJid: string, agentId: string): Promi
   const prompt = formatMessages(missedMessages, false);
   const images = collectMessageImages(virtualChatJid, missedMessages);
   const imagesForAgent = images.length > 0 ? images : undefined;
-  const latestSourceJid = missedMessages[missedMessages.length - 1]?.source_jid || virtualChatJid;
-  const replySourceImJid = getChannelType(latestSourceJid) ? latestSourceJid : null;
+  // Same mixed-source logic as processGroupMessages (#99): only route to IM
+  // when ALL messages share the same IM source.
+  let replySourceImJid: string | null = null;
+  {
+    const firstSourceJid = missedMessages[0]?.source_jid || virtualChatJid;
+    const allSameImSource = getChannelType(firstSourceJid) !== null &&
+      missedMessages.every((m) => (m.source_jid || virtualChatJid) === firstSourceJid);
+    if (allSameImSource) {
+      replySourceImJid = firstSourceJid;
+    }
+  }
 
   // Track idle timer
   let idleTimer: ReturnType<typeof setTimeout> | null = null;

--- a/src/web.ts
+++ b/src/web.ts
@@ -288,37 +288,18 @@ async function handleWebUserMessage(
     shared,
   );
 
-  // For home chat, distinguish safe reuse vs restart scenarios:
-  // - User-specific Web home with its own active runner: safe to IPC-inject
-  // - IM-started runner / shared admin home / no active runner: restart so routing and ownership are recalculated
+  // For home chat, always restart the agent so processGroupMessages can
+  // re-evaluate reply routing (replySourceImJid) from the latest message.
+  // IPC-injecting into a running home container is unsafe because:
+  // 1. web:main is shared — runtime owner must be recalculated per sender.
+  // 2. Any home group may have IM bindings — the running agent's reply
+  //    callback was bound to the *previous* message's source_jid, so a
+  //    web message injected into an IM-started runner would incorrectly
+  //    route replies back to IM instead of staying on web (#99).
   let pipedToActive = false;
   if (group.is_home) {
-    // web:main is a shared admin home. Its runtime owner is selected from the
-    // latest sender during processGroupMessages, so reusing an existing runner
-    // here can leak another admin's session/memory context.
-    const canReuseHomeRunner = chatJid !== 'web:main' && deps.queue.hasDirectActiveRunner(chatJid);
-    if (canReuseHomeRunner) {
-      // Same channel: container was started by this Web JID → IPC inject
-      const images = attachments?.map((attachment) => ({
-        data: attachment.data,
-        mimeType: attachment.mimeType,
-      }));
-      const intent = analyzeIntent(content);
-      const sendResult = deps.queue.sendMessage(chatJid, formatted, images, intent);
-      if (sendResult === 'sent' || sendResult === 'interrupted_stop' || sendResult === 'interrupted_correction') {
-        pipedToActive = true;
-      } else {
-        // Runner exited between hasDirectActiveRunner check and sendMessage (TOCTOU race).
-        // Message is already in DB — enqueueMessageCheck will pick it up.
-        logger.debug({ chatJid, sendResult }, 'Home same-channel IPC missed, falling back to enqueue');
-        deps.queue.enqueueMessageCheck(chatJid);
-      }
-    } else {
-      // Unsafe to reuse (cross-channel, shared admin home, or no active runner):
-      // keep original closeStdin + restart behavior.
-      deps.queue.closeStdin(chatJid);
-      deps.queue.enqueueMessageCheck(chatJid);
-    }
+    deps.queue.closeStdin(chatJid);
+    deps.queue.enqueueMessageCheck(chatJid);
   } else {
     const images = toAgentImages(normalizedAttachments);
     const intent = analyzeIntent(content);


### PR DESCRIPTION
## 问题

修复 #99：从 web 发送的消息会自动广播到 IM（飞书），理论上应该哪里来回到哪里。

## 根因分析

发现两个导致 web 消息错误广播到 IM 的根因：

### 1. Home 群组 IPC 注入绕过 source 路由 (web.ts)

成员用户的 home 群组（`web:home-{userId}`）允许 IPC 注入到已运行的 agent 中。但如果 agent 是由 IM 消息启动的，其回复回调绑定的是之前消息的 `source_jid`（飞书 JID）。当 web 消息通过 IPC 注入时，回复仍然路由到飞书而非留在 web。

**修复**：所有 home 群组（不仅是 `web:main`）在收到 web 消息时都强制重启 agent，让 `processGroupMessages` 重新评估回复路由。

### 2. 混合来源批次路由 (index.ts)

当 web 和 IM 消息同时被批量处理时，`replySourceImJid` 仅由**最后一条**消息的 `source_jid` 决定。如果飞书消息在 web 消息之后到达，回复会错误地路由到飞书。

**修复**：只有当批次中**所有**消息都来自同一个 IM 来源时，才将回复路由到 IM。只要有任何消息来自 web，回复就只留在 web。

## 改动

- `src/web.ts`: 简化 home 群组处理——始终 closeStdin + enqueueMessageCheck
- `src/index.ts`: `processGroupMessages` 和 `processAgentConversation` 都使用基于全批次的 source 检查

## 测试场景

1. ✅ 纯 web 消息 → 回复只在 web
2. ✅ 纯 IM 消息 → 回复路由回 IM
3. ✅ web + IM 混合批次 → 回复只在 web（不广播到 IM）
4. ✅ mirror 策略的 IM 群组 → 仍然正常 mirror