### PR TITLE
修复: 重启恢复机制增强 — lastCommittedCursor + session ghost 防护

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,12 @@ let globalMessageCursor: MessageCursor = { timestamp: '', id: '' };
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, MessageCursor> = {};
+// Tracks the last message that was ACTUALLY PROCESSED by an agent (commitCursor).
+// Used by recoverPendingMessages() to detect IPC-injected but unprocessed messages.
+// lastAgentTimestamp may advance ahead of this when IPC injection succeeds but the
+// agent hasn't finished processing yet — if the service crashes in between, recovery
+// uses this cursor to find the gap.
+let lastCommittedCursor: Record<string, MessageCursor> = {};
 let messageLoopRunning = false;
 let ipcWatcherRunning = false;
 let shuttingDown = false;
@@ -283,6 +289,11 @@ const activeImReplyRoutes = new Map<string, string | null>();
 // Track consecutive IM send failures per JID for auto-unbind
 const imSendFailCounts = new Map<string, number>();
 const IM_SEND_FAIL_THRESHOLD = 3;
+
+// Groups whose pending messages were recovered after a restart.
+// processGroupMessages injects recent conversation history for these groups
+// so the fresh session has context despite the session being cleared.
+const recoveryGroups = new Set<string>();
 
 // Track consecutive IM health check failures per JID for safe auto-unbind
 const imHealthCheckFailCounts = new Map<string, number>();
@@ -755,6 +766,7 @@ async function handleClearCommand(chatJid: string): Promise<string> {
         broadcast: broadcastNewMessage,
         setLastAgentTimestamp: (jid: string, cursor: MessageCursor) => {
           lastAgentTimestamp[jid] = cursor;
+          lastCommittedCursor[jid] = cursor;
           saveState();
         },
       },
@@ -1379,6 +1391,35 @@ function loadState(): void {
     logger.warn('Corrupted last_agent_timestamp in DB, resetting');
     lastAgentTimestamp = {};
   }
+
+  // Load committed cursor (recovery-safe cursor that only advances on commitCursor)
+  const committedTs = getRouterState('last_committed_cursor');
+  try {
+    const parsed = committedTs
+      ? (JSON.parse(committedTs) as Record<string, unknown>)
+      : {};
+    const normalized: Record<string, MessageCursor> = {};
+    for (const [jid, raw] of Object.entries(parsed)) {
+      normalized[jid] = normalizeCursor(raw);
+    }
+    lastCommittedCursor = normalized;
+  } catch {
+    logger.warn('Corrupted last_committed_cursor in DB, resetting');
+    lastCommittedCursor = {};
+  }
+
+  // Migration: if lastCommittedCursor is empty but lastAgentTimestamp has data,
+  // seed lastCommittedCursor from lastAgentTimestamp to avoid re-processing all
+  // historical messages on the first run after this change.
+  if (
+    Object.keys(lastCommittedCursor).length === 0 &&
+    Object.keys(lastAgentTimestamp).length > 0
+  ) {
+    lastCommittedCursor = { ...lastAgentTimestamp };
+    logger.info('Migrated lastCommittedCursor from lastAgentTimestamp');
+    saveState();
+  }
+
   sessions = getAllSessions();
   registeredGroups = getAllRegisteredGroups();
 
