### PR TITLE
修复: Web 端手机查看 AI 回复撑宽页面 + 图片无法显示

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,6 +28,7 @@
         "recharts": "^3.7.0",
         "rehype-highlight": "^7.0.0",
         "rehype-katex": "^7.0.1",
+        "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
@@ -7593,6 +7594,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://bnpm.byted.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-sanitize": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
@@ -7629,6 +7655,25 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://bnpm.byted.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7704,6 +7749,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://bnpm.byted.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/iconv-lite": {
@@ -10513,6 +10568,21 @@
         "hast-util-to-text": "^4.0.0",
         "katex": "^0.16.0",
         "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://bnpm.byted.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
       },
       "funding": {

--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
     "recharts": "^3.7.0",
     "rehype-highlight": "^7.0.0",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",

--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -4,6 +4,7 @@ import remarkBreaks from 'remark-breaks';
 import remarkMath from 'remark-math';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeKatex from 'rehype-katex';
+import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import React, { useState, useMemo, memo } from 'react';
 import { createPortal } from 'react-dom';
@@ -90,6 +91,7 @@ const sanitizeSchema = {
     code: [...(defaultSchema.attributes?.code || []), 'class', 'className'],
     span: [...(defaultSchema.attributes?.span || []), 'class', 'className', 'style', 'aria-hidden'],
     div: [...(defaultSchema.attributes?.div || []), 'class', 'className', 'style'],
+    img: ['src', 'alt', 'width', 'height', 'loading', 'longDesc', 'title'],
     math: ['xmlns', 'display'],
     annotation: ['encoding'],
   },
@@ -196,6 +198,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
     streaming
       ? [[rehypeHighlight, { plainText: ['mermaid'] }] as const]
       : [
+          rehypeRaw,
           [rehypeHighlight, { plainText: ['mermaid'] }] as const,
           [rehypeKatex, { throwOnError: false, strict: false }] as const,
           [rehypeSanitize, sanitizeSchema] as const,
@@ -226,7 +229,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
               className="my-4 max-w-full overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] [touch-action:pan-x_pan-y]"
               data-swipe-back-ignore="true"
             >
-              <table className="w-max min-w-full border-collapse border border-border">
+              <table className="min-w-full border-collapse border border-border">
                 {children}
               </table>
             </div>
@@ -241,12 +244,12 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
             </tr>
           ),
           th: ({ children }) => (
-            <th className={`px-4 py-2 text-left font-semibold text-foreground border border-border whitespace-nowrap break-normal align-top ${tableTextClass}`}>
+            <th className={`px-4 py-2 text-left font-semibold text-foreground border border-border break-words align-top ${tableTextClass}`}>
               {children}
             </th>
           ),
           td: ({ children }) => (
-            <td className={`px-4 py-2 text-foreground border border-border whitespace-nowrap break-normal align-top ${tableTextClass}`}>
+            <td className={`px-4 py-2 text-foreground border border-border break-words align-top ${tableTextClass}`}>
               {children}
             </td>
           ),


### PR DESCRIPTION
## 问题描述

Web 端在手机上查看 AI 回复时存在两个问题：

1. **页面被撑宽**：AI 回复中的 Markdown 表格使用了 `w-max`（`width: max-content`）+ `whitespace-nowrap`，在手机窄屏上表格内容超出视口宽度，导致整个页面可水平滚动。
2. **图片无法显示**：AI 回复中如果包含 HTML `<img>` 标签，由于缺少 `rehype-raw` 插件，`react-markdown` 默认将 HTML 标签当作纯文本显示而非渲染为实际图片。同时 `rehype-sanitize` 的 `img` 属性白名单依赖全局 `*` 属性的隐式继承，不够稳健。

## 修复方案

### `web/src/components/chat/MarkdownRenderer.tsx`

**手机端表格宽度**：
- 移除表格的 `w-max` 样式，保留 `min-w-full` 确保表格至少填满容器宽度
- 将 `th`/`td` 单元格的 `whitespace-nowrap break-normal` 改为 `break-words`，允许文本在手机端自然换行
- 表格外层容器的 `overflow-x-auto` 仍保留，内容确实较宽时仍可水平滚动

**图片渲染**：
- 在 rehype 管道中新增 `rehype-raw` 插件（位于 `rehype-sanitize` 之前），支持解析 Markdown 中嵌入的 HTML 标签
- 仅在非 streaming 模式下启用（streaming 模式无 sanitize，不应解析不可信 HTML）
- 显式声明 `img` 标签允许的属性列表（`src`/`alt`/`width`/`height`/`loading`/`longDesc`/`title`），不再依赖 `defaultSchema` 全局属性的隐式继承

### `web/package.json`
- 新增 `rehype-raw@^7.0.0` 依赖