### PR TITLE
功能: 对话重命名 + 移动端右键/长按操作菜单

### DIFF
--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -21,6 +21,8 @@ import {
   setRegisteredGroup,
   getJidsByFolder,
   updateAgentLastImJid,
+  updateAgentInfo,
+  updateChatName,
 } from '../db.js';
 import { DATA_DIR } from '../config.js';
 import type { RegisteredGroup, SubAgent } from '../types.js';
@@ -160,6 +162,46 @@ router.post('/:jid/agents', authMiddleware, async (c) => {
       created_at: agent.created_at,
     },
   });
+});
+
+// PATCH /api/groups/:jid/agents/:agentId — rename a conversation agent
+router.patch('/:jid/agents/:agentId', authMiddleware, async (c) => {
+  const jid = decodeURIComponent(c.req.param('jid'));
+  const agentId = c.req.param('agentId');
+  const user = c.get('user');
+
+  const group = getRegisteredGroup(jid);
+  if (!group) {
+    return c.json({ error: 'Group not found' }, 404);
+  }
+  if (!canAccessGroup(user, { ...group, jid })) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const agent = getAgent(agentId);
+  if (!agent || agent.chat_jid !== jid) {
+    return c.json({ error: 'Agent not found' }, 404);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!name || name.length > 40) {
+    return c.json({ error: 'Name is required (max 40 chars)' }, 400);
+  }
+
+  // Update agent name in DB
+  updateAgentInfo(agentId, name, agent.prompt);
+
+  // Update virtual chat name
+  const virtualChatJid = `${jid}#agent:${agentId}`;
+  updateChatName(virtualChatJid, name);
+
+  // Broadcast update via WebSocket
+  const { broadcastAgentStatus } = await import('../web.js');
+  broadcastAgentStatus(jid, agentId, agent.status as import('../types.js').AgentStatus, name, agent.prompt);
+
+  logger.info({ agentId, jid, name, userId: user.id }, 'Agent renamed');
+  return c.json({ success: true });
 });
 
 // DELETE /api/groups/:jid/agents/:agentId — stop and delete an agent

