### PR TITLE
优化: IM 消息即时唤醒轮询循环，消除 2 秒延迟

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -14,6 +14,7 @@ import {
   MAX_FILE_SIZE,
   FileTooLargeError,
 } from './im-downloader.js';
+import { notifyNewImMessage } from './message-notifier.js';
 import { broadcastNewMessage } from './web.js';
 import { detectImageMimeType } from './image-detector.js';
 import {
@@ -1110,6 +1111,7 @@ export function createFeishuConnection(
       },
       targetAgentId ?? undefined,
     );
+    notifyNewImMessage();
 
     if (agentRouting && agentRouting.agentId) {
       onAgentMessage?.(chatJid, agentRouting.agentId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   POLL_INTERVAL,
   TIMEZONE,
 } from './config.js';
+import { interruptibleSleep } from './message-notifier.js';
 import {
   AvailableGroup,
   ContainerInput,
@@ -4758,7 +4759,7 @@ async function startMessageLoop(): Promise<void> {
       recoverStuckPendingGroups();
     }
 
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+    await interruptibleSleep(POLL_INTERVAL);
   }
 }
 

--- a/src/message-notifier.ts
+++ b/src/message-notifier.ts
@@ -1,0 +1,40 @@
+/**
+ * Lightweight notification mechanism for IM messages.
+ *
+ * The message polling loop in index.ts sleeps for POLL_INTERVAL (2s) between
+ * iterations.  When a Feishu / Telegram / QQ handler stores a new message it
+ * calls `notifyNewImMessage()` which wakes the loop immediately so the message
+ * is picked up without waiting for the remaining sleep time.
+ *
+ * Web messages are NOT routed through this notifier — they already bypass the
+ * polling loop via direct IPC injection + `enqueueMessageCheck()`.
+ */
+
+let wakeup: (() => void) | null = null;
+
+/**
+ * Returns a Promise that resolves after `ms` milliseconds **or** as soon as
+ * `notifyNewImMessage()` is called — whichever comes first.
+ */
+export function interruptibleSleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      wakeup = null;
+      resolve();
+    }, ms);
+
+    wakeup = () => {
+      clearTimeout(timer);
+      wakeup = null;
+      resolve();
+    };
+  });
+}
+
+/**
+ * Wake the message loop immediately.  Safe to call at any time — if the loop
+ * is not sleeping this is a no-op.
+ */
+export function notifyNewImMessage(): void {
+  wakeup?.();
+}

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -14,6 +14,7 @@ import http from 'node:http';
 import https from 'node:https';
 import WebSocket from 'ws';
 import { storeChatMetadata, storeMessageDirect, updateChatName } from './db.js';
+import { notifyNewImMessage } from './message-notifier.js';
 import { broadcastNewMessage } from './web.js';
 import { logger } from './logger.js';
 import { saveDownloadedFile, MAX_FILE_SIZE } from './im-downloader.js';
@@ -833,6 +834,7 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         },
         agentRouting?.agentId ?? undefined,
       );
+      notifyNewImMessage();
 
       if (agentRouting?.agentId) {
         opts.onAgentMessage?.(jid, agentRouting.agentId);
@@ -1025,6 +1027,7 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         },
         agentRouting?.agentId ?? undefined,
       );
+      notifyNewImMessage();
 
       if (agentRouting?.agentId) {
         opts.onAgentMessage?.(jid, agentRouting.agentId);

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -5,6 +5,7 @@ import https from 'node:https';
 import { Agent as HttpsAgent } from 'node:https';
 import { ProxyAgent } from 'proxy-agent';
 import { storeChatMetadata, storeMessageDirect, updateChatName } from './db.js';
+import { notifyNewImMessage } from './message-notifier.js';
 import { broadcastNewMessage } from './web.js';
 import { logger } from './logger.js';
 import {
@@ -549,6 +550,7 @@ export function createTelegramConnection(
             },
             agentRouting?.agentId ?? undefined,
           );
+          notifyNewImMessage();
 
           // 触发 agent 处理
           if (agentRouting?.agentId) {
@@ -701,6 +703,7 @@ export function createTelegramConnection(
             },
             agentRouting?.agentId ?? undefined,
           );
+          notifyNewImMessage();
 
           if (agentRouting?.agentId) {
             opts.onAgentMessage?.(jid, agentRouting.agentId);
@@ -783,6 +786,7 @@ export function createTelegramConnection(
               },
               earlyRouting?.agentId ?? undefined,
             );
+            notifyNewImMessage();
             return;
           }
 
@@ -845,6 +849,7 @@ export function createTelegramConnection(
             },
             agentRouting?.agentId ?? undefined,
           );
+          notifyNewImMessage();
 
           if (agentRouting?.agentId) {
             opts.onAgentMessage?.(jid, agentRouting.agentId);


### PR DESCRIPTION
## 问题描述

飞书/Telegram/QQ 收到消息后，消息被写入数据库（`storeMessageDirect()`），但主消息轮询循环（`startMessageLoop()`）使用固定 `setTimeout(POLL_INTERVAL)` 休眠 2 秒，导致 IM 消息需要等待最多 2 秒才被发现和处理。

相比之下，Web 端消息已经有直接 IPC 注入 + `enqueueMessageCheck()` 的路径，不受此轮询延迟影响。

这个 2 秒延迟是用户感知到 IM 渠道响应比 Web 慢的主要原因之一。

## 实现方案

### 核心思路

将固定 2 秒休眠改为**可唤醒休眠**：IM 消息写入数据库后立即唤醒轮询循环，而非等待定时器到期。

### `src/message-notifier.ts`（新增）
- `interruptibleSleep(ms)`: 返回一个 Promise，在 `ms` 毫秒后 resolve **或** 被 `notifyNewImMessage()` 提前唤醒
- `notifyNewImMessage()`: 唤醒正在休眠的轮询循环，空闲时调用为 no-op
- 设计极简，无 EventEmitter，仅一个闭包回调

### `src/index.ts`
- `startMessageLoop()` 中将 `await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL))` 替换为 `await interruptibleSleep(POLL_INTERVAL)`
- 无 IM 消息时行为不变（仍按 2 秒轮询）
- 有 IM 消息时立即唤醒，延迟从平均 1 秒降至接近零

### `src/feishu.ts`、`src/telegram.ts`、`src/qq.ts`
- 在每个 `storeMessageDirect()` + `broadcastNewMessage()` 之后调用 `notifyNewImMessage()`
- 飞书 1 处、Telegram 4 处（文本/图片/文件过大/文档）、QQ 2 处（C2C/群聊）

### 安全性

- **Web 消息不经过此通知器**：Web 消息已有直接 IPC 注入路径，若也唤醒轮询可能导致 `globalMessageCursor` 未推进前重复处理
- **多次快速唤醒安全**：`notifyNewImMessage()` 仅清除当前定时器并 resolve 一次，后续调用为 no-op
- **POLL_INTERVAL 常量保留**：作为最大轮询间隔的上限不变，确保即使通知机制失效也不会永久阻塞