### PR TITLE
修复: IM 健康检查误解绑 Telegram/QQ 绑定 (#259)

### DIFF
--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -580,6 +580,11 @@ class IMConnectionManager {
   /**
    * Get chat info for an IM group by JID, auto-routing to the correct connection.
    * Used for health checks to detect disbanded groups.
+   *
+   * Returns:
+   * - object: chat info (reachable)
+   * - null: channel supports getChatInfo but chat is not reachable
+   * - undefined: channel does not support getChatInfo (e.g. Telegram, QQ)
    */
   async getChatInfo(jid: string): Promise<{
     avatar?: string;
@@ -587,7 +592,7 @@ class IMConnectionManager {
     user_count?: string;
     chat_type?: string;
     chat_mode?: string;
-  } | null> {
+  } | null | undefined> {
     const channelType = getChannelType(jid);
     if (!channelType) return null;
 
@@ -596,7 +601,8 @@ class IMConnectionManager {
     if (channel?.getChatInfo) {
       return channel.getChatInfo(chatId);
     }
-    return null;
+    // Channel doesn't implement getChatInfo — not a reachability failure
+    return undefined;
   }
 
   /** Get all user IDs with active connections */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6288,6 +6288,10 @@ async function checkImBindingsHealth(): Promise<void> {
 
     try {
       const info = await imManager.getChatInfo(jid);
+      if (info === undefined) {
+        // Channel doesn't support getChatInfo (e.g. Telegram, QQ) — skip reachability check
+        continue;
+      }
       if (info === null) {
         // Chat not reachable — could be temporary (connection down, API permission issue)
         const count = (imHealthCheckFailCounts.get(jid) ?? 0) + 1;


### PR DESCRIPTION
## 问题描述

关闭 #259。

`checkImBindingsHealth()` 调用 `imManager.getChatInfo(jid)` 检测 IM 群组是否可达。但 Telegram 和 QQ 适配器未实现 `getChatInfo` 方法，导致返回值与"群组不可达"相同（均为 `null`）。经过 3 次健康检查周期后，用户通过 `/bind` 设置的绑定被静默清除。

## 修复方案

区分"渠道不支持 getChatInfo"和"群组不可达"两种情况：

### `src/im-manager.ts`
- `getChatInfo()` 在渠道未实现该方法时返回 `undefined`（而非 `null`）
- `null` 保留为"渠道支持查询但群组不可达"的语义

### `src/index.ts`
- `checkImBindingsHealth()` 遇到 `undefined` 时跳过该 JID 的可达性检查
- 仅对返回 `null` 的情况（飞书等支持查询的渠道）计数并在阈值后解绑


🤖 Generated with [Claude Code](https://claude.com/claude-code)