--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -1,4 +1,5 @@
-import { Plus, X, Link, MessageSquare } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+import { Plus, X, Link, MessageSquare, Pencil, Trash2 } from 'lucide-react';
 import type { AgentInfo } from '../../types';
 
 interface AgentTabBarProps {
@@ -6,6 +7,7 @@ interface AgentTabBarProps {
   activeTab: string | null; // null = main conversation
   onSelectTab: (agentId: string | null) => void;
   onDeleteAgent: (agentId: string) => void;
+  onRenameAgent?: (agentId: string, currentName: string) => void;
   onCreateConversation?: () => void;
   onBindIm?: (agentId: string) => void;
   /** Show bind button on main conversation tab (non-home workspaces) */
@@ -19,80 +21,198 @@ const tabClass = (active: boolean) =>
       : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
   }`;
 
-export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onCreateConversation, onBindIm, onBindMainIm }: AgentTabBarProps) {
+interface ContextMenuState {
+  agentId: string;
+  agentName: string;
+  x: number;
+  y: number;
+}
+
+function ContextMenuOverlay({ menu, onRename, onDelete, onClose }: {
+  menu: ContextMenuState;
+  onRename?: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 min-w-[120px] rounded-md border border-border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95"
+      style={{ left: menu.x, top: menu.y }}
+    >
+      {onRename && (
+        <button
+          onClick={onRename}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground cursor-pointer"
+        >
+          <Pencil className="w-3.5 h-3.5" />
+          重命名
+        </button>
+      )}
+      <button
+        onClick={onDelete}
+        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30 cursor-pointer"
+      >
+        <Trash2 className="w-3.5 h-3.5" />
+        删除
+      </button>
+    </div>
+  );
+}
+
+export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onRenameAgent, onCreateConversation, onBindIm, onBindMainIm }: AgentTabBarProps) {
   const conversations = agents.filter(a => a.kind === 'conversation');
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up long-press timer on unmount
+  useEffect(() => {
+    return () => {
+      if (longPressTimer.current) clearTimeout(longPressTimer.current);
+    };
+  }, []);
 
   // Show bar if there are agents OR if creation is available
   if (conversations.length === 0 && !onCreateConversation) return null;
 
+  const openContextMenu = (agentId: string, agentName: string, x: number, y: number) => {
+    // Clamp position to viewport
+    const menuWidth = 140;
+    const menuHeight = 80;
+    const clampedX = Math.min(x, window.innerWidth - menuWidth);
+    const clampedY = Math.min(y, window.innerHeight - menuHeight);
+    setContextMenu({ agentId, agentName, x: clampedX, y: clampedY });
+  };
+
+  const handleContextMenu = (e: React.MouseEvent, agent: AgentInfo) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openContextMenu(agent.id, agent.name, e.clientX, e.clientY);
+  };
+
+  const handleTouchStart = (agent: AgentInfo, e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    const x = touch.clientX;
+    const y = touch.clientY;
+    longPressTimer.current = setTimeout(() => {
+      longPressTimer.current = null;
+      openContextMenu(agent.id, agent.name, x, y);
+    }, 500);
+  };
+
+  const handleTouchEnd = () => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  };
+
   return (
-    <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border bg-background/80 overflow-x-auto scrollbar-none">
-      {/* Main conversation tab */}
-      <div
-        className={`${tabClass(activeTab === null)} flex items-center gap-1.5 group`}
-        onClick={() => onSelectTab(null)}
-      >
-        <span>主对话</span>
-        {onBindMainIm && (
+    <>
+      <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border bg-background/80 overflow-x-auto scrollbar-none select-none">
+        {/* Main conversation tab */}
+        <div
+          className={`${tabClass(activeTab === null)} flex items-center gap-1.5 group`}
+          onClick={() => onSelectTab(null)}
+        >
+          <span>主对话</span>
+          {onBindMainIm && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onBindMainIm(); }}
+              className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+              title="绑定 IM 群组"
+            >
+              <Link className="w-3 h-3" />
+            </button>
+          )}
+        </div>
+
+        {/* Conversation tabs — same visual level as main */}
+        {conversations.map((agent) => {
+          const hasLinked = agent.linked_im_groups && agent.linked_im_groups.length > 0;
+          return (
+            <div
+              key={agent.id}
+              className={`${tabClass(activeTab === agent.id)} flex items-center gap-1.5 group`}
+              onClick={() => onSelectTab(agent.id)}
+              onContextMenu={(e) => handleContextMenu(e, agent)}
+              onTouchStart={(e) => handleTouchStart(agent, e)}
+              onTouchEnd={handleTouchEnd}
+              onTouchMove={handleTouchEnd}
+            >
+              {agent.status === 'running' && (
+                <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
+              )}
+              {hasLinked && (
+                <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
+                  <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />
+                </span>
+              )}
+              <span className="truncate max-w-[120px]">{agent.name}</span>
+              {onBindIm && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
+                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+                  title="绑定 IM 群组"
+                >
+                  <Link className="w-3 h-3" />
+                </button>
+              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
+                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+                title="关闭对话"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+          );
+        })}
+
+        {/* Create conversation button */}
+        {onCreateConversation && (
           <button
-            onClick={(e) => { e.stopPropagation(); onBindMainIm(); }}
-            className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-            title="绑定 IM 渠道"
+            onClick={onCreateConversation}
+            className="flex-shrink-0 flex items-center gap-0.5 px-2 py-1 rounded-md text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer"
+            title="新建对话"
           >
-            <Link className="w-3 h-3" />
+            <Plus className="w-3.5 h-3.5" />
           </button>
         )}
+
       </div>
 
-      {/* Conversation tabs — same visual level as main */}
-      {conversations.map((agent) => {
-        const hasLinked = agent.linked_im_groups && agent.linked_im_groups.length > 0;
-        return (
-          <div
-            key={agent.id}
-            className={`${tabClass(activeTab === agent.id)} flex items-center gap-1.5 group`}
-            onClick={() => onSelectTab(agent.id)}
-          >
-            {agent.status === 'running' && (
-              <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
-            )}
-            {hasLinked && (
-              <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
-                <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />
-              </span>
-            )}
-            <span className="truncate max-w-[120px]">{agent.name}</span>
-            {onBindIm && (
-              <button
-                onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
-                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-                title="绑定 IM 渠道"
-              >
-                <Link className="w-3 h-3" />
-              </button>
-            )}
-            <button
-              onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-              className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-              title="关闭对话"
-            >
-              <X className="w-3 h-3" />
-            </button>
-          </div>
-        );
-      })}
-
-      {/* Create conversation button */}
-      {onCreateConversation && (
-        <button
-          onClick={onCreateConversation}
-          className="flex-shrink-0 flex items-center gap-0.5 px-2 py-1 rounded-md text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer"
-          title="新建对话"
-        >
-          <Plus className="w-3.5 h-3.5" />
-        </button>
+      {/* Context menu (right-click / long-press) */}
+      {contextMenu && (
+        <ContextMenuOverlay
+          menu={contextMenu}
+          onRename={onRenameAgent ? () => {
+            onRenameAgent(contextMenu.agentId, contextMenu.agentName);
+            setContextMenu(null);
+          } : undefined}
+          onDelete={() => {
+            onDeleteAgent(contextMenu.agentId);
+            setContextMenu(null);
+          }}
+          onClose={() => setContextMenu(null)}
+        />
       )}
-
-    </div>
+    </>
   );
 }

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -69,6 +69,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   // null = dialog closed; MAIN_BINDING = main conversation; other = agent id
   const [bindingAgentId, setBindingAgentId] = useState<string | null>(null);
   const [showNewConversation, setShowNewConversation] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<{ agentId: string; name: string } | null>(null);
   // Code / Plan mode toggle (per group)
   const [permissionMode, setPermissionMode] = useState<'bypassPermissions' | 'plan'>('bypassPermissions');
   const [imStatus, setImStatus] = useState<{ feishu: boolean; telegram: boolean } | null>(null);
@@ -105,6 +106,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const deleteAgentAction = useChatStore(s => s.deleteAgentAction);
   const agentStreaming = useChatStore(s => s.agentStreaming);
   const createConversation = useChatStore(s => s.createConversation);
+  const renameConversation = useChatStore(s => s.renameConversation);
   const loadAgentMessages = useChatStore(s => s.loadAgentMessages);
   const refreshAgentMessages = useChatStore(s => s.refreshAgentMessages);
   const sendAgentMessage = useChatStore(s => s.sendAgentMessage);
@@ -548,6 +550,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
           }
           deleteAgentAction(groupJid, id);
         }}
+        onRenameAgent={(id, currentName) => setRenameTarget({ agentId: id, name: currentName })}
         onCreateConversation={() => setShowNewConversation(true)}
         onBindIm={setBindingAgentId}
         onBindMainIm={!isHome ? () => setBindingAgentId(MAIN_BINDING) : undefined}
@@ -873,6 +876,18 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
           });
         }}
         onClose={() => setShowNewConversation(false)}
+      />
+
+      <PromptDialog
+        open={renameTarget !== null}
+        title="重命名对话"
+        label="对话名称"
+        placeholder="输入新名称"
+        defaultValue={renameTarget?.name ?? ''}
+        onConfirm={(name) => {
+          if (renameTarget) renameConversation(groupJid, renameTarget.agentId, name);
+        }}
+        onClose={() => setRenameTarget(null)}
       />
     </div>
   );

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -209,6 +209,7 @@ interface ChatState {
   setActiveAgentTab: (jid: string, agentId: string | null) => void;
   // Conversation agent actions
   createConversation: (jid: string, name: string, description?: string) => Promise<AgentInfo | null>;
+  renameConversation: (jid: string, agentId: string, name: string) => Promise<boolean>;
   loadAgentMessages: (jid: string, agentId: string, loadMore?: boolean) => Promise<void>;
   sendAgentMessage: (jid: string, agentId: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => void;
   refreshAgentMessages: (jid: string, agentId: string) => Promise<void>;
@@ -1901,6 +1902,21 @@ export const useChatStore = create<ChatState>((set, get) => ({
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
       return null;
+    }
+  },
+
+  renameConversation: async (jid, agentId, name) => {
+    try {
+      await api.patch(`/api/groups/${encodeURIComponent(jid)}/agents/${agentId}`, { name });
+      set((s) => {
+        const agents = (s.agents[jid] || []).map((a) =>
+          a.id === agentId ? { ...a, name } : a,
+        );
+        return { agents: { ...s.agents, [jid]: agents } };
+      });
+      return true;
+    } catch {
+      return false;
     }
   },
 


### PR DESCRIPTION
- 后端新增 PATCH /api/groups/:jid/agents/:agentId 接口，支持修改对话名称
- 前端 AgentTabBar 增加右键菜单（PC）和长按菜单（移动端），包含重命名和删除操作
- 移动端此前无法删除对话（hover 操作不可用），现在通过长按菜单解决
- 标签栏添加 select-none 防止长按触发文字选择