### PR TITLE
feat: improve process text readability with structured timeline display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1412,8 +1412,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             typeof result.result === 'string'
               ? result.result
               : JSON.stringify(result.result);
-          // Strip <internal>...</internal> blocks — agent uses these for internal reasoning
-          const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+          // Strip <internal>...</internal> and <process>...</process> blocks — agent uses these for internal reasoning/process text
+          const text = raw
+            .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+            .replace(/<process>[\s\S]*?<\/process>/g, '')
+            .trim();
           logger.info(
             { group: group.name },
             `Agent output: ${raw.slice(0, 200)}`,
@@ -1618,7 +1621,10 @@ async function runTerminalWarmup(chatJid: string): Promise<void> {
           typeof result.result === 'string'
             ? result.result
             : JSON.stringify(result.result);
-        const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+        const text = raw
+          .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+          .replace(/<process>[\s\S]*?<\/process>/g, '')
+          .trim();
         if (!text || text === warmupReadyToken) return;
         await sendMessage(chatJid, text);
         resetIdleTimer();
@@ -2624,7 +2630,10 @@ async function processAgentConversation(chatJid: string, agentId: string): Promi
     // Agent reply
     if (output.result) {
       const raw = typeof output.result === 'string' ? output.result : JSON.stringify(output.result);
-      const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
+      const text = raw
+        .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+        .replace(/<process>[\s\S]*?<\/process>/g, '')
+        .trim();
       if (text) {
         const msgId = crypto.randomUUID();
         lastAgentReplyMsgId = msgId;

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useChatStore } from '../../stores/chat';
+import { useChatStore, StreamingTimelineEvent } from '../../stores/chat';
 import { useAuthStore } from '../../stores/auth';
 import { EmojiAvatar } from '../common/EmojiAvatar';
 import { MarkdownRenderer } from './MarkdownRenderer';
@@ -49,6 +49,70 @@ function AskUserQuestionCard({ toolInput }: { toolInput: Record<string, unknown>
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+/** Structured timeline event item with icon and color-coding by kind */
+function TimelineEventItem({ item }: { item: StreamingTimelineEvent }) {
+  const isCompleted = item.text.startsWith('✓');
+
+  const toolIcon = (
+    <svg className="w-3 h-3 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z" />
+    </svg>
+  );
+  const skillIcon = (
+    <svg className="w-3 h-3 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+    </svg>
+  );
+  const hookIcon = (
+    <svg className="w-3 h-3 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+    </svg>
+  );
+  const statusIcon = (
+    <svg className="w-3 h-3 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+
+  type StyleConfig = { icon: React.ReactNode; colorClass: string; bgClass: string; borderClass: string };
+  const styles: Record<StreamingTimelineEvent['kind'], StyleConfig> = {
+    tool: {
+      icon: toolIcon,
+      colorClass: isCompleted ? 'text-green-700' : 'text-slate-600',
+      bgClass: isCompleted ? 'bg-green-50' : 'bg-slate-50',
+      borderClass: isCompleted ? 'border-green-200' : 'border-slate-200',
+    },
+    skill: {
+      icon: skillIcon,
+      colorClass: isCompleted ? 'text-blue-700' : 'text-blue-600',
+      bgClass: isCompleted ? 'bg-blue-50' : 'bg-blue-50/60',
+      borderClass: isCompleted ? 'border-blue-200' : 'border-blue-100',
+    },
+    hook: {
+      icon: hookIcon,
+      colorClass: 'text-purple-700',
+      bgClass: 'bg-purple-50',
+      borderClass: 'border-purple-200',
+    },
+    status: {
+      icon: statusIcon,
+      colorClass: 'text-amber-700',
+      bgClass: 'bg-amber-50',
+      borderClass: 'border-amber-200',
+    },
+  };
+
+  const s = styles[item.kind];
+  return (
+    <div className={`flex items-start gap-1.5 px-2 py-1 rounded-md text-[11px] border ${s.colorClass} ${s.bgClass} ${s.borderClass}`}>
+      {s.icon}
+      <span className="break-words leading-relaxed min-w-0 flex-1">{item.text}</span>
     </div>
   );
 }
@@ -320,10 +384,10 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
           {/* Recent events timeline */}
           {streaming.recentEvents.length > 0 && (
             <div className="rounded-lg border border-border bg-muted/30 p-2 mb-2">
-              <div className="text-[11px] font-medium text-slate-500 mb-1">调用轨迹</div>
-              <div className="space-y-1 max-h-28 overflow-y-auto">
+              <div className="text-[11px] font-medium text-slate-500 mb-1.5">调用轨迹</div>
+              <div className="space-y-1 max-h-40 overflow-y-auto">
                 {streaming.recentEvents.map((item) => (
-                  <div key={item.id} className="text-xs text-slate-600 break-words">{item.text}</div>
+                  <TimelineEventItem key={item.id} item={item} />
                 ))}
               </div>
             </div>
@@ -520,12 +584,10 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
             {/* Recent events timeline */}
             {streaming.recentEvents.length > 0 && (
               <div className="rounded-lg border border-border bg-muted/30 p-2 mb-2">
-                <div className="text-[11px] font-medium text-slate-500 mb-1">调用轨迹</div>
-                <div className="space-y-1 max-h-28 overflow-y-auto">
+                <div className="text-[11px] font-medium text-slate-500 mb-1.5">调用轨迹</div>
+                <div className="space-y-1 max-h-40 overflow-y-auto">
                   {streaming.recentEvents.map((item) => (
-                    <div key={item.id} className="text-xs text-slate-600 break-words">
-                      {item.text}
-                    </div>
+                    <TimelineEventItem key={item.id} item={item} />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
Fixes #98

## 问题

过程文本（调用轨迹）可读性差：
- Web UI 中的调用轨迹面板显示的是纯文本列表，所有事件类型看起来完全一样，难以区分
- IM 中有时会有过程文本混入最终输出

## 解决方案

### Web UI（推荐方案：结构化展示）

在 `StreamingDisplay.tsx` 中新增 `TimelineEventItem` 组件，为每种事件类型提供独立的图标和配色方案：

| 事件类型 | 图标 | 颜色 |
|---------|------|------|
| tool（进行中） | 🔧 扳手 | 灰色 |
| tool（已完成 ✓） | 🔧 扳手 | 绿色 |
| skill | ✨ 星型 | 蓝色 |
| hook | 🔗 链接 | 紫色 |
| status | ℹ️ 信息 | 琥珀色 |

每个事件项显示为独立的圆角徽章，带有图标、颜色边框和背景色，视觉层次清晰。同时将最大高度从 112px 增加到 160px，可显示更多历史事件。

### IM 内容过滤

在 `src/index.ts` 中，扩展已有的 `<internal>` 标签过滤逻辑，同时过滤 `<process>...</process>` 标签，防止 Agent 输出的过程文本泄漏到 IM 消息中。

## 文件变更

- `web/src/components/chat/StreamingDisplay.tsx`：新增 `TimelineEventItem` 组件，替换两处纯文本列表渲染
- `src/index.ts`：在三处文本处理位置补充 `<process>` 标签过滤