### PR TITLE
增强: 微信渠道流式打字机、会话恢复、文件/视频下载、Typing 优化

### DIFF
--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -23,6 +23,7 @@ import {
   createWeChatConnection,
   type WeChatConnection,
   type WeChatConnectionConfig,
+  type WeChatStreamingSession,
 } from './wechat.js';
 import { logger } from './logger.js';
 import {
@@ -61,6 +62,8 @@ export interface IMChannelConnectOpts {
   shouldProcessGroupMessage?: (chatJid: string) => boolean;
   /** 飞书流式卡片按钮中断回调 */
   onCardInterrupt?: (chatJid: string) => void;
+  /** WeChat: long-polling cursor update callback for persistence */
+  onWeChatBufUpdate?: (newBuf: string) => void;
 }
 
 export interface IMChannel {
@@ -431,10 +434,18 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
 
 export function createWeChatChannel(
   config: WeChatConnectionConfig,
-): IMChannel {
+): IMChannel & { createWeChatStreamingSession(chatId: string): WeChatStreamingSession | undefined } {
   let inner: WeChatConnection | null = null;
+  let typingTimer: ReturnType<typeof setInterval> | null = null;
 
-  const channel: IMChannel = {
+  function clearTypingTimer(): void {
+    if (typingTimer) {
+      clearInterval(typingTimer);
+      typingTimer = null;
+    }
+  }
+
+  const channel: IMChannel & { createWeChatStreamingSession(chatId: string): WeChatStreamingSession | undefined } = {
     channelType: 'wechat',
 
     async connect(opts: IMChannelConnectOpts): Promise<boolean> {
@@ -448,6 +459,7 @@ export function createWeChatChannel(
           resolveGroupFolder: opts.resolveGroupFolder,
           resolveEffectiveChatJid: opts.resolveEffectiveChatJid,
           onAgentMessage: opts.onAgentMessage,
+          onBufUpdate: opts.onWeChatBufUpdate,
         });
         return inner.isConnected();
       } catch (err) {
@@ -458,6 +470,7 @@ export function createWeChatChannel(
     },
 
     async disconnect(): Promise<void> {
+      clearTypingTimer();
       if (inner) {
         await inner.disconnect();
         inner = null;
@@ -476,12 +489,30 @@ export function createWeChatChannel(
     },
 
     async setTyping(chatId: string, isTyping: boolean): Promise<void> {
-      if (!inner) return;
-      await inner.sendTyping(chatId, isTyping);
+      clearTypingTimer();
+      if (!isTyping || !inner) return;
+
+      // Send immediately, then repeat every 4s (typing indicator expires)
+      const sendAction = async (): Promise<void> => {
+        if (!inner) return;
+        try {
+          await inner.sendTyping(chatId, true);
+        } catch {
+          // best-effort — typing is non-critical
+        }
+      };
+      void sendAction();
+      typingTimer = setInterval(() => {
+        void sendAction();
+      }, 4000);
     },
 
     isConnected(): boolean {
       return inner?.isConnected() ?? false;
+    },
+
+    createWeChatStreamingSession(chatId: string): WeChatStreamingSession | undefined {
+      return inner?.createStreamingSession(chatId);
     },
   };
 

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -18,7 +18,7 @@ import {
 import type { FeishuConnectionConfig } from './feishu.js';
 import type { TelegramConnectionConfig } from './telegram.js';
 import type { QQConnectionConfig } from './qq.js';
-import type { WeChatConnectionConfig } from './wechat.js';
+import type { WeChatConnectionConfig, WeChatStreamingSession } from './wechat.js';
 import type { StreamingCardController } from './feishu-streaming-card.js';
 import { getRegisteredGroup, getJidsByFolder } from './db.js';
 import { logger } from './logger.js';
@@ -229,6 +229,22 @@ class IMConnectionManager {
     const channel = this.findChannelForJid(jid, channelType);
     if (channel?.createStreamingSession) {
       return channel.createStreamingSession(chatId, onCardCreated);
+    }
+    return undefined;
+  }
+
+  /**
+   * Create a WeChat streaming session for typewriter effect.
+   * Returns undefined for non-WeChat channels.
+   */
+  createWeChatStreamingSession(jid: string): WeChatStreamingSession | undefined {
+    const channelType = getChannelType(jid);
+    if (channelType !== 'wechat') return undefined;
+
+    const chatId = extractChatId(jid);
+    const channel = this.findChannelForJid(jid, channelType);
+    if (channel && 'createWeChatStreamingSession' in channel) {
+      return (channel as ReturnType<typeof createWeChatChannel>).createWeChatStreamingSession(chatId);
     }
     return undefined;
   }
@@ -458,6 +474,7 @@ class IMConnectionManager {
         chatJid: string,
       ) => { effectiveJid: string; agentId: string | null } | null;
       onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+      onBufUpdate?: (newBuf: string) => void;
     },
   ): Promise<boolean> {
     if (!config.botToken || !config.ilinkBotId) {
@@ -482,6 +499,7 @@ class IMConnectionManager {
       resolveGroupFolder: options?.resolveGroupFolder,
       resolveEffectiveChatJid: options?.resolveEffectiveChatJid,
       onAgentMessage: options?.onAgentMessage,
+      onWeChatBufUpdate: options?.onBufUpdate,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ import {
   getUserTelegramConfig,
   getUserQQConfig,
   getUserWeChatConfig,
+  saveUserWeChatConfig,
   getSystemSettings,
   saveUserFeishuConfig,
   saveUserTelegramConfig,
@@ -1990,6 +1991,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     logger.debug({ chatJid }, 'Streaming card session created for Feishu');
   }
 
+  // ── WeChat streaming session (typewriter effect) ──
+  let wechatStreamingSession = imManager.createWeChatStreamingSession(streamingSessionJid);
+  if (wechatStreamingSession) {
+    logger.debug({ chatJid }, 'WeChat streaming session created');
+  }
+
   // ── Dynamic reply route updater ──
   // Allows IPC-injected messages (from web.ts / IM polling) to update the
   // reply routing target without killing the agent process.  This replaces
@@ -2012,8 +2019,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         if (streamingSession.isActive()) streamingSession.dispose();
         unregisterStreamingSession(streamingSessionJid);
       }
+      // Dispose WeChat streaming session too
+      if (wechatStreamingSession?.isActive()) wechatStreamingSession.dispose();
+
       streamingSessionJid = newStreamingJid;
       streamingSession = imManager.createStreamingSession(streamingSessionJid, makeOnCardCreated(streamingSessionJid));
+      wechatStreamingSession = imManager.createWeChatStreamingSession(streamingSessionJid);
       streamingAccumulatedText = '';
       if (streamingSession) {
         registerStreamingSession(streamingSessionJid, streamingSession);
@@ -2098,6 +2109,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           // ── Feed stream events into Feishu streaming card ──
           if (streamingSession) {
             feedStreamEventToCard(streamingSession, result.streamEvent, streamingAccumulatedText);
+          }
+
+          // ── Feed text_delta into WeChat streaming session ──
+          if (wechatStreamingSession?.isActive() && result.streamEvent.eventType === 'text_delta') {
+            wechatStreamingSession.append(streamingAccumulatedText);
           }
 
           // ── 中断时立即保存已输出内容 ──
@@ -2405,6 +2421,21 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               }
             }
 
+            // ── Complete WeChat streaming session ──
+            let wechatStreamingHandledIM = false;
+            if (wechatStreamingSession?.isActive()) {
+              try {
+                await wechatStreamingSession.complete(text);
+                wechatStreamingHandledIM = true;
+                logger.debug({ chatJid }, 'WeChat streaming completed with final text');
+              } catch (err) {
+                logger.warn(
+                  { err, chatJid },
+                  'WeChat streaming complete failed, falling back to static message',
+                );
+              }
+            }
+
             // ── Rebuild streaming card after compact_partial / overflow_partial ──
             // The completed card was consumed; create a new one so post-compaction
             // tool-call progress remains visible on Feishu (#223).
@@ -2427,13 +2458,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               }
             }
 
+            // Rebuild WeChat streaming session after partial output
+            if (
+              wechatStreamingHandledIM &&
+              (result.sourceKind === 'compact_partial' || result.sourceKind === 'overflow_partial')
+            ) {
+              streamingAccumulatedText = '';
+              wechatStreamingSession = imManager.createWeChatStreamingSession(streamingSessionJid);
+            }
+
             // Skip IM send to the original chatJid when:
             // 1. Streaming card already handled the IM delivery, OR
             // 2. Reply route switched to a different IM channel (the routed IM
             //    path below will deliver to the correct channel instead).
             // Any send_message content is delivered independently via IPC watcher.
             const routeSwitchedAway = directImReply && replySourceImJid !== null && replySourceImJid !== chatJid;
-            const skipImSend = (streamingCardHandledIM && directImReply) || routeSwitchedAway;
+            const skipImSend = ((streamingCardHandledIM || wechatStreamingHandledIM) && directImReply) || routeSwitchedAway;
             // When the container stays alive and processes multiple IPC messages,
             // result.turnId stays the same (set at container start).  If we already
             // saved a reply with this turnId, the INSERT OR REPLACE would overwrite
@@ -2460,7 +2500,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             // if streaming card handled it. send_message content is already
             // forwarded to IM by the IPC watcher's activeImReplyRoutes logic.
             if (replySourceImJid && replySourceImJid !== chatJid) {
-              if (!streamingCardHandledIM) {
+              if (!streamingCardHandledIM && !wechatStreamingHandledIM) {
                 sendImWithFailTracking(replySourceImJid, text, localImagePaths);
               }
             }
@@ -2528,6 +2568,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         }
       }
       unregisterStreamingSession(streamingSessionJid);
+    }
+
+    // ── WeChat streaming cleanup ──
+    if (wechatStreamingSession?.isActive()) {
+      if (hadError || !output || output.status === 'error') {
+        await wechatStreamingSession.abort('处理出错').catch(() => {});
+      } else if (wasInterrupted) {
+        await wechatStreamingSession.abort('已中断').catch(() => {});
+      } else {
+        wechatStreamingSession.dispose();
+      }
     }
 
     // ── 保存中断内容到数据库 + 广播到 Web ──
@@ -5566,6 +5617,53 @@ function handleCardInterrupt(chatJid: string): void {
 }
 
 /**
+ * Debounced WeChat sync-buf persistence (30s delay to avoid high-frequency IO).
+ * Flushed immediately on graceful shutdown.
+ */
+const wechatBufSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const wechatBufPending = new Map<string, string>();
+
+function debouncedSaveWeChatBuf(userId: string, newBuf: string): void {
+  wechatBufPending.set(userId, newBuf);
+  const existing = wechatBufSaveTimers.get(userId);
+  if (existing) clearTimeout(existing);
+  wechatBufSaveTimers.set(
+    userId,
+    setTimeout(() => {
+      wechatBufSaveTimers.delete(userId);
+      wechatBufPending.delete(userId);
+      try {
+        const config = getUserWeChatConfig(userId);
+        if (config) {
+          saveUserWeChatConfig(userId, { ...config, getUpdatesBuf: newBuf });
+        }
+      } catch (err) {
+        logger.warn({ err, userId }, 'Failed to persist WeChat sync buf');
+      }
+    }, 30_000),
+  );
+}
+
+function flushWeChatBufSaves(): void {
+  for (const [userId, timer] of wechatBufSaveTimers.entries()) {
+    clearTimeout(timer);
+    const buf = wechatBufPending.get(userId);
+    if (buf) {
+      try {
+        const config = getUserWeChatConfig(userId);
+        if (config) {
+          saveUserWeChatConfig(userId, { ...config, getUpdatesBuf: buf });
+        }
+      } catch (err) {
+        logger.warn({ err, userId }, 'Failed to flush WeChat sync buf on shutdown');
+      }
+    }
+  }
+  wechatBufSaveTimers.clear();
+  wechatBufPending.clear();
+}
+
+/**
  * Connect IM channels for a specific user via imManager.
  * Reads the user's IM config and connects if enabled.
  */
@@ -5675,6 +5773,9 @@ async function connectUserIMChannels(
         resolveGroupFolder,
         resolveEffectiveChatJid,
         onAgentMessage,
+        onBufUpdate: (newBuf: string) => {
+          debouncedSaveWeChatBuf(userId, newBuf);
+        },
       },
     );
   }
