### PR TITLE
修复: Docker 不可用时服务启动不再崩溃 + 工作区执行模式智能默认 (#256)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
 export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || 'HappyClaw';
 export const POLL_INTERVAL = 2000;
@@ -73,3 +75,18 @@ export const WEB_SESSION_SECRET = getOrCreateSessionSecret();
 // Proxy trust configuration
 // Set TRUST_PROXY=true when behind a reverse proxy (nginx, Cloudflare, etc.)
 export const TRUST_PROXY = process.env.TRUST_PROXY === 'true';
+
+// Docker availability check (cached for the lifetime of the process)
+const execFileAsync = promisify(execFile);
+let _dockerAvailable: boolean | null = null;
+
+export async function isDockerAvailable(): Promise<boolean> {
+  if (_dockerAvailable !== null) return _dockerAvailable;
+  try {
+    await execFileAsync('docker', ['info'], { timeout: 10000 });
+    _dockerAvailable = true;
+  } catch {
+    _dockerAvailable = false;
+  }
+  return _dockerAvailable;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   MAIN_GROUP_FOLDER,
   POLL_INTERVAL,
   TIMEZONE,
+  isDockerAvailable,
 } from './config.js';
 import { interruptibleSleep } from './message-notifier.js';
 import {
@@ -1158,7 +1159,7 @@ function handleBindCommand(chatJid: string, rawSpec: string): string {
   return `已切换到 ${resolved.display}\n🔁 回复策略: source_only`;
 }
 
-function handleNewCommand(chatJid: string, rawName: string): string {
+async function handleNewCommand(chatJid: string, rawName: string): Promise<string> {
   const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
   if (!group) return '当前 IM 未绑定工作区';
   const userId = group.created_by;
@@ -1177,7 +1178,7 @@ function handleNewCommand(chatJid: string, rawName: string): string {
     name,
     folder,
     added_at: now,
-    executionMode: 'container',
+    executionMode: (await isDockerAvailable()) ? 'container' : 'host',
     created_by: userId,
   };
 
@@ -5213,35 +5214,11 @@ async function ensureDockerRunning(): Promise<void> {
     await execFileAsync('docker', ['info'], { timeout: 10000 });
     logger.debug('Docker daemon is running');
   } catch {
-    logger.error('Docker daemon is not running');
-    console.error(
-      '\n╔════════════════════════════════════════════════════════════════╗',
+    logger.warn(
+      'Docker is not available — container-mode workspaces will fail at message time. ' +
+      'Start Docker if you need container execution (macOS: Docker Desktop, Linux: sudo systemctl start docker).',
     );
-    console.error(
-      '║  FATAL: Docker is not running                                  ║',
-    );
-    console.error(
-      '║                                                                ║',
-    );
-    console.error(
-      '║  Agents cannot run without Docker. To fix:                     ║',
-    );
-    console.error(
-      '║  macOS: Start Docker Desktop                                   ║',
-    );
-    console.error(
-      '║  Linux: sudo systemctl start docker                            ║',
-    );
-    console.error(
-      '║                                                                ║',
-    );
-    console.error(
-      '║  Install from: https://docker.com/products/docker-desktop      ║',
-    );
-    console.error(
-      '╚════════════════════════════════════════════════════════════════╝\n',
-    );
-    throw new Error('Docker is required but not running');
+    return;
   }
 
   // Kill orphaned host agent-runner processes from previous runs

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -9,7 +9,7 @@ import {
 } from '../schemas.js';
 import type { AuthUser, RegisteredGroup, ExecutionMode } from '../types.js';
 import { checkGroupLimit } from '../billing.js';
-import { DATA_DIR, GROUPS_DIR } from '../config.js';
+import { DATA_DIR, GROUPS_DIR, isDockerAvailable } from '../config.js';
 import {
   isHostExecutionGroup,
   hasHostExecutionPermission,
@@ -375,7 +375,8 @@ groupRoutes.post('/', authMiddleware, async (c) => {
     return c.json({ error: 'Group name is required' }, 400);
   }
 
-  const executionMode = validation.data.execution_mode || 'container';
+  // If user didn't specify execution mode, pick based on Docker availability
+  const executionMode = validation.data.execution_mode || (await isDockerAvailable() ? 'container' : 'host');
   const customCwd = validation.data.custom_cwd; // Schema already trims and converts empty to undefined
   const initSourcePath = validation.data.init_source_path;
   const initGitUrl = validation.data.init_git_url;


### PR DESCRIPTION
## 问题描述

关闭 #256。

纯 host 模式部署中，创建 container 模式工作区后重启服务会因 `ensureDockerRunning()` throw 导致整个系统无法启动。

## 修复方案

### `src/config.ts`
- 新增 `isDockerAvailable()` 辅助函数，`docker info` 检测 + 缓存结果

### `src/index.ts`
- `ensureDockerRunning()` Docker 不可用时从 `throw` 改为 `logger.warn` + `return`
- IM `/new` 命令使用 `isDockerAvailable()` 智能选择执行模式

### `src/routes/groups.ts`
- Web 创建工作区默认执行模式从硬编码 `container` 改为根据 Docker 可用性动态判断