### PR TITLE
修复: list_tasks MCP 工具返回空结果

### DIFF
--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -568,57 +568,82 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
       "List all scheduled tasks. From admin home: shows all tasks. From other groups: shows only that group's tasks.",
       {},
       async () => {
-        const tasksFile = path.join(ctx.workspaceIpc, 'current_tasks.json');
-        try {
-          if (!fs.existsSync(tasksFile)) {
-            return {
-              content: [
-                { type: 'text' as const, text: 'No scheduled tasks found.' },
-              ],
-            };
+        const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const resultFileName = `list_tasks_result_${requestId}.json`;
+        const resultFilePath = path.join(TASKS_DIR, resultFileName);
+
+        const data = {
+          type: 'list_tasks',
+          requestId,
+          groupFolder: ctx.groupFolder,
+          isAdminHome: hasCrossGroupAccess,
+          timestamp: new Date().toISOString(),
+        };
+        writeIpcFile(TASKS_DIR, data);
+
+        // Poll for result file (timeout 30s)
+        const timeout = 30_000;
+        const pollInterval = 500;
+        const deadline = Date.now() + timeout;
+
+        while (Date.now() < deadline) {
+          try {
+            if (fs.existsSync(resultFilePath)) {
+              const raw = fs.readFileSync(resultFilePath, 'utf-8');
+              fs.unlinkSync(resultFilePath);
+              const result = JSON.parse(raw);
+              if (!result.success) {
+                return {
+                  content: [
+                    {
+                      type: 'text' as const,
+                      text: `Error listing tasks: ${result.error || 'Unknown error'}`,
+                    },
+                  ],
+                  isError: true,
+                };
+              }
+              const tasks = result.tasks || [];
+              if (tasks.length === 0) {
+                return {
+                  content: [
+                    { type: 'text' as const, text: 'No scheduled tasks found.' },
+                  ],
+                };
+              }
+              const formatted = tasks
+                .map(
+                  (t: {
+                    id: string;
+                    prompt: string;
+                    schedule_type: string;
+                    schedule_value: string;
+                    status: string;
+                    next_run: string;
+                  }) =>
+                    `- [${t.id}] ${t.prompt.slice(0, 50)}... (${t.schedule_type}: ${t.schedule_value}) - ${t.status}, next: ${t.next_run || 'N/A'}`,
+                )
+                .join('\n');
+              return {
+                content: [
+                  { type: 'text' as const, text: `Scheduled tasks:\n${formatted}` },
+                ],
+              };
+            }
+          } catch {
+            // ignore read errors, retry
           }
-          const allTasks = JSON.parse(fs.readFileSync(tasksFile, 'utf-8'));
-          const tasks = hasCrossGroupAccess
-            ? allTasks
-            : allTasks.filter(
-                (t: { groupFolder: string }) =>
-                  t.groupFolder === ctx.groupFolder,
-              );
-          if (tasks.length === 0) {
-            return {
-              content: [
-                { type: 'text' as const, text: 'No scheduled tasks found.' },
-              ],
-            };
-          }
-          const formatted = tasks
-            .map(
-              (t: {
-                id: string;
-                prompt: string;
-                schedule_type: string;
-                schedule_value: string;
-                status: string;
-                next_run: string;
-              }) =>
-                `- [${t.id}] ${t.prompt.slice(0, 50)}... (${t.schedule_type}: ${t.schedule_value}) - ${t.status}, next: ${t.next_run || 'N/A'}`,
-            )
-            .join('\n');
-          return {
-            content: [
-              { type: 'text' as const, text: `Scheduled tasks:\n${formatted}` },
-            ],
-          };
-        } catch (err) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `Error reading tasks: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-          };
+          await new Promise((resolve) => setTimeout(resolve, pollInterval));
         }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Timeout waiting for task list response.',
+            },
+          ],
+          isError: true,
+        };
       },
     ),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3722,7 +3722,8 @@ function startIpcWatcher(): void {
               entry.isFile() &&
               entry.name.endsWith('.json') &&
               (entry.name.startsWith('install_skill_result_') ||
-                entry.name.startsWith('uninstall_skill_result_'))
+                entry.name.startsWith('uninstall_skill_result_') ||
+                entry.name.startsWith('list_tasks_result_'))
             ) {
               try {
                 const filePath = path.join(tasksDir, entry.name);
@@ -3746,7 +3747,8 @@ function startIpcWatcher(): void {
                 entry.isFile() &&
                 entry.name.endsWith('.json') &&
                 !entry.name.startsWith('install_skill_result_') &&
-                !entry.name.startsWith('uninstall_skill_result_'),
+                !entry.name.startsWith('uninstall_skill_result_') &&
+                !entry.name.startsWith('list_tasks_result_'),
             )
             .map((entry) => entry.name);
           for (const file of taskFiles) {
@@ -3860,6 +3862,8 @@ async function processTaskIpc(
     // For send_file
     filePath?: string;
     fileName?: string;
+    // For list_tasks
+    isAdminHome?: boolean;
   },
   sourceGroup: string, // Verified identity from IPC directory
   isAdminHome: boolean, // Whether source is admin home container
@@ -4030,6 +4034,69 @@ async function processTaskIpc(
           logger.warn(
             { taskId: data.taskId, sourceGroup },
             'Unauthorized task cancel attempt',
+          );
+        }
+      }
+      break;
+
+    case 'list_tasks':
+      if (data.requestId) {
+        const requestId = data.requestId;
+        if (!SAFE_REQUEST_ID_RE.test(requestId)) {
+          logger.warn(
+            { sourceGroup, requestId },
+            'Rejected list_tasks request with invalid requestId',
+          );
+          break;
+        }
+        const listTasksDir = path.join(DATA_DIR, 'ipc', sourceGroup, 'tasks');
+        const listTasksDirResolved = path.resolve(listTasksDir);
+        const resultFileName = `list_tasks_result_${requestId}.json`;
+        const resultFilePath = path.resolve(listTasksDir, resultFileName);
+        if (!resultFilePath.startsWith(`${listTasksDirResolved}${path.sep}`)) {
+          logger.warn(
+            { sourceGroup, requestId, resultFilePath },
+            'Rejected list_tasks request with unsafe result file path',
+          );
+          break;
+        }
+
+        try {
+          const allTasks = getAllTasks();
+          // Admin home sees all tasks, others only see their own group's tasks
+          const filteredTasks = isAdminHome
+            ? allTasks
+            : allTasks.filter((t) => t.group_folder === sourceGroup);
+          const taskList = filteredTasks.map((t) => ({
+            id: t.id,
+            groupFolder: t.group_folder,
+            prompt: t.prompt,
+            schedule_type: t.schedule_type,
+            schedule_value: t.schedule_value,
+            status: t.status,
+            next_run: t.next_run,
+          }));
+          const resultData = JSON.stringify({ success: true, tasks: taskList });
+          const tmpPath = `${resultFilePath}.tmp`;
+          fs.mkdirSync(path.dirname(resultFilePath), { recursive: true });
+          fs.writeFileSync(tmpPath, resultData);
+          fs.renameSync(tmpPath, resultFilePath);
+          logger.debug(
+            { sourceGroup, taskCount: taskList.length },
+            'Task list sent via IPC',
+          );
+        } catch (err) {
+          const errorResult = JSON.stringify({
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          const tmpPath = `${resultFilePath}.tmp`;
+          fs.mkdirSync(path.dirname(resultFilePath), { recursive: true });
+          fs.writeFileSync(tmpPath, errorResult);
+          fs.renameSync(tmpPath, resultFilePath);
+          logger.error(
+            { sourceGroup, err },
+            'Failed to list tasks via IPC',
           );
         }
       }


### PR DESCRIPTION
## 问题描述

`list_tasks` MCP 工具读取 `current_tasks.json` 文件获取任务列表，但该文件仅在任务被调度运行时才写入（`task-scheduler.ts` 的 `runTask()` 中调用 `writeTasksSnapshot()`）。这导致用户在 Web 界面能看到任务，但通过 AI Agent 的 `list_tasks` 工具大部分时间返回空结果。

## 修复方案

改为通过 IPC 请求-响应机制向主进程查询数据库中的任务列表，复用 `install_skill`/`uninstall_skill` 相同的 IPC 模式（写请求文件 → 轮询结果文件）。

### `container/agent-runner/src/mcp-tools.ts`
- `list_tasks` 工具改为通过 IPC 发送 `list_tasks` 请求，轮询结果文件获取任务列表
- 移除对 `current_tasks.json` 文件的直接读取

### `src/index.ts`
- `processTaskIpc` 新增 `list_tasks` 类型处理：从数据库查询任务列表，按权限过滤后写入结果文件
- 结果文件清理和过滤逻辑同步更新，覆盖 `list_tasks_result_` 前缀