### PR TITLE
修复: 飞书 Bot open_id 解析路径错误导致 require_mention 失效

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -717,15 +717,6 @@ export function createFeishuConnection(config: FeishuConnectionConfig): FeishuCo
       }
     }
 
-    if (source === 'ws') {
-      addReaction(messageId, 'OnIt')
-        .then((reactionId) => {
-          if (reactionId) {
-            ackReactionByChat.set(chatId, `${messageId}:${reactionId}`);
-          }
-        })
-        .catch(() => {});
-    }
     lastMessageIdByChat.set(chatId, messageId);
 
     const resolvedCreateTimeMs = createTimeMs > 0 ? createTimeMs : Date.now();
@@ -768,6 +759,17 @@ export function createFeishuConnection(config: FeishuConnectionConfig): FeishuCo
         logger.debug({ chatJid, messageId }, 'Dropped group message: mention required but bot not mentioned');
         return;
       }
+    }
+
+    // ── Ack Reaction：确认已收到消息（在 mention 过滤之后，避免对未处理的消息加表情） ──
+    if (source === 'ws') {
+      addReaction(messageId, 'OnIt')
+        .then((reactionId) => {
+          if (reactionId) {
+            ackReactionByChat.set(chatId, `${messageId}:${reactionId}`);
+          }
+        })
+        .catch(() => {});
     }
 
     // Store message and broadcast to WebSocket clients


### PR DESCRIPTION
## 问题

飞书群聊设置 `require_mention=true` 后，存在两个问题：

### 1. Bot open_id 获取失败，mention 过滤完全失效

机器人仍然响应所有消息，@mention 过滤形同虚设。

**根因**：`feishu.ts` 中调用 Bot Info v3 API (`GET /open-apis/bot/v3/info/`) 后，响应解析路径错误：

- **代码期望**：`{ data: { bot: { open_id: "..." } } }`
- **API 实际返回**：`{ bot: { open_id: "..." } }`

导致 `botOpenId` 始终为空字符串，触发安全降级逻辑（`isBotMentioned` 默认 `true`），所有消息都被放行。

**修复**：兼容两种响应格式，优先取 `info.bot.open_id`，fallback 到 `info.data.bot.open_id`。

### 2. 被过滤的消息仍会添加 OnIt Reaction

群消息未 @机器人 时被 `require_mention` 正确过滤，但 `addReaction('OnIt')` 在过滤逻辑之前执行，导致被丢弃的消息仍然会被加上 OnIt 表情，用户误以为机器人已接收。

**修复**：将 `addReaction` 调用从 mention 过滤之前移到之后，确保只有实际处理的消息才会添加确认表情。

## 测试

修复后重启服务：

1. 日志确认 bot open_id 成功获取：
```
[INFO] Fetched bot open_id for mention detection
```

2. 飞书群聊中非 @机器人 的消息不再触发响应，也不再添加 OnIt 表情。