### PR TITLE
样式: UI 重设计 — Blue 主题 + Agent 标签优化 + 自适应宽度

### DIFF
--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -33,13 +33,13 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
   if (conversations.length === 0 && tasks.length === 0 && !onCreateConversation) return null;
 
   return (
-    <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border bg-background/80 overflow-x-auto scrollbar-none">
+    <div className="flex items-center gap-1 px-3 py-1.5 bg-background/80 overflow-x-auto scrollbar-none">
       {/* Main conversation tab */}
       <div
         className={`${tabClass(activeTab === null)} flex items-center gap-1.5 group`}
         onClick={() => onSelectTab(null)}
       >
-        <span>主对话</span>
+        <span>主Agent</span>
         {onBindMainIm && (
           <button
             onClick={(e) => { e.stopPropagation(); onBindMainIm(); }}
@@ -61,14 +61,14 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
             onClick={() => onSelectTab(agent.id)}
           >
             {agent.status === 'running' && (
-              <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
+              <span className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
             )}
             {hasLinked && (
               <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
-                <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />
+                <MessageSquare className="w-3 h-3 text-blue-500 flex-shrink-0" />
               </span>
             )}
-            <span className="truncate max-w-[120px]">{agent.name}</span>
+            <span className="truncate max-w-[80px]">{agent.name.length > 6 ? agent.name.slice(0, 6) : agent.name}</span>
             {onBindIm && (
               <button
                 onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
@@ -115,7 +115,7 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onC
               onClick={() => onSelectTab(agent.id)}
             >
               <span>{TASK_STATUS_ICON[agent.status] || ''}</span>
-              <span className="truncate max-w-[100px]">{agent.name}</span>
+              <span className="truncate max-w-[80px]">{agent.name.length > 6 ? agent.name.slice(0, 6) : agent.name}</span>
               <button
                 onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
                 className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-border transition-all cursor-pointer"

--- a/web/src/components/chat/ChatGroupItem.tsx
+++ b/web/src/components/chat/ChatGroupItem.tsx
@@ -79,7 +79,7 @@ export function ChatGroupItem({
             <Star className="w-3.5 h-3.5 text-yellow-500 fill-yellow-500 flex-shrink-0" />
           )}
           {isPinned && !isHome && (
-            <Pin className="w-3 h-3 text-teal-500 flex-shrink-0" />
+            <Pin className="w-3 h-3 text-blue-500 flex-shrink-0" />
           )}
           <span
             className={cn(

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -634,8 +634,8 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                       <div className="flex flex-col items-center justify-center py-12 px-4 space-y-4">
                         {/* 动画 spinner */}
                         <div className="relative">
-                          <div className="w-12 h-12 rounded-full border-2 border-teal-100" />
-                          <div className="absolute inset-0 w-12 h-12 rounded-full border-2 border-transparent border-t-teal-500 animate-spin" />
+                          <div className="w-12 h-12 rounded-full border-2 border-blue-100" />
+                          <div className="absolute inset-0 w-12 h-12 rounded-full border-2 border-transparent border-t-blue-500 animate-spin" />
                         </div>
 
                         <div className="text-center space-y-2 max-w-md">

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -482,7 +482,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
               </div>
             )}
             {!hasOnlyImages && (
-              <div className="bg-card border border-border text-foreground px-4 py-2.5 rounded-2xl rounded-tr-sm shadow-sm">
+              <div className="text-[var(--user-bubble-fg)] px-4 py-2.5 rounded-2xl rounded-tr-sm shadow-sm" style={{ background: 'var(--user-bubble-bg)' }}>
                 <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words">{message.content}</p>
               </div>
             )}

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -537,7 +537,7 @@ export function MessageInput({
               disabled={!canSend || disabled || sending}
               className={`w-9 h-9 rounded-full flex items-center justify-center transition-all cursor-pointer active:scale-90 ${
                 canSend && !disabled && !sending
-                  ? 'bg-primary text-white hover:bg-primary/90 max-lg:shadow-[0_2px_8px_rgba(13,148,136,0.3)]'
+                  ? 'bg-primary text-white hover:bg-primary/90 max-lg:shadow-[0_2px_8px_rgba(59,130,246,0.3)]'
                   : 'bg-slate-100 text-slate-400'
               }`}
             >

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -230,9 +230,9 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
     <div className="relative flex-1 overflow-hidden overflow-x-hidden">
       <div
         ref={parentRef}
-        className="h-full overflow-y-auto overflow-x-hidden py-6 bg-background"
+        className="h-full overflow-y-auto overflow-x-hidden py-6"
       >
-        <div className={displayMode === 'compact' ? 'mx-auto px-4 min-w-0' : 'max-w-3xl mx-auto px-4 min-w-0'}>
+        <div className="mx-auto px-4 min-w-0">
         {loading && hasMore && (
           <div className="flex justify-center py-4">
             <Loader2 className="animate-spin text-primary" size={24} />

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -361,7 +361,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
       );
     }
     return (
-      <div className="max-w-3xl mx-auto w-full px-4 py-3">
+      <div className="mx-auto w-full px-4 py-3">
         {/* Mobile: compact avatar + name row */}
         <div className="flex items-center gap-2 mb-1.5 lg:hidden">
           <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />
@@ -432,7 +432,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
 
   // ── Chat mode streaming (default) ──
   return (
-    <div className="max-w-3xl mx-auto w-full px-4 py-3">
+    <div className="mx-auto w-full px-4 py-3">
       {/* Mobile: compact avatar + name row */}
       <div className="flex items-center gap-2 mb-1.5 lg:hidden">
         <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />

--- a/web/src/components/layout/NavRail.tsx
+++ b/web/src/components/layout/NavRail.tsx
@@ -29,9 +29,9 @@ export function NavRail() {
 
   return (
     <TooltipProvider delayDuration={200}>
-      <nav className="w-16 h-full bg-background border-r border-border flex flex-col items-center py-4 gap-2">
+      <nav className="w-[52px] h-full bg-background border-r border-border flex flex-col items-center py-4 gap-2">
         {/* Logo */}
-        <div className="w-10 h-10 rounded-xl overflow-hidden mb-2 flex-shrink-0">
+        <div className="w-10 h-10 rounded-2xl overflow-hidden mb-2 flex-shrink-0">
           <img src={`${import.meta.env.BASE_URL}icons/icon-192.png`} alt="HappyClaw" className="w-full h-full object-cover" />
         </div>
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -68,58 +68,62 @@
 }
 
 /* =====================================================
-   Design Token values — Teal theme
-   Primary: #0d9488 (Teal) | Logo accent: #d97706 (Amber) | Base: Slate
+   Design Token values — Blue theme
+   Primary: #3b82f6 (Blue) | Logo accent: #d97706 (Amber) | Base: Slate
    ===================================================== */
 :root {
   /* shadcn/ui semantic tokens */
-  --background: #ffffff;
+  --background: #f7f7f8;
   --foreground: #0f172a;
   --card: #ffffff;
   --card-foreground: #0f172a;
   --popover: #ffffff;
   --popover-foreground: #0f172a;
-  --primary: #0d9488;
+  --primary: #3b82f6;
   --primary-foreground: #ffffff;
   --secondary: #f1f5f9;
   --secondary-foreground: #0f172a;
   --muted: #f1f5f9;
   --muted-foreground: #64748b;
-  --accent: #f0fdfa;
-  --accent-foreground: #134e4a;
+  --accent: #eff6ff;
+  --accent-foreground: #1e3a5f;
   --destructive: #dc2626;
   --destructive-foreground: #ffffff;
   --border: #e2e8f0;
   --input: #e2e8f0;
-  --ring: #0d9488;
+  --ring: #3b82f6;
   --radius: 0.5rem;
 
-  /* Brand color scale (Teal) */
-  --brand-50: #f0fdfa;
-  --brand-100: #ccfbf1;
-  --brand-200: #99f6e4;
-  --brand-300: #5eead4;
-  --brand-400: #2dd4bf;
-  --brand-500: #0d9488;
-  --brand-600: #0f766e;
-  --brand-700: #115e59;
+  /* Brand color scale (Blue) */
+  --brand-50: #eff6ff;
+  --brand-100: #dbeafe;
+  --brand-200: #bfdbfe;
+  --brand-300: #93c5fd;
+  --brand-400: #60a5fa;
+  --brand-500: #3b82f6;
+  --brand-600: #2563eb;
+  --brand-700: #1d4ed8;
+
+  /* User bubble */
+  --user-bubble-bg: #1e293b;
+  --user-bubble-fg: #f1f5f9;
 
   /* Chart colors */
-  --chart-1: #0d9488;
+  --chart-1: #3b82f6;
   --chart-2: #d97706;
-  --chart-3: #4c6ef5;
+  --chart-3: #8b5cf6;
   --chart-4: #9333ea;
   --chart-5: #dc2626;
 
   /* Sidebar */
   --sidebar-background: #f8fafc;
   --sidebar-foreground: #0f172a;
-  --sidebar-primary: #0d9488;
+  --sidebar-primary: #3b82f6;
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: #f1f5f9;
   --sidebar-accent-foreground: #0f172a;
   --sidebar-border: #e2e8f0;
-  --sidebar-ring: #0d9488;
+  --sidebar-ring: #3b82f6;
 
   /* Feedback colors */
   --success: #16a34a;
@@ -153,28 +157,28 @@
   --card-foreground: #e2e8f0;
   --popover: #1e293b;
   --popover-foreground: #e2e8f0;
-  --primary: #2dd4bf;
+  --primary: #60a5fa;
   --primary-foreground: #0f172a;
   --secondary: #1e293b;
   --secondary-foreground: #e2e8f0;
   --muted: #1e293b;
   --muted-foreground: #94a3b8;
-  --accent: #134e4a;
-  --accent-foreground: #99f6e4;
+  --accent: #1e3a5f;
+  --accent-foreground: #bfdbfe;
   --destructive: #f87171;
   --destructive-foreground: #ffffff;
   --border: #334155;
   --input: #334155;
-  --ring: #2dd4bf;
+  --ring: #60a5fa;
 
   --sidebar-background: #0f172a;
   --sidebar-foreground: #cbd5e1;
-  --sidebar-primary: #2dd4bf;
+  --sidebar-primary: #60a5fa;
   --sidebar-primary-foreground: #0f172a;
   --sidebar-accent: #1e293b;
   --sidebar-accent-foreground: #cbd5e1;
   --sidebar-border: #1e293b;
-  --sidebar-ring: #2dd4bf;
+  --sidebar-ring: #60a5fa;
 
   --success: #4ade80;
   --success-bg: #14532d;
@@ -398,9 +402,9 @@ pre code.hljs {
 .floating-nav-item:active { transform: scale(0.92); }
 
 .floating-nav-item.active {
-  background: rgba(13, 148, 136, 0.15);
+  background: rgba(59, 130, 246, 0.15);
   color: var(--primary);
-  box-shadow: 0 2px 8px rgba(13, 148, 136, 0.15),
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.15),
               var(--glass-inner-shadow);
   transition: all 350ms cubic-bezier(0.34, 1.56, 0.64, 1);
   transform: scale(1.08);
@@ -411,7 +415,7 @@ pre code.hljs {
   position: absolute;
   inset: 0;
   border-radius: 9999px;
-  background: radial-gradient(circle, rgba(13, 148, 136, 0.2) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.2) 0%, transparent 70%);
   animation: glass-ripple 400ms ease-out;
 }
 


### PR DESCRIPTION
## Summary
- 主色调从 Teal (#0d9488) 切换到 Blue (#3b82f6)，整体视觉更现代
- 背景色调整为 #f7f7f8，柔和不刺眼
- 新增 user-bubble-bg/fg CSS 变量，用户消息使用深色气泡样式
- "主对话" 改为 "主Agent"，Agent 名称截断到 6 字符
- 移除 max-w-3xl 约束，消息区域自适应宽度
- NavRail 宽度从 64px 缩小到 52px，更紧凑
- 所有硬编码 teal 颜色统一更新为 blue

## 涉及文件
- `web/src/styles/globals.css` — 设计 token 全量更新（Light + Dark）
- `web/src/components/chat/AgentTabBar.tsx` — 标签优化 + 名称截断
- `web/src/components/chat/MessageList.tsx` — 移除宽度限制
- `web/src/components/chat/StreamingDisplay.tsx` — 移除宽度限制
- `web/src/components/chat/MessageBubble.tsx` — 用户消息深色气泡
- `web/src/components/chat/ChatView.tsx` — spinner 颜色更新
- `web/src/components/chat/MessageInput.tsx` — 发送按钮阴影色更新
- `web/src/components/chat/ChatGroupItem.tsx` — Pin 图标颜色更新
- `web/src/components/layout/NavRail.tsx` — 宽度缩小 + 圆角调整

## Test plan
- [ ] 验证 Light / Dark 模式下所有颜色正确显示
- [ ] 验证消息区域在不同屏幕宽度下自适应
- [ ] 验证 Agent 标签名称截断显示
- [ ] 验证用户消息深色气泡样式
- [ ] 移动端 PWA 下验证布局正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)