@@ -5917,6 +6018,9 @@ async function main(): Promise<void> {
     // Stop periodic buffer, then persist streaming text to DB + clean buffer files.
     stopStreamingBuffer();
     saveInterruptedStreamingMessages();
+
+    // Flush pending WeChat sync-buf saves before disconnect
+    flushWeChatBufSaves();
 
     // Run cleanup tasks concurrently with a tight timeout
     await Promise.allSettled([
@@ -6190,6 +6294,9 @@ async function main(): Promise<void> {
               resolveEffectiveFolder(chatJid),
             resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
             onAgentMessage: buildOnAgentMessage(),
+            onBufUpdate: (newBuf: string) => {
+              debouncedSaveWeChatBuf(userId, newBuf);
+            },
           },
         );
         logger.info(

--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -39,6 +39,21 @@ const DEFAULT_LONGPOLL_TIMEOUT_MS = 35000;
 const RECONNECT_MIN_DELAY_MS = 3000;
 const RECONNECT_MAX_DELAY_MS = 60000;
 
+// Session expiry retry (errcode -14)
+const SESSION_RETRY_INITIAL_MS = 60_000; // 60s
+const SESSION_RETRY_MAX_MS = 600_000; // 10min
+const SESSION_RETRY_MAX_ATTEMPTS = 10;
+
+// context_token TTL
+const CONTEXT_TOKEN_TTL = 2 * 60 * 60 * 1000; // 2 hours
+const CONTEXT_TOKEN_CLEANUP_INTERVAL = 30 * 60 * 1000; // 30min
+
+// Typing ticket cache TTL
+const TYPING_TICKET_TTL = 5 * 60 * 1000; // 5min
+
+// Streaming throttle
+const STREAM_THROTTLE_MS = 800;
+
 const IMAGE_MAX_BASE64_SIZE = 5 * 1024 * 1024; // 5 MB for inline base64
 
 const CHANNEL_VERSION = '0.1.0';
@@ -56,7 +71,7 @@ const MESSAGE_ITEM_TYPE_FILE = 4;
 
 // iLink message state
 // const MESSAGE_STATE_NEW = 0;
-// const MESSAGE_STATE_GENERATING = 1;
+const MESSAGE_STATE_GENERATING = 1;
 const MESSAGE_STATE_FINISH = 2;
 
 // errcode for session expired
@@ -82,6 +97,21 @@ export interface WeChatConnectOpts {
     chatJid: string,
   ) => { effectiveJid: string; agentId: string | null } | null;
   onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+  /** Called when long-polling cursor updates — persist for crash recovery */
+  onBufUpdate?: (newBuf: string) => void;
+}
+
+export interface WeChatStreamingSession {
+  /** Append accumulated text (throttled at 800ms intervals) */
+  append(accumulatedText: string): void;
+  /** Send final FINISH message */
+  complete(finalText: string): Promise<void>;
+  /** Abort streaming */
+  abort(reason?: string): Promise<void>;
+  /** Whether the session is still active */
+  isActive(): boolean;
+  /** Clean up resources */
+  dispose(): void;
 }
 
 export interface WeChatConnection {
@@ -95,6 +125,8 @@ export interface WeChatConnection {
   sendTyping(chatId: string, isTyping: boolean): Promise<void>;
   isConnected(): boolean;
   getUpdatesBuf(): string;
+  /** Create a streaming session for typewriter effect */
+  createStreamingSession(chatId: string): WeChatStreamingSession | undefined;
 }
 
 interface WeixinMessage {
@@ -233,9 +265,15 @@ function extractTextContent(items: MessageItem[]): string {
         parts.push('(voice)');
       }
     } else if (item.type === MESSAGE_ITEM_TYPE_FILE) {
-      parts.push(`(file: ${item.file_item?.file_name ?? 'unknown'})`);
+      // Only add placeholder if no CDN media to download (handled by processFileItem)
+      if (!item.file_item?.media?.encrypt_query_param) {
+        parts.push(`(file: ${item.file_item?.file_name ?? 'unknown'})`);
+      }
     } else if (item.type === 5 /* VIDEO */) {
-      parts.push('(video)');
+      // Only add placeholder if no CDN media to download (handled by processVideoItem)
+      if (!item.video_item?.media?.encrypt_query_param) {
+        parts.push('(video)');
+      }
     }
   }
   return parts.join('\n').trim();
@@ -269,8 +307,47 @@ export function createWeChatConnection(
   let connected = false;
   let cancelSleep: (() => void) | null = null;
 
-  // context_token cache: from_user_id -> latest context_token
-  const contextTokenCache = new Map<string, string>();
+  // context_token cache with TTL: from_user_id -> { token, timestamp }
+  interface CachedToken { token: string; timestamp: number; }
+  const contextTokenCache = new Map<string, CachedToken>();
+  let tokenCleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  function getValidToken(userId: string): string | undefined {
+    const cached = contextTokenCache.get(userId);
+    if (!cached) return undefined;
+    if (Date.now() - cached.timestamp > CONTEXT_TOKEN_TTL) {
+      contextTokenCache.delete(userId);
+      return undefined;
+    }
+    return cached.token;
+  }
+
+  function setToken(userId: string, token: string): void {
+    contextTokenCache.set(userId, { token, timestamp: Date.now() });
+  }
+
+  function startTokenCleanup(): void {
+    tokenCleanupTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [key, cached] of contextTokenCache.entries()) {
+        if (now - cached.timestamp > CONTEXT_TOKEN_TTL) {
+          contextTokenCache.delete(key);
+        }
+      }
+    }, CONTEXT_TOKEN_CLEANUP_INTERVAL);
+    tokenCleanupTimer.unref();
+  }
+
+  function stopTokenCleanup(): void {
+    if (tokenCleanupTimer) {
+      clearInterval(tokenCleanupTimer);
+      tokenCleanupTimer = null;
+    }
+  }
+
+  // Typing ticket cache with TTL
+  interface CachedTypingTicket { ticket: string; timestamp: number; }
+  const typingTicketCache = new Map<string, CachedTypingTicket>();
 
   // Known JIDs — skip redundant storeChatMetadata/onNewChat for repeat messages
   const knownJids = new Set<string>();
