### PR TITLE
优化: 移除消息气泡的右键菜单和长按触发入口

### DIFF
--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, memo, lazy, Suspense } from 'react';
+import { useState, memo, lazy, Suspense } from 'react';
 import { Copy, Check, ChevronDown, ChevronUp, Ellipsis, ImageDown } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -138,8 +138,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
   const [lightboxState, setLightboxState] = useState<{ images: string[]; index: number } | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [showShareDialog, setShowShareDialog] = useState(false);
-  const touchTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const touchStartPos = useRef({ x: 0, y: 0 });
   const currentUser = useAuthStore((s) => s.user);
   const appearance = useAuthStore((s) => s.appearance);
   const { mode: displayMode } = useDisplayMode();
@@ -192,11 +190,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
     }
   };
 
-  const handleContextMenu = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setContextMenu({ x: e.clientX, y: e.clientY });
-  };
-
   const handleMenuButton = (e: React.MouseEvent | React.TouchEvent) => {
     e.stopPropagation();
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
@@ -204,27 +197,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
     setContextMenu({ x: rect.left, y: rect.bottom + 4 });
   };
 
-  const handleTouchStart = (e: React.TouchEvent) => {
-    const touch = e.touches[0];
-    touchStartPos.current = { x: touch.clientX, y: touch.clientY };
-    touchTimer.current = setTimeout(() => {
-      mediumTap();
-      setContextMenu({ x: touch.clientX, y: touch.clientY - 10 });
-    }, 500);
-  };
-
-  const handleTouchEnd = () => {
-    if (touchTimer.current) clearTimeout(touchTimer.current);
-  };
-
-  const handleTouchMove = (e: React.TouchEvent) => {
-    const touch = e.touches[0];
-    const dx = Math.abs(touch.clientX - touchStartPos.current.x);
-    const dy = Math.abs(touch.clientY - touchStartPos.current.y);
-    if (dx > 10 || dy > 10) {
-      if (touchTimer.current) clearTimeout(touchTimer.current);
-    }
-  };
 
   // Context overflow system message
   if (message.sender === '__system__' && message.content.startsWith('context_overflow:')) {
@@ -321,7 +293,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
       : (isOtherUser ? (message.sender_name || '用户') : (currentUser?.display_name || currentUser?.username || '我'));
 
     return (
-      <div className="group mb-2 border-b border-border pb-2" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+      <div className="group mb-2 border-b border-border pb-2">
         {/* Sender line — no avatars in compact mode */}
         <div className="flex items-center gap-1.5 mb-1">
           <span className={`text-xs font-semibold ${isAI ? 'text-primary' : 'text-muted-foreground'}`}>{senderName}</span>
@@ -386,7 +358,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
       const otherName = message.sender_name || '用户';
       const initial = otherName[0]?.toUpperCase() || '?';
       return (
-        <div className="group mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+        <div className="group mb-4">
           <div className="flex items-center gap-2 mb-1.5 lg:hidden">
             <div className="w-6 h-6 rounded-full bg-slate-200 flex items-center justify-center text-xs font-medium text-slate-600 flex-shrink-0">
               {initial}
@@ -462,7 +434,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
     // User message (own): right-aligned
     const showSenderLabel = isShared;
     return (
-      <div className="group flex justify-end mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+      <div className="group flex justify-end mb-4">
         <div className="flex flex-col items-end min-w-0 w-full">
           {showSenderLabel && (
             <span className="text-xs text-muted-foreground font-medium mb-1 mr-1">
@@ -532,7 +504,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
   const aiImageUrl = currentUser?.ai_avatar_url;
 
   return (
-    <div className="group mb-4" onContextMenu={handleContextMenu} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd} onTouchMove={handleTouchMove}>
+    <div className="group mb-4">
       {/* Mobile: compact avatar + name row */}
       <div className="flex items-center gap-2 mb-1.5 lg:hidden">
         <EmojiAvatar imageUrl={aiImageUrl} emoji={aiEmoji} color={aiColor} fallbackChar={senderName[0]} size="sm" />


### PR DESCRIPTION
## 问题描述

消息气泡的操作菜单（复制文本/Markdown、删除等）目前有三个触发入口：

| 入口 | 平台 | 状态 |
|------|------|------|
| 长按 500ms | 移动端 | **本 PR 移除** |
| 右键点击 | PC 端 | **本 PR 移除** |
| 右上角 ⋯ 按钮 | 全平台 | 保留 |

### 为什么移除移动端长按

移动端长按 500ms 打开操作菜单，会**拦截系统原生的文本选择操作**。用户在消息气泡上长按的最常见意图是选中一段文字进行复制，但当前实现会抢先弹出自定义菜单（并触发振动反馈），使得原生选择手势无法生效。用户被迫使用菜单中的「复制文本」，但这会复制**整条消息全文**而非用户想选的片段，完全违背用户预期。

### 为什么移除 PC 端右键菜单

PC 端右键弹出自定义菜单同样存在**操作语义不一致**的问题：

1. 用户鼠标拖选了消息中的一段文字
2. 右键，期望看到浏览器原生的「复制」选项（复制选中片段）
3. 实际弹出的是自定义菜单，其中「复制文本」复制的是**整条消息全文**
4. 用户点击后发现剪贴板里是全文而非选中内容，造成困惑

同时，`e.preventDefault()` 阻止了浏览器原生右键菜单，意味着用户在消息区域无法使用浏览器的「检查元素」「翻译」等原生右键功能。

### 为什么 ⋯ 按钮足够

⋯ 按钮在移动端始终可见、PC 端 hover 时显示（`lg:opacity-0 lg:group-hover:opacity-100`），已经完整覆盖操作菜单的使用场景。保留这个明确的、不会与系统手势冲突的入口，既保证了功能完整性，又恢复了平台原生交互行为。

## 修改方案

### `web/src/components/chat/MessageBubble.tsx`（-33 行）
- 移除 `handleContextMenu`（右键菜单处理器）
- 移除 `handleTouchStart` / `handleTouchEnd` / `handleTouchMove`（长按手势处理器）
- 移除 `touchTimer` / `touchStartPos` ref（长按计时状态）
- 从 4 处消息容器 div（compact 模式、他人消息、自己消息、AI 消息）移除事件绑定
- 清理不再使用的 `useRef` 导入

**保留不变**：
- `MessageContextMenu` 组件本身（菜单 UI 和功能完整保留）
- `handleMenuButton`（⋯ 按钮触发器）
- 移动端振动反馈 `mediumTap()`（⋯ 按钮仍使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)