### PR TITLE
修复: 飞书 SDK 图片/文件上传响应格式兼容

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -1638,8 +1638,12 @@ export function createFeishuConnection(
                 image_type: 'message',
                 image: fs.createReadStream(localImagePath),
               },
-            })) as { data?: { image_key?: string } } | null;
-            const imageKey = uploadRes?.data?.image_key;
+            })) as
+              | { image_key?: string; data?: { image_key?: string } }
+              | null
+              | undefined;
+            const imageKey =
+              uploadRes?.image_key ?? uploadRes?.data?.image_key;
             if (!imageKey) {
               logger.warn(
                 { chatId, localImagePath },
@@ -1690,9 +1694,13 @@ export function createFeishuConnection(
             image_type: 'message',
             image: imageBuffer,
           },
-        })) as { data?: { image_key?: string } } | null;
+        })) as
+          | { image_key?: string; data?: { image_key?: string } }
+          | null
+          | undefined;
 
-        const imageKey = uploadResult?.data?.image_key;
+        const imageKey =
+          uploadResult?.image_key ?? uploadResult?.data?.image_key;
         if (!imageKey) {
           logger.error(
             { chatId },
@@ -1783,9 +1791,13 @@ export function createFeishuConnection(
             file_name: fileName,
             file: buffer,
           },
-        })) as { data?: { file_key?: string } } | null;
+        })) as
+          | { file_key?: string; data?: { file_key?: string } }
+          | null
+          | undefined;
 
-        const fileKey = uploadResult?.data?.file_key;
+        const fileKey =
+          uploadResult?.file_key ?? uploadResult?.data?.file_key;
         if (!fileKey) {
           throw new Error('文件上传失败：未返回 file_key');
         }


### PR DESCRIPTION
## 问题描述

飞书 SDK（`@larksuiteoapi/node-sdk`）的图片/文件上传 API 在不同版本中返回格式不一致：
- 旧格式：`{ data: { image_key: "img_v3_xxx" } }`（key 嵌套在 `data` 下）
- 新格式：`{ image_key: "img_v3_xxx" }`（key 直接在顶层）

当前代码三处上传均使用 `as { data?: { image_key?: string } }` 类型断言，
只取 `res?.data?.image_key` 单一路径。当 SDK 返回顶层格式时，`image_key`
取到 `undefined`，上传实际成功但代码判定为失败，打印 `upload failed` 告警
并 fallback 到纯文本发送。

## 影响

- 飞书流式卡片（`StreamingCardController`）中嵌入图片失败
- `sendImageToFeishu()` 单独发送图片消息失败
- `sendFileToFeishu()` 发送文件消息失败

## 修复方案

### `src/feishu.ts`

三处上传响应处理统一修改：

1. **流式卡片图片上传**（`createFeishuConnection` 内 streaming card 逻辑）：
   - 类型断言改为 `{ image_key?: string; data?: { image_key?: string } } | null | undefined`
   - 取值改为 `uploadRes?.image_key ?? uploadRes?.data?.image_key`

2. **`sendImageToFeishu()`**：
   - 同上，类型断言和取值逻辑一致

3. **`sendFileToFeishu()`**：
   - 类型断言改为 `{ file_key?: string; data?: { file_key?: string } } | null | undefined`
   - 取值改为 `uploadResult?.file_key ?? uploadResult?.data?.file_key`

使用 `??`（nullish coalescing）确保优先取顶层值，顶层为 `null`/`undefined` 时
fallback 到 `data` 下的值。