### PR TITLE
修复: 子会话回复后"正在思考"不消失

### DIFF
--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1009,6 +1009,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
         return;
       }
       set((s) => {
+        // Guard: if streaming was already cleared (agent reply received),
+        // ignore late-arriving stream events to prevent "thinking" reappearing.
+        if (!s.agentStreaming[agentId] && s.agentWaiting[agentId] === false) {
+          return s;
+        }
         const prev = s.agentStreaming[agentId] || { ...DEFAULT_STREAMING_STATE };
         const next = { ...prev };
         applyStreamEvent(event, prev, next, 8000);


### PR DESCRIPTION
## Summary

- 修复 agent conversation（子会话）回复后"正在思考"永久卡住的问题
- 根因：`handleStreamEvent` 处理 agent conversation 的 stream_event 时缺少 guard，迟到的 `usage` 等事件在 `agentStreaming` 已被 `new_message` 清除后重新创建了 streaming 状态
- 主对话路径已有此 guard（`!s.streaming[chatJid] && s.waiting[chatJid] === false`），但 agent conversation 路径遗漏

## 复现路径

1. 打开一个 conversation agent（子会话）
2. 发送消息，等待 agent 回复
3. 回复内容正常显示，但"正在思考"指示器不消失

## 修复

在 `web/src/stores/chat.ts` 的 agent stream_event 处理中加入与主对话一致的 guard：

```typescript
if (!s.agentStreaming[agentId] && s.agentWaiting[agentId] === false) {
  return s;
}
```

## Test plan

- [ ] 在子会话中发送消息，确认回复后"正在思考"正常消失
- [ ] 确认主对话的 streaming 行为不受影响
- [ ] 确认中断（interrupted）事件仍能正确清理状态

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)