### PR TITLE
修复: drainGroup 误跳过子会话动态任务导致消息丢失

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -1016,9 +1016,12 @@ export class GroupQueue {
     // Tasks first (they won't be re-discovered from SQLite like messages)
     while (state.pendingTasks.length > 0) {
       const task = state.pendingTasks.shift()!;
-      // Check if scheduled task is still active before occupying a slot
+      // Check if scheduled task is still active before occupying a slot.
+      // Only skip tasks that exist in the DB and are no longer active.
+      // Dynamic tasks (agent conversations, etc.) don't have DB entries
+      // and must always be allowed to run.
       const dbTask = getTaskById(task.id);
-      if (!dbTask || dbTask.status !== 'active') {
+      if (dbTask && dbTask.status !== 'active') {
         logger.info(
           { groupJid, taskId: task.id },
           'Skipping cancelled/deleted task during drain',
@@ -1057,19 +1060,21 @@ export class GroupQueue {
 
       // Prioritize tasks over messages
       if (state.pendingTasks.length > 0) {
-        // Skip cancelled/deleted tasks
+        // Skip cancelled/deleted scheduled tasks (but allow dynamic tasks
+        // like agent conversations that have no DB entry).
         let validTask: QueuedTask | undefined;
         while (state.pendingTasks.length > 0) {
           const candidate = state.pendingTasks.shift()!;
           const dbTask = getTaskById(candidate.id);
-          if (dbTask && dbTask.status === 'active') {
-            validTask = candidate;
-            break;
+          if (dbTask && dbTask.status !== 'active') {
+            logger.info(
+              { groupJid: jid, taskId: candidate.id },
+              'Skipping cancelled/deleted task during drainWaiting',
+            );
+            continue;
           }
-          logger.info(
-            { groupJid: jid, taskId: candidate.id },
-            'Skipping cancelled/deleted task during drainWaiting',
-          );
+          validTask = candidate;
+          break;
         }
         if (validTask) {
           this.runTask(jid, validTask);


### PR DESCRIPTION
## 问题描述

关联子会话 session dropping 问题。

子会话（conversation agent）通过飞书接收到新消息时，如果 Agent 正在运行，`buildOnAgentMessage()` 会先 `closeStdin()` 杀掉当前进程，再 `enqueueTask("agent-im-restart:xxx")` 排队重启。但当 `drainGroup()` 处理这个排队任务时，调用 `getTaskById("agent-im-restart:xxx")` 查 `scheduled_tasks` 表——这不是定时任务，查不到，返回 `null`。

原逻辑 `!dbTask || dbTask.status !== 'active'` 把 `null` 当成"已取消的定时任务"跳过了，导致重启任务永远不执行，新消息永远不被处理。

## 修复方案

### `src/group-queue.ts`

将 `drainGroup()` 和 `drainWaiting()` 的判断条件从：
```typescript
if (!dbTask || dbTask.status !== 'active')  // 跳过
```
改为：
```typescript
if (dbTask && dbTask.status !== 'active')  // 跳过
```

即**只跳过确实存在于 DB 且状态不是 active 的定时任务**。动态任务（如 `agent-im-restart`、`agent-conv`）没有 DB 记录，不会被误杀。

🤖 Generated with [Claude Code](https://claude.com/claude-code)