### PR TITLE
修复: 启动时清理孤儿 host agent-runner 进程

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4981,6 +4981,38 @@ async function ensureDockerRunning(): Promise<void> {
     throw new Error('Docker is required but not running');
   }
 
+  // Kill orphaned host agent-runner processes from previous runs
+  try {
+    const { stdout: psOut } = await execFileAsync('pgrep', [
+      '-f',
+      'node.*container/agent-runner/dist/index\\.js',
+    ], { timeout: 5000 });
+    const pids = (typeof psOut === 'string' ? psOut : String(psOut))
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(Number)
+      .filter((pid) => pid !== process.pid && !isNaN(pid));
+    for (const pid of pids) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        /* already dead */
+      }
+    }
+    if (pids.length > 0) {
+      logger.info(
+        { count: pids.length, pids },
+        'Killed orphaned host agent-runner processes',
+      );
+    }
+  } catch (err: any) {
+    // pgrep exits 1 when no matches — that's fine
+    if (err?.code !== 1) {
+      logger.warn({ err }, 'Failed to clean up orphaned host processes');
+    }
+  }
+
   // Kill and clean up orphaned happyclaw containers from previous runs
   try {
     const { stdout } = await execFileAsync(


### PR DESCRIPTION
## 问题描述

当 HappyClaw 服务被 SIGKILL 或异常崩溃时，host 模式下的 agent-runner 子进程
（`node container/agent-runner/dist/index.js`）不会收到终止信号，成为孤儿进程。

服务重启后，这些孤儿进程仍在运行，可能导致：
- 新的 agent-runner 与旧进程竞争同一个工作目录和 IPC 通道
- 用户消息被旧进程消费，新进程收不到
- 资源泄漏（内存、CPU、API 调用额度）

当前 `ensureDockerRunning()` 已有 Docker 容器孤儿清理逻辑
（`docker ps --filter name=happyclaw-` → `docker stop`），
但缺少 host 模式进程的清理。

## 修复方案

### `src/index.ts`
在 `ensureDockerRunning()` 中 Docker 容器清理之前，新增 host 进程清理：

- `pgrep -f 'node.*container/agent-runner/dist/index\\.js'` 查找匹配进程
- 过滤掉当前进程自身的 PID（`process.pid`）
- 对每个孤儿 PID 发送 `SIGKILL`（孤儿进程可能处于不响应 SIGTERM 的状态）
- `pgrep` 返回码 1（无匹配）正常忽略，其他错误记录 warn 日志
- 5 秒超时防止 pgrep 本身卡住