### PR TITLE
修复: 飞书流式卡片 complete() 失败后状态回滚 + abort 清理

### DIFF
--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -1409,24 +1409,23 @@ export class StreamingCardController {
   async complete(finalText: string): Promise<void> {
     if (this.state !== 'streaming' && this.state !== 'creating') return;
 
+    const prevState = this.state;
     this.accumulatedText = finalText;
     this.state = 'completed';
     this.flushCtrl.dispose();
     this.textFlushCtrl?.dispose();
     this.auxFlushCtrl?.dispose();
 
-    if (this.backendMode === 'streaming' && this.streamingBackend) {
-      try {
+    try {
+      if (this.backendMode === 'streaming' && this.streamingBackend) {
         await this.finalizeStreamingCard('completed');
-      } catch (err) {
-        logger.debug({ err, chatId: this.chatId }, 'Streaming card: finalize failed');
-      }
-    } else if (this.messageId || this.multiCard) {
-      try {
+      } else if (this.messageId || this.multiCard) {
         await this.patchCard('completed');
-      } catch (err) {
-        logger.debug({ err, chatId: this.chatId }, 'Streaming card: final patch failed');
       }
+    } catch (err) {
+      // Revert state so abort() doesn't bail on the 'completed' check
+      this.state = prevState;
+      throw err;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2197,6 +2197,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                   { err, chatJid },
                   'Streaming card complete failed, falling back to static message',
                 );
+                // Abort the card so it doesn't stay stuck in "streaming" state
+                await streamingSession.abort('回复已通过消息发送').catch(() => {});
                 // Fall through to normal sendMessage
               }
             }
@@ -4356,6 +4358,7 @@ async function processAgentConversation(
               { err, chatJid, agentId },
               'Agent streaming card complete failed, falling back to static message',
             );
+            await agentStreamingSession.abort('回复已通过消息发送').catch(() => {});
           }
         }
 


### PR DESCRIPTION
## 问题描述

`StreamingCardController.complete()` 在执行前将 `this.state` 设为 `'completed'`，
随后调用 `finalizeStreamingCard()` 或 `patchCard()` 发送最终卡片。如果这些飞书 API
调用失败（网络超时、token 过期等），存在两个问题：

1. **状态不回滚**：`state` 已被设为 `'completed'`，但卡片实际未完成。此时调用方
   fallback 到 `sendMessage()` 发送纯文本消息，但飞书卡片仍停留在"生成中..."状态。
   后续调用 `abort()` 试图清理时，`abort()` 检查 `this.state === 'completed'`
   直接 return，无法清理卡片。**卡片永远卡在"生成中"。**

2. **错误被吞掉**：原代码中 `finalizeStreamingCard` 和 `patchCard` 各自有独立的
   try-catch，catch 中仅 `logger.debug` 记录后静默继续。调用方无法感知 complete 失败，
   无法执行 fallback 逻辑。

## 修复方案

### `src/feishu-streaming-card.ts`
- 在 `complete()` 开头保存 `const prevState = this.state`
- 将两个独立的 try-catch 合并为一个统一的 try-catch
- catch 中 `this.state = prevState` 回滚状态，然后 `throw err` 向调用方传播错误
- 调用方可以在 catch 中执行 fallback（发纯文本）和 abort（清理卡片）

### `src/index.ts`
- `processGroupMessages()` 中 complete 失败的 catch 块，新增
  `await streamingSession.abort('回复已通过消息发送').catch(() => {})` 清理卡片
- `processAgentConversation()`（Sub-Agent）中同理新增 abort 调用
- `.catch(() => {})` 确保 abort 本身的失败不影响后续 fallback 流程