### PR TITLE
功能: 官方 API Key 认证支持 (#176)

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -103,7 +103,8 @@ function buildSetupStatus() {
   const claudeConfig = getClaudeProviderConfig();
   const officialConfigured =
     !!claudeConfig.claudeCodeOauthToken?.trim() ||
-    !!claudeConfig.claudeOAuthCredentials;
+    !!claudeConfig.claudeOAuthCredentials ||
+    !!claudeConfig.anthropicApiKey?.trim();
   const thirdPartyConfigured = !!(
     claudeConfig.anthropicBaseUrl?.trim() &&
     claudeConfig.anthropicAuthToken?.trim()

--- a/web/src/components/settings/ClaudeProviderSection.tsx
+++ b/web/src/components/settings/ClaudeProviderSection.tsx
@@ -3,6 +3,7 @@ import {
   Edit3,
   ExternalLink,
   HardDrive,
+  Key,
   Loader2,
   Plus,
   RefreshCw,
@@ -32,6 +33,7 @@ type ProfileEditorMode = 'create' | 'edit';
 const RESERVED_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
   'CLAUDE_CODE_OAUTH_TOKEN',
   'ANTHROPIC_MODEL',
 ]);
@@ -79,6 +81,7 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
   const [providerMode, setProviderMode] = useState<ProviderMode>('third_party');
 
   const [officialCode, setOfficialCode] = useState('');
+  const [officialApiKey, setOfficialApiKey] = useState('');
 
   // OAuth flow state
   const [oauthLoading, setOauthLoading] = useState(false);
@@ -188,7 +191,7 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
       }
 
       const inferredMode: ProviderMode =
-        (configData.hasClaudeCodeOauthToken || configData.hasClaudeOAuthCredentials) &&
+        (configData.hasClaudeCodeOauthToken || configData.hasClaudeOAuthCredentials || configData.hasAnthropicApiKey) &&
         !configData.hasAnthropicAuthToken &&
         !configData.anthropicBaseUrl
           ? 'official'
@@ -245,6 +248,31 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
   const updatedAt = useMemo(() => {
     return formatDateTime(config?.updatedAt ?? null);
   }, [config?.updatedAt]);
+
+  // Switch back to official using existing API Key (no re-auth needed)
+  const handleUseExistingApiKey = async () => {
+    setSaving(true);
+    setNotice(null);
+    setError(null);
+    try {
+      await api.put<ClaudeConfigPublic>('/api/config/claude', {
+        anthropicBaseUrl: '',
+      });
+      const saved = await api.put<ClaudeConfigPublic>('/api/config/claude/secrets', {
+        clearAnthropicAuthToken: true,
+        clearClaudeCodeOauthToken: true,
+        clearClaudeOAuthCredentials: true,
+      });
+      setConfig(saved);
+      setProviderMode('official');
+      setNotice('已切换回官方渠道，使用已有 API Key。');
+      await loadConfig();
+    } catch (err) {
+      setError(getErrorMessage(err, '切换失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
 
   // Switch back to official using existing OAuth credentials (no re-auth needed)
   const handleUseExistingOAuth = async () => {
@@ -342,6 +370,37 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
       }
     } catch (err) {
       setError(getErrorMessage(err, '保存官方提供商配置失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSaveApiKey = async () => {
+    if (!officialApiKey.trim()) {
+      setError('请填写 Anthropic API Key');
+      return;
+    }
+
+    setSaving(true);
+    setNotice(null);
+    setError(null);
+    try {
+      await api.put<ClaudeConfigPublic>('/api/config/claude/secrets', {
+        anthropicApiKey: officialApiKey.trim(),
+        clearAnthropicAuthToken: true,
+        clearClaudeCodeOauthToken: true,
+        clearClaudeOAuthCredentials: true,
+      });
+      const saved = await api.put<ClaudeConfigPublic>('/api/config/claude', {
+        anthropicBaseUrl: '',
+      });
+      setConfig(saved);
+      setOfficialApiKey('');
+      setProviderMode('official');
+      setNotice('API Key 已保存。');
+      await loadConfig();
+    } catch (err) {
+      setError(getErrorMessage(err, '保存 API Key 失败'));
     } finally {
       setSaving(false);
     }
@@ -628,6 +687,28 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
             </div>
           )}
 
+          {config?.hasAnthropicApiKey && !config?.hasClaudeOAuthCredentials && (
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 space-y-2">
+              <div className="flex items-center gap-2">
+                <Key className="w-4 h-4 text-emerald-700" />
+                <div className="text-sm font-medium text-emerald-800">API Key 已配置</div>
+              </div>
+              <div className="text-xs text-emerald-700">
+                ANTHROPIC_API_KEY: {config.anthropicApiKeyMasked || '***'}
+              </div>
+              {/* Show switch button when third-party config is still active */}
+              {(config.anthropicBaseUrl || config.hasAnthropicAuthToken) && (
+                <div className="pt-2 border-t border-emerald-200">
+                  <div className="text-xs text-slate-600 mb-2">当前正在使用第三方渠道，可直接切换回官方。</div>
+                  <Button size="sm" onClick={handleUseExistingApiKey} disabled={loading || saving}>
+                    {saving && <Loader2 className="size-4 animate-spin" />}
+                    使用 API Key 切换回官方
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Claude service status */}
           {claudeStatus && (
             <div className={`rounded-lg border p-3 space-y-1.5 ${
@@ -769,6 +850,51 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
           <Button onClick={handleSaveOfficial} disabled={loading || saving}>
             {saving && <Loader2 className="size-4 animate-spin" />}
             保存凭据
+          </Button>
+
+          <div className="relative flex items-center gap-3 text-xs text-slate-400">
+            <div className="flex-1 border-t border-slate-200" />
+            或使用 Anthropic API Key
+            <div className="flex-1 border-t border-slate-200" />
+          </div>
+
+          <div>
+            <label className="block text-xs text-slate-600 mb-1">
+              <div className="flex items-center gap-1.5">
+                <Key className="w-3.5 h-3.5" />
+                ANTHROPIC_API_KEY{' '}
+                {config?.hasAnthropicApiKey ? `(${config.anthropicApiKeyMasked})` : ''}
+              </div>
+            </label>
+            <Input
+              type="password"
+              value={officialApiKey}
+              onChange={(e) => setOfficialApiKey(e.target.value)}
+              disabled={loading || saving}
+              placeholder={
+                config?.hasAnthropicApiKey
+                  ? '输入新值覆盖'
+                  : 'sk-ant-api03-...'
+              }
+              className="font-mono"
+            />
+            <p className="text-xs text-slate-400 mt-1">
+              直接使用 Anthropic 官方 API Key，从{' '}
+              <a
+                href="https://console.anthropic.com/settings/keys"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-teal-600 underline"
+              >
+                console.anthropic.com
+              </a>{' '}
+              获取
+            </p>
+          </div>
+
+          <Button onClick={handleSaveApiKey} disabled={loading || saving}>
+            {saving && <Loader2 className="size-4 animate-spin" />}
+            保存 API Key
           </Button>
         </div>
       ) : (

--- a/web/src/pages/SetupProvidersPage.tsx
+++ b/web/src/pages/SetupProvidersPage.tsx
@@ -17,6 +17,7 @@ type ProviderMode = 'official' | 'third_party';
 const RESERVED_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
   'CLAUDE_CODE_OAUTH_TOKEN',
   'ANTHROPIC_MODEL',
 ]);
@@ -58,7 +59,10 @@ export function SetupProvidersPage() {
   const [feishuAppSecret, setFeishuAppSecret] = useState('');
 
   // Official mode
+  type OfficialTab = 'oauth' | 'setup-token' | 'api-key';
+  const [officialTab, setOfficialTab] = useState<OfficialTab>('oauth');
   const [officialToken, setOfficialToken] = useState('');
+  const [apiKey, setApiKey] = useState('');
 
   // Local Claude Code detection
   const [localCC, setLocalCC] = useState<{
@@ -192,8 +196,8 @@ export function SetupProvidersPage() {
         return;
       }
       customEnv = envResult.customEnv;
-    } else if (!officialToken.trim() && !oauthDone && !localCCImported) {
-      setError('官方渠道请通过一键登录、导入本机凭据或手动填写 setup-token / .credentials.json');
+    } else if (!officialToken.trim() && !apiKey.trim() && !oauthDone && !localCCImported) {
+      setError('官方渠道请通过一键登录、导入本机凭据、填写 API Key 或手动填写 setup-token / .credentials.json');
       return;
     }
 
@@ -210,6 +214,15 @@ export function SetupProvidersPage() {
         if (oauthDone || localCCImported) {
           // OAuth or local import already saved the credentials — just clear base URL
           await api.put('/api/config/claude', { anthropicBaseUrl: '' });
+        } else if (apiKey.trim()) {
+          // API Key mode
+          await api.put('/api/config/claude', { anthropicBaseUrl: '' });
+          await api.put('/api/config/claude/secrets', {
+            anthropicApiKey: apiKey.trim(),
+            clearAnthropicAuthToken: true,
+            clearClaudeCodeOauthToken: true,
+            clearClaudeOAuthCredentials: true,
+          });
         } else {
           await api.put('/api/config/claude', { anthropicBaseUrl: '' });
 
@@ -380,82 +393,154 @@ export function SetupProvidersPage() {
                 </div>
               )}
 
-              {/* OAuth one-click login */}
-              <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3">
-                <div className="text-sm font-medium text-foreground">一键登录 Claude（推荐）</div>
-                <div className="text-xs text-muted-foreground">
-                  点击按钮后会打开 claude.ai 授权页面，完成授权后将页面上显示的授权码粘贴回来。
-                </div>
+              {/* Official auth tabs */}
+              <div className="inline-flex rounded-lg border border-border p-1 bg-muted">
+                <button
+                  type="button"
+                  onClick={() => setOfficialTab('oauth')}
+                  className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
+                    officialTab === 'oauth' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                  }`}
+                >
+                  OAuth 登录
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setOfficialTab('setup-token')}
+                  className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
+                    officialTab === 'setup-token' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                  }`}
+                >
+                  Setup Token
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setOfficialTab('api-key')}
+                  className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
+                    officialTab === 'api-key' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                  }`}
+                >
+                  API Key
+                </button>
+              </div>
 
-                {oauthDone ? (
-                  <div className="text-sm bg-success-bg border border-success/30 text-success rounded-md px-3 py-2">
-                    OAuth 登录成功，点击下方按钮完成配置。
-                  </div>
-                ) : !oauthState ? (
-                  <Button onClick={handleOAuthStart} disabled={oauthLoading || saving}>
-                    {oauthLoading ? <Loader2 className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
-                    一键登录 Claude
-                  </Button>
-                ) : (
-                  <div className="space-y-2">
-                    <div className="text-xs bg-warning-bg border border-warning/30 text-warning rounded-md px-3 py-2">
-                      授权窗口已打开，请在 claude.ai 完成授权后，将页面上显示的授权码粘贴到下方。
+              {officialTab === 'oauth' && (
+                <>
+                  {/* OAuth one-click login */}
+                  <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3">
+                    <div className="text-sm font-medium text-foreground">一键登录 Claude（推荐）</div>
+                    <div className="text-xs text-muted-foreground">
+                      点击按钮后会打开 claude.ai 授权页面，完成授权后将页面上显示的授权码粘贴回来。
                     </div>
-                    <div className="flex gap-2">
-                      <Input
-                        type="text"
-                        value={oauthCode}
-                        onChange={(e) => setOauthCode(e.target.value)}
-                        disabled={oauthExchanging}
-                        placeholder="粘贴授权码"
-                        className="flex-1"
-                      />
-                      <Button onClick={handleOAuthCallback} disabled={oauthExchanging || !oauthCode.trim()}>
-                        {oauthExchanging && <Loader2 className="size-4 animate-spin" />}
-                        确认
+
+                    {oauthDone ? (
+                      <div className="text-sm bg-success-bg border border-success/30 text-success rounded-md px-3 py-2">
+                        OAuth 登录成功，点击下方按钮完成配置。
+                      </div>
+                    ) : !oauthState ? (
+                      <Button onClick={handleOAuthStart} disabled={oauthLoading || saving}>
+                        {oauthLoading ? <Loader2 className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
+                        一键登录 Claude
                       </Button>
-                      <Button variant="outline" onClick={() => { setOauthState(null); setOauthCode(''); }}>
-                        取消
-                      </Button>
-                    </div>
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="text-xs bg-warning-bg border border-warning/30 text-warning rounded-md px-3 py-2">
+                          授权窗口已打开，请在 claude.ai 完成授权后，将页面上显示的授权码粘贴到下方。
+                        </div>
+                        <div className="flex gap-2">
+                          <Input
+                            type="text"
+                            value={oauthCode}
+                            onChange={(e) => setOauthCode(e.target.value)}
+                            disabled={oauthExchanging}
+                            placeholder="粘贴授权码"
+                            className="flex-1"
+                          />
+                          <Button onClick={handleOAuthCallback} disabled={oauthExchanging || !oauthCode.trim()}>
+                            {oauthExchanging && <Loader2 className="size-4 animate-spin" />}
+                            确认
+                          </Button>
+                          <Button variant="outline" onClick={() => { setOauthState(null); setOauthCode(''); }}>
+                            取消
+                          </Button>
+                        </div>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
+                </>
+              )}
 
-              <div className="relative flex items-center gap-3 text-xs text-muted-foreground">
-                <div className="flex-1 border-t border-border" />
-                或手动粘贴 setup-token
-                <div className="flex-1 border-t border-border" />
-              </div>
+              {officialTab === 'setup-token' && (
+                <>
+                  <div className="rounded-lg border border-border bg-muted p-3 text-sm text-foreground">
+                    <div className="font-medium mb-2">获取凭据</div>
+                    <ol className="list-decimal ml-5 space-y-1 text-xs text-muted-foreground">
+                      <li>在目标机器安装 Claude Code CLI（若未安装）。</li>
+                      <li>在终端执行 <code>claude login</code> 完成账号登录。</li>
+                      <li>
+                        方式 A：执行 <code>cat ~/.claude/.credentials.json</code>，复制完整 JSON 内容到下方（推荐）。
+                      </li>
+                      <li>
+                        方式 B：执行 <code>claude setup-token</code>，复制输出 token 到下方。
+                      </li>
+                    </ol>
+                  </div>
 
-              <div className="rounded-lg border border-border bg-muted p-3 text-sm text-foreground">
-                <div className="font-medium mb-2">获取凭据</div>
-                <ol className="list-decimal ml-5 space-y-1 text-xs text-muted-foreground">
-                  <li>在目标机器安装 Claude Code CLI（若未安装）。</li>
-                  <li>在终端执行 <code>claude login</code> 完成账号登录。</li>
-                  <li>
-                    方式 A：执行 <code>cat ~/.claude/.credentials.json</code>，复制完整 JSON 内容到下方（推荐）。
-                  </li>
-                  <li>
-                    方式 B：执行 <code>claude setup-token</code>，复制输出 token 到下方。
-                  </li>
-                </ol>
-              </div>
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1">
+                      setup-token 或 .credentials.json
+                    </label>
+                    <Input
+                      type="password"
+                      value={officialToken}
+                      onChange={(e) => setOfficialToken(e.target.value)}
+                      placeholder="粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      支持粘贴 <code className="bg-muted px-1 rounded">cat ~/.claude/.credentials.json</code> 的 JSON 内容
+                    </p>
+                  </div>
+                </>
+              )}
 
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
-                  setup-token 或 .credentials.json
-                </label>
-                <Input
-                  type="password"
-                  value={officialToken}
-                  onChange={(e) => setOfficialToken(e.target.value)}
-                  placeholder="粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出"
-                />
-                <p className="text-xs text-muted-foreground mt-1">
-                  支持粘贴 <code className="bg-muted px-1 rounded">cat ~/.claude/.credentials.json</code> 的 JSON 内容
-                </p>
-              </div>
+              {officialTab === 'api-key' && (
+                <>
+                  <div className="rounded-lg border border-border bg-muted p-3 text-sm text-foreground">
+                    <div className="font-medium mb-2">Anthropic API Key</div>
+                    <ol className="list-decimal ml-5 space-y-1 text-xs text-muted-foreground">
+                      <li>
+                        前往{' '}
+                        <a
+                          href="https://console.anthropic.com/settings/keys"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary underline"
+                        >
+                          console.anthropic.com
+                        </a>{' '}
+                        创建 API Key。
+                      </li>
+                      <li>将以 <code>sk-ant-api03-</code> 开头的 Key 粘贴到下方。</li>
+                    </ol>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1">
+                      ANTHROPIC_API_KEY
+                    </label>
+                    <Input
+                      type="password"
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                      placeholder="sk-ant-api03-..."
+                      className="font-mono"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      直接使用 Anthropic 官方 API Key 调用 Claude
+                    </p>
+                  </div>
+                </>
+              )}
             </div>
           ) : (
             <div className="space-y-4">


### PR DESCRIPTION
## 问题描述

关闭 #176。

官方 API Key（`sk-ant-api03-`）用户无法通过 Setup 向导完成配置。存储层和环境变量注入已支持，但 UI 和认证判定层缺失。

## 实现方案

### `src/routes/auth.ts`
- `buildSetupStatus()` 的 `officialConfigured` 判断新增 `anthropicApiKey` 检查

### `web/src/pages/SetupProvidersPage.tsx`
- 官方认证区域新增三 Tab 切换：OAuth 登录 / Setup Token / API Key
- API Key Tab 提供输入框和说明
- `ANTHROPIC_API_KEY` 加入 `RESERVED_ENV_KEYS` 防止重复配置

### `web/src/components/settings/ClaudeProviderSection.tsx`
- 新增 API Key 状态卡片（已配置时显示脱敏 Key）
- 新增 API Key 输入和保存功能
- 支持从第三方模式切换回 API Key 官方模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)