### PR TITLE
修复: 对话标签栏过多时撑开页面而非水平滚动

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -59,7 +59,7 @@ export function ChatPage() {
 
       {/* Chat View - Desktop: visible when active group exists, Mobile: only in detail route */}
       {activeGroupJid ? (
-        <div ref={chatViewRef} className={`${groupFolder ? 'flex-1' : 'hidden lg:block flex-1'}`}>
+        <div ref={chatViewRef} className={`${groupFolder ? 'flex-1 min-w-0' : 'hidden lg:block flex-1 min-w-0'}`}>
           <ChatView
             groupJid={activeGroupJid}
             onBack={handleBackToList}


### PR DESCRIPTION
## 问题描述

当对话标签栏（AgentTabBar）中的 tab 过多时，页面会被水平撑开，而不是出现预期的水平滚动。

## 修复方案

### `web/src/pages/ChatPage.tsx`
- 给 ChatView 的包裹 div 添加 `min-w-0`

### 根因分析

ChatPage 中 ChatView 的包裹 div 使用 `flex-1` 但缺少 `min-w-0`。在 flexbox 中，`min-width` 默认为 `auto`（内容固有宽度），导致该 flex 项无法收缩到比 AgentTabBar 内容更窄，`overflow-x-auto` 永远不会触发。

添加 `min-w-0` 后，宽度约束沿 block 布局向下传递，AgentTabBar 的水平滚动行为恢复正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)