@@ -416,6 +493,41 @@ export function createWeChatConnection(
     }
   }
 
+  /**
+   * Send a streaming message update using a persistent clientId.
+   * message_state=GENERATING for intermediate updates, FINISH for final.
+   */
+  async function sendMessageStreamingApi(
+    toUserId: string,
+    contextToken: string,
+    text: string,
+    clientId: string,
+    messageState: typeof MESSAGE_STATE_GENERATING | typeof MESSAGE_STATE_FINISH,
+  ): Promise<void> {
+    const resp = await apiPost<{ ret?: number; errcode?: number; errmsg?: string }>(
+      'ilink/bot/sendmessage',
+      {
+        msg: {
+          to_user_id: toUserId,
+          context_token: contextToken,
+          item_list: text
+            ? [{ type: MESSAGE_ITEM_TYPE_TEXT, text_item: { text } }]
+            : undefined,
+          message_type: MESSAGE_TYPE_BOT,
+          message_state: messageState,
+          client_id: clientId,
+        },
+        base_info: baseInfo(),
+      },
+    );
+
+    if (resp.ret !== undefined && resp.ret !== 0) {
+      throw new Error(
+        `sendMessageStreaming failed: ret=${resp.ret} errcode=${resp.errcode} errmsg=${resp.errmsg ?? ''}`,
+      );
+    }
+  }
+
   async function getTypingTicket(
     ilinkUserId: string,
     contextToken: string,
@@ -537,6 +649,115 @@ export function createWeChatConnection(
     }
   }
 
