### PR TITLE
修复: 批量修复 3 个 bug — process.exit 卡死 + 子代理消息丢弃 + 流式输出丢失 (#236 #240 #241)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1363,6 +1363,21 @@ async function runQuery(
   }
 }
 
+/**
+ * process.exit() with SIGKILL safety net.
+ * When SDK has pending async resources (background Task tools, MCP connections),
+ * process.exit() may hang indefinitely. Force SIGKILL after 5 seconds.
+ * See GitHub issue #236.
+ */
+function forceExitWithSafetyNet(code: number): never {
+  log(`Exiting with code ${code}, SIGKILL safety net in 5s`);
+  setTimeout(() => {
+    console.error('[agent-runner] process.exit() did not terminate, forcing SIGKILL');
+    process.kill(process.pid, 'SIGKILL');
+  }, 5000).unref();
+  process.exit(code);
+}
+
 async function main(): Promise<void> {
   let containerInput: ContainerInput;
 
@@ -1632,15 +1647,18 @@ async function main(): Promise<void> {
       result: null,
       error: errorMessage
     });
-    process.exit(1);
+    forceExitWithSafetyNet(1);
   }
 
   // main() 正常结束后必须显式退出。
   // SDK 内部可能留有未关闭的异步资源（MCP 连接、定时器等），
   // 如果不调用 process.exit()，Node.js 事件循环不会自动退出，
   // 导致 agent-runner 进程以 0% CPU 挂起，阻塞队列。
-  log('main() completed, forcing process exit');
-  process.exit(0);
+  //
+  // Safety net: 当 SDK 的后台 Task (run_in_background) 持有异步资源时，
+  // process.exit() 可能无法终止进程。5 秒后强制 SIGKILL。
+  // 参考 GitHub issue #236。
+  forceExitWithSafetyNet(0);
 }
 
 // 处理管道断开（EPIPE）：父进程关闭管道后仍有写入时，静默退出避免 code 1 错误输出
