### PR TITLE
修复: sendAgentMessage 在 WebSocket 未连接时静默丢失消息

### DIFF
--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1914,7 +1914,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const normalizedAttachments = attachments && attachments.length > 0
       ? attachments.map(att => ({ type: 'image' as const, ...att }))
       : undefined;
-    wsManager.send({ type: 'send_message', chatJid: jid, content, agentId, attachments: normalizedAttachments });
+    const sent = wsManager.send({ type: 'send_message', chatJid: jid, content, agentId, attachments: normalizedAttachments });
+    if (!sent) {
+      showToast('发送失败', 'WebSocket 未连接，请稍后重试');
+      return;
+    }
     set((s) => ({
       agentWaiting: { ...s.agentWaiting, [agentId]: true },
     }));


### PR DESCRIPTION
## 问题描述

`sendAgentMessage`（对话代理消息发送）通过 WebSocket 发送消息，但不检查 `wsManager.send()` 的返回值。当 WebSocket 未连接时（网络波动、后端重启等），消息被静默丢弃，且 UI 立即将 `agentWaiting` 设为 `true`，导致用户看到永久的"等待"状态，无任何错误提示。

**对比**：主会话的 `sendMessage` 使用 HTTP API 并有完整的 try/catch 错误处理，不受此问题影响。

**复现路径**：
1. 打开对话代理聊天界面
2. 断开网络或等待 WebSocket 断连
3. 发送消息
4. 期望：显示错误提示。实际：消息消失，界面停留在"等待"状态

## 修复方案

### `web/src/stores/chat.ts`
- 检查 `wsManager.send()` 的返回值
- 发送失败时调用 `showToast('发送失败', 'WebSocket 未连接，请稍后重试')` 向用户展示错误提示
- 提前 return，不设置 `agentWaiting: true`，避免 UI 进入永久等待状态

🤖 Generated with [Claude Code](https://claude.com/claude-code)