+  // ─── File Handling ───────────────────────────────────────
+
+  async function processFileItem(
+    item: MessageItem,
+    msgIdentifier: string,
+    groupFolder: string | undefined,
+  ): Promise<{ textPrefix?: string }> {
+    const fileItem = item.file_item;
+    if (!fileItem) return {};
+
+    const media = fileItem.media;
+    const fileName = fileItem.file_name || `file_${msgIdentifier}`;
+
+    if (!media?.encrypt_query_param || !media?.aes_key) {
+      logger.debug('WeChat file missing media or aes_key, skipping download');
+      return {}; // extractTextContent() already adds placeholder for non-CDN files
+    }
+
+    if (!groupFolder) {
+      return {}; // extractTextContent() already adds placeholder
+    }
+
+    try {
+      const buffer = await downloadAndDecryptMedia(
+        media.encrypt_query_param,
+        media.aes_key,
+        cdnBaseUrl,
+      );
+
+      if (!buffer || buffer.length === 0) {
+        logger.warn('WeChat file download returned empty buffer');
+        return { textPrefix: `[文件: ${fileName}]` };
+      }
+
+      if (buffer.length > MAX_FILE_SIZE) {
+        logger.warn(
+          { size: buffer.length, fileName },
+          'WeChat file exceeds max file size, skipping download',
+        );
+        return { textPrefix: `[文件: ${fileName} (超过50MB)]` };
+      }
+
+      const relPath = await saveDownloadedFile(
+        groupFolder,
+        'wechat',
+        fileName,
+        buffer,
+      );
+      return { textPrefix: `[文件: ${relPath}]` };
+    } catch (err) {
+      logger.warn({ err, fileName }, 'WeChat file download/decrypt failed');
+      return { textPrefix: `[文件: ${fileName} (下载失败)]` };
+    }
+  }
+
+  // ─── Video Handling ──────────────────────────────────────
+
+  async function processVideoItem(
+    item: MessageItem,
+    msgIdentifier: string,
+    groupFolder: string | undefined,
+  ): Promise<{ textPrefix?: string }> {
+    const videoItem = item.video_item;
+    if (!videoItem) return {};
+
+    const media = videoItem.media;
+    if (!media?.encrypt_query_param || !media?.aes_key) {
+      logger.debug('WeChat video missing media or aes_key, skipping download');
+      return {}; // extractTextContent() already adds placeholder for non-CDN videos
+    }
+
+    if (!groupFolder) {
+      return {}; // extractTextContent() already adds placeholder
+    }
+
+    try {
+      const buffer = await downloadAndDecryptMedia(
+        media.encrypt_query_param,
+        media.aes_key,
+        cdnBaseUrl,
+      );
+
+      if (!buffer || buffer.length === 0) {
+        logger.warn('WeChat video download returned empty buffer');
+        return { textPrefix: '(video)' };
+      }
+
+      if (buffer.length > MAX_FILE_SIZE) {
+        logger.warn(
+          { size: buffer.length },
+          'WeChat video exceeds max file size, skipping download',
+        );
+        return { textPrefix: '(video: 超过50MB)' };
+      }
+
+      const fileName = `wechat_video_${msgIdentifier}.mp4`;
+      const relPath = await saveDownloadedFile(
+        groupFolder,
+        'wechat',
+        fileName,
+        buffer,
+      );
+      return { textPrefix: `[视频: ${relPath}]` };
+    } catch (err) {
+      logger.warn({ err }, 'WeChat video download/decrypt failed');
+      return { textPrefix: '(video: 下载失败)' };
+    }
+  }
+
   // ─── Message Processing ───────────────────────────────────
 
   async function processMessage(
@@ -562,7 +783,7 @@ export function createWeChatConnection(
 
       // Cache context_token for replies
       if (msg.context_token) {
-        contextTokenCache.set(fromUserId, msg.context_token);
+        setToken(fromUserId, msg.context_token);
       }
 
       const jid = `wechat:${fromUserId}`;
@@ -590,7 +811,7 @@ export function createWeChatConnection(
         try {
           const reply = await opts.onCommand(jid, cmdBody);
           if (reply) {
-            const ct = contextTokenCache.get(fromUserId);
+            const ct = getValidToken(fromUserId);
             if (ct) {
               await sendMessageApi(
                 fromUserId,
@@ -602,7 +823,7 @@ export function createWeChatConnection(
           }
         } catch (err) {
           logger.error({ jid, err }, 'WeChat slash command failed');
-          const ct = contextTokenCache.get(fromUserId);
+          const ct = getValidToken(fromUserId);
           if (ct) {
             await sendMessageApi(fromUserId, ct, '命令执行失败，请稍后重试');
           }
@@ -647,19 +868,47 @@ export function createWeChatConnection(
           }
         }
 
-        // Handle file items — note the path in content
-        for (const item of msg.item_list) {
-          if (item.type === MESSAGE_ITEM_TYPE_FILE && item.file_item) {
-            const fileName = item.file_item.file_name || 'unknown_file';
-            content = `[文件: ${fileName}]\n${content}`.trim();
+        // Handle file items — download content to workspace
+        const fileItems = msg.item_list.filter(
+          (item) => item.type === MESSAGE_ITEM_TYPE_FILE,
+        );
+        if (fileItems.length > 0) {
+          const fileResults = await Promise.allSettled(
+            fileItems.map((item) =>
+              processFileItem(item, msgId.slice(-8), groupFolder),
+            ),
+          );
+          for (const r of fileResults) {
+            if (r.status === 'fulfilled' && r.value.textPrefix) {
+              textPrefixes.push(r.value.textPrefix);
+            }
+          }
+        }
+
+        // Handle video items — download to workspace
+        const videoItems = msg.item_list.filter(
+          (item) => item.type === 5 /* VIDEO */,
+        );
+        if (videoItems.length > 0) {
+          const videoResults = await Promise.allSettled(
+            videoItems.map((item) =>
+              processVideoItem(item, msgId.slice(-8), groupFolder),
+            ),
+          );
+          for (const r of videoResults) {
+            if (r.status === 'fulfilled' && r.value.textPrefix) {
+              textPrefixes.push(r.value.textPrefix);
+            }
           }
         }
 
         if (imageAttachments.length > 0) {
           attachmentsJson = JSON.stringify(imageAttachments);
-          if (textPrefixes.length > 0) {
-            content = `${textPrefixes.join('\n')}\n${content}`.trim();
-          }
+        }
+
+        // Merge text prefixes (image paths, file paths, video paths) into content
+        if (textPrefixes.length > 0) {
+          content = `${textPrefixes.join('\n')}\n${content}`.trim();
         }
 
         if (!content && imageAttachments.length > 0) {
@@ -723,6 +972,8 @@ export function createWeChatConnection(
 
   async function pollLoop(opts: WeChatConnectOpts): Promise<void> {
     let reconnectDelay = RECONNECT_MIN_DELAY_MS;
+    let sessionRetryDelay = SESSION_RETRY_INITIAL_MS;
+    let sessionRetryCount = 0;
 
     while (!stopping) {
       try {
@@ -733,11 +984,24 @@ export function createWeChatConnection(
           longpollTimeoutMs = response.longpolling_timeout_ms;
         }
 
-        // Check for session expiry
+        // Check for session expiry — retry with exponential backoff
         if (response.ret === ERRCODE_SESSION_EXPIRED) {
-          logger.warn('WeChat session expired (errcode -14), stopping poll loop');
-          connected = false;
-          break;
+          sessionRetryCount++;
+          if (sessionRetryCount > SESSION_RETRY_MAX_ATTEMPTS) {
+            logger.error(
+              { retries: sessionRetryCount },
+              'WeChat session expired and max retries exceeded, stopping',
+            );
+            connected = false;
+            break;
+          }
+          logger.warn(
+            { delay: sessionRetryDelay, attempt: sessionRetryCount },
+            'WeChat session expired (errcode -14), retrying after backoff',
+          );
+          await sleep(sessionRetryDelay);
+          sessionRetryDelay = Math.min(sessionRetryDelay * 2, SESSION_RETRY_MAX_MS);
+          continue;
         }
 
         // ret is absent (undefined) when the request succeeds — treat as 0
@@ -753,10 +1017,13 @@ export function createWeChatConnection(
 
         // Reset backoff on success
         reconnectDelay = RECONNECT_MIN_DELAY_MS;
+        sessionRetryCount = 0;
+        sessionRetryDelay = SESSION_RETRY_INITIAL_MS;
 
-        // Update cursor
+        // Update cursor and persist
         if (response.get_updates_buf) {
           currentGetUpdatesBuf = response.get_updates_buf;
+          opts.onBufUpdate?.(currentGetUpdatesBuf);
         }
 
         // Process messages
@@ -798,7 +1065,9 @@ export function createWeChatConnection(
       connected = true;
       msgCache.clear();
       contextTokenCache.clear();
+      typingTicketCache.clear();
       knownJids.clear();
+      startTokenCleanup();
 
       logger.info(
         { baseUrl, ilinkBotId: config.ilinkBotId },
@@ -823,8 +1092,10 @@ export function createWeChatConnection(
       cancelSleep?.();
       cancelSleep = null;
 
+      stopTokenCleanup();
       msgCache.clear();
       contextTokenCache.clear();
+      typingTicketCache.clear();
       knownJids.clear();
       logger.info('WeChat iLink bot disconnected');
     },
@@ -834,10 +1105,9 @@ export function createWeChatConnection(
       text: string,
       _localImagePaths?: string[],
     ): Promise<void> {
-      // chatId is the raw WeChat user ID (prefix already stripped by IM manager)
       const userId = chatId;
 
-      const contextToken = contextTokenCache.get(userId);
+      const contextToken = getValidToken(userId);
       if (!contextToken) {
         logger.warn(
           { chatId },
@@ -862,13 +1132,22 @@ export function createWeChatConnection(
     },
 
     async sendTyping(chatId: string, isTyping: boolean): Promise<void> {
-      // chatId is the raw WeChat user ID (prefix already stripped by IM manager)
       const userId = chatId;
 
-      const contextToken = contextTokenCache.get(userId);
+      const contextToken = getValidToken(userId);
       if (!contextToken) return;
 
-      const ticket = await getTypingTicket(userId, contextToken);
+      // Check typing ticket cache first
+      let ticket: string | null = null;
+      const cached = typingTicketCache.get(userId);
+      if (cached && Date.now() - cached.timestamp < TYPING_TICKET_TTL) {
+        ticket = cached.ticket;
+      } else {
+        ticket = await getTypingTicket(userId, contextToken);
+        if (ticket) {
+          typingTicketCache.set(userId, { ticket, timestamp: Date.now() });
+        }
+      }
       if (!ticket) return;
 
       await sendTypingApi(userId, ticket, isTyping ? 1 : 2);
@@ -880,6 +1159,105 @@ export function createWeChatConnection(
 
     getUpdatesBuf(): string {
       return currentGetUpdatesBuf;
+    },
+
+    createStreamingSession(chatId: string): WeChatStreamingSession | undefined {
+      const contextToken = getValidToken(chatId);
+      if (!contextToken) return undefined;
+
+      const clientId = String(crypto.randomBytes(4).readUInt32BE(0));
+      let state: 'streaming' | 'completed' | 'aborted' = 'streaming';
+      let pendingText = '';
+      let lastSentText = '';
+      let lastSendTime = 0;
+      let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+      let sendChain = Promise.resolve(); // serialize sends to prevent out-of-order delivery
+
+      const doSend = async (text: string, done: boolean): Promise<void> => {
+        const cleaned = markdownToPlainText(text);
+        if (cleaned === lastSentText && !done) return;
+
+        // Always get the latest context_token
+        const ct = getValidToken(chatId) || contextToken;
+        try {
+          await sendMessageStreamingApi(
+            chatId,
+            ct,
+            cleaned,
+            clientId,
+            done ? MESSAGE_STATE_FINISH : MESSAGE_STATE_GENERATING,
+          );
+          lastSentText = cleaned;
+          lastSendTime = Date.now();
+        } catch (err) {
+          logger.warn({ err, chatId, done }, 'WeChat streaming send failed');
+        }
+      };
+
+      const session: WeChatStreamingSession = {
+        append(accumulatedText: string): void {
+          if (state !== 'streaming' || !accumulatedText) return;
+          pendingText = accumulatedText;
+
+          const elapsed = Date.now() - lastSendTime;
+          if (elapsed >= STREAM_THROTTLE_MS) {
+            if (throttleTimer) {
+              clearTimeout(throttleTimer);
+              throttleTimer = null;
+            }
+            sendChain = sendChain.then(() => doSend(pendingText, false)).catch(() => {});
+          } else if (!throttleTimer) {
+            throttleTimer = setTimeout(() => {
+              throttleTimer = null;
+              if (state === 'streaming') {
+                sendChain = sendChain.then(() => doSend(pendingText, false)).catch(() => {});
+              }
+            }, STREAM_THROTTLE_MS - elapsed);
+          }
+        },
+
+        async complete(finalText: string): Promise<void> {
+          if (state !== 'streaming') return;
+          state = 'completed';
+          if (throttleTimer) {
+            clearTimeout(throttleTimer);
+            throttleTimer = null;
+          }
+          // Wait for pending sends, then send FINISH to clear "generating" state
+          await sendChain;
+          await doSend(finalText || lastSentText, true);
+        },
+
+        async abort(reason?: string): Promise<void> {
+          if (state !== 'streaming') return;
+          state = 'aborted';
+          if (throttleTimer) {
+            clearTimeout(throttleTimer);
+            throttleTimer = null;
+          }
+          // Wait for pending sends, then send FINISH with abort info
+          await sendChain.catch(() => {});
+          const abortText = reason
+            ? `${lastSentText}\n\n(${reason})`
+            : lastSentText;
+          if (abortText) {
+            await doSend(abortText, true).catch(() => {});
+          }
+        },
+
+        isActive(): boolean {
+          return state === 'streaming';
+        },
+
+        dispose(): void {
+          if (throttleTimer) {
+            clearTimeout(throttleTimer);
+            throttleTimer = null;
+          }
+        },
+      };
+
+      return session;
     },
   };
 


### PR DESCRIPTION
## 问题描述

对比 [weixin-ai-bridge](https://github.com/yansc153/weixin-ai-bridge) 项目后，发现 HappyClaw 微信渠道有 4 个可改进点。同时调研了 Claude Code SDK 返回的所有消息类型，确认 SDK 事件在 agent-runner → 后端 → 前端链路上覆盖完整，差距集中在 IM 渠道的流式体验。

## 实现方案

### 1. 流式打字机效果（用户体验最大提升）

利用 iLink API 原生的 `GENERATING(1) → FINISH(2)` 流式消息协议：
- 新增 `WeChatStreamingSession` 类，800ms 节流推送中间文本
- 同一 `clientId` 贯穿整个响应，微信客户端自动替换前一条消息
- 集成到 `index.ts` 的 `onOutput` 回调，拦截 `text_delta` 事件推送
- `sendChain` Promise 串行化防止并发乱序

### `src/wechat.ts`
- 新增 `sendMessageStreamingApi()` — 支持 clientId 复用和 messageState 参数
- 新增 `WeChatStreamingSession` — append/complete/abort 生命周期管理

### `src/index.ts`
- `processGroupMessages()` 中创建 WeChat streaming session
- `onOutput` 回调中 `text_delta` → `append()`
- 最终回复 → `complete()`，`skipImSend` 计算纳入 `wechatStreamingHandledIM`
- 动态路由切换和 finally 块中正确清理 session

### 2. 会话过期自动恢复 + 同步位点持久化

### `src/wechat.ts`
- errcode -14 从直接 `break` 改为指数退避重试（60s→10min，最多 10 次）
- `context_token` 使用 2h TTL + 30min 清理定时器，防止内存泄漏
- `onBufUpdate` 回调透传同步位点变更

### `src/index.ts`
- `debouncedSaveWeChatBuf()` — 30s debounce 写入配置文件
- `flushWeChatBufSaves()` — 优雅关闭时立即持久化

### 3. 文件和视频下载

### `src/wechat.ts`
- 新增 `processFileItem()` — CDN 下载 + AES 解密 + 保存到 `downloads/wechat/`
- 新增 `processVideoItem()` — 同上，50MB 限制
- `extractTextContent()` 有 CDN 参数的文件/视频不再添加占位符（避免重复）
- `processMessage()` 中用 `Promise.allSettled()` 并行下载

### 4. Typing 指示器优化

### `src/wechat.ts`
- `typingTicketCache` — 5min TTL 缓存，避免每次 sendTyping 都调 getConfig

### `src/im-channel.ts`
- WeChat 适配器 setTyping 改为 4s 间隔定时重发（参考 Telegram 模式）
- sendAction 加 try-catch 防止 unhandled rejection

## 测试计划

- [ ] 发送需要 Agent 长时间执行的问题，观察微信端打字机效果
- [ ] 重启服务后发送消息，确认不会重复处理旧消息
- [ ] 检查 `data/config/user-im/{userId}/wechat.json` 中 `getUpdatesBuf` 被持久化
- [ ] 通过微信发送 PDF/Word 文件，确认下载到 `downloads/wechat/` 并被 Agent 引用
- [ ] 通过微信发送视频，确认下载保存
- [ ] `make typecheck` 通过