### PR TITLE
修复: 意图分析改为精确匹配，消除误触发中断

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4138,6 +4138,15 @@ async function startMessageLoop(): Promise<void> {
               { chatJid },
               'Message queued (drain mode), cursor not advanced',
             );
+          } else if (intent === 'stop') {
+            // Stop intent but no active runner — nothing to interrupt.
+            // Advance cursor so this "cancel" message doesn't start a new agent.
+            const lastProcessed = messagesToSend[messagesToSend.length - 1];
+            lastAgentTimestamp[chatJid] = {
+              timestamp: lastProcessed.timestamp,
+              id: lastProcessed.id,
+            };
+            saveState();
           } else {
             // no_active — enqueue for a new one
             queue.enqueueMessageCheck(chatJid);

--- a/src/intent-analyzer.ts
+++ b/src/intent-analyzer.ts
@@ -1,5 +1,8 @@
 export type MessageIntent = 'stop' | 'correction' | 'continue';
 
+// Keywords that trigger stop/correction intent.
+// ALL keywords use exact-match only to avoid false positives when a keyword
+// appears as part of a normal sentence (e.g. "取消订单", "cancel the order").
 const STOP_KEYWORDS = [
   '停',
   '暂停',
@@ -44,10 +47,6 @@ const CORRECTION_KEYWORDS = [
 
 const MAX_SHORT_MESSAGE_LENGTH = 50;
 
-// Short keywords that are common substrings of other words (e.g., "esc" in
-// "describe", "fix" in "prefix") — only match exactly, never as substrings.
-const EXACT_ONLY = new Set(['esc', 'wait', 'fix', 'correct', 'redo']);
-
 export function analyzeIntent(text: string): MessageIntent {
   const trimmed = text.trim();
 
@@ -57,20 +56,12 @@ export function analyzeIntent(text: string): MessageIntent {
 
   const lower = trimmed.toLowerCase();
 
-  // Exact match first
+  // Exact match only — the entire message must be the keyword
   for (const kw of STOP_KEYWORDS) {
     if (lower === kw) return 'stop';
   }
   for (const kw of CORRECTION_KEYWORDS) {
     if (lower === kw) return 'correction';
-  }
-
-  // Substring match (skip keywords that are common substrings of normal words)
-  for (const kw of STOP_KEYWORDS) {
-    if (!EXACT_ONLY.has(kw) && lower.includes(kw)) return 'stop';
-  }
-  for (const kw of CORRECTION_KEYWORDS) {
-    if (!EXACT_ONLY.has(kw) && lower.includes(kw)) return 'correction';
   }
 
   return 'continue';

--- a/src/web.ts
+++ b/src/web.ts
@@ -214,6 +214,7 @@ app.post('/api/messages', authMiddleware, async (c) => {
     success: true,
     messageId: result.messageId,
     timestamp: result.timestamp,
+    ...(result.intent ? { intent: result.intent } : {}),
   });
 });
 
@@ -230,6 +231,7 @@ async function handleWebUserMessage(
       ok: true;
       messageId: string;
       timestamp: string;
+      intent?: 'stop' | 'correction';
     }
   | {
       ok: false;
@@ -274,6 +276,9 @@ async function handleWebUserMessage(
     { attachments: attachmentsStr },
   );
 
+  // Analyze intent early so we can include it in the broadcast
+  const intent = analyzeIntent(content);
+
   broadcastNewMessage(chatJid, {
     id: messageId,
     chat_jid: chatJid,
@@ -283,6 +288,7 @@ async function handleWebUserMessage(
     timestamp,
     is_from_me: false,
     attachments: attachmentsStr,
+    ...(intent !== 'continue' ? { intent } : {}),
   });
 
   if (group.created_by) {
@@ -313,7 +319,7 @@ async function handleWebUserMessage(
         });
         deps.setLastAgentTimestamp(chatJid, { timestamp, id: messageId });
         deps.advanceGlobalCursor({ timestamp, id: messageId });
-        return { ok: true, messageId, timestamp };
+        return { ok: true, messageId, timestamp, ...(intent !== 'continue' ? { intent } : {}) };
       }
     }
   }
@@ -338,7 +344,6 @@ async function handleWebUserMessage(
   // longer need to kill and restart the process (#99).
   let pipedToActive = false;
   const images = toAgentImages(normalizedAttachments);
-  const intent = analyzeIntent(content);
   const updateRoute = deps.updateReplyRoute;
   const sendResult = deps.queue.sendMessage(
     chatJid,
@@ -363,6 +368,11 @@ async function handleWebUserMessage(
     // Message queued for next container run; don't advance cursor so
     // processGroupMessages re-reads it from DB. Drain sentinel already
     // written — the current runner will exit and drainGroup picks it up.
+  } else if (intent === 'stop') {
+    // Stop intent but no active runner — nothing to interrupt.
+    // Advance cursor so this message doesn't get picked up later, but
+    // don't start a new agent just to process a "cancel" message.
+    pipedToActive = true;
   } else {
     deps.queue.enqueueMessageCheck(chatJid);
   }
@@ -373,7 +383,7 @@ async function handleWebUserMessage(
     deps.setLastAgentTimestamp(chatJid, { timestamp, id: messageId });
   }
   deps.advanceGlobalCursor({ timestamp, id: messageId });
-  return { ok: true, messageId, timestamp };
+  return { ok: true, messageId, timestamp, ...(intent !== 'continue' ? { intent } : {}) };
 }
 
 // --- Agent Conversation Message Handler ---

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -359,7 +359,12 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
             {isAI ? (
               <MarkdownRenderer content={message.content} groupJid={message.chat_jid} variant="chat" />
             ) : (
-              <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words text-foreground">{message.content}</p>
+              <>
+                <p className={`text-[15px] leading-relaxed whitespace-pre-wrap break-words ${message.intent === 'stop' ? 'text-red-600' : message.intent === 'correction' ? 'text-orange-600' : 'text-foreground'}`}>
+                  {message.content}
+                  {message.intent && <span className="text-[11px] ml-2 opacity-70">{message.intent === 'stop' ? '⏹ 已中断' : '🔄 已纠正'}</span>}
+                </p>
+              </>
             )}
           </div>
         )}
@@ -461,6 +466,12 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
 
     // User message (own): right-aligned
     const showSenderLabel = isShared;
+    const isInterrupt = message.intent === 'stop' || message.intent === 'correction';
+    const interruptBorderClass = message.intent === 'stop'
+      ? 'border-red-400 bg-red-50/50 dark:bg-red-950/20'
+      : message.intent === 'correction'
+        ? 'border-orange-400 bg-orange-50/50 dark:bg-orange-950/20'
+        : '';
     return (
       <div className="group flex justify-end mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
         <div className="flex flex-col items-end min-w-0 w-full">
@@ -485,8 +496,13 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
               </div>
             )}
             {!hasOnlyImages && (
-              <div className="bg-card border border-border text-foreground px-4 py-2.5 rounded-2xl rounded-tr-sm shadow-sm">
+              <div className={`px-4 py-2.5 rounded-2xl rounded-tr-sm shadow-sm ${isInterrupt ? `border-2 ${interruptBorderClass}` : 'bg-card border border-border text-foreground'}`}>
                 <p className="text-[15px] leading-relaxed whitespace-pre-wrap break-words">{message.content}</p>
+                {isInterrupt && (
+                  <span className={`text-[11px] mt-1 block ${message.intent === 'stop' ? 'text-red-500' : 'text-orange-500'}`}>
+                    {message.intent === 'stop' ? '⏹ 已中断' : '🔄 已纠正'}
+                  </span>
+                )}
               </div>
             )}
             {!hasOnlyImages && (

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -24,6 +24,8 @@ export interface Message {
   sdk_message_uuid?: string | null;
   source_kind?: 'sdk_final' | 'sdk_send_message' | 'interrupt_partial' | 'legacy' | null;
   finalization_reason?: 'completed' | 'interrupted' | 'error' | null;
+  /** Set when this user message triggered a stop/correction interrupt */
+  intent?: 'stop' | 'correction';
 }
 
 // Streaming event types (canonical source: shared/stream-event.ts)
@@ -800,7 +802,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         body.attachments = attachments.map(att => ({ type: 'image', ...att }));
       }
 
-      const data = await api.post<{ success: boolean; messageId: string; timestamp: string }>('/api/messages', body);
+      const data = await api.post<{ success: boolean; messageId: string; timestamp: string; intent?: 'stop' | 'correction' }>('/api/messages', body);
       if (data.success) {
         // Add user message to local state immediately
         const authState = useAuthStore.getState();
@@ -824,16 +826,29 @@ export const useChatStore = create<ChatState>((set, get) => ({
             [msg],
           );
           const latest = merged.length > 0 ? merged[merged.length - 1] : null;
+          const isStopIntent = data.intent === 'stop' || data.intent === 'correction';
           const shouldWait =
+            !isStopIntent &&
             !!latest &&
             latest.is_from_me === false &&
             !isTerminalSystemMessage(latest);
+
+          // Stop/correction intent: also clear streaming state
+          const nextStreaming = isStopIntent
+            ? (() => { const n = { ...s.streaming }; delete n[jid]; return n; })()
+            : s.streaming;
+          const nextPending = isStopIntent
+            ? (() => { const n = { ...s.pendingThinking }; delete n[jid]; return n; })()
+            : s.pendingThinking;
+
           return {
             messages: {
               ...s.messages,
               [jid]: merged,
             },
             waiting: { ...s.waiting, [jid]: shouldWait },
+            streaming: nextStreaming,
+            pendingThinking: nextPending,
             error: null,
           };
         });
@@ -1436,6 +1451,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       sdk_message_uuid: wsMsg.sdk_message_uuid ?? null,
       source_kind: wsMsg.source_kind ?? null,
       finalization_reason: wsMsg.finalization_reason ?? null,
+      ...(wsMsg.intent ? { intent: wsMsg.intent } : {}),
     };
 
     // Route to agentMessages if this is a conversation agent message
@@ -1502,6 +1518,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
           streaming: nextStreaming,
           pendingThinking: nextPending,
           ...(thinkingText ? { thinkingCache: capThinkingCache({ ...s.thinkingCache, [msg.id]: thinkingText }) } : {}),
+        };
+      }
+
+      // Stop/correction intent from user: clear waiting & streaming state
+      if (msg.intent === 'stop' || msg.intent === 'correction') {
+        const nextStreaming = { ...s.streaming };
+        delete nextStreaming[chatJid];
+        const nextPending = { ...s.pendingThinking };
+        delete nextPending[chatJid];
+        return {
+          messages: { ...s.messages, [chatJid]: updated },
+          waiting: { ...s.waiting, [chatJid]: false },
+          streaming: nextStreaming,
+          pendingThinking: nextPending,
         };
       }
 


