### PR TITLE
修复: IM 消息 source 属性改用 channel:chatId，使 Agent 能区分不同群

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ import {
 } from './db.js';
 // feishu.js deprecated exports are no longer needed; imManager handles all connections
 import { imManager } from './im-manager.js';
-import { getChannelType } from './im-channel.js';
+import { getChannelType, extractChatId } from './im-channel.js';
 import {
   registerStreamingSession,
   unregisterStreamingSession,
@@ -1421,7 +1421,14 @@ function escapeXml(s: string): string {
 function formatMessages(messages: NewMessage[], isShared = false): string {
   const lines = messages.map((m) => {
     const content = isShared ? `[${m.sender_name}] ${m.content}` : m.content;
-    return `<message sender="${escapeXml(m.sender_name)}" time="${m.timestamp}">${escapeXml(content)}</message>`;
+    const sourceJid = m.source_jid || m.chat_jid;
+    const channelType = getChannelType(sourceJid);
+    let sourceAttr = '';
+    if (channelType) {
+      const chatId = extractChatId(sourceJid);
+      sourceAttr = ` source="${escapeXml(channelType)}:${escapeXml(chatId)}"`;
+    }
+    return `<message sender="${escapeXml(m.sender_name)}"${sourceAttr} time="${m.timestamp}">${escapeXml(content)}</message>`;
   });
   return `<messages>\n${lines.join('\n')}\n</messages>`;
 }


### PR DESCRIPTION
之前所有飞书群消息的 source 都是 "飞书群聊"，Agent 无法区分来源。
现在改为直接使用 channel type + chat ID（如 feishu:oc_abc123）， 确保每个群有唯一标识。