### PR TITLE
修复: /bind 后 /list 未显示当前位置导致绑定状态误判

### DIFF
--- a/src/im-command-utils.ts
+++ b/src/im-command-utils.ts
@@ -63,6 +63,7 @@ export function formatWorkspaceList(
   workspaces: WorkspaceInfo[],
   currentFolder: string,
   currentAgentId: string | null,
+  currentOnMain = true,
 ): string {
   if (workspaces.length === 0) return '没有可用的工作区';
 
@@ -73,7 +74,7 @@ export function formatWorkspaceList(
     const marker = isCurrent ? ' ▶' : '';
     lines.push(`${marker} ${ws.name} (${ws.folder})`);
 
-    const mainMarker = isCurrent && !currentAgentId ? ' ← 当前' : '';
+    const mainMarker = isCurrent && currentOnMain ? ' ← 当前' : '';
     lines.push(`  · 主对话${mainMarker}`);
 
     for (const agent of ws.agents) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -881,9 +881,25 @@ function handleListCommand(chatJid: string): string {
   const workspaces = collectWorkspaces(userId);
   if (workspaces.length === 0) return '没有可用的工作区';
 
+  const lookupGroup = (jid: string) =>
+    registeredGroups[jid] ?? getRegisteredGroup(jid);
+  const location = resolveLocationInfo(
+    group,
+    lookupGroup,
+    getAgent,
+    findGroupNameByFolder,
+  );
+
+  const currentAgentId = group.target_agent_id ?? null;
+  const currentOnMain = !currentAgentId;
+
   return (
-    formatWorkspaceList(workspaces, group.folder, null) +
-    '\n💡 使用 /bind <workspace> 或 /bind <workspace>/<agent短ID>'
+    formatWorkspaceList(
+      workspaces,
+      location.folder,
+      currentAgentId,
+      currentOnMain,
+    ) + '\n💡 使用 /bind <workspace> 或 /bind <workspace>/<agent短ID>'
   );
 }
 


### PR DESCRIPTION
## 问题描述

用户在飞书群组执行 `/bind` 后，系统实际上已经把该群组绑定到了目标工作区或目标会话，绑定写入本身是成功的，后续消息路由也已经能够感知这层绑定关系。

真正的问题出在 `/list` 的“当前位置”展示：它没有按绑定后的真实位置来计算，而是仍然按当前 IM 群组自身默认映射的工作区/主对话来标记当前位置。

这会造成一个非常强的误导：

- 用户刚执行完 `/bind`，提示成功
- 但重新执行 `/list` 时，看到“当前”仍然落在默认工作区主对话
- 于是误以为绑定没有生效
- 进一步会误判为“所有飞书群组都还在默认工作区主对话里”

所以这个问题的本质不是绑定失败，也不是消息路由本身失效，而是 `/list` 的当前位置展示没有消费绑定信息，导致用户对系统当前状态产生错误判断。

## 修复方案 / 实现方案

### `src/index.ts`
- 调整 `/list` 的当前位置解析逻辑
- 不再直接按当前 IM 群组自身的 `folder` 推断当前位置
- 改为复用已有的 `resolveLocationInfo()`，先解析该群组在绑定后的真实落点，再把这个真实位置用于 `/list` 渲染
- 同时把“当前是否在主对话”以及“当前 agent 是谁”一并传入工作区列表格式化逻辑，避免当前位置判断只做了一半

### `src/im-command-utils.ts`
- 扩展 `formatWorkspaceList()` 的入参，新增对 `currentOnMain` 的显式支持
- 让工作区主对话的“当前”标记基于绑定后的真实位置判断，而不是基于旧的默认上下文判断
- 保证以下几种场景的展示一致：
  - 绑定到某个工作区主对话
  - 绑定到某个工作区下的 agent 会话
  - 未绑定、仍停留在默认主对话

## 修复后的效果

修复后，`/list` 会按绑定后的真实位置展示“当前位置”：

- 如果当前飞书群组绑定到了某个工作区主对话，就在那个主对话上标记“当前”
- 如果绑定到了某个 agent，会在对应 agent 上标记“当前”
- 不会再出现绑定已经成功，但 `/list` 仍把默认主对话错误标成“当前”的情况

这样用户在执行 `/bind` 之后，通过 `/list` 看到的状态就会和真实绑定状态、真实消息路由状态保持一致。

## Test plan
- [x] `make typecheck`
- [x] 手工检查 `/list` 改为基于 `resolveLocationInfo()` 的结果判断当前位置
- [x] 手工检查主对话与 agent 会话的“当前”标记逻辑在绑定后保持一致
- [x] 手工确认该 PR 不再错误关联无关 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
