### PR TITLE
优化: 定时任务并行执行 + IM 全渠道广播 + 手动试运行

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1257,6 +1257,7 @@ async function main(): Promise<void> {
     groupFolder: containerInput.groupFolder,
     isHome,
     isAdminHome,
+    isScheduledTask: containerInput.isScheduledTask || false,
     workspaceIpc: WORKSPACE_IPC,
     workspaceGroup: WORKSPACE_GROUP,
     workspaceGlobal: WORKSPACE_GLOBAL,

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -21,6 +21,7 @@ export interface McpContext {
   groupFolder: string;
   isHome: boolean;
   isAdminHome: boolean;
+  isScheduledTask?: boolean;
   workspaceIpc: string;
   workspaceGroup: string;
   workspaceGlobal: string;
@@ -128,13 +129,16 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
       "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times. Note: when running as a scheduled task, your final output is NOT sent to the user — use this tool if you need to communicate with the user or group.",
       { text: z.string().describe('The message text to send') },
       async (args) => {
-        const data = {
+        const data: Record<string, unknown> = {
           type: 'message',
           chatJid: ctx.chatJid,
           text: args.text,
           groupFolder: ctx.groupFolder,
           timestamp: new Date().toISOString(),
         };
+        if (ctx.isScheduledTask) {
+          data.isScheduledTask = true;
+        }
         writeIpcFile(MESSAGES_DIR, data);
         return { content: [{ type: 'text' as const, text: 'Message sent.' }] };
       },
@@ -246,7 +250,7 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
           };
         }
 
-        const data = {
+        const data: Record<string, unknown> = {
           type: 'image',
           chatJid: ctx.chatJid,
           imageBase64: base64,
@@ -256,6 +260,9 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
           groupFolder: ctx.groupFolder,
           timestamp: new Date().toISOString(),
         };
+        if (ctx.isScheduledTask) {
+          data.isScheduledTask = true;
+        }
         writeIpcFile(MESSAGES_DIR, data);
         return {
           content: [

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -102,6 +102,8 @@ export interface ContainerInput {
   isHome?: boolean;
   isAdminHome?: boolean;
   isScheduledTask?: boolean;
+  /** Isolated task run ID — determines IPC namespace (tasks-run/{taskRunId}/) */
+  taskRunId?: string;
   images?: Array<{ data: string; mimeType?: string }>;
   agentId?: string;
   agentName?: string;
@@ -147,6 +149,7 @@ function buildVolumeMounts(
   selectedSkills: string[] | null = null,
   agentId?: string,
   ownerHomeFolder?: string,
+  taskRunId?: string,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -296,10 +299,13 @@ function buildVolumeMounts(
 
   // Per-group IPC namespace: each group gets its own IPC directory
   // Sub-agents get their own IPC subdirectory under agents/{agentId}/
+  // Isolated tasks get their own IPC subdirectory under tasks-run/{taskRunId}/
   // Use 0o777 so container (node/1000) and host (agent/1002) can both read/write.
   const groupIpcDir = agentId
     ? path.join(DATA_DIR, 'ipc', group.folder, 'agents', agentId)
-    : path.join(DATA_DIR, 'ipc', group.folder);
+    : taskRunId
+      ? path.join(DATA_DIR, 'ipc', group.folder, 'tasks-run', taskRunId)
+      : path.join(DATA_DIR, 'ipc', group.folder);
   mkdirForContainer(groupIpcDir);
   // All agents (main + sub/conversation) get agents/ subdir for spawn/message IPC
   // Use chmod 777 so both host (agent/1002) and container (node/1000) can write
@@ -429,6 +435,7 @@ export async function runContainerAgent(
     group.selected_skills ?? null,
     input.agentId,
     ownerHomeFolder,
+    input.taskRunId,
   );
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const agentSuffix = input.agentId
@@ -781,9 +788,12 @@ export async function runHostAgent(
 
   // 2. 确保目录结构（宿主机模式下限制目录权限）
   // Sub-agents get their own IPC and session directories
+  // Isolated tasks get their own IPC subdirectory under tasks-run/{taskRunId}/
   const groupIpcDir = input.agentId
     ? path.join(DATA_DIR, 'ipc', group.folder, 'agents', input.agentId)
-    : path.join(DATA_DIR, 'ipc', group.folder);
+    : input.taskRunId
+      ? path.join(DATA_DIR, 'ipc', group.folder, 'tasks-run', input.taskRunId)
+      : path.join(DATA_DIR, 'ipc', group.folder);
   fs.mkdirSync(path.join(groupIpcDir, 'messages'), {
     recursive: true,
     mode: 0o700,

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -40,6 +40,8 @@ interface GroupState {
   displayName: string | null;
   groupFolder: string | null;
   agentId: string | null;
+  /** Isolated task run ID — used for tasks-run/{taskRunId}/ IPC namespace. */
+  taskRunId: string | null;
   retryCount: number;
   retryTimer: ReturnType<typeof setTimeout> | null;
   restarting: boolean;
@@ -86,6 +88,7 @@ export class GroupQueue {
         displayName: null,
         groupFolder: null,
         agentId: null,
+        taskRunId: null,
         retryCount: 0,
         retryTimer: null,
         restarting: false,
@@ -365,6 +368,7 @@ export class GroupQueue {
     groupFolder?: string,
     displayName?: string,
     agentId?: string,
+    taskRunId?: string,
   ): void {
     const state = this.getGroup(groupJid);
     state.process = proc;
@@ -372,6 +376,7 @@ export class GroupQueue {
     state.displayName = displayName || null;
     if (groupFolder) state.groupFolder = groupFolder;
     state.agentId = agentId || null;
+    state.taskRunId = taskRunId || null;
     if (state.pendingMessages && !state.agentId) {
       this.requestDrainForActiveRunner(
         groupJid,
@@ -385,6 +390,16 @@ export class GroupQueue {
    * Sub-agents use a nested path: data/ipc/{folder}/agents/{agentId}/input/
    */
   private resolveIpcInputDir(state: ActiveGroupState): string {
+    if (state.taskRunId) {
+      return path.join(
+        DATA_DIR,
+        'ipc',
+        state.groupFolder,
+        'tasks-run',
+        state.taskRunId,
+        'input',
+      );
+    }
     if (state.agentId) {
       return path.join(
         DATA_DIR,
@@ -512,10 +527,16 @@ export class GroupQueue {
    * subsequent runner for the same folder does not immediately see stale
    * sentinels and exit prematurely.
    */
-  private cleanupIpcSentinels(groupFolder: string, agentId?: string | null): void {
-    const inputDir = agentId
-      ? path.join(DATA_DIR, 'ipc', groupFolder, 'agents', agentId, 'input')
-      : path.join(DATA_DIR, 'ipc', groupFolder, 'input');
+  private cleanupIpcSentinels(
+    groupFolder: string,
+    agentId?: string | null,
+    taskRunId?: string | null,
+  ): void {
+    const inputDir = taskRunId
+      ? path.join(DATA_DIR, 'ipc', groupFolder, 'tasks-run', taskRunId, 'input')
+      : agentId
+        ? path.join(DATA_DIR, 'ipc', groupFolder, 'agents', agentId, 'input')
+        : path.join(DATA_DIR, 'ipc', groupFolder, 'input');
     for (const name of ['_drain', '_close']) {
       try {
         fs.unlinkSync(path.join(inputDir, name));
@@ -872,7 +893,7 @@ export class GroupQueue {
       // Clean up stale sentinel files before clearing groupFolder/agentId
       if (state.groupFolder) {
         try {
-          this.cleanupIpcSentinels(state.groupFolder, state.agentId);
+          this.cleanupIpcSentinels(state.groupFolder, state.agentId, state.taskRunId);
         } catch (err) {
           logger.warn({ groupJid, err }, 'Failed to clean up IPC sentinels');
         }
@@ -886,6 +907,7 @@ export class GroupQueue {
       state.displayName = null;
       state.groupFolder = null;
       state.agentId = null;
+      state.taskRunId = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;
@@ -949,7 +971,7 @@ export class GroupQueue {
       // Clean up stale sentinel files before clearing groupFolder/agentId
       if (state.groupFolder) {
         try {
-          this.cleanupIpcSentinels(state.groupFolder, state.agentId);
+          this.cleanupIpcSentinels(state.groupFolder, state.agentId, state.taskRunId);
         } catch (err) {
           logger.warn({ groupJid, err }, 'Failed to clean up IPC sentinels');
         }
@@ -964,6 +986,7 @@ export class GroupQueue {
       state.displayName = null;
       state.groupFolder = null;
       state.agentId = null;
+      state.taskRunId = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -269,6 +269,20 @@ class IMConnectionManager {
     return undefined;
   }
 
+  /**
+   * Get all connected channel types for a user.
+   * Used by scheduled task IM broadcast to discover available channels.
+   */
+  getConnectedChannelTypes(userId: string): string[] {
+    const conn = this.connections.get(userId);
+    if (!conn) return [];
+    const types: string[] = [];
+    for (const [type, ch] of conn.channels.entries()) {
+      if (ch.isConnected()) types.push(type);
+    }
+    return types;
+  }
+
   // ─── Convenience Methods (API-compatible wrappers) ──────────
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ import {
   type WorkspaceInfo,
 } from './im-command-utils.js';
 import { analyzeIntent } from './intent-analyzer.js';
-import { invalidateSessionCache } from './web-context.js';
+import { invalidateSessionCache, getWebDeps } from './web-context.js';
 import {
   getFeishuProviderConfigWithSource,
   getTelegramProviderConfig,
@@ -115,7 +115,7 @@ import type {
   QQConnectConfig,
 } from './im-manager.js';
 import { GroupQueue } from './group-queue.js';
-import { startSchedulerLoop } from './task-scheduler.js';
+import { startSchedulerLoop, triggerTaskNow } from './task-scheduler.js';
 import {
   checkBillingAccessFresh,
   formatBillingAccessDeniedMessage,
@@ -2697,7 +2697,7 @@ function startIpcWatcher(): void {
       );
       const isHome = !!sourceGroupEntry?.is_home;
 
-      // Collect all IPC roots: main group dir + agents/*/
+      // Collect all IPC roots: main group dir + agents/*/ + tasks-run/*/
       const groupIpcRoot = path.join(ipcBaseDir, sourceGroup);
       const ipcRoots = [groupIpcRoot];
       try {
@@ -2712,6 +2712,19 @@ function startIpcWatcher(): void {
         }
       } catch {
         /* agents dir may not exist */
+      }
+      try {
+        const tasksRunDir = path.join(groupIpcRoot, 'tasks-run');
+        const taskRunEntries = await fsp.readdir(tasksRunDir, {
+          withFileTypes: true,
+        });
+        for (const entry of taskRunEntries) {
+          if (entry.isDirectory()) {
+            ipcRoots.push(path.join(tasksRunDir, entry.name));
+          }
+        }
+      } catch {
+        /* tasks-run dir may not exist */
       }
 
       for (const ipcRoot of ipcRoots) {
@@ -2760,6 +2773,53 @@ function startIpcWatcher(): void {
                     );
                     sendImWithFailTracking(ipcImRoute, data.text, localImages);
                   }
+
+                  // Scheduled task: broadcast to all connected IM channels of the owner
+                  if (data.isScheduledTask && sourceGroupEntry?.created_by) {
+                    const sentChannelTypes = new Set<string>();
+                    // Mark already-sent channel types
+                    const primaryType = getChannelType(data.chatJid);
+                    if (primaryType) sentChannelTypes.add(primaryType);
+                    if (ipcImRoute) {
+                      const routeType = getChannelType(ipcImRoute);
+                      if (routeType) sentChannelTypes.add(routeType);
+                    }
+
+                    const connectedTypes = imManager.getConnectedChannelTypes(
+                      sourceGroupEntry.created_by,
+                    );
+                    const ownerGroups = getGroupsByOwner(
+                      sourceGroupEntry.created_by,
+                    );
+
+                    for (const channelType of connectedTypes) {
+                      if (sentChannelTypes.has(channelType)) continue;
+                      // Find an IM JID of this channel type (prefer same folder)
+                      const sameFolderGroup = ownerGroups.find(
+                        (g) =>
+                          getChannelType(g.jid) === channelType &&
+                          g.folder === sourceGroup,
+                      );
+                      const anyGroup =
+                        sameFolderGroup ||
+                        ownerGroups.find(
+                          (g) => getChannelType(g.jid) === channelType,
+                        );
+                      if (anyGroup) {
+                        const taskLocalImages = extractLocalImImagePaths(
+                          data.text,
+                          sourceGroup,
+                        );
+                        sendImWithFailTracking(
+                          anyGroup.jid,
+                          data.text,
+                          taskLocalImages,
+                        );
+                        sentChannelTypes.add(channelType);
+                      }
+                    }
+                  }
+
                   ipcMessageSentFolders.add(sourceGroup);
                   logger.info(
                     { chatJid: data.chatJid, sourceGroup, imRoute: ipcImRoute },
@@ -2845,6 +2905,56 @@ function startIpcWatcher(): void {
                       finalization_reason: null,
                     });
                     broadcastToWebClients(data.chatJid, displayText);
+
+                    // Scheduled task: broadcast image to all connected IM channels
+                    if (data.isScheduledTask && sourceGroupEntry?.created_by) {
+                      const sentImgChannelTypes = new Set<string>();
+                      const imgPrimaryType = getChannelType(data.chatJid);
+                      if (imgPrimaryType) sentImgChannelTypes.add(imgPrimaryType);
+                      if (imgImRoute) {
+                        const imgRouteType = getChannelType(imgImRoute);
+                        if (imgRouteType)
+                          sentImgChannelTypes.add(imgRouteType);
+                      }
+
+                      const imgConnectedTypes =
+                        imManager.getConnectedChannelTypes(
+                          sourceGroupEntry.created_by,
+                        );
+                      const imgOwnerGroups = getGroupsByOwner(
+                        sourceGroupEntry.created_by,
+                      );
+
+                      for (const ct of imgConnectedTypes) {
+                        if (sentImgChannelTypes.has(ct)) continue;
+                        const target =
+                          imgOwnerGroups.find(
+                            (g) =>
+                              getChannelType(g.jid) === ct &&
+                              g.folder === sourceGroup,
+                          ) ||
+                          imgOwnerGroups.find(
+                            (g) => getChannelType(g.jid) === ct,
+                          );
+                        if (target) {
+                          imManager
+                            .sendImage(
+                              target.jid,
+                              imageBuffer,
+                              mimeType,
+                              caption,
+                              fileName,
+                            )
+                            .catch((err) =>
+                              logger.warn(
+                                { jid: target.jid, err },
+                                'Failed to broadcast task image to IM',
+                              ),
+                            );
+                          sentImgChannelTypes.add(ct);
+                        }
+                      }
+                    }
 
                     logger.info(
                       {
@@ -5258,11 +5368,18 @@ async function main(): Promise<void> {
 
   queue.setProcessMessagesFn(processGroupMessages);
   queue.setHostModeChecker((groupJid: string) => {
-    let group = registeredGroups[groupJid];
+    // Strip virtual JID suffixes to resolve the actual registered group
+    let baseJid = groupJid;
+    const taskSep = baseJid.indexOf('#task:');
+    if (taskSep >= 0) baseJid = baseJid.slice(0, taskSep);
+    const agentSep = baseJid.indexOf('#agent:');
+    if (agentSep >= 0) baseJid = baseJid.slice(0, agentSep);
+
+    let group = registeredGroups[baseJid];
     if (!group) {
-      const dbGroup = getRegisteredGroup(groupJid);
+      const dbGroup = getRegisteredGroup(baseJid);
       if (dbGroup) {
-        registeredGroups[groupJid] = dbGroup;
+        registeredGroups[baseJid] = dbGroup;
         group = dbGroup;
       }
     }
@@ -5281,6 +5398,14 @@ async function main(): Promise<void> {
       const folder = group?.folder || baseJid;
       return `${folder}#${agentId}`;
     }
+    // Task virtual JIDs: {chatJid}#task:{taskId} → separate serialization key
+    const taskSep = groupJid.indexOf('#task:');
+    if (taskSep >= 0) {
+      const baseJid = groupJid.slice(0, taskSep);
+      const taskId = groupJid.slice(taskSep + 6);
+      const group = registeredGroups[baseJid];
+      return `${group?.folder || baseJid}#task:${taskId}`;
+    }
     const group = registeredGroups[groupJid];
     return group?.folder || groupJid;
   });
@@ -5297,7 +5422,13 @@ async function main(): Promise<void> {
   // Billing: user-level concurrent container limit
   queue.setUserConcurrentLimitChecker((groupJid: string) => {
     if (!isBillingEnabled()) return { allowed: true };
-    const group = registeredGroups[groupJid];
+    // Strip virtual JID suffixes
+    let baseJid = groupJid;
+    const taskSep = baseJid.indexOf('#task:');
+    if (taskSep >= 0) baseJid = baseJid.slice(0, taskSep);
+    const agentSep = baseJid.indexOf('#agent:');
+    if (agentSep >= 0) baseJid = baseJid.slice(0, agentSep);
+    const group = registeredGroups[baseJid];
     if (!group?.created_by) return { allowed: true };
     const owner = getUserById(group.created_by);
     if (!owner || owner.role === 'admin') return { allowed: true };
@@ -5312,17 +5443,19 @@ async function main(): Promise<void> {
     }
     return { allowed: userActive < limit };
   });
-  startSchedulerLoop({
+  const schedulerDeps: import('./task-scheduler.js').SchedulerDependencies = {
     registeredGroups: () => registeredGroups,
     getSessions: () => sessions,
     queue,
-    onProcess: (groupJid, proc, containerName, groupFolder, displayName) =>
+    onProcess: (groupJid, proc, containerName, groupFolder, displayName, taskRunId) =>
       queue.registerProcess(
         groupJid,
         proc,
         containerName,
         groupFolder,
         displayName,
+        undefined, // agentId
+        taskRunId,
       ),
     sendMessage,
     assistantName: ASSISTANT_NAME,
@@ -5330,7 +5463,16 @@ async function main(): Promise<void> {
       logger,
       dataDir: DATA_DIR,
     },
-  });
+  };
+  startSchedulerLoop(schedulerDeps);
+
+  // Inject triggerTaskRun into WebDeps (schedulerDeps must exist first)
+  const webDeps = getWebDeps();
+  if (webDeps) {
+    webDeps.triggerTaskRun = (taskId: string) =>
+      triggerTaskNow(taskId, schedulerDeps);
+  }
+
   startIpcWatcher();
   recoverPendingMessages();
   startMessageLoop();

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -21,6 +21,7 @@ import {
   isHostExecutionGroup,
   hasHostExecutionPermission,
   canAccessGroup,
+  getWebDeps,
 } from '../web-context.js';
 
 const tasksRoutes = new Hono<{ Variables: Variables }>();
@@ -188,6 +189,37 @@ tasksRoutes.delete('/:id', authMiddleware, (c) => {
     }
   }
   deleteTask(id);
+  return c.json({ success: true });
+});
+
+tasksRoutes.post('/:id/run', authMiddleware, (c) => {
+  const id = c.req.param('id');
+  const existing = getTaskById(id);
+  if (!existing) return c.json({ error: 'Task not found' }, 404);
+  const authUser = c.get('user') as AuthUser;
+  const group = getRegisteredGroup(existing.chat_jid);
+  if (!group) {
+    if (authUser.role !== 'admin')
+      return c.json({ error: 'Task not found' }, 404);
+  } else {
+    if (!canAccessGroup({ id: authUser.id, role: authUser.role }, group)) {
+      return c.json({ error: 'Task not found' }, 404);
+    }
+    if (isHostExecutionGroup(group) && !hasHostExecutionPermission(authUser)) {
+      return c.json(
+        { error: 'Insufficient permissions for host execution mode' },
+        403,
+      );
+    }
+  }
+
+  const deps = getWebDeps();
+  if (!deps?.triggerTaskRun)
+    return c.json({ error: 'Scheduler not available' }, 503);
+
+  const result = deps.triggerTaskRun(id);
+  if (!result.success) return c.json({ error: result.error }, 409);
+
   return c.json({ success: true });
 });
 

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 import {
+  DATA_DIR,
   GROUPS_DIR,
   MAIN_GROUP_FOLDER,
   SCHEDULER_POLL_INTERVAL,
@@ -42,6 +43,7 @@ export interface SchedulerDependencies {
     containerName: string | null,
     groupFolder: string,
     displayName?: string,
+    taskRunId?: string,
   ) => void;
   sendMessage: (
     jid: string,
@@ -50,6 +52,13 @@ export interface SchedulerDependencies {
   ) => Promise<string | undefined | void>;
   assistantName: string;
   dailySummaryDeps?: DailySummaryDeps;
+}
+
+export interface RunTaskOptions {
+  /** Unique ID for isolated task IPC namespace (tasks-run/{taskRunId}/) */
+  taskRunId?: string;
+  /** Manual trigger — don't update next_run, skip isTaskStillActive check */
+  manualRun?: boolean;
 }
 
 const runningTaskIds = new Set<string>();
@@ -95,8 +104,13 @@ async function runTask(
   task: ScheduledTask,
   deps: SchedulerDependencies,
   groupJid: string,
+  options?: RunTaskOptions,
 ): Promise<void> {
-  if (!isTaskStillActive(task.id, 'task')) return;
+  if (!options?.manualRun && !isTaskStillActive(task.id, 'task')) return;
+
+  const effectiveJid = options?.taskRunId
+    ? `${groupJid}#task:${options.taskRunId}`
+    : groupJid;
 
   runningTaskIds.add(task.id);
   const startTime = Date.now();
@@ -198,7 +212,7 @@ async function runTask(
         { taskId: task.id },
         'Scheduled task idle timeout, closing container stdin',
       );
-      deps.queue.closeStdin(groupJid);
+      deps.queue.closeStdin(effectiveJid);
     }, getSystemSettings().idleTimeout);
   };
 
@@ -231,14 +245,16 @@ async function runTask(
         isHome,
         isAdminHome,
         isScheduledTask: true,
+        taskRunId: options?.taskRunId,
       },
       (proc, identifier) =>
         deps.onProcess(
-          groupJid,
+          effectiveJid,
           proc,
           executionMode === 'container' ? identifier : null,
           task.group_folder,
           identifier,
+          options?.taskRunId,
         ),
       async (streamedOutput: ContainerOutput) => {
         if (streamedOutput.result) {
@@ -274,6 +290,21 @@ async function runTask(
     logger.error({ taskId: task.id, error }, 'Task failed');
   } finally {
     runningTaskIds.delete(task.id);
+    // Clean up isolated task IPC directory
+    if (options?.taskRunId) {
+      const taskRunDir = path.join(
+        DATA_DIR,
+        'ipc',
+        task.group_folder,
+        'tasks-run',
+        options.taskRunId,
+      );
+      try {
+        fs.rmSync(taskRunDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
   }
 
   const durationMs = Date.now() - startTime;
@@ -287,7 +318,8 @@ async function runTask(
     error,
   });
 
-  const nextRun = computeNextRun(task);
+  // manualRun: preserve original next_run schedule
+  const nextRun = options?.manualRun ? task.next_run : computeNextRun(task);
 
   const resultSummary = error
     ? `Error: ${error}`
@@ -301,8 +333,9 @@ async function runScriptTask(
   task: ScheduledTask,
   deps: SchedulerDependencies,
   groupJid: string,
+  manualRun = false,
 ): Promise<void> {
-  if (!isTaskStillActive(task.id, 'script task')) return;
+  if (!manualRun && !isTaskStillActive(task.id, 'script task')) return;
 
   runningTaskIds.add(task.id);
   const startTime = Date.now();
@@ -419,7 +452,8 @@ async function runScriptTask(
     error,
   });
 
-  const nextRun = computeNextRun(task);
+  // manualRun: preserve original next_run schedule
+  const nextRun = manualRun ? task.next_run : computeNextRun(task);
   const resultSummary = error
     ? `Error: ${error}`
     : result
@@ -516,7 +550,16 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
               'Unhandled error in runScriptTask',
             );
           });
+        } else if (currentTask.context_mode === 'isolated') {
+          // Isolated tasks use a virtual JID for independent serialization
+          const virtualJid = `${targetGroupJid}#task:${currentTask.id}`;
+          deps.queue.enqueueTask(virtualJid, currentTask.id, () =>
+            runTask(currentTask, deps, targetGroupJid, {
+              taskRunId: currentTask.id,
+            }),
+          );
         } else {
+          // Group-mode tasks share the group's serialization key
           deps.queue.enqueueTask(targetGroupJid, currentTask.id, () =>
             runTask(currentTask, deps, targetGroupJid),
           );
@@ -530,4 +573,58 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
   };
 
   loop();
+}
+
+/**
+ * Manually trigger a task to run now (fire-and-forget).
+ * Does not change next_run — the task continues its normal schedule.
+ */
+export function triggerTaskNow(
+  taskId: string,
+  deps: SchedulerDependencies,
+): { success: boolean; error?: string } {
+  const task = getTaskById(taskId);
+  if (!task) return { success: false, error: 'Task not found' };
+  if (task.status === 'completed')
+    return { success: false, error: 'Task already completed' };
+  if (runningTaskIds.has(taskId))
+    return { success: false, error: 'Task is already running' };
+
+  // Resolve target group JID (same logic as scheduler loop)
+  const groups = deps.registeredGroups();
+  let targetGroupJid = task.chat_jid;
+  const directTarget = groups[targetGroupJid];
+  if (!directTarget || directTarget.folder !== task.group_folder) {
+    const sameFolder = Object.entries(groups).filter(
+      ([, g]) => g.folder === task.group_folder,
+    );
+    const preferred =
+      sameFolder.find(([jid]) => jid.startsWith('web:')) || sameFolder[0];
+    targetGroupJid = preferred?.[0] || '';
+  }
+  if (!targetGroupJid)
+    return { success: false, error: 'Target group not registered' };
+
+  if (task.execution_type === 'script') {
+    if (!hasScriptCapacity())
+      return { success: false, error: 'Script concurrency limit reached' };
+    runScriptTask(task, deps, targetGroupJid, true).catch((err) =>
+      logger.error({ taskId, err }, 'Manual script task failed'),
+    );
+  } else {
+    const opts: RunTaskOptions = { manualRun: true };
+    if (task.context_mode === 'isolated') {
+      opts.taskRunId = task.id;
+      const virtualJid = `${targetGroupJid}#task:${task.id}`;
+      deps.queue.enqueueTask(virtualJid, task.id, () =>
+        runTask(task, deps, targetGroupJid, opts),
+      );
+    } else {
+      deps.queue.enqueueTask(targetGroupJid, task.id, () =>
+        runTask(task, deps, targetGroupJid, opts),
+      );
+    }
+  }
+
+  return { success: true };
 }

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -61,6 +61,7 @@ export interface WebDeps {
   } | null>;
   clearImFailCounts?: (jid: string) => void;
   updateReplyRoute?: (folder: string, sourceJid: string | null) => void;
+  triggerTaskRun?: (taskId: string) => { success: boolean; error?: string };
 }
 
 export type Variables = {

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronUp, Pause, Play, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Pause, Play, Trash2, Zap } from 'lucide-react';
 import { ScheduledTask } from '../../stores/tasks';
 import { TaskDetail } from './TaskDetail';
 
@@ -8,10 +8,12 @@ interface TaskCardProps {
   onPause: (id: string) => void;
   onResume: (id: string) => void;
   onDelete: (id: string) => void;
+  onRunNow?: (id: string) => void;
 }
 
-export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
+export function TaskCard({ task, onPause, onResume, onDelete, onRunNow }: TaskCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const [runningNow, setRunningNow] = useState(false);
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -45,6 +47,17 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
       onPause(task.id);
     } else {
       onResume(task.id);
+    }
+  };
+
+  const handleRunNow = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!onRunNow || runningNow) return;
+    setRunningNow(true);
+    try {
+      await onRunNow(task.id);
+    } finally {
+      setTimeout(() => setRunningNow(false), 3000);
     }
   };
 
@@ -110,6 +123,22 @@ export function TaskCard({ task, onPause, onResume, onDelete }: TaskCardProps) {
 
           {/* Action Buttons */}
           <div className="flex items-center gap-2 flex-shrink-0">
+            {/* Run Now */}
+            {onRunNow &&
+              (task.status === 'active' || task.status === 'paused') && (
+                <button
+                  onClick={handleRunNow}
+                  disabled={runningNow}
+                  className="p-2 text-slate-600 hover:text-amber-600 hover:bg-amber-50 rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+                  title="立即运行"
+                  aria-label="立即运行任务"
+                >
+                  <Zap
+                    className={`w-5 h-5 ${runningNow ? 'animate-pulse text-amber-500' : ''}`}
+                  />
+                </button>
+              )}
+
             {/* Pause/Resume */}
             {(task.status === 'active' || task.status === 'paused') && (
               <button

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -11,7 +11,7 @@ import { EmptyState } from '@/components/common/EmptyState';
 import { Button } from '@/components/ui/button';
 
 export function TasksPage() {
-  const { tasks, loading, error, loadTasks, createTask, updateTaskStatus, deleteTask } = useTasksStore();
+  const { tasks, loading, error, loadTasks, createTask, updateTaskStatus, deleteTask, runTaskNow } = useTasksStore();
   const { groups, loadGroups } = useChatStore();
   const { user } = useAuthStore();
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -132,6 +132,7 @@ export function TasksPage() {
                       onPause={handlePause}
                       onResume={handleResume}
                       onDelete={handleDelete}
+                      onRunNow={runTaskNow}
                     />
                   ))}
                 </div>
@@ -149,6 +150,7 @@ export function TasksPage() {
                       onPause={handlePause}
                       onResume={handleResume}
                       onDelete={handleDelete}
+                      onRunNow={runTaskNow}
                     />
                   ))}
                 </div>
@@ -166,6 +168,7 @@ export function TasksPage() {
                       onPause={handlePause}
                       onResume={handleResume}
                       onDelete={handleDelete}
+                      onRunNow={runTaskNow}
                     />
                   ))}
                 </div>

--- a/web/src/stores/tasks.ts
+++ b/web/src/stores/tasks.ts
@@ -47,6 +47,7 @@ interface TasksState {
   updateTaskStatus: (id: string, status: 'active' | 'paused') => Promise<void>;
   deleteTask: (id: string) => Promise<void>;
   loadLogs: (taskId: string) => Promise<void>;
+  runTaskNow: (id: string) => Promise<void>;
 }
 
 function normalizeOnceScheduleValue(value: string): string {
@@ -139,6 +140,17 @@ export const useTasksStore = create<TasksState>((set, get) => ({
         logs: { ...s.logs, [taskId]: data.logs },
         error: null,
       }));
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err) });
+    }
+  },
+
+  runTaskNow: async (id: string) => {
+    try {
+      await api.post(`/api/tasks/${id}/run`);
+      set({ error: null });
+      // Refresh after a short delay (task runs in background)
+      setTimeout(() => get().loadTasks(), 2000);
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
     }


### PR DESCRIPTION
## 问题描述

1. 两个定时任务（`0 10 * * *`）共享 `group_folder = main`，被 GroupQueue 的 folder 级串行化阻塞，导致 34 分钟延迟
2. `chat_jid = web:main` 的任务通过 `send_message` 发送的结果仅在 Web 端可见，未转发到飞书/Telegram/QQ
3. 缺少手动试运行入口，调试和验证不便

## 修复方案

### 一、isolated 定时任务并行执行
- `src/task-scheduler.ts`: `isolated` 模式任务使用 `{chatJid}#task:{taskId}` 虚拟 JID 入队，每个任务获得独立序列化键
- `src/group-queue.ts`: `GroupState` 增加 `taskRunId`，`resolveIpcInputDir` 支持 `tasks-run/{taskRunId}/` 路径
- `src/container-runner.ts`: IPC 目录构建支持 `taskRunId`（Docker 和宿主机模式）
- `src/index.ts`: `serializationKeyResolver`/`hostModeChecker`/`userConcurrentLimitChecker` 处理 `#task:` 虚拟 JID；IPC watcher 扫描 `tasks-run/*/`

### 二、定时任务结果转发到所有 IM 渠道
- `container/agent-runner/src/mcp-tools.ts`: `send_message`/`send_image` IPC 数据携带 `isScheduledTask` 标记
- `src/im-manager.ts`: 新增 `getConnectedChannelTypes(userId)` 方法
- `src/index.ts`: IPC handler 检测 `isScheduledTask` 后广播到 owner 所有已连接 IM 渠道（去重已发送渠道）

### 三、手动试运行按钮
- `src/task-scheduler.ts`: 新增 `triggerTaskNow()` 导出函数（fire-and-forget，不改变 `next_run`）
- `src/routes/tasks.ts`: 新增 `POST /api/tasks/:id/run` 路由
- 前端: TaskCard 增加 Zap 图标试运行按钮（active/paused 状态可用）

## Test plan
- [ ] `make build && make typecheck` 通过
- [ ] 创建两个 cron isolated 任务在同一 folder，通过试运行按钮触发，验证并行启动
- [ ] 验证 send_message 输出同时出现在 Web 和所有已连接 IM 渠道
- [ ] 验证手动触发不改变 next_run，但 last_run 和日志正确记录
- [ ] 验证 group 模式任务仍与用户消息串行化

🤖 Generated with [Claude Code](https://claude.com/claude-code)