### PR TITLE
优化: 主Agent 文案 + 对话区域宽度放宽 (#180)

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -404,7 +404,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
         <div className="flex-1 min-w-0">
           <h2 className="font-semibold text-slate-900 text-[15px] truncate">{group.name}</h2>
           <div className="flex items-center gap-1.5 text-xs text-slate-500">
-            <span>{isWaiting ? '正在思考...' : group.is_home ? '主工作区' : '工作区'}</span>
+            <span>{isWaiting ? '正在思考...' : group.is_home ? '主 Agent' : 'Agent'}</span>
             {!isWaiting && group.is_shared && (
               <>
                 <span className="text-slate-300">·</span>

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -322,7 +322,7 @@ export function MessageInput({
       className="px-4 pt-2 pb-6 bg-background ios-pwa-bottom-safe max-lg:bg-background/60 max-lg:backdrop-blur-xl max-lg:saturate-[1.8] max-lg:border-t max-lg:border-border/40"
       style={{ paddingBottom: `max(1.5rem, var(--keyboard-height, 0px))` }}
     >
-      <div className={isCompact ? 'mx-auto' : 'max-w-3xl mx-auto'}>
+      <div className={isCompact ? 'mx-auto' : 'max-w-4xl mx-auto'}>
         {/* Upload progress bar */}
         {uploading && uploadProgress && (
           <div className={`mb-2 px-4 py-2.5 ${isCompact ? 'bg-card border border-border' : 'bg-card rounded-xl border border-border shadow-sm'}`}>

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -259,7 +259,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
         ref={parentRef}
         className="h-full overflow-y-auto overflow-x-hidden py-6 bg-background"
       >
-        <div className={displayMode === 'compact' ? 'mx-auto px-4 min-w-0' : 'max-w-3xl mx-auto px-4 min-w-0'}>
+        <div className={displayMode === 'compact' ? 'mx-auto px-4 min-w-0' : 'max-w-4xl mx-auto px-4 min-w-0'}>
         {loading && hasMore && (
           <div className="flex justify-center py-4">
             <Loader2 className="animate-spin text-primary" size={24} />

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -480,7 +480,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
       );
     }
     return (
-      <div className="max-w-3xl mx-auto w-full px-4 py-3">
+      <div className="max-w-4xl mx-auto w-full px-4 py-3">
         {/* Mobile: compact avatar + name row */}
         <div className="flex items-center gap-2 mb-1.5 lg:hidden">
           <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />
@@ -557,7 +557,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
 
   // ── Chat mode streaming (default) ──
   return (
-    <div className="max-w-3xl mx-auto w-full px-4 py-3">
+    <div className="max-w-4xl mx-auto w-full px-4 py-3">
       {/* Mobile: compact avatar + name row */}
       <div className="flex items-center gap-2 mb-1.5 lg:hidden">
         <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />


### PR DESCRIPTION
## 问题描述

关联 #180（部分修复：需求 1/4/5）。

## 实现方案

### 需求 1：文案修改
- `ChatView.tsx`："主工作区" → "主 Agent"，"工作区" → "Agent"

### 需求 4/5：宽度自适应
将 4 个聊天组件中的 `max-w-3xl`(768px) 统一改为 `max-w-4xl`(896px)：
- `MessageList.tsx` — 消息列表
- `MessageInput.tsx` — 聊天输入框
- `StreamingDisplay.tsx` — 流式显示（2 处）

🤖 Generated with [Claude Code](https://claude.com/claude-code)