### PR TITLE
修复: side-query 吞噬用户 IPC 消息导致 queryInFlight 死锁

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -901,6 +901,14 @@ async function runQuery(
       ipcPolling = false;
       return;
     }
+    // Side-queries (emitOutput=false, e.g. memory flush / CLAUDE.md update) must NOT
+    // consume user IPC messages — those belong to the main query loop. Only sentinels
+    // are checked above. Without this guard, a user message arriving during a side-query
+    // gets silently consumed, leaving queryInFlight=true on the host forever (bug #259).
+    if (!emitOutput) {
+      setTimeout(pollIpcDuringQuery, IPC_POLL_MS);
+      return;
+    }
     const { messages, modeChange } = drainIpcInput();
     if (modeChange) {
       currentPermissionMode = modeChange as PermissionMode;


### PR DESCRIPTION
## 问题描述

`agent-runner` 中的 `pollIpcDuringQuery()` 在查询进行中持续轮询 IPC 输入目录。
该函数不区分当前 query 是主查询还是 side-query（`emitOutput=false`，
如记忆刷新、CLAUDE.md 自动更新等内部操作）。

当 side-query 运行期间恰好有用户消息通过 IPC 注入到 `input/` 目录时，
`drainIpcInput()` 会读取并消费该消息文件（读后删除），然后 `stream.push()`
注入到 side-query 的消息流中。side-query 完成后，消息已被消费且无输出，
主进程的 `queryInFlight` 标记永远等不到回复，该群组的消息处理永久阻塞。

## 复现路径

1. Agent 正在执行 side-query（如 `emitOutput=false` 的内部 query）
2. 用户发送新消息 → 主进程写入 `ipc/{folder}/input/*.json`
3. side-query 的 `pollIpcDuringQuery()` 调用 `drainIpcInput()` 消费该文件
4. 消息被注入 side-query 流，side-query 完成后该消息丢失
5. 主进程 `queryInFlight=true` 永远不会被清除 → 该群组死锁

## 修复方案

### `container/agent-runner/src/index.ts`
- 在 `pollIpcDuringQuery()` 中，sentinel 检查（`_close` 文件）之后、
  `drainIpcInput()` 之前，增加 `emitOutput` 守卫
- 当 `!emitOutput`（side-query 模式）时，仅检查 sentinel 后 `setTimeout` 继续轮询，
  跳过 `drainIpcInput()`
- 用户 IPC 消息留在 `input/` 目录中，由主 query 循环在下一轮正常消费