@@ -1540,6 +1581,7 @@ function saveState(): void {
   setRouterState('last_timestamp', globalMessageCursor.timestamp);
   setRouterState('last_timestamp_id', globalMessageCursor.id);
   setRouterState('last_agent_timestamp', JSON.stringify(lastAgentTimestamp));
+  setRouterState('last_committed_cursor', JSON.stringify(lastCommittedCursor));
 }
 
 function registerGroup(jid: string, group: RegisteredGroup): void {
@@ -1733,7 +1775,42 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   activeImReplyRoutes.set(effectiveGroup.folder, replySourceImJid);
 
   const shared = isGroupShared(group.folder);
-  const prompt = formatMessages(missedMessages, shared);
+  let prompt = formatMessages(missedMessages, shared);
+
+  // Recovery mode: session was cleared to prevent session ghost, so inject
+  // recent conversation history to give the fresh session context.
+  const isRecovery = recoveryGroups.delete(chatJid);
+  if (isRecovery) {
+    const RECOVERY_HISTORY_LIMIT = 20;
+    const recentHistory = getMessagesPage(chatJid, undefined, RECOVERY_HISTORY_LIMIT);
+    // getMessagesPage returns DESC order; reverse to chronological, exclude
+    // the pending messages themselves (already in prompt).
+    const pendingIds = new Set(missedMessages.map((m) => m.id));
+    const historyMsgs = recentHistory
+      .reverse()
+      .filter((m) => !pendingIds.has(m.id));
+    if (historyMsgs.length > 0) {
+      const historyLines = historyMsgs.map((m) => {
+        const role = m.is_from_me ? 'assistant' : m.sender_name;
+        const truncated = m.content.length > 500
+          ? m.content.slice(0, 500) + '…'
+          : m.content;
+        // Strip lone surrogates to avoid API JSON errors
+        const cleaned = truncated.replace(/[\uD800-\uDFFF]/g, '');
+        return `[${role}] ${cleaned}`;
+      });
+      prompt =
+        '<system_context>\n' +
+        '服务刚重启，当前为新会话。以下是重启前的最近对话记录，供你了解上下文：\n\n' +
+        historyLines.join('\n') +
+        '\n</system_context>\n\n' +
+        prompt;
+      logger.info(
+        { group: group.name, historyCount: historyMsgs.length },
+        'Recovery: injected recent conversation history into prompt',
+      );
+    }
+  }
 
   const images = collectMessageImages(chatJid, missedMessages);
   const imagesForAgent = images.length > 0 ? images : undefined;
@@ -1745,6 +1822,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       directImReply,
       imageCount: images.length,
       shared,
+      isRecovery,
     },
     'Processing messages',
   );
@@ -1841,10 +1919,16 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   const commitCursor = (): void => {
     if (cursorCommitted) return;
-    lastAgentTimestamp[chatJid] = {
-      timestamp: lastProcessed.timestamp,
-      id: lastProcessed.id,
-    };
+    // Use the higher of lastProcessed and the current lastAgentTimestamp.
+    // IPC injection may have advanced lastAgentTimestamp beyond lastProcessed
+    // (the initial batch); don't regress it.
+    const initial = { timestamp: lastProcessed.timestamp, id: lastProcessed.id };
+    const current = lastAgentTimestamp[chatJid];
+    const target =
+      current && current.timestamp > initial.timestamp ? current : initial;
+    lastAgentTimestamp[chatJid] = target;
+    // Mark this position as "actually processed by agent" for recovery safety.
+    lastCommittedCursor[chatJid] = target;
     saveState();
     cursorCommitted = true;
   };
