### PR TITLE
功能: 多提供商负载均衡 — 会话级自动分配 + 健康追踪

### DIFF
--- a/src/agent-output-parser.ts
+++ b/src/agent-output-parser.ts
@@ -579,3 +579,36 @@ function parseLegacyOutput(ctx: CloseHandlerContext): void {
     });
   }
 }
+
+// ─── API Error Classification ────────────────────────────────────────
+
+/** Patterns that indicate an API-level error (provider issue, not user code bug) */
+const API_ERROR_PATTERNS = [
+  /\bapi[_ ]?key\b.*\b(invalid|missing|expired|required)\b/i,
+  /\bauthentication\s+(failed|error|required)\b/i,
+  /\b(401|403)\b.*\bunauthorized\b/i,
+  /\brate[_ ]?limit(ed)?\b/i,
+  /\bquota\s+(exceeded|exhausted)\b/i,
+  /\boverloaded\b/i,
+  /\binternal\s+server\s+error\b/i,
+  /\b(502|503|504|529)\b/,
+  /ANTHROPIC_API_KEY/,
+  /ANTHROPIC_AUTH_TOKEN/,
+  /\binvalid[_ ]?api\b/i,
+  /\bbilling\s+(error|issue|limit)\b/i,
+  /\bcredit(s)?\s+(exhausted|insufficient)\b/i,
+  /connection\s*(refused|reset|timed?\s*out)/i,
+  /ECONNREFUSED|ECONNRESET|ETIMEDOUT/,
+];
+
+/**
+ * Classify whether stderr output indicates an API-level error
+ * (provider unreachable, auth failure, rate limit, etc.)
+ * vs a normal agent exit or user code issue.
+ *
+ * Used by container-runner to decide whether to report failure to ProviderPool.
+ */
+export function isApiError(stderr: string): boolean {
+  if (!stderr) return false;
+  return API_ERROR_PATTERNS.some((pattern) => pattern.test(stderr));
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -22,11 +22,16 @@ import {
   buildContainerEnvLines,
   getClaudeProviderConfig,
   getContainerEnvConfig,
+  getCustomEnvForProfile,
   getSystemSettings,
   mergeClaudeEnvConfig,
+  resolveProfileToConfig,
   shellQuoteEnvLines,
   writeCredentialsFile,
 } from './runtime-config.js';
+import { providerPool } from './provider-pool.js';
+import { isApiError } from './agent-output-parser.js';
+import type { ClaudeProviderConfig } from './runtime-config.js';
 import { resolveGroupMcpServers } from './mcp-utils.js';
 import { RegisteredGroup, StreamEvent } from './types.js';
 import {
@@ -90,7 +95,6 @@ function ensureSettingsJson(
   fs.writeFileSync(settingsFile, newContent, { mode: 0o644 });
 }
 
-
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -118,7 +122,13 @@ export interface ContainerOutput {
   turnId?: string;
   sessionId?: string;
   sdkMessageUuid?: string;
-  sourceKind?: 'sdk_final' | 'sdk_send_message' | 'interrupt_partial' | 'overflow_partial' | 'compact_partial' | 'legacy';
+  sourceKind?:
+    | 'sdk_final'
+    | 'sdk_send_message'
+    | 'interrupt_partial'
+    | 'overflow_partial'
+    | 'compact_partial'
+    | 'legacy';
   finalizationReason?: 'completed' | 'interrupted' | 'error';
 }
 
@@ -142,6 +152,11 @@ function mkdirForContainer(dirPath: string): void {
   }
 }
 
+interface ResolvedProvider {
+  config: ClaudeProviderConfig;
+  customEnv: Record<string, string>;
+}
+
 function buildVolumeMounts(
   group: RegisteredGroup,
   isAdminHome: boolean,
@@ -150,6 +165,7 @@ function buildVolumeMounts(
   agentId?: string,
   ownerHomeFolder?: string,
   taskRunId?: string,
+  resolvedProvider?: ResolvedProvider,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -328,9 +344,13 @@ function buildVolumeMounts(
   // Global config merged with per-container overrides.
   const envDir = path.join(DATA_DIR, 'env', group.folder);
   fs.mkdirSync(envDir, { recursive: true });
-  const globalConfig = getClaudeProviderConfig();
+  const globalConfig = resolvedProvider?.config ?? getClaudeProviderConfig();
   const containerOverride = getContainerEnvConfig(group.folder);
-  const envLines = buildContainerEnvLines(globalConfig, containerOverride);
+  const envLines = buildContainerEnvLines(
+    globalConfig,
+    containerOverride,
+    resolvedProvider?.customEnv,
+  );
   if (envLines.length > 0) {
     const envFilePath = path.join(envDir, 'env');
     const quotedLines = shellQuoteEnvLines(envLines);
@@ -424,166 +444,223 @@ export async function runContainerAgent(
   const groupDir = path.join(GROUPS_DIR, group.folder);
   mkdirForContainer(groupDir);
 
-  // Determine if this is an admin home container (full privileges)
-  const isAdminHome = !!group.is_home && group.folder === 'main';
-  // Per-user skills: always mount if the group has an owner
-  const shouldMountUserSkills = !!group.created_by;
-  const mounts = buildVolumeMounts(
-    group,
-    isAdminHome,
-    shouldMountUserSkills,
-    group.selected_skills ?? null,
-    input.agentId,
-    ownerHomeFolder,
-    input.taskRunId,
-  );
-  const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
-  const agentSuffix = input.agentId
-    ? `-${input.agentId.replace(/[^a-zA-Z0-9-]/g, '-')}`
-    : '';
-  const containerName = `happyclaw-${safeName}${agentSuffix}-${Date.now()}`;
-  const containerArgs = buildContainerArgs(mounts, containerName);
-
-  logger.debug(
-    {
-      group: group.name,
-      containerName,
-      mounts: mounts.map(
-        (m) =>
-          `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
-      ),
-      containerArgs: containerArgs.join(' '),
-    },
-    'Container mount configuration',
+  // ─── Provider Pool selection ───
+  const containerOverrideForCheck = getContainerEnvConfig(group.folder);
+  const hasProviderOverride = !!(
+    containerOverrideForCheck.anthropicApiKey ||
+    containerOverrideForCheck.anthropicAuthToken ||
+    containerOverrideForCheck.anthropicBaseUrl
   );
 
-  logger.info(
-    {
-      group: group.name,
-      containerName,
-      mountCount: mounts.length,
-      isMain: input.isMain,
-    },
-    'Spawning container agent',
-  );
+  let selectedProfileId: string | null = null;
+  let resolvedProvider: ResolvedProvider | undefined;
 
-  const logsDir = path.join(GROUPS_DIR, group.folder, 'logs');
-  fs.mkdirSync(logsDir, { recursive: true });
-
-  return new Promise((resolve) => {
-    const container = spawn('docker', containerArgs, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    onProcess(container, containerName);
-
-    const stdoutState = createStdoutParserState();
-    const stderrState = createStderrState();
-
-    // Write input and close stdin (容器需要 EOF 来刷新 stdin 管道)
-    container.stdin.on('error', (err) => {
-      logger.error({ group: group.name, err }, 'Container stdin write failed');
-      container.kill();
-    });
-    container.stdin.write(JSON.stringify(input));
-    container.stdin.end();
-
-    let timedOut = false;
-    const timeoutMs =
-      group.containerConfig?.timeout || getSystemSettings().containerTimeout;
-
-    const killOnTimeout = () => {
-      timedOut = true;
-      logger.error(
-        { group: group.name, containerName },
-        'Container timeout, stopping gracefully',
+  if (!hasProviderOverride && providerPool.getConfig().mode === 'pool') {
+    try {
+      selectedProfileId = providerPool.selectProvider();
+      resolvedProvider = {
+        config: resolveProfileToConfig(selectedProfileId),
+        customEnv: getCustomEnvForProfile(selectedProfileId),
+      };
+      providerPool.acquireSession(selectedProfileId);
+    } catch (err) {
+      logger.warn(
+        { err },
+        'Provider pool selection failed, falling back to active profile',
       );
-      execFile('docker', ['stop', containerName], { timeout: 15000 }, (err) => {
-        if (err) {
-          logger.warn(
-            { group: group.name, containerName, err },
-            'Graceful stop failed, force killing',
-          );
-          container.kill('SIGKILL');
-        }
+      selectedProfileId = null;
+      resolvedProvider = undefined;
+    }
+  }
+
+  try {
+    // Determine if this is an admin home container (full privileges)
+    const isAdminHome = !!group.is_home && group.folder === 'main';
+    // Per-user skills: always mount if the group has an owner
+    const shouldMountUserSkills = !!group.created_by;
+    const mounts = buildVolumeMounts(
+      group,
+      isAdminHome,
+      shouldMountUserSkills,
+      group.selected_skills ?? null,
+      input.agentId,
+      ownerHomeFolder,
+      input.taskRunId,
+      resolvedProvider,
+    );
+    const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
+    const agentSuffix = input.agentId
+      ? `-${input.agentId.replace(/[^a-zA-Z0-9-]/g, '-')}`
+      : '';
+    const containerName = `happyclaw-${safeName}${agentSuffix}-${Date.now()}`;
+    const containerArgs = buildContainerArgs(mounts, containerName);
+
+    logger.debug(
+      {
+        group: group.name,
+        containerName,
+        mounts: mounts.map(
+          (m) =>
+            `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+        ),
+        containerArgs: containerArgs.join(' '),
+      },
+      'Container mount configuration',
+    );
+
+    logger.info(
+      {
+        group: group.name,
+        containerName,
+        mountCount: mounts.length,
+        isMain: input.isMain,
+      },
+      'Spawning container agent',
+    );
+
+    const logsDir = path.join(GROUPS_DIR, group.folder, 'logs');
+    fs.mkdirSync(logsDir, { recursive: true });
+
+    const result = await new Promise<ContainerOutput>((resolve) => {
+      const container = spawn('docker', containerArgs, {
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
-    };
 
-    let timeout = setTimeout(killOnTimeout, timeoutMs);
+      onProcess(container, containerName);
 
-    const resetTimeout = () => {
-      clearTimeout(timeout);
-      timeout = setTimeout(killOnTimeout, timeoutMs);
-    };
+      const stdoutState = createStdoutParserState();
+      const stderrState = createStderrState();
 
-    // Attach stdout/stderr handlers using shared parser
-    attachStdoutHandler(container.stdout, stdoutState, {
-      groupName: group.name,
-      label: 'Container',
-      onOutput,
-      resetTimeout,
-    });
-    attachStderrHandler(container.stderr, stderrState, group.name, {
-      container: group.folder,
-    });
+      // Write input and close stdin (容器需要 EOF 来刷新 stdin 管道)
+      container.stdin.on('error', (err) => {
+        logger.error(
+          { group: group.name, err },
+          'Container stdin write failed',
+        );
+        container.kill();
+      });
+      container.stdin.write(JSON.stringify(input));
+      container.stdin.end();
 
-    container.on('close', (code, signal) => {
-      clearTimeout(timeout);
-      const duration = Date.now() - startTime;
+      let timedOut = false;
+      const timeoutMs =
+        group.containerConfig?.timeout || getSystemSettings().containerTimeout;
 
-      const closeCtx: CloseHandlerContext = {
-        groupName: group.name,
-        label: 'Container',
-        filePrefix: 'container',
-        identifier: containerName,
-        logsDir,
-        input,
-        stdoutState,
-        stderrState,
-        onOutput,
-        resolvePromise: resolve,
-        startTime,
-        timeoutMs,
-        extraSummaryLines: [
-          ``,
-          `=== Mounts ===`,
-          mounts
-            .map((m) => `${m.containerPath}${m.readonly ? ' (ro)' : ''}`)
-            .join('\n'),
-        ],
-        extraVerboseLines: [
-          `=== Container Args ===`,
-          containerArgs.join(' '),
-          ``,
-          `=== Mounts (detailed) ===`,
-          mounts
-            .map(
-              (m) =>
-                `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
-            )
-            .join('\n'),
-        ],
+      const killOnTimeout = () => {
+        timedOut = true;
+        logger.error(
+          { group: group.name, containerName },
+          'Container timeout, stopping gracefully',
+        );
+        execFile(
+          'docker',
+          ['stop', containerName],
+          { timeout: 15000 },
+          (err) => {
+            if (err) {
+              logger.warn(
+                { group: group.name, containerName, err },
+                'Graceful stop failed, force killing',
+              );
+              container.kill('SIGKILL');
+            }
+          },
+        );
       };
 
-      if (handleTimeoutClose(closeCtx, code, duration, timedOut)) return;
-      const logFile = writeRunLog(closeCtx, code, duration);
-      if (handleNonZeroExit(closeCtx, code, signal, duration, logFile)) return;
-      handleSuccessClose(closeCtx, duration);
-    });
+      let timeout = setTimeout(killOnTimeout, timeoutMs);
 
-    container.on('error', (err) => {
-      clearTimeout(timeout);
-      logger.error(
-        { group: group.name, containerName, error: err },
-        'Container spawn error',
-      );
-      resolve({
-        status: 'error',
-        result: null,
-        error: `Container spawn error: ${err.message}`,
+      const resetTimeout = () => {
+        clearTimeout(timeout);
+        timeout = setTimeout(killOnTimeout, timeoutMs);
+      };
+
+      // Attach stdout/stderr handlers using shared parser
+      attachStdoutHandler(container.stdout, stdoutState, {
+        groupName: group.name,
+        label: 'Container',
+        onOutput,
+        resetTimeout,
+      });
+      attachStderrHandler(container.stderr, stderrState, group.name, {
+        container: group.folder,
+      });
+
+      container.on('close', (code, signal) => {
+        clearTimeout(timeout);
+        const duration = Date.now() - startTime;
+
+        const closeCtx: CloseHandlerContext = {
+          groupName: group.name,
+          label: 'Container',
+          filePrefix: 'container',
+          identifier: containerName,
+          logsDir,
+          input,
+          stdoutState,
+          stderrState,
+          onOutput,
+          resolvePromise: resolve,
+          startTime,
+          timeoutMs,
+          extraSummaryLines: [
+            ``,
+            `=== Mounts ===`,
+            mounts
+              .map((m) => `${m.containerPath}${m.readonly ? ' (ro)' : ''}`)
+              .join('\n'),
+          ],
+          extraVerboseLines: [
+            `=== Container Args ===`,
+            containerArgs.join(' '),
+            ``,
+            `=== Mounts (detailed) ===`,
+            mounts
+              .map(
+                (m) =>
+                  `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
+              )
+              .join('\n'),
+          ],
+        };
+
+        if (handleTimeoutClose(closeCtx, code, duration, timedOut)) return;
+        const logFile = writeRunLog(closeCtx, code, duration);
+        if (handleNonZeroExit(closeCtx, code, signal, duration, logFile))
+          return;
+        handleSuccessClose(closeCtx, duration);
+      });
+
+      container.on('error', (err) => {
+        clearTimeout(timeout);
+        logger.error(
+          { group: group.name, containerName, error: err },
+          'Container spawn error',
+        );
+        resolve({
+          status: 'error',
+          result: null,
+          error: `Container spawn error: ${err.message}`,
+        });
       });
     });
-  });
+
+    // ─── Provider Pool health reporting ───
+    if (selectedProfileId) {
+      if (result.status === 'success' || result.status === 'closed') {
+        providerPool.reportSuccess(selectedProfileId);
+      } else if (result.status === 'error' && isApiError(result.error || '')) {
+        providerPool.reportFailure(selectedProfileId);
+      }
+    }
+
+    return result;
+  } finally {
+    // Guarantee session release even if buildVolumeMounts/spawn throws
+    if (selectedProfileId) {
+      providerPool.releaseSession(selectedProfileId);
+    }
+  }
 }
 
 export function writeTasksSnapshot(
@@ -665,7 +742,10 @@ export function writeGroupsSnapshot(
  * 杀死进程及其所有子进程。
  * 如果进程以 detached 模式启动（独立进程组），使用负 PID 杀整个进程组。
  */
-export function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): boolean {
+export function killProcessTree(
+  proc: ChildProcess,
+  signal: NodeJS.Signals = 'SIGTERM',
+): boolean {
   try {
     if (proc.pid) {
       process.kill(-proc.pid, signal);
@@ -889,261 +969,315 @@ export async function runHostAgent(
     ...(process.env as Record<string, string>),
   };
 
-  // 配置层环境变量
-  const globalConfig = getClaudeProviderConfig();
+  // ─── Provider Pool selection (host mode) ───
   const containerOverride = getContainerEnvConfig(group.folder);
-  const envLines = buildContainerEnvLines(globalConfig, containerOverride);
-  for (const line of envLines) {
-    const eqIdx = line.indexOf('=');
-    if (eqIdx > 0) {
-      hostEnv[line.slice(0, eqIdx)] = line.slice(eqIdx + 1);
-    }
-  }
+  const hasProviderOverride = !!(
+    containerOverride.anthropicApiKey ||
+    containerOverride.anthropicAuthToken ||
+    containerOverride.anthropicBaseUrl
+  );
 
-  // Write .credentials.json for OAuth credentials
-  const mergedConfig = mergeClaudeEnvConfig(globalConfig, containerOverride);
-  if (mergedConfig.claudeOAuthCredentials) {
+  let hostSelectedProfileId: string | null = null;
+  let hostProviderCustomEnv: Record<string, string> | undefined;
+  let globalConfig: ClaudeProviderConfig;
+
+  if (!hasProviderOverride && providerPool.getConfig().mode === 'pool') {
     try {
-      writeCredentialsFile(groupSessionsDir, mergedConfig);
+      hostSelectedProfileId = providerPool.selectProvider();
+      globalConfig = resolveProfileToConfig(hostSelectedProfileId);
+      hostProviderCustomEnv = getCustomEnvForProfile(hostSelectedProfileId);
+      providerPool.acquireSession(hostSelectedProfileId);
     } catch (err) {
       logger.warn(
-        { folder: group.folder, err },
-        'Failed to write .credentials.json for host agent',
+        { err },
+        'Provider pool selection failed in host mode, falling back',
       );
+      hostSelectedProfileId = null;
+      globalConfig = getClaudeProviderConfig();
     }
-  }
-
-  // 路径映射
-  hostEnv['HAPPYCLAW_WORKSPACE_GROUP'] = groupDir;
-  // Per-user global memory
-  const ownerId = group.created_by;
-  if (ownerId) {
-    const userGlobalDir = path.join(GROUPS_DIR, 'user-global', ownerId);
-    fs.mkdirSync(userGlobalDir, { recursive: true });
-    hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = userGlobalDir;
   } else {
-    const legacyGlobalDir = path.join(GROUPS_DIR, 'global');
-    fs.mkdirSync(legacyGlobalDir, { recursive: true });
-    hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = legacyGlobalDir;
-  }
-  const memoryFolder = group.is_home
-    ? group.folder
-    : ownerHomeFolder || group.folder;
-  hostEnv['HAPPYCLAW_WORKSPACE_MEMORY'] = path.join(
-    DATA_DIR,
-    'memory',
-    memoryFolder,
-  );
-  hostEnv['HAPPYCLAW_WORKSPACE_IPC'] = groupIpcDir;
-  hostEnv['CLAUDE_CONFIG_DIR'] = groupSessionsDir;
-  // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败
-  hostEnv['DEBUG_CLAUDE_AGENT_SDK'] = '1';
-  // CLI 禁止 root 用户使用 --dangerously-skip-permissions，
-  // 通过 IS_SANDBOX 标记告知 CLI 当前运行在受控环境中以绕过此限制
-  if (typeof process.getuid === 'function' && process.getuid() === 0) {
-    hostEnv['IS_SANDBOX'] = '1';
+    globalConfig = getClaudeProviderConfig();
   }
 
-  // 6. 编译检查
-  const projectRoot = process.cwd();
-  const agentRunnerRoot = path.join(projectRoot, 'container', 'agent-runner');
-  const agentRunnerNodeModules = path.join(agentRunnerRoot, 'node_modules');
-  const agentRunnerDist = path.join(agentRunnerRoot, 'dist', 'index.js');
-  const requiredDeps = ['@anthropic-ai/claude-agent-sdk'];
-  const missingDeps = requiredDeps.filter((dep) => {
-    const depJson = path.join(
-      agentRunnerNodeModules,
-      ...dep.split('/'),
-      'package.json',
-    );
-    return !fs.existsSync(depJson);
-  });
-  if (missingDeps.length > 0) {
-    const missing = missingDeps.join(', ');
-    logger.error(
-      { group: group.name, missingDeps },
-      'Host agent preflight failed: dependencies missing',
-    );
-    return hostModeSetupError(
-      `缺少 agent-runner 依赖（${missing}）。请先执行：${setupInstallHint}`,
-    );
-  }
-  if (!fs.existsSync(agentRunnerDist)) {
-    logger.error(
-      { group: group.name, agentRunnerDist },
-      'Host agent preflight failed: dist not found',
-    );
-    return hostModeSetupError(
-      `agent-runner 未编译。请先执行：${setupBuildHint}`,
-    );
-  }
-
-  // Auto-rebuild if dist is stale (src newer than dist)
   try {
-    const distMtime = fs.statSync(agentRunnerDist).mtimeMs;
-    const srcDir = path.join(agentRunnerRoot, 'src');
-    const srcFiles = fs.readdirSync(srcDir);
-    const newestSrc = Math.max(
-      ...srcFiles.map((f) => fs.statSync(path.join(srcDir, f)).mtimeMs),
+    // 配置层环境变量
+    const envLines = buildContainerEnvLines(
+      globalConfig,
+      containerOverride,
+      hostProviderCustomEnv,
     );
-    if (newestSrc > distMtime) {
-      logger.info(
-        { group: group.name },
-        'agent-runner dist 已过期，自动重新编译...',
-      );
+    for (const line of envLines) {
+      const eqIdx = line.indexOf('=');
+      if (eqIdx > 0) {
+        hostEnv[line.slice(0, eqIdx)] = line.slice(eqIdx + 1);
+      }
+    }
+
+    // Write .credentials.json for OAuth credentials
+    const mergedConfig = mergeClaudeEnvConfig(globalConfig, containerOverride);
+    if (mergedConfig.claudeOAuthCredentials) {
       try {
-        const { execSync } = await import('child_process');
-        execSync('npm run build', {
-          cwd: agentRunnerRoot,
-          stdio: 'pipe',
-          timeout: 30_000,
-        });
-        logger.info(
-          { group: group.name },
-          'agent-runner 自动编译完成',
-        );
-      } catch (buildErr) {
+        writeCredentialsFile(groupSessionsDir, mergedConfig);
+      } catch (err) {
         logger.warn(
-          { group: group.name, err: buildErr },
-          `agent-runner 自动编译失败，使用旧版 dist。手动执行：${setupBuildHint}`,
+          { folder: group.folder, err },
+          'Failed to write .credentials.json for host agent',
         );
       }
     }
-  } catch {
-    // Best effort, don't block execution
-  }
 
-  logger.info(
-    {
-      group: group.name,
-      workingDir: groupDir,
-      isMain: input.isMain,
-    },
-    'Spawning host agent',
-  );
+    // 路径映射
+    hostEnv['HAPPYCLAW_WORKSPACE_GROUP'] = groupDir;
+    // Per-user global memory
+    const ownerId = group.created_by;
+    if (ownerId) {
+      const userGlobalDir = path.join(GROUPS_DIR, 'user-global', ownerId);
+      fs.mkdirSync(userGlobalDir, { recursive: true });
+      hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = userGlobalDir;
+    } else {
+      const legacyGlobalDir = path.join(GROUPS_DIR, 'global');
+      fs.mkdirSync(legacyGlobalDir, { recursive: true });
+      hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = legacyGlobalDir;
+    }
+    const memoryFolder = group.is_home
+      ? group.folder
+      : ownerHomeFolder || group.folder;
+    hostEnv['HAPPYCLAW_WORKSPACE_MEMORY'] = path.join(
+      DATA_DIR,
+      'memory',
+      memoryFolder,
+    );
+    hostEnv['HAPPYCLAW_WORKSPACE_IPC'] = groupIpcDir;
+    hostEnv['CLAUDE_CONFIG_DIR'] = groupSessionsDir;
+    // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败
+    hostEnv['DEBUG_CLAUDE_AGENT_SDK'] = '1';
+    // CLI 禁止 root 用户使用 --dangerously-skip-permissions，
+    // 通过 IS_SANDBOX 标记告知 CLI 当前运行在受控环境中以绕过此限制
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      hostEnv['IS_SANDBOX'] = '1';
+    }
 
-  const logsDir = path.join(groupDir, 'logs');
-
-  return new Promise((resolve) => {
-    let settled = false;
-    const resolveOnce = (output: ContainerOutput): void => {
-      if (settled) return;
-      settled = true;
-      resolve(output);
-    };
-
-    // 7. 启动进程
-    const proc = spawn('node', [agentRunnerDist], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: hostEnv,
-      cwd: groupDir,
-      detached: true,
-    });
-
-    const processId = `host-${group.folder}-${Date.now()}`;
-    onProcess(proc, processId);
-
-    const stdoutState = createStdoutParserState();
-    const stderrState = createStderrState();
-
-    // 8. stdin 输入
-    proc.stdin.on('error', (err) => {
-      logger.error({ group: group.name, err }, 'Host agent stdin write failed');
-      killProcessTree(proc);
-    });
-    proc.stdin.write(JSON.stringify(input));
-    proc.stdin.end();
-
-    // 9. 超时管理
-    let timedOut = false;
-    const timeoutMs =
-      group.containerConfig?.timeout || getSystemSettings().containerTimeout;
-
-    let killTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const killOnTimeout = () => {
-      timedOut = true;
-      logger.error(
-        { group: group.name, processId },
-        'Host agent timeout, killing',
+    // 6. 编译检查
+    const projectRoot = process.cwd();
+    const agentRunnerRoot = path.join(projectRoot, 'container', 'agent-runner');
+    const agentRunnerNodeModules = path.join(agentRunnerRoot, 'node_modules');
+    const agentRunnerDist = path.join(agentRunnerRoot, 'dist', 'index.js');
+    const requiredDeps = ['@anthropic-ai/claude-agent-sdk'];
+    const missingDeps = requiredDeps.filter((dep) => {
+      const depJson = path.join(
+        agentRunnerNodeModules,
+        ...dep.split('/'),
+        'package.json',
       );
-      killProcessTree(proc, 'SIGTERM');
-      killTimer = setTimeout(() => {
-        if (proc.exitCode === null && proc.signalCode === null) {
-          killProcessTree(proc, 'SIGKILL');
-        }
-      }, 5000);
-    };
-
-    let timeout = setTimeout(killOnTimeout, timeoutMs);
-
-    const resetTimeout = () => {
-      clearTimeout(timeout);
-      timeout = setTimeout(killOnTimeout, timeoutMs);
-    };
-
-    // 10. stdout/stderr 解析
-    attachStdoutHandler(proc.stdout, stdoutState, {
-      groupName: group.name,
-      label: 'Host agent',
-      onOutput,
-      resetTimeout,
+      return !fs.existsSync(depJson);
     });
-    attachStderrHandler(proc.stderr, stderrState, group.name, {
-      host: group.folder,
-    });
+    if (missingDeps.length > 0) {
+      const missing = missingDeps.join(', ');
+      logger.error(
+        { group: group.name, missingDeps },
+        'Host agent preflight failed: dependencies missing',
+      );
+      return hostModeSetupError(
+        `缺少 agent-runner 依赖（${missing}）。请先执行：${setupInstallHint}`,
+      );
+    }
+    if (!fs.existsSync(agentRunnerDist)) {
+      logger.error(
+        { group: group.name, agentRunnerDist },
+        'Host agent preflight failed: dist not found',
+      );
+      return hostModeSetupError(
+        `agent-runner 未编译。请先执行：${setupBuildHint}`,
+      );
+    }
 
-    // 11. close 事件处理
-    proc.on('close', (code, signal) => {
-      clearTimeout(timeout);
-      if (killTimer) clearTimeout(killTimer);
-      const duration = Date.now() - startTime;
-
-      const closeCtx: CloseHandlerContext = {
-        groupName: group.name,
-        label: 'Host Agent',
-        filePrefix: 'host',
-        identifier: processId,
-        logsDir,
-        input,
-        stdoutState,
-        stderrState,
-        onOutput,
-        resolvePromise: resolveOnce,
-        startTime,
-        timeoutMs,
-        extraSummaryLines: [`Working Directory: ${groupDir}`],
-        enrichError: (stderrContent, exitLabel) => {
-          const missingPackageMatch = stderrContent.match(
-            /Cannot find package '([^']+)' imported from/u,
+    // Auto-rebuild if dist is stale (src newer than dist)
+    try {
+      const distMtime = fs.statSync(agentRunnerDist).mtimeMs;
+      const srcDir = path.join(agentRunnerRoot, 'src');
+      const srcFiles = fs.readdirSync(srcDir);
+      const newestSrc = Math.max(
+        ...srcFiles.map((f) => fs.statSync(path.join(srcDir, f)).mtimeMs),
+      );
+      if (newestSrc > distMtime) {
+        logger.info(
+          { group: group.name },
+          'agent-runner dist 已过期，自动重新编译...',
+        );
+        try {
+          const { execSync } = await import('child_process');
+          execSync('npm run build', {
+            cwd: agentRunnerRoot,
+            stdio: 'pipe',
+            timeout: 30_000,
+          });
+          logger.info({ group: group.name }, 'agent-runner 自动编译完成');
+        } catch (buildErr) {
+          logger.warn(
+            { group: group.name, err: buildErr },
+            `agent-runner 自动编译失败，使用旧版 dist。手动执行：${setupBuildHint}`,
           );
-          const userFacingError = missingPackageMatch
-            ? `宿主机模式启动失败：缺少依赖 ${missingPackageMatch[1]}。请先执行：${setupInstallHint}`
-            : null;
-          return {
-            result: userFacingError,
-            error: `Host agent exited with ${exitLabel}: ${stderrContent.slice(-200)}`,
-          };
-        },
+        }
+      }
+    } catch {
+      // Best effort, don't block execution
+    }
+
+    logger.info(
+      {
+        group: group.name,
+        workingDir: groupDir,
+        isMain: input.isMain,
+      },
+      'Spawning host agent',
+    );
+
+    const logsDir = path.join(groupDir, 'logs');
+
+    const hostResult = await new Promise<ContainerOutput>((resolve) => {
+      let settled = false;
+      const resolveOnce = (output: ContainerOutput): void => {
+        if (settled) return;
+        settled = true;
+        resolve(output);
       };
 
-      if (handleTimeoutClose(closeCtx, code, duration, timedOut)) return;
-      const logFile = writeRunLog(closeCtx, code, duration);
-      if (handleNonZeroExit(closeCtx, code, signal, duration, logFile)) return;
-      handleSuccessClose(closeCtx, duration);
-    });
+      // 7. 启动进程
+      const proc = spawn('node', [agentRunnerDist], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: hostEnv,
+        cwd: groupDir,
+        detached: true,
+      });
 
-    proc.on('error', (err) => {
-      clearTimeout(timeout);
-      logger.error(
-        { group: group.name, processId, error: err },
-        'Host agent spawn error',
-      );
-      resolveOnce({
-        status: 'error',
-        result: null,
-        error: `Host agent spawn error: ${err.message}`,
+      const processId = `host-${group.folder}-${Date.now()}`;
+      onProcess(proc, processId);
+
+      const stdoutState = createStdoutParserState();
+      const stderrState = createStderrState();
+
+      // 8. stdin 输入
+      proc.stdin.on('error', (err) => {
+        logger.error(
+          { group: group.name, err },
+          'Host agent stdin write failed',
+        );
+        killProcessTree(proc);
+      });
+      proc.stdin.write(JSON.stringify(input));
+      proc.stdin.end();
+
+      // 9. 超时管理
+      let timedOut = false;
+      const timeoutMs =
+        group.containerConfig?.timeout || getSystemSettings().containerTimeout;
+
+      let killTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const killOnTimeout = () => {
+        timedOut = true;
+        logger.error(
+          { group: group.name, processId },
+          'Host agent timeout, killing',
+        );
+        killProcessTree(proc, 'SIGTERM');
+        killTimer = setTimeout(() => {
+          if (proc.exitCode === null && proc.signalCode === null) {
+            killProcessTree(proc, 'SIGKILL');
+          }
+        }, 5000);
+      };
+
+      let timeout = setTimeout(killOnTimeout, timeoutMs);
+
+      const resetTimeout = () => {
+        clearTimeout(timeout);
+        timeout = setTimeout(killOnTimeout, timeoutMs);
+      };
+
+      // 10. stdout/stderr 解析
+      attachStdoutHandler(proc.stdout, stdoutState, {
+        groupName: group.name,
+        label: 'Host agent',
+        onOutput,
+        resetTimeout,
+      });
+      attachStderrHandler(proc.stderr, stderrState, group.name, {
+        host: group.folder,
+      });
+
+      // 11. close 事件处理
+      proc.on('close', (code, signal) => {
+        clearTimeout(timeout);
+        if (killTimer) clearTimeout(killTimer);
+        const duration = Date.now() - startTime;
+
+        const closeCtx: CloseHandlerContext = {
+          groupName: group.name,
+          label: 'Host Agent',
+          filePrefix: 'host',
+          identifier: processId,
+          logsDir,
+          input,
+          stdoutState,
+          stderrState,
+          onOutput,
+          resolvePromise: resolveOnce,
+          startTime,
+          timeoutMs,
+          extraSummaryLines: [`Working Directory: ${groupDir}`],
+          enrichError: (stderrContent, exitLabel) => {
+            const missingPackageMatch = stderrContent.match(
+              /Cannot find package '([^']+)' imported from/u,
+            );
+            const userFacingError = missingPackageMatch
+              ? `宿主机模式启动失败：缺少依赖 ${missingPackageMatch[1]}。请先执行：${setupInstallHint}`
+              : null;
+            return {
+              result: userFacingError,
+              error: `Host agent exited with ${exitLabel}: ${stderrContent.slice(-200)}`,
+            };
+          },
+        };
+
+        if (handleTimeoutClose(closeCtx, code, duration, timedOut)) return;
+        const logFile = writeRunLog(closeCtx, code, duration);
+        if (handleNonZeroExit(closeCtx, code, signal, duration, logFile))
+          return;
+        handleSuccessClose(closeCtx, duration);
+      });
+
+      proc.on('error', (err) => {
+        clearTimeout(timeout);
+        logger.error(
+          { group: group.name, processId, error: err },
+          'Host agent spawn error',
+        );
+        resolveOnce({
+          status: 'error',
+          result: null,
+          error: `Host agent spawn error: ${err.message}`,
+        });
       });
     });
-  });
+
+    // ─── Provider Pool health reporting (host mode) ───
+    if (hostSelectedProfileId) {
+      if (hostResult.status === 'success' || hostResult.status === 'closed') {
+        providerPool.reportSuccess(hostSelectedProfileId);
+      } else if (
+        hostResult.status === 'error' &&
+        isApiError(hostResult.error || '')
+      ) {
+        providerPool.reportFailure(hostSelectedProfileId);
+      }
+    }
+
+    return hostResult;
+  } finally {
+    // Guarantee session release even if spawn/setup throws
+    if (hostSelectedProfileId) {
+      providerPool.releaseSession(hostSelectedProfileId);
+    }
+  }
 }

--- a/src/provider-pool.ts
+++ b/src/provider-pool.ts
@@ -1,0 +1,316 @@
+/**
+ * Provider Pool — 多提供商负载均衡
+ *
+ * 支持三种策略：round-robin、weighted-round-robin、failover
+ * 健康状态纯内存管理，配置持久化到 data/config/provider-pool.json
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { DATA_DIR } from './config.js';
+import { logger } from './logger.js';
+
+// ─── 类型定义 ──────────────────────────────────────────────
+
+export interface StoredProviderPoolConfig {
+  version: 1;
+  mode: 'fixed' | 'pool';
+  strategy: 'round-robin' | 'weighted-round-robin' | 'failover';
+  members: ProviderPoolMember[];
+  unhealthyThreshold: number;
+  recoveryIntervalMs: number;
+  updatedAt: string;
+}
+
+export interface ProviderPoolMember {
+  profileId: string;
+  weight: number;
+  enabled: boolean;
+}
+
+export interface ProviderHealthStatus {
+  profileId: string;
+  healthy: boolean;
+  consecutiveErrors: number;
+  lastErrorAt: number | null;
+  lastSuccessAt: number | null;
+  unhealthySince: number | null;
+  activeSessionCount: number;
+}
+
+// ─── 常量 ──────────────────────────────────────────────────
+
+const CLAUDE_CONFIG_DIR = path.join(DATA_DIR, 'config');
+const POOL_CONFIG_FILE = path.join(CLAUDE_CONFIG_DIR, 'provider-pool.json');
+
+const DEFAULT_UNHEALTHY_THRESHOLD = 3;
+const DEFAULT_RECOVERY_INTERVAL_MS = 300_000; // 5 minutes
+
+function defaultConfig(): StoredProviderPoolConfig {
+  return {
+    version: 1,
+    mode: 'fixed',
+    strategy: 'round-robin',
+    members: [],
+    unhealthyThreshold: DEFAULT_UNHEALTHY_THRESHOLD,
+    recoveryIntervalMs: DEFAULT_RECOVERY_INTERVAL_MS,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makeHealthStatus(profileId: string): ProviderHealthStatus {
+  return {
+    profileId,
+    healthy: true,
+    consecutiveErrors: 0,
+    lastErrorAt: null,
+    lastSuccessAt: null,
+    unhealthySince: null,
+    activeSessionCount: 0,
+  };
+}
+
+// ─── ProviderPool 类 ──────────────────────────────────────
+
+export class ProviderPool {
+  private config: StoredProviderPoolConfig;
+  private healthMap: Map<string, ProviderHealthStatus> = new Map();
+  private roundRobinIndex = 0;
+  private configMtimeMs = 0;
+
+  constructor() {
+    this.config = this.loadConfigFromDisk();
+  }
+
+  // ─── 配置管理 ────────────────────────────────────────────
+
+  private loadConfigFromDisk(): StoredProviderPoolConfig {
+    try {
+      if (!fs.existsSync(POOL_CONFIG_FILE)) return defaultConfig();
+      const content = fs.readFileSync(POOL_CONFIG_FILE, 'utf-8');
+      const parsed = JSON.parse(content) as StoredProviderPoolConfig;
+      if (parsed.version !== 1) return defaultConfig();
+      this.configMtimeMs = fs.statSync(POOL_CONFIG_FILE).mtimeMs;
+      return parsed;
+    } catch (err) {
+      logger.warn({ err }, 'Failed to read provider-pool.json, using defaults');
+      return defaultConfig();
+    }
+  }
+
+  /** Reload config from disk if file changed */
+  reload(): void {
+    try {
+      if (!fs.existsSync(POOL_CONFIG_FILE)) {
+        this.config = defaultConfig();
+        this.configMtimeMs = 0;
+        return;
+      }
+      const stat = fs.statSync(POOL_CONFIG_FILE);
+      if (stat.mtimeMs === this.configMtimeMs) return; // unchanged
+      this.config = this.loadConfigFromDisk();
+      // Clean up health entries for removed members
+      const memberIds = new Set(this.config.members.map((m) => m.profileId));
+      for (const key of this.healthMap.keys()) {
+        if (!memberIds.has(key)) this.healthMap.delete(key);
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Failed to reload provider-pool.json');
+    }
+  }
+
+  saveConfig(config: StoredProviderPoolConfig): void {
+    fs.mkdirSync(CLAUDE_CONFIG_DIR, { recursive: true });
+    const tmp = `${POOL_CONFIG_FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, POOL_CONFIG_FILE);
+    this.config = config;
+    try {
+      this.configMtimeMs = fs.statSync(POOL_CONFIG_FILE).mtimeMs;
+    } catch {
+      /* ignore */
+    }
+  }
+
+  getConfig(): StoredProviderPoolConfig {
+    return this.config;
+  }
+
+  // ─── 选择算法 ────────────────────────────────────────────
+
+  /** 选择一个提供商，返回 profileId */
+  selectProvider(): string {
+    // Auto-reload config if file changed on disk
+    this.reload();
+
+    const { strategy, members, recoveryIntervalMs } = this.config;
+    const now = Date.now();
+
+    // Auto-recover unhealthy members (skip disabled ones)
+    for (const member of members) {
+      if (!member.enabled) continue;
+      const health = this.healthMap.get(member.profileId);
+      if (
+        health &&
+        !health.healthy &&
+        health.unhealthySince !== null &&
+        now - health.unhealthySince >= recoveryIntervalMs
+      ) {
+        health.healthy = true;
+        health.consecutiveErrors = 0;
+        health.unhealthySince = null;
+        logger.info(
+          { profileId: member.profileId },
+          'Provider auto-recovered after recovery interval',
+        );
+      }
+    }
+
+    // Filter to enabled + healthy candidates
+    const candidates = members.filter((m) => {
+      if (!m.enabled) return false;
+      const health = this.healthMap.get(m.profileId);
+      return !health || health.healthy;
+    });
+
+    if (candidates.length === 0) {
+      // All unhealthy — best-effort: return first enabled member, or first member
+      const firstEnabled = members.find((m) => m.enabled);
+      const fallback = firstEnabled || members[0];
+      if (fallback) {
+        logger.warn(
+          { profileId: fallback.profileId, strategy },
+          'All providers unhealthy, falling back to first available',
+        );
+        return fallback.profileId;
+      }
+      // No members at all — shouldn't happen if mode=pool, but be safe
+      throw new Error('Provider pool has no members configured');
+    }
+
+    let selected: ProviderPoolMember;
+
+    switch (strategy) {
+      case 'round-robin': {
+        const idx = this.roundRobinIndex % candidates.length;
+        selected = candidates[idx];
+        this.roundRobinIndex = idx + 1;
+        break;
+      }
+
+      case 'weighted-round-robin': {
+        // Build weighted array
+        const weighted: ProviderPoolMember[] = [];
+        for (const c of candidates) {
+          const w = Math.max(1, Math.min(100, c.weight || 1));
+          for (let i = 0; i < w; i++) {
+            weighted.push(c);
+          }
+        }
+        const idx = this.roundRobinIndex % weighted.length;
+        selected = weighted[idx];
+        this.roundRobinIndex = idx + 1;
+        break;
+      }
+
+      case 'failover': {
+        // Return first healthy candidate (preserves original order)
+        selected = candidates[0];
+        break;
+      }
+
+      default: {
+        selected = candidates[0];
+        break;
+      }
+    }
+
+    logger.info(
+      { profileId: selected.profileId, strategy },
+      'Selected provider for session',
+    );
+    return selected.profileId;
+  }
+
+  // ─── 健康上报 ────────────────────────────────────────────
+
+  reportSuccess(profileId: string): void {
+    const health = this.getOrCreateHealth(profileId);
+    health.consecutiveErrors = 0;
+    health.lastSuccessAt = Date.now();
+    if (!health.healthy) {
+      health.healthy = true;
+      health.unhealthySince = null;
+      logger.info({ profileId }, 'Provider recovered after success report');
+    }
+  }
+
+  reportFailure(profileId: string): void {
+    const health = this.getOrCreateHealth(profileId);
+    health.consecutiveErrors += 1;
+    health.lastErrorAt = Date.now();
+
+    if (
+      health.healthy &&
+      health.consecutiveErrors >= this.config.unhealthyThreshold
+    ) {
+      health.healthy = false;
+      health.unhealthySince = Date.now();
+      logger.warn(
+        {
+          profileId,
+          consecutiveErrors: health.consecutiveErrors,
+          threshold: this.config.unhealthyThreshold,
+        },
+        'Provider marked unhealthy after consecutive failures',
+      );
+    }
+  }
+
+  // ─── 会话计数 ────────────────────────────────────────────
+
+  acquireSession(profileId: string): void {
+    const health = this.getOrCreateHealth(profileId);
+    health.activeSessionCount += 1;
+  }
+
+  releaseSession(profileId: string): void {
+    const health = this.getOrCreateHealth(profileId);
+    health.activeSessionCount = Math.max(0, health.activeSessionCount - 1);
+  }
+
+  // ─── 查询 ───────────────────────────────────────────────
+
+  getHealthStatuses(): ProviderHealthStatus[] {
+    // Ensure all configured members have health entries
+    for (const member of this.config.members) {
+      this.getOrCreateHealth(member.profileId);
+    }
+    return this.config.members.map(
+      (m) => this.healthMap.get(m.profileId) || makeHealthStatus(m.profileId),
+    );
+  }
+
+  getHealthStatus(profileId: string): ProviderHealthStatus {
+    return this.healthMap.get(profileId) || makeHealthStatus(profileId);
+  }
+
+  resetHealth(profileId: string): void {
+    this.healthMap.set(profileId, makeHealthStatus(profileId));
+  }
+
+  // ─── 内部工具 ────────────────────────────────────────────
+
+  private getOrCreateHealth(profileId: string): ProviderHealthStatus {
+    let health = this.healthMap.get(profileId);
+    if (!health) {
+      health = makeHealthStatus(profileId);
+      this.healthMap.set(profileId, health);
+    }
+    return health;
+  }
+}
+
+// ─── 单例 ──────────────────────────────────────────────────
+
+export const providerPool = new ProviderPool();

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -28,6 +28,7 @@ import {
   RegistrationConfigSchema,
   AppearanceConfigSchema,
   SystemSettingsSchema,
+  ProviderPoolSchema,
 } from '../schemas.js';
 import {
   getClaudeProviderConfig,
@@ -72,7 +73,13 @@ import type { ClaudeOAuthCredentials } from '../runtime-config.js';
 import type { AuthUser, RegisteredGroup } from '../types.js';
 import { hasPermission } from '../permissions.js';
 import { logger } from '../logger.js';
-import { checkImChannelLimit, isBillingEnabled, clearBillingEnabledCache } from '../billing.js';
+import {
+  checkImChannelLimit,
+  isBillingEnabled,
+  clearBillingEnabledCache,
+} from '../billing.js';
+import { providerPool } from '../provider-pool.js';
+import type { StoredProviderPoolConfig } from '../provider-pool.js';
 
 const configRoutes = new Hono<{ Variables: Variables }>();
 
@@ -85,8 +92,10 @@ function countOtherEnabledImChannels(
   excludeChannel: 'feishu' | 'telegram' | 'qq',
 ): number {
   let count = 0;
-  if (excludeChannel !== 'feishu' && getUserFeishuConfig(userId)?.enabled) count++;
-  if (excludeChannel !== 'telegram' && getUserTelegramConfig(userId)?.enabled) count++;
+  if (excludeChannel !== 'feishu' && getUserFeishuConfig(userId)?.enabled)
+    count++;
+  if (excludeChannel !== 'telegram' && getUserTelegramConfig(userId)?.enabled)
+    count++;
   if (excludeChannel !== 'qq' && getUserQQConfig(userId)?.enabled) count++;
   return count;
 }
@@ -982,7 +991,10 @@ function applyBindingUpdate(imJid: string, updated: RegisteredGroup): void {
 }
 
 configRoutes.get('/feishu', authMiddleware, systemConfigMiddleware, (c) => {
-  logDeprecationOnce('GET /api/config/feishu', 'GET /api/config/user-im/feishu');
+  logDeprecationOnce(
+    'GET /api/config/feishu',
+    'GET /api/config/user-im/feishu',
+  );
   try {
     const { config, source } = getFeishuProviderConfigWithSource();
     const pub = toPublicFeishuProviderConfig(config, source);
@@ -1055,7 +1067,10 @@ configRoutes.put(
 // ─── Telegram config ─────────────────────────────────────────────
 
 configRoutes.get('/telegram', authMiddleware, systemConfigMiddleware, (c) => {
-  logDeprecationOnce('GET /api/config/telegram', 'GET /api/config/user-im/telegram');
+  logDeprecationOnce(
+    'GET /api/config/telegram',
+    'GET /api/config/user-im/telegram',
+  );
   try {
     const { config, source } = getTelegramProviderConfigWithSource();
     const pub = toPublicTelegramProviderConfig(config, source);
@@ -1380,7 +1395,11 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
   if (validation.data.enabled === true && isBillingEnabled()) {
     const currentFeishu = getUserFeishuConfig(user.id);
     if (!currentFeishu?.enabled) {
-      const limit = checkImChannelLimit(user.id, user.role, countOtherEnabledImChannels(user.id, 'feishu'));
+      const limit = checkImChannelLimit(
+        user.id,
+        user.role,
+        countOtherEnabledImChannels(user.id, 'feishu'),
+      );
       if (!limit.allowed) {
         return c.json({ error: limit.reason }, 403);
       }
@@ -1490,7 +1509,11 @@ configRoutes.put('/user-im/telegram', authMiddleware, async (c) => {
   if (validation.data.enabled === true && isBillingEnabled()) {
     const currentTg = getUserTelegramConfig(user.id);
     if (!currentTg?.enabled) {
-      const limit = checkImChannelLimit(user.id, user.role, countOtherEnabledImChannels(user.id, 'telegram'));
+      const limit = checkImChannelLimit(
+        user.id,
+        user.role,
+        countOtherEnabledImChannels(user.id, 'telegram'),
+      );
       if (!limit.allowed) {
         return c.json({ error: limit.reason }, 403);
       }
@@ -1715,7 +1738,11 @@ configRoutes.put('/user-im/qq', authMiddleware, async (c) => {
   if (validation.data.enabled === true && isBillingEnabled()) {
     const currentQQ = getUserQQConfig(user.id);
     if (!currentQQ?.enabled) {
-      const limit = checkImChannelLimit(user.id, user.role, countOtherEnabledImChannels(user.id, 'qq'));
+      const limit = checkImChannelLimit(
+        user.id,
+        user.role,
+        countOtherEnabledImChannels(user.id, 'qq'),
+      );
       if (!limit.allowed) {
         return c.json({ error: limit.reason }, 403);
       }
@@ -1955,16 +1982,23 @@ configRoutes.put('/user-im/bindings/:imJid', authMiddleware, async (c) => {
       return c.json({ error: 'Agent not found' }, 404);
     }
     if (agent.kind !== 'conversation') {
-      return c.json({ error: 'Only conversation agents can bind IM groups' }, 400);
+      return c.json(
+        { error: 'Only conversation agents can bind IM groups' },
+        400,
+      );
     }
     // Check user can access the workspace that owns this agent
     const ownerGroup = getRegisteredGroup(agent.chat_jid);
-    if (!ownerGroup || !canAccessGroup(user, { ...ownerGroup, jid: agent.chat_jid })) {
+    if (
+      !ownerGroup ||
+      !canAccessGroup(user, { ...ownerGroup, jid: agent.chat_jid })
+    ) {
       return c.json({ error: 'Forbidden' }, 403);
     }
 
     const force = body.force === true;
-    const replyPolicy = body.reply_policy === 'mirror' ? 'mirror' : 'source_only';
+    const replyPolicy =
+      body.reply_policy === 'mirror' ? 'mirror' : 'source_only';
     const hasConflict =
       (imGroup.target_agent_id && imGroup.target_agent_id !== agentId) ||
       !!imGroup.target_main_jid;
@@ -1979,7 +2013,10 @@ configRoutes.put('/user-im/bindings/:imJid', authMiddleware, async (c) => {
       reply_policy: replyPolicy,
     };
     applyBindingUpdate(imJid, updated);
-    logger.info({ imJid, agentId, userId: user.id }, 'IM group bound to agent (bindings page)');
+    logger.info(
+      { imJid, agentId, userId: user.id },
+      'IM group bound to agent (bindings page)',
+    );
     return c.json({ success: true });
   }
 
@@ -1994,11 +2031,15 @@ configRoutes.put('/user-im/bindings/:imJid', authMiddleware, async (c) => {
       return c.json({ error: 'Forbidden' }, 403);
     }
     if (targetGroup.is_home) {
-      return c.json({ error: 'Home workspace main conversation uses default IM routing' }, 400);
+      return c.json(
+        { error: 'Home workspace main conversation uses default IM routing' },
+        400,
+      );
     }
 
     const force = body.force === true;
-    const replyPolicy = body.reply_policy === 'mirror' ? 'mirror' : 'source_only';
+    const replyPolicy =
+      body.reply_policy === 'mirror' ? 'mirror' : 'source_only';
     const legacyMainJid = `web:${targetGroup.folder}`;
     const hasConflict =
       !!imGroup.target_agent_id ||
@@ -2016,11 +2057,17 @@ configRoutes.put('/user-im/bindings/:imJid', authMiddleware, async (c) => {
       reply_policy: replyPolicy,
     };
     applyBindingUpdate(imJid, updated);
-    logger.info({ imJid, targetMainJid, userId: user.id }, 'IM group bound to workspace (bindings page)');
+    logger.info(
+      { imJid, targetMainJid, userId: user.id },
+      'IM group bound to workspace (bindings page)',
+    );
     return c.json({ success: true });
   }
 
-  return c.json({ error: 'Must provide target_main_jid, target_agent_id, or unbind' }, 400);
+  return c.json(
+    { error: 'Must provide target_main_jid, target_agent_id, or unbind' },
+    400,
+  );
 });
 
 // ─── Local Claude Code detection ──────────────────────────────────
@@ -2073,6 +2120,169 @@ configRoutes.post(
       logger.warn({ err }, 'Failed to import local Claude Code credentials');
       return c.json({ error: message }, 500);
     }
+  },
+);
+
+// ─── Provider Pool Routes ──────────────────────────────────────────
+
+/** GET /claude/pool — Pool config + health + available profiles */
+configRoutes.get(
+  '/claude/pool',
+  authMiddleware,
+  systemConfigMiddleware,
+  (c) => {
+    const config = providerPool.getConfig();
+    const healthStatuses = providerPool.getHealthStatuses();
+    const { activeProfileId, profiles } = listClaudeThirdPartyProfiles();
+
+    // Build member list with health + profile name + isOfficial tag
+    const membersWithHealth = config.members.map((m) => {
+      const isOfficial = m.profileId === '__official__';
+      const profile = profiles.find((p) => p.id === m.profileId);
+      const health = healthStatuses.find(
+        (h) => h.profileId === m.profileId,
+      ) || {
+        profileId: m.profileId,
+        healthy: true,
+        consecutiveErrors: 0,
+        lastErrorAt: null,
+        lastSuccessAt: null,
+        unhealthySince: null,
+        activeSessionCount: 0,
+      };
+      return {
+        profileId: m.profileId,
+        profileName: isOfficial ? '官方 Claude' : profile?.name || m.profileId,
+        isOfficial,
+        weight: m.weight,
+        enabled: m.enabled,
+        health,
+      };
+    });
+
+    // Available profiles not yet in pool
+    const poolIds = new Set(config.members.map((m) => m.profileId));
+    const availableProfiles = [
+      {
+        id: '__official__',
+        name: '官方 Claude',
+        isOfficial: true,
+        inPool: poolIds.has('__official__'),
+      },
+      ...profiles.map((p) => ({
+        id: p.id,
+        name: p.name,
+        isOfficial: false,
+        inPool: poolIds.has(p.id),
+      })),
+    ];
+
+    return c.json({
+      mode: config.mode,
+      strategy: config.strategy,
+      members: membersWithHealth,
+      unhealthyThreshold: config.unhealthyThreshold,
+      recoveryIntervalMs: config.recoveryIntervalMs,
+      updatedAt: config.updatedAt,
+      availableProfiles,
+    });
+  },
+);
+
+/** PUT /claude/pool — Update pool config */
+configRoutes.put(
+  '/claude/pool',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const body = await c.req.json();
+    const parsed = ProviderPoolSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(
+        { error: 'Invalid pool config', details: parsed.error.issues },
+        400,
+      );
+    }
+
+    const input = parsed.data;
+    const current = providerPool.getConfig();
+
+    const updated: StoredProviderPoolConfig = {
+      version: 1,
+      mode: input.mode,
+      strategy: input.strategy ?? current.strategy,
+      members:
+        input.members?.map((m) => ({
+          profileId: m.profileId,
+          weight: m.weight,
+          enabled: m.enabled,
+        })) ?? current.members,
+      unhealthyThreshold:
+        input.unhealthyThreshold ?? current.unhealthyThreshold,
+      recoveryIntervalMs:
+        input.recoveryIntervalMs ?? current.recoveryIntervalMs,
+      updatedAt: new Date().toISOString(),
+    };
+
+    providerPool.saveConfig(updated);
+
+    const user = c.get('user') as AuthUser;
+    appendClaudeConfigAudit(user.username, 'update_pool', [
+      `mode:${updated.mode}`,
+      `strategy:${updated.strategy}`,
+      `members:${updated.members.length}`,
+    ]);
+
+    return c.json({ ok: true });
+  },
+);
+
+/** POST /claude/pool/members/:profileId/toggle — Enable/disable a member */
+configRoutes.post(
+  '/claude/pool/members/:profileId/toggle',
+  authMiddleware,
+  systemConfigMiddleware,
+  (c) => {
+    const profileId = c.req.param('profileId');
+    const current = providerPool.getConfig();
+    const idx = current.members.findIndex((m) => m.profileId === profileId);
+    if (idx === -1) {
+      return c.json({ error: 'Member not found in pool' }, 404);
+    }
+
+    // Clone to avoid mutating in-memory reference directly
+    const updated: StoredProviderPoolConfig = {
+      ...current,
+      members: current.members.map((m, i) =>
+        i === idx ? { ...m, enabled: !m.enabled } : { ...m },
+      ),
+      updatedAt: new Date().toISOString(),
+    };
+    providerPool.saveConfig(updated);
+
+    return c.json({ profileId, enabled: updated.members[idx].enabled });
+  },
+);
+
+/** POST /claude/pool/members/:profileId/reset-health — Reset health status */
+configRoutes.post(
+  '/claude/pool/members/:profileId/reset-health',
+  authMiddleware,
+  systemConfigMiddleware,
+  (c) => {
+    const profileId = c.req.param('profileId');
+    providerPool.resetHealth(profileId);
+    return c.json({ ok: true });
+  },
+);
+
+/** GET /claude/pool/health — Health statuses only (for polling) */
+configRoutes.get(
+  '/claude/pool/health',
+  authMiddleware,
+  systemConfigMiddleware,
+  (c) => {
+    return c.json({ statuses: providerPool.getHealthStatuses() });
   },
 );
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -606,7 +606,9 @@ function fromStoredProfile(
     name: normalizeProfileName(stored.name),
     anthropicBaseUrl: normalizeBaseUrl(stored.anthropicBaseUrl),
     anthropicAuthToken: secrets.anthropicAuthToken,
-    anthropicModel: normalizeModel(stored.anthropicModel ?? (stored as any).happyclawModel ?? ''),
+    anthropicModel: normalizeModel(
+      stored.anthropicModel ?? (stored as any).happyclawModel ?? '',
+    ),
     updatedAt: stored.updatedAt || null,
     customEnv: sanitizeCustomEnvMap(stored.customEnv || {}, {
       skipReservedClaudeKeys: true,
@@ -1695,7 +1697,10 @@ export function shellQuoteEnvLines(lines: string[]): string[] {
   });
 }
 
-export function buildClaudeEnvLines(config: ClaudeProviderConfig): string[] {
+export function buildClaudeEnvLines(
+  config: ClaudeProviderConfig,
+  profileCustomEnv?: Record<string, string>,
+): string[] {
   const lines: string[] = [];
 
   // When full OAuth credentials exist, authentication is handled by .credentials.json file.
@@ -1722,7 +1727,8 @@ export function buildClaudeEnvLines(config: ClaudeProviderConfig): string[] {
     lines.push(`ANTHROPIC_MODEL=${sanitizeEnvValue(config.anthropicModel)}`);
   }
 
-  const customEnv = getActiveProfileCustomEnv();
+  // Use explicit profileCustomEnv if provided (pool mode), otherwise active profile
+  const customEnv = profileCustomEnv ?? getActiveProfileCustomEnv();
   for (const [key, value] of Object.entries(customEnv)) {
     if (RESERVED_CLAUDE_ENV_KEYS.has(key)) continue;
     lines.push(`${key}=${sanitizeEnvValue(value)}`);
@@ -1747,6 +1753,79 @@ export function getActiveProfileCustomEnv(): Record<string, string> {
   if (!active) return {};
 
   return sanitizeCustomEnvMap(active.customEnv || {}, {
+    skipReservedClaudeKeys: true,
+  });
+}
+
+/**
+ * Resolve any profileId to a full ClaudeProviderConfig.
+ * Used by ProviderPool to build env for a non-active profile.
+ */
+export function resolveProfileToConfig(
+  profileId: string,
+): ClaudeProviderConfig {
+  const state = readStoredState();
+  if (!state) return defaultsFromEnv();
+
+  if (isOfficialClaudeMode(profileId)) {
+    return buildOfficialClaudeProviderConfig(
+      state.officialSecrets,
+      state.officialUpdatedAt,
+    );
+  }
+
+  const stored = state.profiles.find((p) => p.id === profileId);
+  if (!stored) {
+    // Profile not found — fallback to current active config
+    logger.warn(
+      { profileId },
+      'resolveProfileToConfig: profile not found, falling back to active',
+    );
+    return getClaudeProviderConfig();
+  }
+
+  const profile = fromStoredProfile(stored);
+  return buildConfig(
+    {
+      anthropicBaseUrl: profile.anthropicBaseUrl,
+      anthropicAuthToken: profile.anthropicAuthToken,
+      anthropicApiKey: state.officialSecrets.anthropicApiKey,
+      claudeCodeOauthToken: state.officialSecrets.claudeCodeOauthToken,
+      claudeOAuthCredentials:
+        state.officialSecrets.claudeOAuthCredentials ?? null,
+      anthropicModel: profile.anthropicModel,
+    },
+    profile.updatedAt || state.officialUpdatedAt,
+  );
+}
+
+/**
+ * Get customEnv for a specific profileId (not necessarily the active one).
+ */
+export function getCustomEnvForProfile(
+  profileId: string,
+): Record<string, string> {
+  const state = readStoredState();
+  if (!state) return {};
+
+  if (isOfficialClaudeMode(profileId)) {
+    return sanitizeCustomEnvMap(state.officialCustomEnv || {}, {
+      skipReservedClaudeKeys: true,
+    });
+  }
+
+  const exact = state.profiles.find((p) => p.id === profileId);
+  if (!exact) {
+    logger.warn(
+      { profileId },
+      'getCustomEnvForProfile: profile not found, falling back to active',
+    );
+  }
+  const profile = exact || state.profiles[0];
+  if (!profile) return {};
+
+  const resolved = fromStoredProfile(profile);
+  return sanitizeCustomEnvMap(resolved.customEnv || {}, {
     skipReservedClaudeKeys: true,
   });
 }
@@ -1830,7 +1909,10 @@ export function getContainerEnvConfig(folder: string): ContainerEnvConfig {
         fs.readFileSync(filePath, 'utf-8'),
       ) as ContainerEnvConfig & { happyclawModel?: string };
       // Backward compat: migrate old field name
-      if (stored.anthropicModel === undefined && stored.happyclawModel !== undefined) {
+      if (
+        stored.anthropicModel === undefined &&
+        stored.happyclawModel !== undefined
+      ) {
         stored.anthropicModel = stored.happyclawModel;
         delete stored.happyclawModel;
       }
@@ -2001,9 +2083,10 @@ export function saveRegistrationConfig(
 export function buildContainerEnvLines(
   global: ClaudeProviderConfig,
   override: ContainerEnvConfig,
+  profileCustomEnv?: Record<string, string>,
 ): string[] {
   const merged = mergeClaudeEnvConfig(global, override);
-  const lines = buildClaudeEnvLines(merged);
+  const lines = buildClaudeEnvLines(merged, profileCustomEnv);
 
   // Append custom env vars (with safety sanitization as defense-in-depth)
   if (override.customEnv) {
@@ -2691,8 +2774,7 @@ function buildEnvFallbackSettings(): SystemSettings {
       DEFAULT_SYSTEM_SETTINGS.billingMinStartBalanceUsd,
     ),
     billingCurrency:
-      process.env.BILLING_CURRENCY ||
-      DEFAULT_SYSTEM_SETTINGS.billingCurrency,
+      process.env.BILLING_CURRENCY || DEFAULT_SYSTEM_SETTINGS.billingCurrency,
     billingCurrencyRate: parseFloatEnv(
       process.env.BILLING_CURRENCY_RATE,
       DEFAULT_SYSTEM_SETTINGS.billingCurrencyRate,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -456,7 +456,11 @@ export const TerminalStopSchema = z.object({
 // --- Billing schemas ---
 
 export const BillingPlanCreateSchema = z.object({
-  id: z.string().min(1).max(64).regex(/^[\w-]+$/, 'ID must be alphanumeric with hyphens/underscores'),
+  id: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[\w-]+$/, 'ID must be alphanumeric with hyphens/underscores'),
   name: z.string().min(1).max(64),
   description: z.string().max(500).nullable().optional(),
   tier: z.number().int().min(0).max(100).optional(),
@@ -483,7 +487,9 @@ export const BillingPlanCreateSchema = z.object({
   is_active: z.boolean().optional(),
 });
 
-export const BillingPlanPatchSchema = BillingPlanCreateSchema.omit({ id: true }).partial();
+export const BillingPlanPatchSchema = BillingPlanCreateSchema.omit({
+  id: true,
+}).partial();
 
 export const AssignPlanSchema = z.object({
   plan_id: z.string().min(1),
@@ -502,39 +508,48 @@ export const BatchAssignPlanSchema = z.object({
   duration_days: z.number().int().min(1).max(3650).optional(),
 });
 
-export const RedeemCodeCreateSchema = z.object({
-  type: z.enum(['balance', 'subscription', 'trial']),
-  value_usd: z.number().min(0.01).optional(),
-  plan_id: z.string().min(1).optional(),
-  duration_days: z.number().int().min(1).max(3650).optional(),
-  max_uses: z.number().int().min(1).max(10000).optional(),
-  count: z.number().int().min(1).max(100).optional(), // 批量生成数量
-  prefix: z.string().max(16).regex(/^[\w-]*$/).optional(), // 兑换码前缀
-  expires_in_hours: z.number().int().min(1).max(87600).optional(),
-  notes: z.string().max(500).optional(),
-}).superRefine((data, ctx) => {
-  if (data.type === 'balance' && (!data.value_usd || data.value_usd <= 0)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['value_usd'],
-      message: 'Balance type requires a positive value_usd',
-    });
-  }
-  if (data.type === 'subscription' && !data.plan_id) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['plan_id'],
-      message: 'Subscription type requires a plan_id',
-    });
-  }
-  if (data.type === 'trial' && (!data.duration_days || data.duration_days <= 0)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['duration_days'],
-      message: 'Trial type requires a positive duration_days',
-    });
-  }
-});
+export const RedeemCodeCreateSchema = z
+  .object({
+    type: z.enum(['balance', 'subscription', 'trial']),
+    value_usd: z.number().min(0.01).optional(),
+    plan_id: z.string().min(1).optional(),
+    duration_days: z.number().int().min(1).max(3650).optional(),
+    max_uses: z.number().int().min(1).max(10000).optional(),
+    count: z.number().int().min(1).max(100).optional(), // 批量生成数量
+    prefix: z
+      .string()
+      .max(16)
+      .regex(/^[\w-]*$/)
+      .optional(), // 兑换码前缀
+    expires_in_hours: z.number().int().min(1).max(87600).optional(),
+    notes: z.string().max(500).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.type === 'balance' && (!data.value_usd || data.value_usd <= 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value_usd'],
+        message: 'Balance type requires a positive value_usd',
+      });
+    }
+    if (data.type === 'subscription' && !data.plan_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['plan_id'],
+        message: 'Subscription type requires a plan_id',
+      });
+    }
+    if (
+      data.type === 'trial' &&
+      (!data.duration_days || data.duration_days <= 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['duration_days'],
+        message: 'Trial type requires a positive duration_days',
+      });
+    }
+  });
 
 export const RedeemCodeSchema = z.object({
   code: z.string().min(1).max(64),
@@ -582,4 +597,25 @@ export const BugReportGenerateSchema = z.object({
 export const BugReportSubmitSchema = z.object({
   title: z.string().min(1).max(256),
   body: z.string().min(1).max(65536),
+});
+
+// ─── Provider Pool ──────────────────────────────────────────
+
+export const ProviderPoolSchema = z.object({
+  mode: z.enum(['fixed', 'pool']),
+  strategy: z
+    .enum(['round-robin', 'weighted-round-robin', 'failover'])
+    .optional(),
+  members: z
+    .array(
+      z.object({
+        profileId: z.string().min(1).max(64),
+        weight: z.number().int().min(1).max(100).optional().default(1),
+        enabled: z.boolean().optional().default(true),
+      }),
+    )
+    .max(20)
+    .optional(),
+  unhealthyThreshold: z.number().int().min(1).max(20).optional(),
+  recoveryIntervalMs: z.number().int().min(30000).max(3600000).optional(),
 });

--- a/web/src/components/settings/ClaudeProviderSection.tsx
+++ b/web/src/components/settings/ClaudeProviderSection.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
   Edit3,
   ExternalLink,
   HardDrive,
@@ -7,6 +10,7 @@ import {
   Loader2,
   Plus,
   RefreshCw,
+  RotateCcw,
   Rocket,
   Trash2,
   X,
@@ -23,6 +27,8 @@ import type {
   ClaudeThirdPartyProfileItem,
   ClaudeThirdPartyProfilesResp,
   EnvRow,
+  ProviderPoolResponse,
+  ProviderPoolMemberWithHealth,
   SettingsNotification,
 } from './types';
 import { getErrorMessage } from './types';
@@ -120,6 +126,12 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
   const [showApplyConfirm, setShowApplyConfirm] = useState(false);
   const [pendingDeleteProfile, setPendingDeleteProfile] = useState<ClaudeThirdPartyProfileItem | null>(null);
 
+  // Provider Pool state
+  const [poolData, setPoolData] = useState<ProviderPoolResponse | null>(null);
+  const [poolExpanded, setPoolExpanded] = useState(false);
+  const [poolSaving, setPoolSaving] = useState(false);
+  const [poolAdvancedOpen, setPoolAdvancedOpen] = useState(false);
+
   const activeProfile = useMemo(() => {
     if (!profilesState) return null;
     return (
@@ -207,6 +219,138 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
   useEffect(() => {
     loadConfig();
   }, [loadConfig]);
+
+  // ─── Provider Pool loading ───
+  const loadPoolData = useCallback(async () => {
+    try {
+      const data = await api.get<ProviderPoolResponse>('/api/config/claude/pool');
+      setPoolData(data);
+    } catch {
+      // Pool API may not be available — ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPoolData();
+  }, [loadPoolData]);
+
+  // Auto-poll health when pool is expanded and mode=pool
+  useEffect(() => {
+    if (!poolExpanded || poolData?.mode !== 'pool') return;
+    const interval = setInterval(async () => {
+      try {
+        const data = await api.get<{ statuses: ProviderPoolResponse['members'][0]['health'][] }>(
+          '/api/config/claude/pool/health',
+        );
+        setPoolData((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            members: prev.members.map((m) => {
+              const updated = data.statuses.find((s) => s.profileId === m.profileId);
+              return updated ? { ...m, health: updated } : m;
+            }),
+          };
+        });
+      } catch {
+        // ignore
+      }
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [poolExpanded, poolData?.mode]);
+
+  const handlePoolModeToggle = useCallback(async () => {
+    if (!poolData) return;
+    setPoolSaving(true);
+    try {
+      const newMode = poolData.mode === 'fixed' ? 'pool' : 'fixed';
+      await api.put('/api/config/claude/pool', {
+        mode: newMode,
+        strategy: poolData.strategy,
+        members: poolData.members.map((m) => ({
+          profileId: m.profileId,
+          weight: m.weight,
+          enabled: m.enabled,
+        })),
+      });
+      await loadPoolData();
+      setNotice(newMode === 'pool' ? '已启用负载均衡模式' : '已切换回固定模式');
+    } catch (err) {
+      setError(getErrorMessage(err, '切换模式失败'));
+    } finally {
+      setPoolSaving(false);
+    }
+  }, [poolData, loadPoolData, setNotice, setError]);
+
+  const handlePoolSave = useCallback(async (updates: Partial<{
+    strategy: string;
+    members: { profileId: string; weight: number; enabled: boolean }[];
+    unhealthyThreshold: number;
+    recoveryIntervalMs: number;
+  }>) => {
+    if (!poolData) return;
+    setPoolSaving(true);
+    try {
+      await api.put('/api/config/claude/pool', {
+        mode: poolData.mode,
+        ...updates,
+      });
+      await loadPoolData();
+      setNotice('负载均衡配置已保存');
+    } catch (err) {
+      setError(getErrorMessage(err, '保存配置失败'));
+    } finally {
+      setPoolSaving(false);
+    }
+  }, [poolData, loadPoolData, setNotice, setError]);
+
+  const handlePoolToggleMember = useCallback(async (profileId: string) => {
+    try {
+      await api.post(`/api/config/claude/pool/members/${profileId}/toggle`);
+      await loadPoolData();
+    } catch (err) {
+      setError(getErrorMessage(err, '切换成员状态失败'));
+    }
+  }, [loadPoolData, setError]);
+
+  const handlePoolResetHealth = useCallback(async (profileId: string) => {
+    try {
+      await api.post(`/api/config/claude/pool/members/${profileId}/reset-health`);
+      await loadPoolData();
+      setNotice('健康状态已重置');
+    } catch (err) {
+      setError(getErrorMessage(err, '重置健康状态失败'));
+    }
+  }, [loadPoolData, setNotice, setError]);
+
+  const handleAddToPool = useCallback(async (profileId: string) => {
+    if (!poolData) return;
+    const exists = poolData.members.some((m) => m.profileId === profileId);
+    if (exists) return;
+    await handlePoolSave({
+      members: [
+        ...poolData.members.map((m) => ({
+          profileId: m.profileId,
+          weight: m.weight,
+          enabled: m.enabled,
+        })),
+        { profileId, weight: 1, enabled: true },
+      ],
+    });
+  }, [poolData, handlePoolSave]);
+
+  const handleRemoveFromPool = useCallback(async (profileId: string) => {
+    if (!poolData) return;
+    await handlePoolSave({
+      members: poolData.members
+        .filter((m) => m.profileId !== profileId)
+        .map((m) => ({
+          profileId: m.profileId,
+          weight: m.weight,
+          enabled: m.enabled,
+        })),
+    });
+  }, [poolData, handlePoolSave]);
 
   // Detect local Claude Code credentials
   useEffect(() => {
@@ -1191,6 +1335,199 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
         </div>
       )}
 
+      {/* ─── Provider Pool Section ─── */}
+      {poolData && (
+        <div className="border border-slate-200 rounded-lg overflow-hidden">
+          <button
+            type="button"
+            className="w-full flex items-center justify-between px-4 py-3 bg-slate-50 hover:bg-slate-100 transition-colors cursor-pointer"
+            onClick={() => setPoolExpanded(!poolExpanded)}
+          >
+            <div className="flex items-center gap-2">
+              <Activity className="w-4 h-4 text-slate-500" />
+              <span className="text-sm font-medium">负载均衡</span>
+              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                poolData.mode === 'pool'
+                  ? 'bg-teal-100 text-teal-800'
+                  : 'bg-slate-100 text-slate-600'
+              }`}>
+                {poolData.mode === 'pool' ? '已启用' : '固定模式'}
+              </span>
+            </div>
+            {poolExpanded ? (
+              <ChevronDown className="w-4 h-4 text-slate-400" />
+            ) : (
+              <ChevronRight className="w-4 h-4 text-slate-400" />
+            )}
+          </button>
+
+          {poolExpanded && (
+            <div className="p-4 space-y-4">
+              {/* Mode toggle */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-medium">模式</div>
+                  <div className="text-xs text-slate-500">
+                    {poolData.mode === 'pool'
+                      ? '多个提供商轮流处理会话请求'
+                      : '使用单一活跃配置处理所有请求'}
+                  </div>
+                </div>
+                <Button
+                  variant={poolData.mode === 'pool' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={handlePoolModeToggle}
+                  disabled={poolSaving}
+                >
+                  {poolSaving && <Loader2 className="w-3 h-3 animate-spin" />}
+                  {poolData.mode === 'pool' ? '切换为固定' : '启用负载均衡'}
+                </Button>
+              </div>
+
+              {poolData.mode === 'pool' && (
+                <>
+                  {/* Strategy selector */}
+                  <div>
+                    <label className="text-sm font-medium block mb-1">策略</label>
+                    <select
+                      className="w-full border border-slate-200 rounded-md px-3 py-1.5 text-sm bg-white"
+                      value={poolData.strategy}
+                      onChange={(e) =>
+                        handlePoolSave({ strategy: e.target.value })
+                      }
+                    >
+                      <option value="round-robin">轮询</option>
+                      <option value="weighted-round-robin">加权轮询</option>
+                      <option value="failover">故障转移</option>
+                    </select>
+                  </div>
+
+                  {/* Pool members */}
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm font-medium">提供商池</span>
+                    </div>
+                    {poolData.members.length === 0 ? (
+                      <div className="text-sm text-slate-400 text-center py-4 border border-dashed border-slate-200 rounded-lg">
+                        暂无提供商，请从下方添加
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {poolData.members.map((member) => (
+                          <PoolMemberRow
+                            key={member.profileId}
+                            member={member}
+                            strategy={poolData.strategy}
+                            onToggle={() => handlePoolToggleMember(member.profileId)}
+                            onResetHealth={() => handlePoolResetHealth(member.profileId)}
+                            onRemove={() => handleRemoveFromPool(member.profileId)}
+                            onWeightChange={(w) => {
+                              handlePoolSave({
+                                members: poolData.members.map((m) =>
+                                  m.profileId === member.profileId
+                                    ? { profileId: m.profileId, weight: w, enabled: m.enabled }
+                                    : { profileId: m.profileId, weight: m.weight, enabled: m.enabled },
+                                ),
+                              });
+                            }}
+                          />
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Add to pool */}
+                    {poolData.availableProfiles.filter((p) => !p.inPool).length > 0 && (
+                      <div className="mt-3">
+                        <div className="text-xs text-slate-500 mb-1">可添加的提供商：</div>
+                        <div className="flex flex-wrap gap-2">
+                          {poolData.availableProfiles
+                            .filter((p) => !p.inPool)
+                            .map((p) => (
+                              <button
+                                key={p.id}
+                                type="button"
+                                className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-slate-200 rounded-md hover:bg-slate-50 cursor-pointer transition-colors"
+                                onClick={() => handleAddToPool(p.id)}
+                              >
+                                <Plus className="w-3 h-3" />
+                                {p.name}
+                                <span className={`px-1 py-0.5 rounded text-[10px] leading-none ${
+                                  p.isOfficial ? 'bg-blue-100 text-blue-700' : 'bg-amber-100 text-amber-700'
+                                }`}>
+                                  {p.isOfficial ? '官方' : '第三方'}
+                                </span>
+                              </button>
+                            ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Advanced settings */}
+                  <div className="border-t border-slate-100 pt-3">
+                    <button
+                      type="button"
+                      className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 cursor-pointer"
+                      onClick={() => setPoolAdvancedOpen(!poolAdvancedOpen)}
+                    >
+                      {poolAdvancedOpen ? (
+                        <ChevronDown className="w-3 h-3" />
+                      ) : (
+                        <ChevronRight className="w-3 h-3" />
+                      )}
+                      高级设置
+                    </button>
+                    {poolAdvancedOpen && (
+                      <div className="mt-2 grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="text-xs text-slate-500 block mb-1">
+                            不健康阈值（连续失败次数）
+                          </label>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={20}
+                            value={poolData.unhealthyThreshold}
+                            onChange={(e) =>
+                              handlePoolSave({
+                                unhealthyThreshold: Math.max(
+                                  1,
+                                  Math.min(20, parseInt(e.target.value) || 3),
+                                ),
+                              })
+                            }
+                            className="h-8 text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500 block mb-1">
+                            自动恢复间隔（秒）
+                          </label>
+                          <Input
+                            type="number"
+                            min={30}
+                            max={3600}
+                            value={Math.round(poolData.recoveryIntervalMs / 1000)}
+                            onChange={(e) =>
+                              handlePoolSave({
+                                recoveryIntervalMs:
+                                  Math.max(30, Math.min(3600, parseInt(e.target.value) || 300)) *
+                                  1000,
+                              })
+                            }
+                            className="h-8 text-sm"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="pt-4 border-t border-slate-100 flex flex-wrap items-center gap-3">
         <Button variant="outline" onClick={loadConfig} disabled={loading || saving || applying}>
           <RefreshCw className="w-4 h-4" />
@@ -1229,6 +1566,127 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
         confirmVariant="danger"
         loading={deletingProfileId !== null}
       />
+    </div>
+  );
+}
+
+// ─── Pool Member Row ──────────────────────────────────────────
+
+function PoolMemberRow({
+  member,
+  strategy,
+  onToggle,
+  onResetHealth,
+  onRemove,
+  onWeightChange,
+}: {
+  member: ProviderPoolMemberWithHealth;
+  strategy: string;
+  onToggle: () => void;
+  onResetHealth: () => void;
+  onRemove: () => void;
+  onWeightChange: (weight: number) => void;
+}) {
+  const health = member.health;
+  const statusColor = !member.enabled
+    ? 'bg-slate-300'
+    : health.healthy
+      ? 'bg-emerald-400'
+      : health.consecutiveErrors > 0
+        ? 'bg-red-400'
+        : 'bg-amber-400';
+
+  return (
+    <div className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
+      member.enabled ? 'border-slate-200 bg-white' : 'border-slate-100 bg-slate-50 opacity-60'
+    }`}>
+      {/* Status dot */}
+      <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${statusColor}`} />
+
+      {/* Name & info */}
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate flex items-center gap-1.5">
+          {member.profileName}
+          <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium leading-none ${
+            member.isOfficial
+              ? 'bg-blue-100 text-blue-700'
+              : 'bg-amber-100 text-amber-700'
+          }`}>
+            {member.isOfficial ? '官方' : '第三方'}
+          </span>
+        </div>
+        <div className="text-xs text-slate-400 flex items-center gap-2 flex-wrap">
+          {health.activeSessionCount > 0 && (
+            <span className="text-teal-600">{health.activeSessionCount} 活跃会话</span>
+          )}
+          {health.consecutiveErrors > 0 && (
+            <span className="text-red-500">连续错误 {health.consecutiveErrors}</span>
+          )}
+          {health.lastErrorAt && (
+            <span>
+              最近错误{' '}
+              {new Date(health.lastErrorAt).toLocaleTimeString('zh-CN', {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+          )}
+          {!health.healthy && health.unhealthySince && (
+            <span className="text-red-500 font-medium">不健康</span>
+          )}
+        </div>
+      </div>
+
+      {/* Weight (only for weighted strategy) */}
+      {strategy === 'weighted-round-robin' && (
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-slate-400">权重</span>
+          <input
+            type="number"
+            min={1}
+            max={100}
+            value={member.weight}
+            onChange={(e) =>
+              onWeightChange(Math.max(1, Math.min(100, parseInt(e.target.value) || 1)))
+            }
+            className="w-14 h-7 border border-slate-200 rounded px-2 text-xs text-center"
+          />
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-1">
+        {!health.healthy && (
+          <button
+            type="button"
+            className="p-1 rounded hover:bg-slate-100 text-slate-400 hover:text-slate-600 cursor-pointer"
+            onClick={onResetHealth}
+            title="重置健康状态"
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          className={`p-1 rounded cursor-pointer transition-colors ${
+            member.enabled
+              ? 'hover:bg-slate-100 text-teal-500 hover:text-teal-700'
+              : 'hover:bg-slate-100 text-slate-300 hover:text-slate-500'
+          }`}
+          onClick={onToggle}
+          title={member.enabled ? '禁用' : '启用'}
+        >
+          <Activity className="w-3.5 h-3.5" />
+        </button>
+        <button
+          type="button"
+          className="p-1 rounded hover:bg-red-50 text-slate-300 hover:text-red-500 cursor-pointer transition-colors"
+          onClick={onRemove}
+          title="从池中移除"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -84,6 +84,44 @@ export interface SystemSettings {
 
 export type SettingsTab = 'claude' | 'registration' | 'appearance' | 'system' | 'profile' | 'my-channels' | 'security' | 'groups' | 'memory' | 'skills' | 'mcp-servers' | 'agent-definitions' | 'users' | 'about' | 'bindings';
 
+// ─── Provider Pool Types ──────────────────────────────────────────
+
+export interface ProviderPoolHealthStatus {
+  profileId: string;
+  healthy: boolean;
+  consecutiveErrors: number;
+  lastErrorAt: number | null;
+  lastSuccessAt: number | null;
+  unhealthySince: number | null;
+  activeSessionCount: number;
+}
+
+export interface ProviderPoolMemberWithHealth {
+  profileId: string;
+  profileName: string;
+  isOfficial: boolean;
+  weight: number;
+  enabled: boolean;
+  health: ProviderPoolHealthStatus;
+}
+
+export interface ProviderPoolAvailableProfile {
+  id: string;
+  name: string;
+  isOfficial: boolean;
+  inPool: boolean;
+}
+
+export interface ProviderPoolResponse {
+  mode: 'fixed' | 'pool';
+  strategy: 'round-robin' | 'weighted-round-robin' | 'failover';
+  members: ProviderPoolMemberWithHealth[];
+  unhealthyThreshold: number;
+  recoveryIntervalMs: number;
+  updatedAt: string;
+  availableProfiles: ProviderPoolAvailableProfile[];
+}
+
 export function getErrorMessage(err: unknown, fallback: string): string {
   if (typeof err === 'object' && err !== null && 'message' in err) {
     const msg = (err as { message?: unknown }).message;


### PR DESCRIPTION
## Summary
- 新增 ProviderPool 核心模块，支持多个 Claude API 提供商同时生效
- 三种策略：轮询 / 加权轮询 / 故障转移，会话级自动选择
- 前端负载均衡管理面板，官方/第三方标签区分，健康状态实时监控
- 完全向后兼容：默认 fixed 模式，不配置 = 行为不变

## Test plan
- [ ] 配置 2 个 profile 进入 pool，触发多个会话，检查 env 文件中 API Key 交替变化
- [ ] 模拟连续失败，验证 threshold 后标记不健康 + 恢复间隔后自动恢复
- [ ] 删除 provider-pool.json，验证所有现有行为不变
- [ ] `make typecheck` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)