### PR TITLE
修复: 无容器模式群组时跳过 Docker 检查

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1269,6 +1269,16 @@ export function getJidsByFolder(folder: string): string[] {
   return rows.map((r) => r.jid);
 }
 
+/** Check if any registered group uses container execution mode (efficient targeted query). */
+export function hasContainerModeGroups(): boolean {
+  const row = db
+    .prepare(
+      "SELECT 1 FROM registered_groups WHERE execution_mode = 'container' OR execution_mode IS NULL LIMIT 1",
+    )
+    .get();
+  return row !== undefined;
+}
+
 export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
   const rows = db.prepare('SELECT * FROM registered_groups').all() as RegisteredGroupRow[];
   const result: Record<string, RegisteredGroup> = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
+  hasContainerModeGroups,
   getAllTasks,
   getJidsByFolder,
   getLastGroupSync,
@@ -2896,49 +2897,45 @@ function recoverPendingMessages(): void {
 }
 
 async function ensureDockerRunning(): Promise<void> {
+  // Skip all Docker checks when no groups use container mode
+  if (!hasContainerModeGroups()) {
+    logger.info('All groups use host execution mode, skipping Docker checks');
+    return;
+  }
+
   try {
     await execFileAsync('docker', ['info'], { timeout: 10000 });
     logger.debug('Docker daemon is running');
   } catch {
-    // 如果有容器模式的 group，Docker 必须运行
-    const hasContainerGroups = Object.values(registeredGroups).some(
-      (g) => (g.executionMode || 'container') === 'container',
+    logger.error('Docker daemon is not running');
+    console.error(
+      '\n╔════════════════════════════════════════════════════════════════╗',
     );
-    if (hasContainerGroups) {
-      logger.error('Docker daemon is not running');
-      console.error(
-        '\n╔════════════════════════════════════════════════════════════════╗',
-      );
-      console.error(
-        '║  FATAL: Docker is not running                                  ║',
-      );
-      console.error(
-        '║                                                                ║',
-      );
-      console.error(
-        '║  Agents cannot run without Docker. To fix:                     ║',
-      );
-      console.error(
-        '║  macOS: Start Docker Desktop                                   ║',
-      );
-      console.error(
-        '║  Linux: sudo systemctl start docker                            ║',
-      );
-      console.error(
-        '║                                                                ║',
-      );
-      console.error(
-        '║  Install from: https://docker.com/products/docker-desktop      ║',
-      );
-      console.error(
-        '╚════════════════════════════════════════════════════════════════╝\n',
-      );
-      throw new Error('Docker is required but not running');
-    } else {
-      logger.warn(
-        'Docker is not running, but all groups use host execution mode',
-      );
-    }
+    console.error(
+      '║  FATAL: Docker is not running                                  ║',
+    );
+    console.error(
+      '║                                                                ║',
+    );
+    console.error(
+      '║  Agents cannot run without Docker. To fix:                     ║',
+    );
+    console.error(
+      '║  macOS: Start Docker Desktop                                   ║',
+    );
+    console.error(
+      '║  Linux: sudo systemctl start docker                            ║',
+    );
+    console.error(
+      '║                                                                ║',
+    );
+    console.error(
+      '║  Install from: https://docker.com/products/docker-desktop      ║',
+    );
+    console.error(
+      '╚════════════════════════════════════════════════════════════════╝\n',
+    );
+    throw new Error('Docker is required but not running');
   }
 
   // Kill and clean up orphaned happyclaw containers from previous runs

--- a/src/routes/monitor.ts
+++ b/src/routes/monitor.ts
@@ -13,7 +13,7 @@ import {
   canAccessGroup,
   getWebDeps,
 } from '../web-context.js';
-import { getRegisteredGroup, getRouterState } from '../db.js';
+import { getRegisteredGroup, getRouterState, hasContainerModeGroups } from '../db.js';
 import { CONTAINER_IMAGE } from '../config.js';
 import { getSystemSettings } from '../runtime-config.js';
 import { logger } from '../logger.js';
@@ -121,6 +121,8 @@ monitorRoutes.get('/health', async (c) => {
 });
 
 async function checkDockerImageExists(): Promise<boolean> {
+  // Skip Docker check entirely when no groups use container mode
+  if (!hasContainerModeGroups()) return false;
   try {
     const { stdout } = await execFileAsync(
       'docker',


### PR DESCRIPTION
## Summary
- 当所有群组使用 host 执行模式且 Docker Desktop 未运行时，`checkDockerImageExists()` 和 `ensureDockerRunning()` 仍调用 docker CLI，导致 CLOSE_WAIT 连接堆积，阻塞事件循环引发服务崩溃
- 在 `db.ts` 添加高效的 `hasContainerModeGroups()` 查询（`SELECT 1 ... LIMIT 1`），避免全表扫描
- `monitor.ts` 和 `index.ts` 统一使用该共享函数，无容器群组时提前跳过所有 Docker 操作

## Test plan

- [x] 停止 Docker Desktop，确认 HappyClaw 正常运行（host 模式）
- [x] 注册一个 container 模式群组，确认 Docker 检查恢复
- [x] 验证 `/api/status` 轮询不再触发 `docker images` 调用

## Test results

| 测试项 | 结果 | 详情 |
|--------|------|------|
| 停止 Docker，服务正常运行 | ✅ 通过 | 连续 5 次健康检查全部 healthy，0 个 CLOSE\_WAIT 连接 |
| container 模式群组 + Docker 停止 | ✅ 通过 | `checkDockerImageExists()` catch 静默返回 false，不崩溃；Docker 恢复后正常检测到镜像 |
| 无 container 群组时跳过 docker 调用 | ✅ 通过 | 所有群组设为 host 模式后，15 秒内 0 次 docker 进程调用，日志无 docker 相关记录 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)