@@ -4173,10 +4257,12 @@ async function processAgentConversation(
   const lastProcessed = missedMessages[missedMessages.length - 1];
   const commitCursor = (): void => {
     if (cursorCommitted) return;
-    lastAgentTimestamp[virtualChatJid] = {
-      timestamp: lastProcessed.timestamp,
-      id: lastProcessed.id,
-    };
+    const initial = { timestamp: lastProcessed.timestamp, id: lastProcessed.id };
+    const current = lastAgentTimestamp[virtualChatJid];
+    const target =
+      current && current.timestamp > initial.timestamp ? current : initial;
+    lastAgentTimestamp[virtualChatJid] = target;
+    lastCommittedCursor[virtualChatJid] = target;
     saveState();
     cursorCommitted = true;
   };
@@ -4738,10 +4824,12 @@ async function startMessageLoop(): Promise<void> {
 
                 // Advance cursor past these messages so they aren't re-processed
                 const lastMsg = groupMessages[groupMessages.length - 1];
-                lastAgentTimestamp[chatJid] = {
+                const billingCursor = {
                   timestamp: lastMsg.timestamp,
                   id: lastMsg.id,
                 };
+                lastAgentTimestamp[chatJid] = billingCursor;
+                lastCommittedCursor[chatJid] = billingCursor;
                 saveState();
                 continue;
               }
@@ -4841,17 +4929,41 @@ function recoverStuckPendingGroups(): void {
 
 /**
  * Startup recovery: check for unprocessed messages in registered groups.
- * Handles crash between advancing global cursor and processing messages.
+ *
+ * Uses `lastCommittedCursor` (updated only in commitCursor when an agent
+ * actually finishes processing) rather than `lastAgentTimestamp` (which
+ * advances when IPC injection succeeds).  This correctly detects messages
+ * that were IPC-injected but never processed because the service was
+ * killed before the agent could handle them.
+ *
+ * When pending messages are found, the group's SDK session is cleared to
+ * prevent the "session ghost" bug: if the previous agent was killed mid-
+ * response (SIGKILL / crash), the SDK session is left in a dirty state.
+ * Resuming it would cause the agent to complete the OLD interrupted work
+ * instead of processing the NEW pending messages, sending irrelevant
+ * replies to the user.
  */
 function recoverPendingMessages(): void {
   for (const [chatJid, group] of Object.entries(registeredGroups)) {
-    const sinceCursor = lastAgentTimestamp[chatJid] || EMPTY_CURSOR;
+    const sinceCursor = lastCommittedCursor[chatJid] || EMPTY_CURSOR;
     const pending = getMessagesSince(chatJid, sinceCursor);
     if (pending.length > 0) {
+      // Clear stale session to avoid "session ghost" — the agent will start
+      // a fresh conversation and process the pending messages cleanly.
+      if (sessions[group.folder]) {
+        logger.info(
+          { group: group.name, folder: group.folder },
+          'Recovery: clearing stale session to prevent session ghost',
+        );
+        delete sessions[group.folder];
+        deleteSession(group.folder);
+      }
+
       logger.info(
         { group: group.name, pendingCount: pending.length },
         'Recovery: found unprocessed messages',
       );
+      recoveryGroups.add(chatJid);
       queue.enqueueMessageCheck(chatJid);
     }
   }
@@ -5952,6 +6064,7 @@ async function main(): Promise<void> {
     getLastAgentTimestamp: () => lastAgentTimestamp,
     setLastAgentTimestamp: (jid: string, cursor: MessageCursor) => {
       lastAgentTimestamp[jid] = cursor;
+      lastCommittedCursor[jid] = cursor;
       saveState();
     },
     advanceGlobalCursor: (cursor: MessageCursor) => {


### PR DESCRIPTION
## 问题描述

当前重启恢复（`recoverPendingMessages()`）使用 `lastAgentTimestamp` 检测未处理消息。
但 `lastAgentTimestamp` 在多个场景下会被提前推进：

- IPC 消息注入成功时（`sendMessage` → `setLastAgentTimestamp`）
- billing-only 快速路径跳过消息时

当服务在 IPC 注入成功 → Agent 实际处理完成之间崩溃时，`lastAgentTimestamp` 已推进，
重启后 `recoverPendingMessages()` 看不到这些已注入但未处理的消息，**导致用户消息丢失**。

此外，Agent 被 SIGKILL 后 SDK session 处于 dirty 状态。如果恢复时使用同一 `sessionId`
调用 `query({ resume: sessionId })`，Agent 会继续完成上次中断的工作（"session ghost"），
而非处理新的待恢复消息，向用户发送不相关的回复。

## 修复方案

### `src/index.ts`

**新增 `lastCommittedCursor` 双游标机制**：
- 新增模块级变量 `lastCommittedCursor: Record<string, MessageCursor>`
- 仅在 `commitCursor()`（Agent 实际完成处理的回调）中推进，不在 IPC 注入时推进
- 通过 `router_state` 表独立持久化（key = `last_committed_cursor`）
- `loadState()` 中加载并 JSON 解析，损坏时安全重置
- `saveState()` 中与 `lastAgentTimestamp` 一起序列化保存

**自动迁移**：
- `loadState()` 检测到 `lastCommittedCursor` 为空且 `lastAgentTimestamp` 有数据时，
  从后者拷贝种子数据，避免首次运行重处理所有历史消息

**Recovery 逻辑改进**：
- `recoverPendingMessages()` 改用 `lastCommittedCursor` 替代 `lastAgentTimestamp`
  作为恢复基准
- 发现待恢复消息时，删除该群组的旧 SDK session（`delete sessions[folder]` +
  `deleteSession(folder)`），防止 session ghost
- 将该群组标记到 `recoveryGroups: Set<string>`

**恢复上下文注入**：
- `processGroupMessages()` 检查并消费 `recoveryGroups` 标记
- 从 DB 获取最近 20 条对话历史（`getMessagesPage`），排除当前待处理消息后，
  格式化为 `[role] content` 行，截断至 500 字符/条
- 包裹在 `<system_context>` XML 标签中注入到 prompt 前部，告知 Agent "服务刚重启"

**commitCursor 防回退**：
- `commitCursor()` 中取 `lastProcessed` 与当前 `lastAgentTimestamp[chatJid]` 的较大者，
  防止 IPC 注入推进的时间戳被初始批次的较早时间戳回退
- `processAgentConversation()`（Sub-Agent）中的 `commitCursor` 同步应用相同逻辑
- `startMessageLoop()` 中 billing 快速路径同步更新 `lastCommittedCursor`

**`handleClearCommand` 同步**：
- `/clear` 命令的 `setLastAgentTimestamp` 回调同时更新 `lastCommittedCursor`
- `main()` 中的全局 `setLastAgentTimestamp` 回调同理