### PR TITLE
修复: 启用 1M 上下文窗口，解决所有工作区实际仅 200K 的问题

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1067,6 +1067,7 @@ async function runQuery(
     prompt: stream,
     options: {
       model: CLAUDE_MODEL,
+      betas: ['context-1m-2025-08-07'],
       cwd: WORKSPACE_GROUP,
       additionalDirectories: extraDirs,
       resume: sessionId,


### PR DESCRIPTION
## 问题描述

`agent-runner` 中 `query()` 调用未传入 `betas` 参数。SDK 内部的上下文窗口选择逻辑
（`sM()` 函数）在没有匹配到 beta flag 时 fallback 到默认 200K，导致所有工作区的
Agent 实际可用上下文远低于模型能力上限。

长对话或复杂任务中，Agent 会过早触发上下文压缩（compact），丢失前序对话信息，
影响连续推理和任务跟踪能力。

## 修复方案

### `container/agent-runner/src/index.ts`
- 在 `runQuery()` 中 `query()` 的 `options` 对象中添加 `betas: ['context-1m-2025-08-07']`
- SDK 的 `sM()` 匹配到该 beta flag 后返回 1M 上下文窗口

改动 1 行，无 breaking change。