### PR TITLE
修复: register_group 支持 execution_mode + PATCH API 支持运行时切换 (#253)

### DIFF
--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -702,7 +702,8 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       'register_group',
       `Register a new group so the agent can respond to messages there. Admin home only.
 
-Use available_groups.json to find the JID for a group. The folder name should be lowercase with hyphens (e.g., "family-chat").`,
+Use available_groups.json to find the JID for a group. The folder name should be lowercase with hyphens (e.g., "family-chat").
+You can optionally specify execution_mode: "container" (default, isolated Docker) or "host" (direct host access, admin only).`,
       {
         jid: z.string().describe('The chat JID (e.g., "feishu:oc_xxxx")'),
         name: z.string().describe('Display name for the group'),
@@ -710,6 +711,12 @@ Use available_groups.json to find the JID for a group. The folder name should be
           .string()
           .describe(
             'Folder name for group files (lowercase, hyphens, e.g., "family-chat")',
+          ),
+        execution_mode: z
+          .enum(['container', 'host'])
+          .optional()
+          .describe(
+            'Execution mode: "container" (default, isolated Docker) or "host" (direct host access)',
           ),
       },
       async (args) => {
@@ -729,6 +736,7 @@ Use available_groups.json to find the JID for a group. The folder name should be
           jid: args.jid,
           name: args.name,
           folder: args.folder,
+          executionMode: args.execution_mode,
           timestamp: new Date().toISOString(),
         };
         writeIpcFile(TASKS_DIR, data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3826,6 +3826,7 @@ async function processTaskIpc(
     name?: string;
     folder?: string;
     containerConfig?: RegisteredGroup['containerConfig'];
+    executionMode?: string;
     // For install_skill / uninstall_skill
     package?: string;
     requestId?: string;
@@ -4046,12 +4047,17 @@ async function processTaskIpc(
         const sourceEntry = Object.values(registeredGroups).find(
           (g) => g.folder === sourceGroup,
         );
+        const execMode =
+          data.executionMode === 'host' || data.executionMode === 'container'
+            ? data.executionMode
+            : undefined;
         registerGroup(data.jid, {
           name: data.name,
           folder: data.folder,
           added_at: new Date().toISOString(),
           containerConfig: data.containerConfig,
           created_by: sourceEntry?.created_by,
+          executionMode: execMode,
         });
       } else {
         logger.warn(

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -696,6 +696,7 @@ groupRoutes.patch('/:jid', authMiddleware, async (c) => {
     name: rawName,
     is_pinned,
     activation_mode,
+    execution_mode,
   } = validation.data;
   const name = rawName ? normalizeGroupName(rawName) : undefined;
 
@@ -703,16 +704,34 @@ groupRoutes.patch('/:jid', authMiddleware, async (c) => {
   if (
     !name &&
     is_pinned === undefined &&
-    activation_mode === undefined
+    activation_mode === undefined &&
+    execution_mode === undefined
   ) {
     return c.json({ error: 'No fields to update' }, 400);
+  }
+
+  // 不允许修改 is_home=true 的主容器执行模式（主容器由 loadState 强制管理）
+  if (execution_mode !== undefined && existing.is_home) {
+    return c.json(
+      { error: 'Cannot change execution mode of home containers' },
+      403,
+    );
+  }
+
+  // member 用户不允许使用 host 模式（安全限制）
+  if (execution_mode === 'host' && !hasHostExecutionPermission(authUser)) {
+    return c.json(
+      { error: 'Insufficient permissions for host execution mode' },
+      403,
+    );
   }
 
   // Pin/unpin only requires canAccessGroup (it's a per-user preference)
   const isPinOnly =
     is_pinned !== undefined &&
     !name &&
-    activation_mode === undefined;
+    activation_mode === undefined &&
+    execution_mode === undefined;
   if (isPinOnly) {
     if (
       !canAccessGroup(
@@ -754,14 +773,17 @@ groupRoutes.patch('/:jid', authMiddleware, async (c) => {
     unpinGroup(authUser.id, jid);
   }
 
-  // Update registered group if name or activation_mode changed
-  if (name || activation_mode !== undefined) {
+  // Update registered group if name, activation_mode, or execution_mode changed
+  if (name || activation_mode !== undefined || execution_mode !== undefined) {
     const updated: RegisteredGroup = {
       name: name || existing.name,
       folder: existing.folder,
       added_at: existing.added_at,
       containerConfig: existing.containerConfig,
-      executionMode: existing.executionMode,
+      executionMode:
+        execution_mode !== undefined
+          ? (execution_mode as ExecutionMode)
+          : existing.executionMode,
       customCwd: existing.customCwd,
       initSourcePath: existing.initSourcePath,
       initGitUrl: existing.initGitUrl,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -184,6 +184,7 @@ export const GroupPatchSchema = z.object({
   activation_mode: z
     .enum(['auto', 'always', 'when_mentioned', 'disabled'])
     .optional(),
+  execution_mode: z.enum(['container', 'host']).optional(),
 });
 
 export const LoginSchema = z.object({


### PR DESCRIPTION
## 问题描述

关闭 #253。

register_group MCP 工具没有 execution_mode 参数，注册的群组永远是 container 模式。PATCH API 也不支持修改执行模式，运行时无法切换。

## 修复方案

### `container/agent-runner/src/mcp-tools.ts`
- register_group 工具新增 `execution_mode` 可选参数

### `src/index.ts`
- IPC handler 读取并传递 `executionMode` 给 `registerGroup()`

### `src/schemas.ts`
- `GroupPatchSchema` 新增 `execution_mode` 字段

### `src/routes/groups.ts`
- PATCH handler 支持修改 `execution_mode`
- 安全校验：禁止修改主容器执行模式（403）、非 admin 不允许 host 模式（403）