### PR TITLE
功能: Conversation Agent 飞书流式卡片支持

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3073,6 +3073,9 @@ async function processAgentConversation(
   }
 
   // ── Feishu Streaming Card (conversation agent) ──
+  // Unlike processGroupMessages which falls back to chatJid, conversation agents
+  // only stream when the message originates from an IM channel (replySourceImJid).
+  // Web-only interactions don't need a Feishu streaming card.
   const streamingSessionJid = replySourceImJid;
   const agentStreamingSession = streamingSessionJid
     ? imManager.createStreamingSession(streamingSessionJid)
@@ -3346,6 +3349,7 @@ async function processAgentConversation(
 
     commitCursor();
   } catch (err) {
+    hadError = true;
     logger.error({ agentId, chatJid, err }, 'Agent conversation error');
   } finally {
     if (idleTimer) clearTimeout(idleTimer);


### PR DESCRIPTION
为子会话（conversation agent）添加飞书流式卡片打字机效果：
- processAgentConversation 中创建 streaming session
- text_delta 事件实时喂入流式卡片
- 完成时 complete() 替代静态消息，失败时 fallback
- finally 中清理 streaming session 并 unregister