### PR TITLE
修复: 补充 #214 遗漏场景 — 同一 query 内多个 sdk_final 互相覆盖

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1160,6 +1160,10 @@ async function runQuery(
         sourceKind: 'sdk_final',
         finalizationReason: 'completed',
       });
+      // After emitting an sdk_final result, rotate turnId so that if
+      // another result is emitted within the same query (e.g. user sent
+      // a follow-up via IPC mid-query), it won't overwrite this one (#214).
+      containerInput.turnId = generateTurnId();
 
       // Emit usage stream event with token counts and cost
       const resultMsg = message as Record<string, unknown>;


### PR DESCRIPTION
## 问题描述

关联 #214。这是对 fa77191 的**补充修复**，覆盖了一个遗漏的 edge case。

fa77191 已经在 query 之间（`waitForIpcMessage()` 返回后和中断恢复后）通过 `generateTurnId()` 轮转 turnId，解决了大部分场景。

但还有一个场景未覆盖：**用户在 AI 回复过程中发送新消息时**，IPC 消息通过 `stream.push()` 注入到正在执行的 query 中（`pollIpcDuringQuery` → `drainIpcInput` → `stream.push`），导致同一 query 内产生多个 `sdk_final` 结果。由于这些结果共享相同的 `containerInput.turnId`，`storeMessageDirect()` 的去重逻辑仍然会覆盖前一条回复。

经本地实测验证，仅有 fa77191 时此场景仍会丢失一条 AI 回复，加上本 PR 后问题完全解决。

## 修复方案

### `container/agent-runner/src/index.ts`

- 在每次 `emit({ sourceKind: 'sdk_final' })` 后立即调用 `containerInput.turnId = generateTurnId()`
- 确保同一 query 内如果产生多个 sdk_final 结果，每个都有独立的 turnId，不会互相覆盖

## 测试

在子会话中快速连续发送多条消息（AI 回复过程中发下一条），确认所有 AI 回复在页面刷新后均保留。