### PR TITLE
修复: drainGroup 与 scheduleRetry 竞态导致主会话重复回复

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -882,6 +882,9 @@ export class GroupQueue {
         const success = await this.processMessagesFn(groupJid);
         if (success) {
           state.retryCount = 0;
+          // Defensive: clear any lingering retry timer from a previous failed
+          // run that was superseded by a successful drain-triggered run.
+          this.clearRetryTimer(state);
         } else {
           this.scheduleRetry(groupJid, state);
         }
@@ -1090,8 +1093,11 @@ export class GroupQueue {
       return;
     }
 
-    // Then pending messages
-    if (state.pendingMessages) {
+    // Then pending messages — but NOT if a retry timer is already scheduled.
+    // When processMessagesFn() fails, both scheduleRetry() and drainGroup() fire.
+    // Without this guard, drainGroup would start a new container while the retry
+    // timer later starts another, causing duplicate processing of the same messages.
+    if (state.pendingMessages && !state.retryTimer) {
       this.runForGroup(groupJid, 'drain');
       return;
     }
@@ -1136,11 +1142,13 @@ export class GroupQueue {
         }
         if (validTask) {
           this.runTask(jid, validTask);
-        } else if (state.pendingMessages) {
+        } else if (state.pendingMessages && !state.retryTimer) {
           // All tasks were stale, fall through to messages
+          // (skip if retry timer is pending to avoid duplicate processing)
           this.runForGroup(jid, 'drain');
         }
-      } else if (state.pendingMessages) {
+      } else if (state.pendingMessages && !state.retryTimer) {
+        // Skip if retry timer is pending to avoid duplicate processing
         this.runForGroup(jid, 'drain');
       }
       // If neither pending, skip this group


### PR DESCRIPTION
## 问题描述

关联 #199。修复主会话两个问题：
- **重复回复**：用户发一次消息，Agent 回复两次
- **潜在消息丢失**：发了消息没有响应

### 根因分析

当 `processMessagesFn()` 失败时，`runForGroup()` 中两个恢复机制同时触发：

1. **`scheduleRetry()`**（L846）：设置指数退避定时器（5s→10s→...），到时间后调用 `enqueueMessageCheck()` 重新处理
2. **`drainGroup()`**（L879，finally 块）：检查 `pendingMessages=true` 后**立即**启动新容器处理

两者可能同时处理同一批消息，导致用户收到重复回复。

**触发时序**：
```
T1: 容器处理 M1（长任务），用户发 M2
T2: sendMessage() → 'queued'，pendingMessages=true
T3: 容器超时/出错 → processMessagesFn() return false
T4: scheduleRetry() 设 5s 定时器
T5: finally → drainGroup() → pendingMessages=true → 立即启动新容器 B
T6: 容器 B 处理 M1+M2 → 回复用户
T7: 5s 后定时器触发 → enqueueMessageCheck() → 可能再次处理
```

## 修复方案

### `src/group-queue.ts`

- **`drainGroup()`**：检查 `pendingMessages` 时增加 `!state.retryTimer` 守卫。如果重试定时器已在等待，跳过 `pendingMessages` 处理，由定时器统一负责重试
- **`drainWaiting()`**：同样增加 `!state.retryTimer` 守卫（两处）
- **`runForGroup()` 成功路径**：防御性调用 `clearRetryTimer()`，清除可能残留的定时器（例如上一次失败设的定时器被 drain 触发的成功运行覆盖的情况）

### 影响范围

仅修改 `group-queue.ts`，改动集中在 drain/retry 交互逻辑，不影响正常消息处理流程。