### PR TITLE
修复: IM 会话绑定在重启后丢失的问题 (#237)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4968,6 +4968,20 @@ function buildOnNewChat(
       // Don't override groups with explicit IM routing configured.
       if (existing.target_agent_id || existing.target_main_jid) return;
 
+      // Backfill missing created_by without changing folder binding.
+      // Legacy IM groups may have NULL created_by after migration;
+      // we should claim ownership but preserve the user's chosen folder.
+      if (!existing.created_by) {
+        existing.created_by = userId;
+        setRegisteredGroup(chatJid, existing);
+        registeredGroups[chatJid] = existing;
+        logger.info(
+          { chatJid, chatName, userId, folder: existing.folder },
+          'Backfilled created_by for IM chat (preserved existing folder)',
+        );
+        return;
+      }
+
       // Different user's connection now owns this IM app.
       // Re-route the chat to the current user's home folder.
       // This handles the common case where the same Feishu app credentials


### PR DESCRIPTION
## 问题描述

关闭 #237。

飞书/Telegram 绑定的会话在每次重启后丢失绑定关系，自动回到 home main。

## 根因

`buildOnNewChat()` 中，当 `registered_groups.created_by` 为 NULL 时，`null === userId` 始终为 false，导致代码进入「IM 凭据迁移」分支，将自定义工作区的 folder 错误覆写为用户的 homeFolder。

Feishu 和 Telegram 的 `onNewChat()` 在每条消息到达时都会被调用，因此重启后收到第一条消息就会触发覆写。

## 修复方案

### `src/index.ts`

- 在 `buildOnNewChat()` 中增加 `created_by` 为空的前置判断
- 当 `created_by` 为 NULL 时，仅补填 `created_by` 为当前用户，**保留现有的 folder 绑定**
- 不再错误地进入凭据迁移逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)