### PR TITLE
修复: 斜杠命令大小写不敏感

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -680,8 +680,8 @@ async function handleCommand(
   command: string,
 ): Promise<string | null> {
   const parts = command.split(/\s+/);
-  const cmd = parts[0];
-  const rawArgs = command.slice(cmd.length).trim();
+  const cmd = parts[0].toLowerCase();
+  const rawArgs = command.slice(parts[0].length).trim();
 
   switch (cmd) {
     case 'clear':

--- a/src/web.ts
+++ b/src/web.ts
@@ -736,7 +736,7 @@ function setupWebSocket(server: any): WebSocketServer {
           }
 
           // ── /clear command: reset session without entering message pipeline ──
-          if (content.trim() === '/clear' && deps) {
+          if (content.trim().toLowerCase() === '/clear' && deps) {
             const targetGroup = getRegisteredGroup(chatJid);
             if (targetGroup) {
               try {


### PR DESCRIPTION
## 问题描述

斜杠命令（`/clear`、`/list` 等）对大小写敏感，输入 `/Clear`、`/LIST` 会被当作普通消息发给 Agent。

手机输入法常自动首字母大写，容易触发此问题。Claude Code 本身命令不区分大小写，HappyClaw 应保持一致。

## 修复方案

### `src/index.ts`
- `handleCommand()` 中对提取的命令名做 `toLowerCase()` 处理

### `src/web.ts`
- Web 端 `/clear` 匹配改为大小写不敏感


🤖 Generated with [Claude Code](https://claude.com/claude-code)