### PR TITLE
修复: 流式显示气泡在连续消息场景下提前消失

### DIFF
--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1843,10 +1843,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
   },
 
-  // Runner 状态同步：idle 时清理残留的 streaming/waiting 状态
+  // Runner 状态同步：idle 时清理残留状态，running 时重新启用 stream event 接收
   handleRunnerState: (chatJid, state) => {
     if (state === 'idle') {
       get().clearStreaming(chatJid);
+    } else if (state === 'running') {
+      // 新进程启动时重新设置 waiting=true，确保 handleStreamEvent 的防重入
+      // guard（!streaming && waiting===false）不会丢弃新进程的 stream events。
+      // 典型场景：上一进程的 idle 清除了 waiting，drainGroup 立即启动新进程。
+      set((s) => ({
+        waiting: { ...s.waiting, [chatJid]: true },
+      }));
     }
   },
 


### PR DESCRIPTION
## Summary

- 修复用户在 Agent 处理中发送新消息时，"正在思考..."气泡瞬间消失、20+秒无视觉反馈的 bug
- 根因：`handleRunnerState('running')` 未重置 `waiting` 状态，导致 `handleStreamEvent` 的防重入 guard 将新进程的所有 stream events 丢弃
- 修复：在 `handleRunnerState` 中增加 `running` 状态处理，新进程启动时重新设置 `waiting=true`

## Root Cause

当用户在 Agent 进程运行期间发送新消息时：

1. 新消息被排队（`pendingMessages=true`），等待当前进程结束
2. 当前进程完成 → `agent_reply` 到达 → `waiting=false`
3. 进程退出 → `runner_state: idle` → `clearStreaming()`
4. `drainGroup()` 启动新进程 → `runner_state: running` → **什么都不做**
5. 新进程的 stream events → guard 检查 `!streaming && waiting===false` → **全部丢弃**
6. 用户看到 20+秒空白后回复突然出现

引入 commit: `5f0fda6`

## Test Plan

- [x] Agent 空闲时发送消息 → "正在思考..."气泡持续显示直到回复出现
- [x] Agent 处理中发送第二条消息 → 第一条回复到达后，第二条的 streaming 持续显示
- [x] 定时任务触发时 → streaming 正常显示
- [x] 快速连续发送 3+ 条消息 → 每条回复都有完整的 streaming 过程
- [x] 页面刷新/WebSocket 重连后 → streaming 状态正确恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)