### PR TITLE
fix: 流式事件分支中重置 idle timer，防止长时间 MCP 工具调用期间进程被误杀 (#251)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2133,6 +2133,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             }
           }
 
+          // Reset idle timer on stream events so long-running tool calls
+          // (e.g. MCP batch writes) don't get killed while the agent is
+          // actively working. Previously only final results triggered a reset.
+          resetIdleTimer();
           return;
         }
 
@@ -4262,6 +4266,10 @@ async function processAgentConversation(
           );
         }
       }
+
+      // Reset idle timer on stream events so long-running tool calls
+      // don't get killed while the agent is actively working.
+      resetIdleTimer();
       return;
     }
 


### PR DESCRIPTION
## 问题

修复 #251

`processGroupMessages()` 和 `processAgentConversation()` 的 `onOutput` 回调中，stream 事件分支在 `return` 前从未调用 `resetIdleTimer()`。当 Agent 在执行耗时工具调用（如 MCP batch 写入飞书文档）时，即便持续有 `text_delta`、`tool_use_start/end` 等流式事件输出，idle timer 也不会被重置，最终超过 `idleTimeout`（默认 30 分钟）后进程被 `closeStdin()` 杀掉。

## 根因

```typescript
// stream 分支仅处理事件并 return，跳过了后面的 resetIdleTimer()
if (result.status === 'stream' && result.streamEvent) {
  broadcastStreamEvent(chatJid, result.streamEvent);
  // ... 各种 stream event 处理 ...
  return;  // ← 跳过 resetIdleTimer()
}

// 只有这里才重置 idle timer
if (result.result) {
  // ...
  resetIdleTimer();
}
```

## 修复

在两处 stream 分支的 `return` 前加入 `resetIdleTimer()` 调用：

1. `processGroupMessages()` 的 `onOutput` 回调
2. `processAgentConversation()` 的 `wrappedOnOutput` 回调

流式事件本身就说明 Agent 在活跃工作，应当重置空闲计时器。

## 变更文件

- `src/index.ts`：两处 stream 事件分支各增加一行 `resetIdleTimer()` 调用

## 测试

- TypeScript 编译通过（`tsc --noEmit` 无报错）
- 修复前：执行耗时 MCP 工具（如 `batch_create_feishu_blocks`）超过 idleTimeout 后进程被杀
- 修复后：每次流式事件都会重置 idle timer，Agent 可正常完成长时间任务