### PR DESCRIPTION
## 问题描述

消息中包含"取消"、"cancel"等中断关键字作为子串时（如"取消订单"、"cancel the order"），会误触发中断逻辑，导致：
1. 正常消息被识别为中断意图，不会启动 Agent 处理
2. 发送中断关键字（如单独输入"取消"）后，前端仍显示"正在思考..."不消失

## 修复方案

### `src/intent-analyzer.ts`
- 移除子串匹配逻辑（`lower.includes(kw)`），仅保留精确匹配（`lower === kw`）
- 整条消息必须完全等于关键字才会触发中断，避免误判

### `src/web.ts`
- `POST /api/messages` 返回值新增 `intent` 字段，供前端判断是否需要等待 Agent 响应
- 中断意图消息在无运行中 Agent 时不再调用 `enqueueMessageCheck()`

### `src/index.ts`
- IM 消息循环中同样添加 `intent === 'stop'` 守卫，防止为中断消息启动新 Agent

### `web/src/stores/chat.ts`
- `sendMessage`: 收到 `intent === 'stop'/'correction'` 时不设置 `waiting: true`，同时清除 streaming 状态
- `handleWsNewMessage`: 传递 `wsMsg.intent` 到 `msg` 对象，收到中断意图时清除 waiting/streaming 状态

### `web/src/components/chat/MessageBubble.tsx`
- 中断消息（stop intent）显示红色边框 + "⏹ 已中断" 标签
- 纠正消息（correction intent）显示橙色边框 + "🔄 已纠正" 标签
<img width="468" height="444" alt="image" src="https://github.com/user-attachments/assets/50d6340b-63ee-44d8-831b-5c3bc4d9d532" />

## Test Plan

- [x] 发送"取消"（无 Agent 运行时）→ 不应显示"正在思考..."，不应启动新 Agent
- [x] 发送"取消"（Agent 运行中）→ 应中断 Agent，消息显示红色边框和"⏹ 已中断"标签
- [x] 发送"取消订单"→ 应作为正常消息处理，启动 Agent 响应
- [x] 发送"cancel the meeting"→ 应作为正常消息处理
- [x] 发送"stop"→ 应触发中断
- [x] 发送"等等"→ 应触发纠正（橙色边框 + "🔄 已纠正"标签）
- [x] 飞书/Telegram 发送"取消"→ 同样不启动新 Agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)