### PR TITLE
修复: 子会话消息在 Web 端丢失

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -103,6 +103,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const agentStreaming = useChatStore(s => s.agentStreaming);
   const createConversation = useChatStore(s => s.createConversation);
   const loadAgentMessages = useChatStore(s => s.loadAgentMessages);
+  const refreshAgentMessages = useChatStore(s => s.refreshAgentMessages);
   const sendAgentMessage = useChatStore(s => s.sendAgentMessage);
   const agentMessages = useChatStore(s => s.agentMessages);
   const agentWaiting = useChatStore(s => s.agentWaiting);
@@ -194,10 +195,19 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
     restoreActiveState();
     const unsub = wsManager.on('connected', () => {
       restoreActiveState();
+      // Refresh conversation agent messages that may have been missed during WS disconnection
+      const state = useChatStore.getState();
+      const currentTab = state.activeAgentTab[groupJid];
+      if (currentTab) {
+        const agentInfo = (state.agents[groupJid] || []).find(a => a.id === currentTab);
+        if (agentInfo?.kind === 'conversation') {
+          refreshAgentMessages(groupJid, currentTab);
+        }
+      }
     });
     return () => { unsub(); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [groupJid]);
 
   // Derived: active agent info and kind
   const activeAgent = activeAgentTab ? agents.find(a => a.id === activeAgentTab) : null;

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1457,11 +1457,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
           ? (() => { const n = { ...s.agentStreaming }; delete n[agentId]; return n; })()
           : s.agentStreaming;
 
+        // For user messages (non-reply), set agentWaiting=true so subsequent
+        // streaming events are accepted.  This handles messages injected from
+        // Feishu/Telegram which don't go through sendAgentMessage().
+        const nextAgentWaiting = isAgentReply
+          ? { ...s.agentWaiting, [agentId]: false }
+          : !msg.is_from_me
+            ? { ...s.agentWaiting, [agentId]: true }
+            : s.agentWaiting;
+
         return {
           agentMessages: { ...s.agentMessages, [agentId]: updated },
-          agentWaiting: isAgentReply
-            ? { ...s.agentWaiting, [agentId]: false }
-            : s.agentWaiting,
+          agentWaiting: nextAgentWaiting,
           agentStreaming: nextAgentStreaming,
         };
       });
@@ -1600,9 +1607,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
       }
 
+      // Conversation agent started running: reset agentWaiting so stream events
+      // are accepted (mirrors handleRunnerState for the main conversation).
+      // Without this, Feishu-sourced messages (which skip sendAgentMessage) would
+      // leave agentWaiting=false and cause all streaming events to be dropped.
+      const nextAgentWaiting =
+        resolvedKind === 'conversation' && status === 'running'
+          ? { ...s.agentWaiting, [agentId]: true }
+          : s.agentWaiting;
+
       return {
         agents: { ...s.agents, [chatJid]: updated },
         agentStreaming: nextAgentStreaming,
+        agentWaiting: nextAgentWaiting,
         sdkTasks: nextSdkTasks,
         sdkTaskAliases: nextSdkTaskAliases,
       };


### PR DESCRIPTION
## 问题描述

子会话（conversation agent）的消息在 Web 端丢失，但飞书群中显示正常。

### 触发场景

1. 用户从飞书向子会话 Agent 发消息
2. Agent 开始处理并流式输出
3. Web 端看不到 streaming 状态（thinking/tool cards），甚至看不到最终回复
4. 飞书群中回复正常

### 根因分析

**问题 1: `agentWaiting` 守卫阻断 streaming**

`handleStreamEvent` 中有守卫 `!s.agentStreaming[agentId] && s.agentWaiting[agentId] === false`，当条件为 true 时丢弃所有 stream events。

- 只有 `sendAgentMessage()` 会设置 `agentWaiting[agentId] = true`（Web 端发送）
- 飞书来源的消息通过 `handleWsNewMessage` 到达，**不会设置** `agentWaiting = true`
- `handleAgentStatus(status='running')` 也**不会设置** `agentWaiting = true`
- 对比：主会话的 `handleRunnerState(state='running')` **会设置** `waiting[chatJid] = true`

**问题 2: WebSocket 断连后无恢复机制**

- 主会话有 `restoreActiveState()` 在重连时刷新状态
- 子会话没有任何消息补回机制
- 断连期间的 `new_message` 广播丢失后，消息永远不会显示

## 修复方案

### `web/src/stores/chat.ts`

1. **`handleAgentStatus`**: conversation agent 状态变为 `running` 时设置 `agentWaiting[agentId] = true`，与 `handleRunnerState` 对齐
2. **`handleWsNewMessage`**: 收到非 agent-reply 的用户消息（`!msg.is_from_me`）时设置 `agentWaiting[agentId] = true`，确保后续 streaming 被接受

### `web/src/components/chat/ChatView.tsx`

3. WebSocket `connected` 事件回调中，检查当前活跃的 conversation agent tab，调用 `refreshAgentMessages()` 补回断连期间丢失的消息

🤖 Generated with [Claude Code](https://claude.com/claude-code)