### PR TITLE
样式: 对话区域和输入框自适应宽度

### DIFF
--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -322,7 +322,7 @@ export function MessageInput({
       className="px-4 pt-2 pb-6 bg-background ios-pwa-bottom-safe max-lg:bg-background/60 max-lg:backdrop-blur-xl max-lg:saturate-[1.8] max-lg:border-t max-lg:border-border/40"
       style={{ paddingBottom: `max(1.5rem, var(--keyboard-height, 0px))` }}
     >
-      <div className={isCompact ? 'mx-auto' : 'max-w-3xl mx-auto'}>
+      <div className="mx-auto">
         {/* Upload progress bar */}
         {uploading && uploadProgress && (
           <div className={`mb-2 px-4 py-2.5 ${isCompact ? 'bg-card border border-border' : 'bg-card rounded-xl border border-border shadow-sm'}`}>

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -230,9 +230,9 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
     <div className="relative flex-1 overflow-hidden overflow-x-hidden">
       <div
         ref={parentRef}
-        className="h-full overflow-y-auto overflow-x-hidden py-6 bg-background"
+        className="h-full overflow-y-auto overflow-x-hidden py-6"
       >
-        <div className={displayMode === 'compact' ? 'mx-auto px-4 min-w-0' : 'max-w-3xl mx-auto px-4 min-w-0'}>
+        <div className="mx-auto px-4 min-w-0">
         {loading && hasMore && (
           <div className="flex justify-center py-4">
             <Loader2 className="animate-spin text-primary" size={24} />

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -361,7 +361,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
       );
     }
     return (
-      <div className="max-w-3xl mx-auto w-full px-4 py-3">
+      <div className="mx-auto w-full px-4 py-3">
         {/* Mobile: compact avatar + name row */}
         <div className="flex items-center gap-2 mb-1.5 lg:hidden">
           <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />
@@ -432,7 +432,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
 
   // ── Chat mode streaming (default) ──
   return (
-    <div className="max-w-3xl mx-auto w-full px-4 py-3">
+    <div className="mx-auto w-full px-4 py-3">
       {/* Mobile: compact avatar + name row */}
       <div className="flex items-center gap-2 mb-1.5 lg:hidden">
         <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />


### PR DESCRIPTION
## Summary

- 移除 MessageList、StreamingDisplay、MessageInput 中的 `max-w-3xl` 宽度约束
- 消息区域和输入框现在自适应父容器宽度
- 宽屏显示器不再浪费左右空间

## Test plan

- [ ] 验证宽屏（>1200px）下消息区域撑满可用宽度
- [ ] 验证窄屏/移动端下布局不被破坏
- [ ] 验证流式输出区域同样自适应

🤖 Generated with [Claude Code](https://claude.com/claude-code)