### PR TITLE
修复: backfill 消息缺少 chatType 导致 mention 过滤失效

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -387,6 +387,7 @@ export function createFeishuConnection(
   const ackReactionByChat = new Map<string, string>();
   const typingReactionByChat = new Map<string, string>();
   const knownChatIds = new Set<string>();
+  const chatTypeById = new Map<string, string>(); // chatId → 'group' | 'p2p'
   const lastCreateTimeByChat = new Map<string, number>();
 
   let client: lark.Client | null = null;
@@ -402,8 +403,9 @@ export function createFeishuConnection(
   let disconnectedSince: number | null = null;
   let healthTimer: NodeJS.Timeout | null = null;
 
-  function rememberChatProgress(chatId: string, createTimeMs: number): void {
+  function rememberChatProgress(chatId: string, createTimeMs: number, chatType?: string): void {
     knownChatIds.add(chatId);
+    if (chatType) chatTypeById.set(chatId, chatType);
     const prev = lastCreateTimeByChat.get(chatId) || 0;
     if (createTimeMs > prev) {
       lastCreateTimeByChat.set(chatId, createTimeMs);
@@ -829,7 +831,7 @@ export function createFeishuConnection(
 
     const resolvedCreateTimeMs = createTimeMs > 0 ? createTimeMs : Date.now();
     const timestamp = new Date(resolvedCreateTimeMs).toISOString();
-    rememberChatProgress(chatId, resolvedCreateTimeMs);
+    rememberChatProgress(chatId, resolvedCreateTimeMs, chatType);
 
     // ── 斜杠指令：拦截已知 /xxx 命令，不进入消息流 ──
     // 群聊中 @机器人 后跟斜杠命令，mention 替换后文本为 "@botname /cmd"，
@@ -1023,7 +1025,7 @@ export function createFeishuConnection(
             createTimeMs: toEpochMs(item.create_time),
             messageType: item.msg_type || item.message_type || '',
             content: item.body?.content || item.content || '',
-            chatType: item.chat_type,
+            chatType: item.chat_type || chatTypeById.get(chatId) || 'group',
             mentions: item.mentions,
             senderOpenId,
           };


### PR DESCRIPTION
## 问题

飞书断线重连后，通过历史消息 API（`GET /open-apis/im/v1/messages`）补发的 backfill 消息不包含 `chat_type` 字段，导致 `chatType` 为 `undefined`。

## 根因

mention 过滤条件为 `chatType === 'group'`，backfill 消息的 `chatType` 始终为 `undefined`，该条件永远不成立，所有 backfill 消息都绕过了 `require_mention` 检查。

这意味着断线重连后，群聊中未 @机器人 的消息也会被处理。

## 修复方案

1. 新增 `chatTypeById` Map，在实时 WebSocket 消息处理时记录每个 `chatId` 的类型（`group` / `p2p`）
2. `rememberChatProgress()` 增加可选 `chatType` 参数，实时消息调用时传入
3. backfill 消息构造时，`chatType` 优先使用 API 返回值 → fallback 到已记录的类型 → 最终 fallback 到 `'group'`（安全默认值，宁可多过滤也不漏处理）

## 测试验证

- 正常实时消息：chatType 从 WebSocket 事件获取，同时记录到 `chatTypeById`，行为不变
- 断线重连 backfill：chatType 从 `chatTypeById` 获取已记录的类型，mention 过滤正常生效
- 首次连接 backfill（无历史记录）：fallback 到 `'group'`，触发 mention 过滤（安全默认值）