### PR TITLE
修复: 飞书流式卡片冲突 + #240 补充防御 + RegisteredGroup 类型补全

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4110,11 +4110,14 @@ async function processAgentConversation(
   // Unlike processGroupMessages which falls back to chatJid, conversation agents
   // only stream when the message originates from an IM channel (replySourceImJid).
   // Web-only interactions don't need a Feishu streaming card.
-  const streamingSessionJid = replySourceImJid;
-  let agentStreamingSession = streamingSessionJid
+  // Use agent-scoped key to avoid colliding with the main session's streaming card (#242).
+  const streamingSessionJid = replySourceImJid
+    ? `${replySourceImJid}#agent:${agentId}`
+    : undefined;
+  let agentStreamingSession = replySourceImJid
     ? imManager.createStreamingSession(
-        streamingSessionJid,
-        (messageId) => registerMessageIdMapping(messageId, streamingSessionJid),
+        replySourceImJid,
+        (messageId) => registerMessageIdMapping(messageId, streamingSessionJid!),
       )
     : undefined;
   let agentStreamingAccText = '';
@@ -4344,8 +4347,8 @@ async function processAgentConversation(
           agentStreamingAccText = '';
           unregisterStreamingSession(streamingSessionJid);
           agentStreamingSession = imManager.createStreamingSession(
-            streamingSessionJid,
-            (messageId) => registerMessageIdMapping(messageId, streamingSessionJid),
+            replySourceImJid!,
+            (messageId) => registerMessageIdMapping(messageId, streamingSessionJid!),
           );
           if (agentStreamingSession) {
             registerStreamingSession(streamingSessionJid, agentStreamingSession);

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,8 @@ export interface RegisteredGroup {
   reply_policy?: 'source_only' | 'mirror'; // IM 绑定的回复策略
   require_mention?: boolean; // 群聊是否需要 @机器人 才响应（默认 false）
   activation_mode?: 'auto' | 'always' | 'when_mentioned' | 'disabled'; // 消息门控模式（默认 'auto'，兼容 require_mention）
+  mcp_mode?: 'inherit' | 'custom'; // MCP 配置模式（默认 'inherit' 继承用户配置）
+  selected_mcps?: string[] | null; // custom 模式下选中的 MCP server IDs
 }
 
 export interface GroupMember {

--- a/src/web.ts
+++ b/src/web.ts
@@ -460,7 +460,9 @@ async function handleAgentConversationMessage(
     agentImages,
   );
   if (agentSendResult === 'no_active') {
-    // No running process — start one via processAgentConversation
+    // No running process — force close any stale state and start fresh.
+    // Mirrors the reliable IM path in buildOnAgentMessage() (#240).
+    deps.queue.closeStdin(virtualChatJid);
     if (deps.processAgentConversation) {
       const taskId = `agent-conv:${agentId}:${Date.now()}`;
       deps.queue.enqueueTask(virtualChatJid, taskId, async () => {


### PR DESCRIPTION
## 问题描述

修复 3 个问题：

1. **飞书流式卡片冲突**：子代理完成时会 abort 主会话正在使用的流式卡片，导致主会话的飞书回复被覆盖/丢失
2. **#240 补充防御**：`handleAgentConversationMessage` 的 `'no_active'` 分支缺少 stale state 清理
3. **类型编译错误**：`73fc3e3` 新增 MCP 配置路由但漏了 `RegisteredGroup` 类型定义

## 修复方案

### `src/index.ts` — 飞书流式卡片冲突
- 子代理的 streaming session key 从 `replySourceImJid` 改为 `${replySourceImJid}#agent:${agentId}`
- `activeSessions` 的 key 区分了主会话和子代理，避免互相 abort
- `createStreamingSession` 仍传真实飞书 chatId，确保消息发到正确的群

### `src/web.ts` — #240 补充防御
- 在 `'no_active'` 分支加 `deps.queue.closeStdin(virtualChatJid)`
- 与 #250 的 finally 块检测互补：#250 在进程退出后检测残留 IPC，本改动在发送端主动清理 stale state

### `src/types.ts` — RegisteredGroup 类型补全
- 补全 `mcp_mode` 和 `selected_mcps` 字段，修复 `src/routes/groups.ts` 编译错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)