### PR TITLE
修复: Sub-Agent 会话中图片流式结束后无法显示

### DIFF
--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -27,8 +27,10 @@ interface MarkdownRendererProps {
 function resolveImageSrc(src: string, groupJid?: string): string {
   if (!groupJid || !src) return src;
   if (/^(https?:\/\/|data:|\/\/)/.test(src) || src.startsWith('/')) return src;
+  // Strip #agent:xxx suffix — file API uses the base group JID
+  const baseJid = groupJid.replace(/#agent:.*$/, '');
   const encoded = toBase64Url(src);
-  return withBasePath(`/api/groups/${encodeURIComponent(groupJid)}/files/download/${encoded}`);
+  return withBasePath(`/api/groups/${encodeURIComponent(baseJid)}/files/download/${encoded}`);
 }
 
 /** Image lightbox for markdown images */


### PR DESCRIPTION
## 问题描述

Sub-Agent 会话中，markdown 图片在 SSE 流式输出期间能正常渲染，但流式结束后变为错误回退状态（图片 icon + alt 文字标签）。

### 根因

Sub-Agent 消息的 `chat_jid` 带有 `#agent:xxx` 后缀（如 `web:main#agent:0db39148-...`）。`MessageBubble` 将 `message.chat_jid` 传给 `MarkdownRenderer` 的 `groupJid` prop，`resolveImageSrc` 用这个完整 JID 构建文件下载 URL：

```
/api/groups/web%3Amain%23agent%3A0db39148-.../files/download/...
```

该 URL 不匹配任何注册群组，API 返回 404，触发 `<img>` 的 `onError` 回退。

而 `StreamingDisplay` 收到的 `groupJid` 是纯净的 `web:main`（不含 agent 后缀），所以流式期间图片正常。

### 复现路径

1. 在 Web 端与 Sub-Agent 对话（或主会话中 Agent 使用子对话）
2. Agent 回复中包含 markdown 图片（如 `![alt](image.png)`）
3. 流式输出期间图片正常显示
4. 流式结束后，图片变成 icon + alt 文字标签

## 修复方案

### `web/src/components/chat/MarkdownRenderer.tsx`

在 `resolveImageSrc` 中剥离 `#agent:xxx` 后缀，使用 base JID 构建文件下载 URL：

```typescript
const baseJid = groupJid.replace(/#agent:.*$/, '');
```

改动仅 3 行，不影响非 Sub-Agent 场景（无 `#agent:` 后缀时 `replace` 为 no-op）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)