### PR TITLE
优化: 脚本任务无输出时不发送通知

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -449,15 +449,17 @@ async function runScriptTask(
       error = scriptResult.stderr.trim() || `退出码: ${scriptResult.exitCode}`;
       result = scriptResult.stdout.trim() || null;
     } else {
-      result = scriptResult.stdout.trim() || '(无输出)';
+      result = scriptResult.stdout.trim() || null;
     }
 
-    // Send result to user
-    const text = error
-      ? `[脚本] 执行失败: ${error}${result ? `\n输出:\n${result.slice(0, 500)}` : ''}`
-      : `[脚本] ${result!.slice(0, 1000)}`;
+    // Send result to user (skip if no output and no error)
+    if (error || result) {
+      const text = error
+        ? `[脚本] 执行失败: ${error}${result ? `\n输出:\n${result.slice(0, 500)}` : ''}`
+        : `[脚本] ${result!.slice(0, 1000)}`;
 
-    await deps.sendMessage(groupJid, `${deps.assistantName}: ${text}`, { source: 'scheduled_task' });
+      await deps.sendMessage(groupJid, `${deps.assistantName}: ${text}`, { source: 'scheduled_task' });
+    }
 
     logger.info(
       {


### PR DESCRIPTION
## 问题描述

脚本模式的定时任务（如文件同步、健康检查）大多数时候没有变化，但每次执行都会发送一条 `[脚本] (无输出)` 的消息，对用户造成不必要的干扰。

## 修复方案

### `src/task-scheduler.ts`
- 脚本执行成功但无 stdout 输出时，跳过消息发送
- 仅在有实际输出或执行出错时才通知用户
- 脚本如需主动通知，echo 输出即可

🤖 Generated with [Claude Code](https://claude.com/claude-code)