### PR TITLE
修复: drainGroup 误跳过子会话动态任务导致消息丢失

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -1016,9 +1016,12 @@ export class GroupQueue {
     // Tasks first (they won't be re-discovered from SQLite like messages)
     while (state.pendingTasks.length > 0) {
       const task = state.pendingTasks.shift()!;
-      // Check if scheduled task is still active before occupying a slot
+      // Check if scheduled task is still active before occupying a slot.
+      // Only skip tasks that exist in the DB and are no longer active.
+      // Dynamic tasks (agent conversations, etc.) don't have DB entries
+      // and must always be allowed to run.
       const dbTask = getTaskById(task.id);
-      if (!dbTask || dbTask.status !== 'active') {
+      if (dbTask && dbTask.status !== 'active') {
         logger.info(
           { groupJid, taskId: task.id },
           'Skipping cancelled/deleted task during drain',
@@ -1057,19 +1060,21 @@ export class GroupQueue {
 
       // Prioritize tasks over messages
       if (state.pendingTasks.length > 0) {
-        // Skip cancelled/deleted tasks
+        // Skip cancelled/deleted scheduled tasks (but allow dynamic tasks
+        // like agent conversations that have no DB entry).
         let validTask: QueuedTask | undefined;
         while (state.pendingTasks.length > 0) {
           const candidate = state.pendingTasks.shift()!;
           const dbTask = getTaskById(candidate.id);
-          if (dbTask && dbTask.status === 'active') {
-            validTask = candidate;
-            break;
+          if (dbTask && dbTask.status !== 'active') {
+            logger.info(
+              { groupJid: jid, taskId: candidate.id },
+              'Skipping cancelled/deleted task during drainWaiting',
+            );
+            continue;
           }
-          logger.info(
-            { groupJid: jid, taskId: candidate.id },
-            'Skipping cancelled/deleted task during drainWaiting',
-          );
+          validTask = candidate;
+          break;
         }
         if (validTask) {
           this.runTask(jid, validTask);


### PR DESCRIPTION
## 问题描述

`drainGroup()` 和 `drainWaiting()` 在处理排队任务时，调用 `getTaskById()` 检查定时任务是否仍然有效。但远端 commit `0724261` 将判断条件改为 `if (!dbTask || dbTask.status !== 'active')`，会导致动态任务（如 `agent-im-restart`、`agent-conv`）因不存在于 `scheduled_tasks` 表而被误跳过。

### 触发场景

1. 子会话 Agent 正在运行
2. 用户从飞书发送新消息
3. `buildOnAgentMessage()` 调用 `closeStdin()` 杀掉 Agent
4. `enqueueTask("agent-im-restart:xxx")` 将重启任务排队
5. Agent 退出 → `drainGroup()` 处理排队任务
6. `getTaskById("agent-im-restart:xxx")` → null → **任务被跳过**
7. 新消息永远不会被处理（消息丢失）

## 修复方案

### `src/group-queue.ts`

将判断条件从 `!dbTask || status !== 'active'` 改为 `dbTask && status !== 'active'`：

- 只跳过确实存在于 DB 中且状态不是 active 的定时任务
- 动态任务（无 DB 记录）正常执行

同时在 `drainGroup()` 和 `drainWaiting()` 两处均应用此修复。

## 代码审计

同步审计了远端 2 个 commit（`e03ee4d` + `0724261`）的全部改动（24 文件，+751/-252 行），整体质量高：

- 飞书 Markdown 渲染优化（heading 降级、表格间距、无效图片清理）
- CardKit API 从 v2 迁移到 v1 streaming_mode
- PTY Worker 进程模式（解决 Bun 无法加载 node-pty）
- 移动端 PWA 体验优化（禁止缩放、键盘适配、自动重连）
- 流式渲染性能（rAF 批量合并 text_delta、streaming 模式跳过 KaTeX）
- 快速关闭优化（并发清理 + 2s 超时）

本 PR 仅修复 `group-queue.ts` 中的任务校验逻辑回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)