### PR TITLE
修复: OOM 死循环自动恢复 + IPC 多轮回复覆盖 (#212)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1614,6 +1614,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let lastError = '';
   let cursorCommitted = false;
   let lastReplyMsgId: string | undefined;
+  let lastSavedTurnId: string | undefined;  // tracks last turnId saved to DB, prevents UPSERT overwrite
   const queryTaskIds = new Set<string>();
   const lastProcessed = missedMessages[missedMessages.length - 1];
 
@@ -2072,17 +2073,27 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             // Any send_message content is delivered independently via IPC watcher.
             const routeSwitchedAway = directImReply && replySourceImJid !== null && replySourceImJid !== chatJid;
             const skipImSend = (streamingCardHandledIM && directImReply) || routeSwitchedAway;
+            // When the container stays alive and processes multiple IPC messages,
+            // result.turnId stays the same (set at container start).  If we already
+            // saved a reply with this turnId, the INSERT OR REPLACE would overwrite
+            // the previous reply.  Use a fresh ID to prevent that.
+            const effectiveTurnId = (result.turnId || lastProcessed.id);
+            const turnIdForDb = (sentReply && effectiveTurnId === lastSavedTurnId)
+              ? undefined  // no turnId → fresh INSERT, no UPSERT dedup
+              : effectiveTurnId;
+
             lastReplyMsgId = await sendMessage(chatJid, text, {
               sendToIM: directImReply && !skipImSend,
               localImagePaths,
               messageMeta: {
-                turnId: result.turnId || lastProcessed.id,
+                turnId: turnIdForDb,
                 sessionId: result.sessionId || activeSessionId,
                 sdkMessageUuid: result.sdkMessageUuid,
                 sourceKind: result.sourceKind || 'sdk_final',
                 finalizationReason: result.finalizationReason || 'completed',
               },
             });
+            lastSavedTurnId = effectiveTurnId;
 
             // For routed IM (web JID with IM source), skip the source channel
             // if streaming card handled it. send_message content is already


### PR DESCRIPTION
## 问题描述

关联 #212。修复两个导致消息丢失和进程死循环的 bug。

> compact_partial（上下文压缩保存）已在 PR #219 中实现，本 PR 不再重复包含。

## 修复方案

### 1. 连续 OOM（exit code 137）自动重置会话

#### `src/index.ts`
- 新增 `consecutiveOomExits` 计数器，按 folder 跟踪连续 OOM 退出次数
- 连续 2 次 exit code 137 / SIGKILL 后，自动清除会话文件并重置 session
- 发送系统消息通知用户会话已重置
- 非 OOM 退出时计数器归零

### 2. IPC 多轮回复被 turnId 去重覆盖

#### `src/index.ts`
- 新增 `lastSavedTurnId` 变量，追踪上次保存到 DB 的 turnId
- 当同一 turnId 已保存过一条回复后，后续回复使用 `undefined` 作为 turnId
- 避免 `storeMessageDirect()` 的 `INSERT OR REPLACE` 用 turnId 匹配到旧消息导致覆盖

#### 根因
容器在 IPC 多轮模式下，所有回复共享启动时的 `containerInput.turnId`。`storeMessageDirect()` 中 `sdk_final` 类型消息会按 turnId 查找已有记录并 UPSERT，导致第 N 次回复覆盖第 N-1 次。

## 测试计划

- [x] IPC 注入 3 条消息到同一容器，验证 3 条 AI 回复全部独立保存（不同 id、不同 turn_id）
- [ ] 模拟连续 2 次 OOM（exit 137），验证自动重置会话并发送通知