### PR TITLE
修复: Telegram 连接增加 ignoreMessagesBefore 过滤

### DIFF
--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -266,6 +266,7 @@ export function createTelegramChannel(
           isChatAuthorized: opts.isChatAuthorized ?? (() => true),
           onPairAttempt: opts.onPairAttempt,
           onCommand: opts.onCommand,
+          ignoreMessagesBefore: opts.ignoreMessagesBefore,
           resolveGroupFolder: opts.resolveGroupFolder,
           resolveEffectiveChatJid: opts.resolveEffectiveChatJid,
           onAgentMessage: opts.onAgentMessage,

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -338,6 +338,7 @@ class IMConnectionManager {
     ) => Promise<boolean>,
     options?: {
       onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+      ignoreMessagesBefore?: number;
       resolveGroupFolder?: (jid: string) => string | undefined;
       resolveEffectiveChatJid?: (
         chatJid: string,
@@ -365,6 +366,7 @@ class IMConnectionManager {
       isChatAuthorized,
       onPairAttempt,
       onCommand: options?.onCommand,
+      ignoreMessagesBefore: options?.ignoreMessagesBefore,
       resolveGroupFolder: options?.resolveGroupFolder,
       resolveEffectiveChatJid: options?.resolveEffectiveChatJid,
       onAgentMessage: options?.onAgentMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5294,6 +5294,7 @@ async function connectUserIMChannels(
       buildOnPairAttempt(userId),
       {
         onCommand: handleCommand,
+        ignoreMessagesBefore,
         resolveGroupFolder,
         resolveEffectiveChatJid,
         onAgentMessage,
@@ -5678,6 +5679,7 @@ async function main(): Promise<void> {
         buildOnPairAttempt(adminUser.id),
         {
           onCommand: handleCommand,
+          ignoreMessagesBefore: Date.now(),
           resolveGroupFolder: (chatJid) => resolveEffectiveFolder(chatJid),
           resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
           onAgentMessage: buildOnAgentMessage(),
@@ -5757,6 +5759,7 @@ async function main(): Promise<void> {
           buildOnPairAttempt(userId),
           {
             onCommand: handleCommand,
+            ignoreMessagesBefore,
             resolveGroupFolder: (chatJid: string) =>
               resolveEffectiveFolder(chatJid),
             resolveEffectiveChatJid: buildResolveEffectiveChatJid(),

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -34,6 +34,8 @@ export interface TelegramConnectOpts {
   ) => Promise<boolean>;
   /** 斜杠指令回调（如 /clear），返回回复文本或 null */
   onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+  /** 热重连时设置：丢弃 date 早于此时间戳（epoch ms）的消息，避免处理渠道关闭期间的堆积消息 */
+  ignoreMessagesBefore?: number;
   /** 根据 jid 解析群组 folder，用于下载文件/图片到工作区 */
   resolveGroupFolder?: (jid: string) => string | undefined;
   /** 将 IM chatJid 解析为绑定目标 JID（conversation agent 或工作区主对话） */
@@ -391,6 +393,18 @@ export function createTelegramConnection(
           }
           markSeen(msgId);
 
+          // Skip stale messages from before connection (hot-reload scenario)
+          if (opts.ignoreMessagesBefore) {
+            const msgTimeMs = ctx.message.date * 1000;
+            if (msgTimeMs < opts.ignoreMessagesBefore) {
+              logger.info(
+                { msgId, msgTime: msgTimeMs, threshold: opts.ignoreMessagesBefore },
+                'Skipping stale Telegram message from before reconnection',
+              );
+              return;
+            }
+          }
+
           const chatId = String(ctx.chat.id);
           const jid = `telegram:${chatId}`;
           const chatName =
@@ -582,6 +596,12 @@ export function createTelegramConnection(
           if (isDuplicate(msgId)) return;
           markSeen(msgId);
 
+          // Skip stale messages from before connection (hot-reload scenario)
+          if (opts.ignoreMessagesBefore) {
+            const msgTimeMs = ctx.message.date * 1000;
+            if (msgTimeMs < opts.ignoreMessagesBefore) return;
+          }
+
           const chatId = String(ctx.chat.id);
           const jid = `telegram:${chatId}`;
           const chatName =
@@ -722,6 +742,12 @@ export function createTelegramConnection(
             String(ctx.message.message_id) + ':' + String(ctx.chat.id);
           if (isDuplicate(msgId)) return;
           markSeen(msgId);
+
+          // Skip stale messages from before connection (hot-reload scenario)
+          if (opts.ignoreMessagesBefore) {
+            const msgTimeMs = ctx.message.date * 1000;
+            if (msgTimeMs < opts.ignoreMessagesBefore) return;
+          }
 
           const chatId = String(ctx.chat.id);
           const jid = `telegram:${chatId}`;


### PR DESCRIPTION
## 问题描述

Feishu 和 QQ 连接均实现了 `ignoreMessagesBefore` 参数，在热重连（IM 配置保存触发断开→重连）时过滤掉断连期间堆积的旧消息。但 Telegram 连接缺少此机制：

- `TelegramConnectOpts` 接口没有 `ignoreMessagesBefore` 字段
- 三个消息处理器（`message:text`、`message:photo`、`message:document`）没有时间过滤逻辑
- `im-manager.ts`、`im-channel.ts`、`index.ts` 中调用 Telegram 连接时均未传递此参数

**影响**：Telegram 热重连后，Long Polling 间隙堆积的旧消息会被当作新消息处理，导致 Agent 回复已过时的消息。

## 修复方案

### `src/telegram.ts`
- `TelegramConnectOpts` 接口增加 `ignoreMessagesBefore?: number` 字段
- 在 `message:text`、`message:photo`、`message:document` 三个处理器中，dedup 之后、业务逻辑之前，检查 `ctx.message.date * 1000 < opts.ignoreMessagesBefore` 并跳过旧消息
- `message:text` 跳过时输出 info 日志（与 Feishu 一致），photo/document 静默跳过（与 QQ 一致）

### `src/im-channel.ts`
- Telegram adapter 的 `connect()` 将 `opts.ignoreMessagesBefore` 传递给底层 `TelegramConnectOpts`

### `src/im-manager.ts`
- `connectUserTelegram()` 的 options 参数增加 `ignoreMessagesBefore` 字段并透传

### `src/index.ts`
- `connectUserIMChannels()` 中调用 `connectUserTelegram` 时传入 `ignoreMessagesBefore`（与 Feishu 一致）
- `reloadUserIMConfig()` Telegram 热重连路径传入 `ignoreMessagesBefore`
- `reloadTelegramConnection()`（deprecated 路径）传入 `Date.now()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)