### PR TITLE
重构: home 群组消息处理从杀进程重启改为 IPC 注入 + 动态路由

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -317,6 +317,7 @@ export class GroupQueue {
     text: string,
     images?: Array<{ data: string; mimeType?: string }>,
     intent: MessageIntent = 'continue',
+    onInjected?: () => void,
   ): SendMessageResult {
     const state = this.resolveActiveState(groupJid);
     if (!state) return 'no_active';
@@ -365,6 +366,7 @@ export class GroupQueue {
         JSON.stringify({ type: 'message', text, images }),
       );
       fs.renameSync(tempPath, filepath);
+      onInjected?.();
       return intent === 'correction' ? 'interrupted_correction' : 'sent';
     } catch {
       return 'no_active';

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,12 @@ const queue = new GroupQueue();
 const EMPTY_CURSOR: MessageCursor = { timestamp: '', id: '' };
 const terminalWarmupInFlight = new Set<string>();
 
+// Per-folder reply route updater: lets sendMessage callers update the
+// reply routing of a running processGroupMessages without killing the process.
+// Key is group folder (one active processGroupMessages per folder).
+type ReplyRouteUpdater = (newSourceJid: string | null) => void;
+const activeRouteUpdaters = new Map<string, ReplyRouteUpdater>();
+
 // Track consecutive IM send failures per JID for auto-unbind
 const imSendFailCounts = new Map<string, number>();
 const IM_SEND_FAIL_THRESHOLD = 3;
@@ -1572,14 +1578,44 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   // ── Feishu Streaming Card ──
   // Create a streaming session for Feishu channels (typing-machine effect).
   // Non-Feishu channels get undefined → all streaming logic is no-op.
-  const streamingSessionJid = replySourceImJid ?? chatJid;
-  const streamingSession =
+  let streamingSessionJid = replySourceImJid ?? chatJid;
+  let streamingSession =
     imManager.createStreamingSession(streamingSessionJid);
   let streamingAccumulatedText = '';
   if (streamingSession) {
     registerStreamingSession(streamingSessionJid, streamingSession);
     logger.debug({ chatJid }, 'Streaming card session created for Feishu');
   }
+
+  // ── Dynamic reply route updater ──
+  // Allows IPC-injected messages (from web.ts / IM polling) to update the
+  // reply routing target without killing the agent process.  This replaces
+  // the old "closeStdin + restart" approach for home groups (#99).
+  activeRouteUpdaters.set(effectiveGroup.folder, (newSourceJid) => {
+    const newImJid =
+      newSourceJid && getChannelType(newSourceJid) ? newSourceJid : null;
+    if (newImJid === replySourceImJid) return; // no change
+    logger.debug(
+      { chatJid, oldRoute: replySourceImJid, newRoute: newImJid },
+      'Reply route updated via IPC injection',
+    );
+    replySourceImJid = newImJid;
+
+    // Rebuild streaming session if the target channel changed
+    const newStreamingJid = replySourceImJid ?? chatJid;
+    if (newStreamingJid !== streamingSessionJid) {
+      if (streamingSession) {
+        if (streamingSession.isActive()) streamingSession.dispose();
+        unregisterStreamingSession(streamingSessionJid);
+      }
+      streamingSessionJid = newStreamingJid;
+      streamingSession = imManager.createStreamingSession(streamingSessionJid);
+      streamingAccumulatedText = '';
+      if (streamingSession) {
+        registerStreamingSession(streamingSessionJid, streamingSession);
+      }
+    }
+  });
 
   const pickRunningTaskForNotification = (): string | null => {
     const runningInQuery = Array.from(queryTaskIds)
@@ -1971,6 +2007,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   await setTyping(chatJid, false);
   if (idleTimer) clearTimeout(idleTimer);
+  activeRouteUpdaters.delete(effectiveGroup.folder);
 
   // ── Streaming card cleanup ──
   if (streamingSession) {
@@ -3604,14 +3641,6 @@ async function startMessageLoop(): Promise<void> {
           }
         }
 
-        // Build set of home folders: IM messages sharing a home folder must
-        // force-restart the container so reply routing is correct (e.g., feishu
-        // messages get feishu replies instead of being silently absorbed by web:main).
-        const homeFolders = new Set<string>();
-        for (const g of Object.values(registeredGroups)) {
-          if (g.is_home) homeFolders.add(g.folder);
-        }
-
         for (const [chatJid, groupMessages] of messagesByGroup) {
           let group = registeredGroups[chatJid];
           if (!group) {
@@ -3626,25 +3655,6 @@ async function startMessageLoop(): Promise<void> {
           // Skip groups with target_agent_id — their messages are routed
           // to conversation agents at IM ingestion time (feishu.ts/telegram.ts)
           if (group.target_agent_id) continue;
-
-          if (group.is_home) homeFolders.add(group.folder);
-
-          // Handle cold-cache/newly-added groups: detect home folders from DB
-          // even if the in-memory map has not been fully refreshed yet.
-          if (!homeFolders.has(group.folder)) {
-            const siblingJids = getJidsByFolder(group.folder);
-            for (const siblingJid of siblingJids) {
-              const sibling =
-                registeredGroups[siblingJid] ?? getRegisteredGroup(siblingJid);
-              if (sibling && !registeredGroups[siblingJid]) {
-                registeredGroups[siblingJid] = sibling;
-              }
-              if (sibling?.is_home) {
-                homeFolders.add(group.folder);
-                break;
-              }
-            }
-          }
 
           // Billing quota check before processing
           if (group.created_by) {
@@ -3703,32 +3713,10 @@ async function startMessageLoop(): Promise<void> {
           const messagesToSend =
             allPending.length > 0 ? allPending : groupMessages;
 
-          // Groups sharing a home folder always run as a fresh batch.
-          // This prevents IM messages from being piped into an active web:main
-          // container (whose onOutput callback wouldn't route replies to IM).
-          if (homeFolders.has(group.folder)) {
-            // Only close the active runner's stdin if it is handling user
-            // messages (not a scheduled task).  Sending the _close sentinel to
-            // a running task container prematurely terminates the task, which
-            // causes its reply to be swallowed or delivered to the wrong IM
-            // context.  When the runner is a task, simply enqueue the message
-            // check; GroupQueue will start it once the task finishes.
-            // See GitHub issue riba2534/happyclaw#151.
-            if (!queue.isActiveRunnerTask(chatJid)) {
-              queue.closeStdin(chatJid);
-              logger.debug(
-                { chatJid },
-                'Home-folder message received, forcing stdin close before enqueue',
-              );
-            } else {
-              logger.debug(
-                { chatJid },
-                'Home-folder message received while scheduled task is running; deferring until task completes',
-              );
-            }
-            queue.enqueueMessageCheck(chatJid);
-            continue;
-          }
+          // Home and non-home groups now share the same IPC injection path.
+          // Reply routing is dynamically updated via activeRouteUpdaters when
+          // the message is successfully injected, so we no longer need to kill
+          // the process for home groups.
 
           const shared = !group.is_home && isGroupShared(group.folder);
           const formatted = formatMessages(messagesToSend, shared);
@@ -3738,11 +3726,20 @@ async function startMessageLoop(): Promise<void> {
 
           const lastRawText = messagesToSend[messagesToSend.length - 1].content;
           const intent = analyzeIntent(lastRawText);
+
+          // Determine the IM source JID for route update on successful injection
+          const lastSourceJidForRoute =
+            messagesToSend[messagesToSend.length - 1]?.source_jid || chatJid;
+
           const sendResult = queue.sendMessage(
             chatJid,
             formatted,
             imagesForAgent,
             intent,
+            () => {
+              // IPC write succeeded — update reply route for the running agent
+              activeRouteUpdaters.get(group.folder)?.(lastSourceJidForRoute);
+            },
           );
           if (sendResult === 'sent') {
             logger.debug(
@@ -4765,6 +4762,9 @@ async function main(): Promise<void> {
       imManager.getFeishuChatInfo(userId, chatId),
     clearImFailCounts: (jid: string) => {
       imHealthCheckFailCounts.delete(jid);
+    },
+    updateReplyRoute: (folder: string, sourceJid: string | null) => {
+      activeRouteUpdaters.get(folder)?.(sourceJid);
     },
   });
 

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -59,6 +59,7 @@ export interface WebDeps {
     chat_mode?: string;
   } | null>;
   clearImFailCounts?: (jid: string) => void;
+  updateReplyRoute?: (folder: string, sourceJid: string | null) => void;
 }
 
 export type Variables = {

--- a/src/web.ts
+++ b/src/web.ts
@@ -328,38 +328,33 @@ async function handleWebUserMessage(
     shared,
   );
 
-  // For home chat, always restart the agent so processGroupMessages can
-  // re-evaluate reply routing (replySourceImJid) from the latest message.
-  // IPC-injecting into a running home container is unsafe because:
-  // 1. web:main is shared — runtime owner must be recalculated per sender.
-  // 2. Any home group may have IM bindings — the running agent's reply
-  //    callback was bound to the *previous* message's source_jid, so a
-  //    web message injected into an IM-started runner would incorrectly
-  //    route replies back to IM instead of staying on web (#99).
+  // IPC-inject the message into the running agent process.  For home groups,
+  // the reply route is dynamically updated via activeRouteUpdaters so we no
+  // longer need to kill and restart the process (#99).
   let pipedToActive = false;
-  if (group.is_home) {
-    deps.queue.closeStdin(chatJid);
-    deps.queue.enqueueMessageCheck(chatJid);
+  const images = toAgentImages(normalizedAttachments);
+  const intent = analyzeIntent(content);
+  const sendResult = deps.queue.sendMessage(
+    chatJid,
+    formatted,
+    images,
+    intent,
+    () => {
+      // IPC write succeeded — update reply route for home groups.
+      // Web messages have no IM source, so clear the IM route.
+      deps!.updateReplyRoute?.(group.folder, null);
+    },
+  );
+  if (sendResult === 'sent') {
+    pipedToActive = true;
+  } else if (sendResult === 'interrupted_stop') {
+    // Stop intent: cursor updated, no enqueue needed
+    pipedToActive = true;
+  } else if (sendResult === 'interrupted_correction') {
+    // Correction intent: IPC message written, agent handles it after interrupt
+    pipedToActive = true;
   } else {
-    const images = toAgentImages(normalizedAttachments);
-    const intent = analyzeIntent(content);
-    const sendResult = deps.queue.sendMessage(
-      chatJid,
-      formatted,
-      images,
-      intent,
-    );
-    if (sendResult === 'sent') {
-      pipedToActive = true;
-    } else if (sendResult === 'interrupted_stop') {
-      // Stop intent: cursor updated, no enqueue needed
-      pipedToActive = true;
-    } else if (sendResult === 'interrupted_correction') {
-      // Correction intent: IPC message written, agent handles it after interrupt
-      pipedToActive = true;
-    } else {
-      deps.queue.enqueueMessageCheck(chatJid);
-    }
+    deps.queue.enqueueMessageCheck(chatJid);
   }
 
   // Only advance per-group cursor when we piped directly into a running container.


### PR DESCRIPTION
解决子 agent（SDK Task）在 home 群组中因新消息到达被杀死的问题。

原因：home 群组每收到新消息就 closeStdin 杀掉 agent 进程再重启，
因为回复路由（replySourceImJid）绑定在闭包中不可变。这导致进程
内运行的所有 Task（background 和 foreground）一起被杀。

改为：home 群组与非 home 群组统一走 IPC 注入路径，通过
activeRouteUpdaters 机制动态更新回复路由目标。Node.js 单线程
保证 sendMessage 和 onOutput 回调不会并发，无竞争问题。

- group-queue.ts: sendMessage() 新增 onInjected 回调参数
- index.ts: processGroupMessages 注册 per-folder 路由更新器， streaming session 改为可变以支持渠道切换
- index.ts: IM 消息轮询移除 homeFolders 特殊分支
- web.ts: 移除 home 群组的 closeStdin + enqueueMessageCheck 分支
- web-context.ts: WebDeps 新增 updateReplyRoute 方法