@@ -1658,12 +1676,12 @@ async function main(): Promise<void> {
  */
 process.on('SIGTERM', () => {
   log('Received SIGTERM, exiting gracefully');
-  process.exit(0);
+  forceExitWithSafetyNet(0);
 });
 
 process.on('SIGINT', () => {
   log('Received SIGINT, exiting gracefully');
-  process.exit(0);
+  forceExitWithSafetyNet(0);
 });
 
 process.on('uncaughtException', (err: unknown) => {

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -65,6 +65,9 @@ export class GroupQueue {
   private userConcurrentLimitFn:
     | ((groupJid: string) => { allowed: boolean })
     | null = null;
+  private onUnconsumedAgentIpcFn:
+    | ((groupJid: string, agentId: string) => void)
+    | null = null;
 
   private getGroup(groupJid: string): GroupState {
     let state = this.groups.get(groupJid);
@@ -122,6 +125,17 @@ export class GroupQueue {
     fn: (groupJid: string) => { allowed: boolean },
   ): void {
     this.userConcurrentLimitFn = fn;
+  }
+
+  /**
+   * Called when an agent runner exits with unconsumed IPC message files.
+   * The callback should re-enqueue processAgentConversation for the agent.
+   * See GitHub issue #240.
+   */
+  setOnUnconsumedAgentIpc(
+    fn: (groupJid: string, agentId: string) => void,
+  ): void {
+    this.onUnconsumedAgentIpcFn = fn;
   }
 
   /**
@@ -519,6 +533,30 @@ export class GroupQueue {
   }
 
   /**
+   * Check if there are unconsumed IPC message files (.json) in the input directory.
+   * Called after process exit to detect messages written via sendMessage() that were
+   * never consumed due to a race condition (process exiting before reading IPC).
+   * See GitHub issue #240.
+   */
+  private hasRemainingIpcMessages(
+    groupFolder: string,
+    agentId?: string | null,
+    taskRunId?: string | null,
+  ): boolean {
+    const inputDir = taskRunId
+      ? path.join(DATA_DIR, 'ipc', groupFolder, 'tasks-run', taskRunId, 'input')
+      : agentId
+        ? path.join(DATA_DIR, 'ipc', groupFolder, 'agents', agentId, 'input')
+        : path.join(DATA_DIR, 'ipc', groupFolder, 'input');
+    try {
+      const files = fs.readdirSync(inputDir);
+      return files.some(f => f.endsWith('.json'));
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Signal the active container to finish the current query and then exit.
    * Unlike _close which exits immediately from waitForIpcMessage, _drain
    * is only checked after the current query completes, ensuring one-question-
@@ -872,6 +910,28 @@ export class GroupQueue {
         } catch (err) {
           logger.warn({ groupJid, err }, 'Failed to clean up IPC sentinels');
         }
+        // Check for unconsumed IPC message files (race condition: message written
+        // via sendMessage() but process exited before reading it). See issue #240.
+        try {
+          if (this.hasRemainingIpcMessages(state.groupFolder, state.agentId, state.taskRunId)) {
+            if (state.agentId && this.onUnconsumedAgentIpcFn) {
+              logger.warn(
+                { groupJid, agentId: state.agentId },
+                'Unconsumed IPC messages found after agent exit, re-enqueuing',
+              );
+              this.onUnconsumedAgentIpcFn(groupJid, state.agentId);
+            } else if (!state.taskRunId) {
+              // Main conversation: mark pending so drainGroup restarts processing
+              state.pendingMessages = true;
+              logger.warn(
+                { groupJid },
+                'Unconsumed IPC messages found after process exit, marking pending',
+              );
+            }
+          }
+        } catch (err) {
+          logger.warn({ groupJid, err }, 'Failed to check remaining IPC messages');
+        }
       }
       state.active = false;
       state.drainSentinelWritten = false;
@@ -949,6 +1009,27 @@ export class GroupQueue {
           this.cleanupIpcSentinels(state.groupFolder, state.agentId, state.taskRunId);
         } catch (err) {
           logger.warn({ groupJid, err }, 'Failed to clean up IPC sentinels');
+        }
+        // Check for unconsumed IPC message files (race: sendMessage 'sent' but
+        // process exited before consuming). See issue #240.
+        try {
+          if (this.hasRemainingIpcMessages(state.groupFolder, state.agentId, state.taskRunId)) {
+            if (state.agentId && this.onUnconsumedAgentIpcFn) {
+              logger.warn(
+                { groupJid, agentId: state.agentId },
+                'Unconsumed IPC messages found after agent task exit, re-enqueuing',
+              );
+              this.onUnconsumedAgentIpcFn(groupJid, state.agentId);
+            } else if (!state.taskRunId) {
+              state.pendingMessages = true;
+              logger.warn(
+                { groupJid },
+                'Unconsumed IPC messages found after task exit, marking pending',
+              );
+            }
+          }
+        } catch (err) {
+          logger.warn({ groupJid, err }, 'Failed to check remaining IPC messages');
         }
       }
       state.active = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6052,6 +6052,21 @@ async function main(): Promise<void> {
     }
     return { allowed: userActive < limit };
   });
+  // Recovery: when agent process exits with unconsumed IPC messages,
+  // re-enqueue processAgentConversation to pick them up. See issue #240.
+  queue.setOnUnconsumedAgentIpc((groupJid: string, agentId: string) => {
+    // Extract base chat JID from virtual JID (e.g. web:main#agent:abc → web:main)
+    const baseChatJid = groupJid.includes('#agent:')
+      ? groupJid.split('#agent:')[0]
+      : groupJid;
+    const agent = getAgent(agentId);
+    const homeChatJid = agent?.chat_jid || baseChatJid;
+    const virtualChatJid = `${homeChatJid}#agent:${agentId}`;
+    const taskId = `agent-ipc-recovery:${agentId}:${Date.now()}`;
+    queue.enqueueTask(virtualChatJid, taskId, async () => {
+      await processAgentConversation(homeChatJid, agentId);
+    });
+  });
   const schedulerDeps: import('./task-scheduler.js').SchedulerDependencies = {
     registeredGroups: () => registeredGroups,
     getSessions: () => sessions,

--- a/src/web.ts
+++ b/src/web.ts
@@ -579,8 +579,10 @@ function setupWebSocket(server: any): WebSocketServer {
     if (connSession && streamingSnapshots.size > 0) {
       const userId = connSession.user_id;
       for (const [jid, snap] of streamingSnapshots) {
-        // Skip stale snapshots (> 5 min)
-        if (Date.now() - snap.updatedAt > 5 * 60 * 1000) {
+        // Skip stale snapshots (> 30 min)
+        // Extended from 5 min to 30 min to support long-running sub-agents.
+        // See GitHub issue #241.
+        if (Date.now() - snap.updatedAt > 30 * 60 * 1000) {
           streamingSnapshots.delete(jid);
           continue;
         }
@@ -1447,8 +1449,6 @@ export function clearStreamingSnapshot(chatJid: string): void {
 export function getActiveStreamingTexts(): Map<string, string> {
   const result = new Map<string, string>();
   for (const [jid, fullText] of streamingFullTexts) {
-    // Skip agent virtual JIDs (e.g. web:main#agent:abc) — only persist main streams
-    if (jid.includes('#agent:')) continue;
     const text = fullText.trim();
     if (text) {
       result.set(jid, text);


### PR DESCRIPTION
## 问题描述

关闭 #236、关闭 #240、关闭 #241（部分修复）。

批量修复 3 个影响子代理稳定性的 bug。

## 修复方案

### #236: agent-runner process.exit() 无法终止进程

**根因**：SDK 后台 Task (run_in_background) 持有异步资源，`process.exit()` 被阻塞。

**修复**：新增 `forceExitWithSafetyNet()` 函数，在 `process.exit()` 前设置 5 秒 SIGKILL 超时：

### `container/agent-runner/src/index.ts`
- 新增 `forceExitWithSafetyNet(code)` — setTimeout + SIGKILL 安全网
- 替换所有 `process.exit()` 调用（正常退出、错误退出、SIGTERM/SIGINT 处理）

---

### #240: Web 端发送给子代理的消息被静默丢弃

**根因**：`sendMessage()` 返回 `'sent'` 写入 IPC 文件，但进程已退出（close 事件未触发），IPC 文件无人消费。

**修复**：在进程退出的 finally 块中检测残留 IPC 消息，自动重新入队处理：

### `src/group-queue.ts`
- 新增 `hasRemainingIpcMessages()` — 检测 IPC 目录中未消费的 `.json` 文件
- 新增 `onUnconsumedAgentIpcFn` 回调 — agent 场景的恢复入口
- `runForGroup` / `runTask` 的 finally 块增加残留 IPC 检测

### `src/index.ts`
- 注册 `setOnUnconsumedAgentIpc` 回调，通过 `enqueueTask` + `processAgentConversation` 恢复

---

### #241: 子代理流式输出丢失（部分修复）

**根因**：3 层防线（磁盘缓冲、内存快照、WS 重放）对子代理均有漏洞。本次修复前 2 层。

### `src/web.ts`
- 移除 `getActiveStreamingTexts()` 中对 `#agent:` JID 的跳过 — 子代理流式文本也写入磁盘缓冲
- 将流式快照过期时间从 5 分钟延长到 30 分钟 — 适配长时间运行的子代理

## Test plan

- [ ] 验证 agent-runner 在后台 Task 场景下 5 秒内强制退出（`ps` 观察进程不再挂起）
- [ ] 验证 Web 端发送子代理消息后进程退出，消息通过 IPC 恢复机制重新处理
- [ ] 验证 WS 断连后重连，子代理流式快照在 30 分钟内可恢复
- [ ] 验证 `data/streaming-buffer/` 目录包含子代理 JID 的缓冲文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)