### PR TITLE
修复: Cookie 安全性 — HTTPS 动态感知替代启动时固定判断

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,12 +33,11 @@ export const TIMEZONE =
 export const WEB_PORT = parseInt(process.env.WEB_PORT || '3000', 10);
 
 // Cookie configuration
-// Production (non-localhost): use __Host- prefix (requires Secure; Path=/; no Domain)
-// Development (localhost): use plain name (no Secure flag needed)
-const isProduction = process.env.NODE_ENV === 'production';
-export const SESSION_COOKIE_NAME = isProduction
-  ? '__Host-happyclaw_session'
-  : 'happyclaw_session';
+// When accessed over HTTPS: use __Host- prefix (requires Secure; Path=/; no Domain)
+// When accessed over HTTP (localhost dev or no TLS): use plain name
+// Determined per-request via isSecureRequest(), not at startup
+export const SESSION_COOKIE_NAME_SECURE = '__Host-happyclaw_session';
+export const SESSION_COOKIE_NAME_PLAIN = 'happyclaw_session';
 const SESSION_SECRET_FILE = path.join(DATA_DIR, 'config', 'session-secret.key');
 
 function getOrCreateSessionSecret(): string {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -15,11 +15,16 @@ import {
 import { isSessionExpired } from '../auth.js';
 import type { AuthUser, Permission } from '../types.js';
 import { hasPermission } from '../permissions.js';
-import { SESSION_COOKIE_NAME } from '../config.js';
+import {
+  SESSION_COOKIE_NAME_SECURE,
+  SESSION_COOKIE_NAME_PLAIN,
+} from '../config.js';
 
 export const authMiddleware = async (c: any, next: any) => {
   const cookies = parseCookie(c.req.header('cookie'));
-  const token = cookies[SESSION_COOKIE_NAME];
+  // Accept either cookie name — the browser will send whichever was set
+  const token =
+    cookies[SESSION_COOKIE_NAME_SECURE] || cookies[SESSION_COOKIE_NAME_PLAIN];
   if (!token) {
     return c.json({ error: 'Unauthorized' }, 401);
   }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -52,21 +52,49 @@ import {
 import type { AuthUser, User, UserPublic } from '../types.js';
 import { logger } from '../logger.js';
 import { lastActiveCache, invalidateSessionCache, invalidateUserSessions } from '../web-context.js';
-import { SESSION_COOKIE_NAME } from '../config.js';
+import {
+  SESSION_COOKIE_NAME_SECURE,
+  SESSION_COOKIE_NAME_PLAIN,
+  TRUST_PROXY,
+} from '../config.js';
 import { getSystemSettings } from '../runtime-config.js';
 
 const authRoutes = new Hono<{ Variables: Variables }>();
 
 // --- Helper Functions ---
 
-export function setSessionCookie(token: string): string {
-  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
-  return `${SESSION_COOKIE_NAME}=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=${30 * 24 * 60 * 60}${secure}`;
+/** Detect if the current request arrived over HTTPS (direct or behind proxy) */
+function isSecureRequest(c: any): boolean {
+  if (TRUST_PROXY) {
+    const proto = c.req.header('x-forwarded-proto');
+    if (proto === 'https') return true;
+  }
+  // Hono / node-server: URL scheme
+  try {
+    const url = new URL(c.req.url, 'http://localhost');
+    if (url.protocol === 'https:') return true;
+  } catch {
+    /* ignore */
+  }
+  return false;
 }
 
-export function clearSessionCookie(): string {
-  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
-  return `${SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0${secure}`;
+function getSessionCookieName(secure: boolean): string {
+  return secure ? SESSION_COOKIE_NAME_SECURE : SESSION_COOKIE_NAME_PLAIN;
+}
+
+export function setSessionCookie(c: any, token: string): string {
+  const secure = isSecureRequest(c);
+  const name = getSessionCookieName(secure);
+  const secureSuffix = secure ? '; Secure' : '';
+  return `${name}=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=${30 * 24 * 60 * 60}${secureSuffix}`;
+}
+
+export function clearSessionCookie(c: any): string {
+  const secure = isSecureRequest(c);
+  const name = getSessionCookieName(secure);
+  const secureSuffix = secure ? '; Secure' : '';
+  return `${name}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0${secureSuffix}`;
 }
 
 export function isUsernameConflictError(err: unknown): boolean {
@@ -220,7 +248,7 @@ authRoutes.post('/setup', async (c) => {
       status: 201,
       headers: {
         'Content-Type': 'application/json',
-        'Set-Cookie': setSessionCookie(token),
+        'Set-Cookie': setSessionCookie(c, token),
       },
     },
   );
@@ -343,7 +371,7 @@ authRoutes.post('/login', async (c) => {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Set-Cookie': setSessionCookie(token),
+        'Set-Cookie': setSessionCookie(c, token),
       },
     },
   );
@@ -504,7 +532,7 @@ authRoutes.post('/register', async (c) => {
       status: 201,
       headers: {
         'Content-Type': 'application/json',
-        'Set-Cookie': setSessionCookie(token),
+        'Set-Cookie': setSessionCookie(c, token),
       },
     },
   );
@@ -525,7 +553,7 @@ authRoutes.post('/logout', authMiddleware, (c) => {
     status: 200,
     headers: {
       'Content-Type': 'application/json',
-      'Set-Cookie': clearSessionCookie(),
+      'Set-Cookie': clearSessionCookie(c),
     },
   });
 });
@@ -688,7 +716,7 @@ authRoutes.put('/password', authMiddleware, async (c) => {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Set-Cookie': setSessionCookie(newToken),
+        'Set-Cookie': setSessionCookie(c, newToken),
       },
     },
   );

--- a/src/web.ts
+++ b/src/web.ts
@@ -81,7 +81,12 @@ import type {
   StreamEvent,
   UserRole,
 } from './types.js';
-import { WEB_PORT, SESSION_COOKIE_NAME, ASSISTANT_NAME } from './config.js';
+import {
+  WEB_PORT,
+  SESSION_COOKIE_NAME_SECURE,
+  SESSION_COOKIE_NAME_PLAIN,
+  ASSISTANT_NAME,
+} from './config.js';
 import { logger } from './logger.js';
 import { executeSessionReset } from './commands.js';
 import {
@@ -539,7 +544,8 @@ function setupWebSocket(server: any): WebSocketServer {
 
     // Verify session cookie
     const cookies = parseCookie(request.headers.cookie);
-    const token = cookies[SESSION_COOKIE_NAME];
+    const token =
+      cookies[SESSION_COOKIE_NAME_SECURE] || cookies[SESSION_COOKIE_NAME_PLAIN];
     if (!token) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
       socket.destroy();


### PR DESCRIPTION
## 问题描述

当前 Cookie 的 `Secure` 标记和 `__Host-` 前缀在 `src/config.ts` 中通过
`process.env.NODE_ENV === 'production'` 在进程启动时一次性判断。这在以下场景不工作：

1. **反向代理 HTTPS**：Nginx/Caddy 终结 TLS 后以 HTTP 转发到后端。
   `NODE_ENV` 通常未设为 `production` → Cookie name 为 `happyclaw_session`（无 `Secure`）
   → 但浏览器地址栏是 HTTPS，服务端应发 `__Host-happyclaw_session; Secure`
   → 实际未发 → 浏览器拒绝在 HTTPS 页面使用非 `Secure` cookie → 登录失败

2. **混合访问**：同一实例同时通过 HTTP（内网直连）和 HTTPS（外网反代）访问，
   启动时只能选一种策略

## 修复方案

### `src/config.ts`
- 移除 `isProduction` 启动时判断和单一 `SESSION_COOKIE_NAME`
- 导出两个常量：`SESSION_COOKIE_NAME_SECURE = '__Host-happyclaw_session'`
  和 `SESSION_COOKIE_NAME_PLAIN = 'happyclaw_session'`

### `src/routes/auth.ts`
- 新增 `isSecureRequest(c)` 函数：
  - `TRUST_PROXY=true` 时检查 `X-Forwarded-Proto: https` 请求头
  - 否则检查请求 URL 的 protocol 是否为 `https:`
- 新增 `getSessionCookieName(secure)` 函数：按 HTTPS 状态选择 cookie name
- `setSessionCookie(token)` → `setSessionCookie(c, token)`：接收请求上下文，
  按请求动态决定 cookie name + `Secure` 后缀
- `clearSessionCookie()` → `clearSessionCookie(c)`：同上
- 5 个调用点（setup/login/register/logout/change-password）传入 `c`

### `src/middleware/auth.ts`
- `authMiddleware` 中 cookie 解析同时尝试两个 name：
  `cookies[SESSION_COOKIE_NAME_SECURE] || cookies[SESSION_COOKIE_NAME_PLAIN]`
- 确保从 HTTP 切换到 HTTPS（或反之）后旧 cookie 仍可识别

### `src/web.ts`
- WebSocket upgrade 握手的 cookie 验证同样接受两个 name