### PR TITLE
修复: 移动端无法选择和复制文本

### DIFF
--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, memo, lazy, Suspense } from 'react';
+import { useState, memo, lazy, Suspense } from 'react';
 import { Copy, Check, ChevronDown, ChevronUp, Ellipsis, ImageDown } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -138,8 +138,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
   const [lightboxState, setLightboxState] = useState<{ images: string[]; index: number } | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [showShareDialog, setShowShareDialog] = useState(false);
-  const touchTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const touchStartPos = useRef({ x: 0, y: 0 });
   const currentUser = useAuthStore((s) => s.user);
   const appearance = useAuthStore((s) => s.appearance);
   const { mode: displayMode } = useDisplayMode();
@@ -197,33 +195,11 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
     setContextMenu({ x: e.clientX, y: e.clientY });
   };
 
-  const handleMenuButton = (e: React.MouseEvent | React.TouchEvent) => {
+  const handleMenuButton = (e: React.MouseEvent) => {
     e.stopPropagation();
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     mediumTap();
     setContextMenu({ x: rect.left, y: rect.bottom + 4 });
-  };
-
-  const handleTouchStart = (e: React.TouchEvent) => {
-    const touch = e.touches[0];
-    touchStartPos.current = { x: touch.clientX, y: touch.clientY };
-    touchTimer.current = setTimeout(() => {
-      mediumTap();
-      setContextMenu({ x: touch.clientX, y: touch.clientY - 10 });
-    }, 500);
-  };
-
-  const handleTouchEnd = () => {
-    if (touchTimer.current) clearTimeout(touchTimer.current);
-  };
-
-  const handleTouchMove = (e: React.TouchEvent) => {
-    const touch = e.touches[0];
-    const dx = Math.abs(touch.clientX - touchStartPos.current.x);
-    const dy = Math.abs(touch.clientY - touchStartPos.current.y);
-    if (dx > 10 || dy > 10) {
-      if (touchTimer.current) clearTimeout(touchTimer.current);
-    }
   };
 
   // Context overflow system message
@@ -321,14 +297,14 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
       : (isOtherUser ? (message.sender_name || '用户') : (currentUser?.display_name || currentUser?.username || '我'));
 
     return (
-      <div className="group mb-2 border-b border-border pb-2" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+      <div className="group mb-2 border-b border-border pb-2" onContextMenu={handleContextMenu}>
         {/* Sender line — no avatars in compact mode */}
         <div className="flex items-center gap-1.5 mb-1">
           <span className={`text-xs font-semibold ${isAI ? 'text-primary' : 'text-muted-foreground'}`}>{senderName}</span>
           {showTime && <span className="text-[11px] text-slate-400">{time}</span>}
           <button
             onClick={handleCopy}
-            className="ml-1 w-5 h-5 rounded flex items-center justify-center text-slate-300 hover:text-slate-600 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+            className="ml-1 w-5 h-5 rounded flex items-center justify-center text-slate-300 hover:text-slate-600 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity cursor-pointer"
             title="复制"
           >
             {copied ? <Check className="w-3 h-3 text-primary" /> : <Copy className="w-3 h-3" />}
@@ -386,7 +362,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
       const otherName = message.sender_name || '用户';
       const initial = otherName[0]?.toUpperCase() || '?';
       return (
-        <div className="group mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+        <div className="group mb-4" onContextMenu={handleContextMenu}>
           <div className="flex items-center gap-2 mb-1.5 lg:hidden">
             <div className="w-6 h-6 rounded-full bg-slate-200 flex items-center justify-center text-xs font-medium text-slate-600 flex-shrink-0">
               {initial}
@@ -462,7 +438,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
     // User message (own): right-aligned
     const showSenderLabel = isShared;
     return (
-      <div className="group flex justify-end mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+      <div className="group flex justify-end mb-4" onContextMenu={handleContextMenu}>
         <div className="flex flex-col items-end min-w-0 w-full">
           {showSenderLabel && (
             <span className="text-xs text-muted-foreground font-medium mb-1 mr-1">
@@ -532,7 +508,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
   const aiImageUrl = currentUser?.ai_avatar_url;
 
   return (
-    <div className="group mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+    <div className="group mb-4" onContextMenu={handleContextMenu}>
       {/* Mobile: compact avatar + name row */}
       <div className="flex items-center gap-2 mb-1.5 lg:hidden">
         <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />
@@ -558,7 +534,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
             <div className="absolute top-2 right-2 flex items-center gap-0.5 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
               <button
                 onClick={() => setShowShareDialog(true)}
-                className="w-7 h-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-foreground/10 max-lg:hidden cursor-pointer"
+                className="w-7 h-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-foreground/10 cursor-pointer"
                 title="分享图片"
                 aria-label="生成分享图片"
               >
@@ -566,7 +542,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
               </button>
               <button
                 onClick={handleCopy}
-                className="w-7 h-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-foreground/10 max-lg:hidden cursor-pointer"
+                className="w-7 h-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-foreground/10 cursor-pointer"
                 title="复制"
                 aria-label="复制消息"
               >

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -319,7 +319,6 @@ pre code.hljs {
   /* 全局禁止双击缩放 */
   body {
     touch-action: manipulation;
-    -webkit-touch-callout: none;
   }
 
   /*


### PR DESCRIPTION
## 问题描述

移动端用户无法选择和复制消息文本。根因是自定义长按手势处理器与浏览器原生文本选择机制冲突。

### 具体表现

1. **文本不可选** — `handleTouchStart` 设置 500ms 定时器弹出自定义上下文菜单，与 iOS/Android 原生文本选择时机（~500ms）完全重叠，用户每次尝试选择文字都被自定义菜单拦截
2. **复制按钮不可见** — 紧凑模式的复制按钮使用 `opacity-0 group-hover:opacity-100`，触摸设备无 hover 状态；AI 消息的复制/分享按钮使用 `max-lg:hidden` 在移动端完全隐藏
3. **iOS PWA 原生复制被禁用** — `-webkit-touch-callout: none` 阻止了 iOS 的原生长按复制菜单

## 修复方案

核心原则：**不跟浏览器打架**。原生文本选择是用户最基本的期望。

### `web/src/components/chat/MessageBubble.tsx`

- **移除 `onTouchStart/End/Move` 和 500ms 长按定时器** — 自定义长按手势是多余的，Ellipsis 菜单按钮已提供完全相同的功能（弹出上下文菜单），且在移动端始终可见。移除后浏览器原生文本选择回归正常
- **紧凑模式复制按钮**：`opacity-0` → `lg:opacity-0`，移动端始终可见
- **AI 消息复制/分享按钮**：移除 `max-lg:hidden`，移动端可直接点击
- **保留 `mediumTap()` 触觉反馈**（菜单按钮点击时）

### `web/src/styles/globals.css`

- **PWA 模式移除 `-webkit-touch-callout: none`** — 让 iOS 用户选中文字后能弹出系统的「拷贝/全选」菜单

## 桌面端零影响

本次修改仅涉及触摸事件和移动端 CSS，**桌面端行为完全不变**：

- `onContextMenu`（鼠标右键）保留在所有消息容器上，右键自定义菜单正常工作
- 复制/分享/菜单按钮的 `lg:opacity-0 lg:group-hover:opacity-100` hover 行为不变
- `-webkit-touch-callout` 仅影响触摸设备，桌面浏览器本身就不使用该属性
- 移除的 `onTouchStart/End/Move` 是纯触摸事件，桌面端从不触发

## 改动量

纯减法：+9 -34 行，删除代码多于新增。