### PR TITLE
功能: 微信直连模式开关 — 支持在 Web UI 切换绕过/使用代理

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,43 @@ function getOrCreateSessionSecret(): string {
 
 export const WEB_SESSION_SECRET = getOrCreateSessionSecret();
 
+// Ensure WeChat iLink API domains bypass HTTP proxy.
+// These Chinese domestic services are unreachable through most overseas proxies.
+const WECHAT_NO_PROXY_DOMAINS = [
+  'ilinkai.weixin.qq.com',
+  'novac2c.cdn.weixin.qq.com',
+];
+
+/** Add or remove WeChat domains from NO_PROXY based on bypassProxy flag. */
+export function updateWeChatNoProxy(bypassProxy: boolean): void {
+  const current = process.env.NO_PROXY || process.env.no_proxy || '';
+  const existing = new Set(current.split(',').map((s) => s.trim()).filter(Boolean));
+
+  if (bypassProxy) {
+    const toAdd = WECHAT_NO_PROXY_DOMAINS.filter((d) => !existing.has(d));
+    if (toAdd.length) {
+      const updated = current ? `${current},${toAdd.join(',')}` : toAdd.join(',');
+      process.env.NO_PROXY = updated;
+      process.env.no_proxy = updated;
+    }
+  } else {
+    for (const d of WECHAT_NO_PROXY_DOMAINS) existing.delete(d);
+    const updated = [...existing].join(',');
+    process.env.NO_PROXY = updated;
+    process.env.no_proxy = updated;
+  }
+}
+
+/** Check if WeChat domains are currently in NO_PROXY. */
+export function isWeChatBypassingProxy(): boolean {
+  const current = process.env.NO_PROXY || process.env.no_proxy || '';
+  const existing = new Set(current.split(',').map((s) => s.trim()).filter(Boolean));
+  return WECHAT_NO_PROXY_DOMAINS.every((d) => existing.has(d));
+}
+
+// Apply default: bypass proxy on startup
+updateWeChatNoProxy(true);
+
 // Proxy trust configuration
 // Set TRUST_PROXY=true when behind a reverse proxy (nginx, Cloudflare, etc.)
 export const TRUST_PROXY = process.env.TRUST_PROXY === 'true';

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -5,6 +5,7 @@ import { Agent as HttpsAgent } from 'node:https';
 import { ProxyAgent } from 'proxy-agent';
 import QRCode from 'qrcode';
 import { Hono } from 'hono';
+import { updateWeChatNoProxy } from '../config.js';
 import type { Variables } from '../web-context.js';
 import { canAccessGroup, getWebDeps } from '../web-context.js';
 import { getChannelType } from '../im-channel.js';
@@ -1735,6 +1736,7 @@ configRoutes.get('/user-im/wechat', authMiddleware, (c) => {
         ilinkBotId: '',
         hasBotToken: false,
         botTokenMasked: null,
+        bypassProxy: true,
         enabled: false,
         updatedAt: null,
         connected,
@@ -1744,6 +1746,7 @@ configRoutes.get('/user-im/wechat', authMiddleware, (c) => {
       ilinkBotId: config.ilinkBotId || '',
       hasBotToken: !!config.botToken,
       botTokenMasked: maskBotToken(config.botToken),
+      bypassProxy: config.bypassProxy ?? true,
       enabled: config.enabled ?? false,
       updatedAt: config.updatedAt,
       connected,
@@ -1787,6 +1790,7 @@ configRoutes.put('/user-im/wechat', authMiddleware, async (c) => {
     baseUrl: current?.baseUrl,
     cdnBaseUrl: current?.cdnBaseUrl,
     getUpdatesBuf: current?.getUpdatesBuf,
+    bypassProxy: current?.bypassProxy ?? true,
     enabled: current?.enabled ?? false,
   };
 
@@ -1797,9 +1801,15 @@ configRoutes.put('/user-im/wechat', authMiddleware, async (c) => {
   if (typeof validation.data.enabled === 'boolean') {
     next.enabled = validation.data.enabled;
   }
+  if (typeof validation.data.bypassProxy === 'boolean') {
+    next.bypassProxy = validation.data.bypassProxy;
+  }
 
   try {
     const saved = saveUserWeChatConfig(user.id, next);
+
+    // Update NO_PROXY based on bypassProxy setting
+    updateWeChatNoProxy(saved.bypassProxy ?? true);
 
     // Hot-reload: reconnect user's WeChat channel
     if (deps?.reloadUserIMConfig) {
@@ -1818,6 +1828,7 @@ configRoutes.put('/user-im/wechat', authMiddleware, async (c) => {
       ilinkBotId: saved.ilinkBotId || '',
       hasBotToken: !!saved.botToken,
       botTokenMasked: maskBotToken(saved.botToken),
+      bypassProxy: saved.bypassProxy ?? true,
       enabled: saved.enabled ?? false,
       updatedAt: saved.updatedAt,
       connected,

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3227,6 +3227,7 @@ export interface UserWeChatConfig {
   baseUrl?: string; // 默认 https://ilinkai.weixin.qq.com
   cdnBaseUrl?: string; // 默认 https://novac2c.cdn.weixin.qq.com/c2c
   getUpdatesBuf?: string; // 长轮询游标
+  bypassProxy?: boolean; // 直连模式：绕过 HTTP 代理（默认 true）
   enabled?: boolean;
   updatedAt: string | null;
 }
@@ -3237,6 +3238,7 @@ interface StoredWeChatProviderConfigV1 {
   baseUrl?: string;
   cdnBaseUrl?: string;
   getUpdatesBuf?: string;
+  bypassProxy?: boolean;
   enabled?: boolean;
   updatedAt: string;
   secret: EncryptedSecrets;
@@ -3297,6 +3299,7 @@ export function getUserWeChatConfig(userId: string): UserWeChatConfig | null {
       baseUrl: stored.baseUrl,
       cdnBaseUrl: stored.cdnBaseUrl,
       getUpdatesBuf: stored.getUpdatesBuf,
+      bypassProxy: stored.bypassProxy ?? true, // 默认直连
       enabled: stored.enabled,
       updatedAt: stored.updatedAt || null,
     };
@@ -3316,6 +3319,7 @@ export function saveUserWeChatConfig(
     baseUrl: next.baseUrl?.trim() || undefined,
     cdnBaseUrl: next.cdnBaseUrl?.trim() || undefined,
     getUpdatesBuf: next.getUpdatesBuf,
+    bypassProxy: next.bypassProxy ?? true,
     enabled: next.enabled,
     updatedAt: new Date().toISOString(),
   };
@@ -3326,6 +3330,7 @@ export function saveUserWeChatConfig(
     baseUrl: normalized.baseUrl,
     cdnBaseUrl: normalized.cdnBaseUrl,
     getUpdatesBuf: normalized.getUpdatesBuf,
+    bypassProxy: normalized.bypassProxy,
     enabled: normalized.enabled,
     updatedAt: normalized.updatedAt || new Date().toISOString(),
     secret: encryptWeChatSecret({ botToken: normalized.botToken }),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -677,4 +677,5 @@ export const BalancingConfigSchema = z.object({
 export const WeChatConfigSchema = z.object({
   enabled: z.boolean().optional(),
   clearBotToken: z.boolean().optional(),
+  bypassProxy: z.boolean().optional(),
 });

--- a/web/src/components/settings/WeChatChannelCard.tsx
+++ b/web/src/components/settings/WeChatChannelCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Loader2, LogOut, QrCode } from 'lucide-react';
+import { Loader2, LogOut, QrCode, Shield, Smartphone } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { ToggleSwitch } from '@/components/ui/toggle-switch';
@@ -12,6 +12,7 @@ interface UserWeChatConfig {
   ilinkBotId: string;
   hasBotToken: boolean;
   botTokenMasked: string | null;
+  bypassProxy: boolean;
   enabled: boolean;
   connected: boolean;
   updatedAt: string | null;
@@ -23,6 +24,7 @@ export function WeChatChannelCard({ setNotice, setError }: WeChatChannelCardProp
   const [config, setConfig] = useState<UserWeChatConfig | null>(null);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
+  const [togglingProxy, setTogglingProxy] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [qrDialogOpen, setQrDialogOpen] = useState(false);
 
@@ -59,6 +61,21 @@ export function WeChatChannelCard({ setNotice, setError }: WeChatChannelCardProp
     }
   };
 
+  const handleBypassProxyToggle = async (newBypass: boolean) => {
+    setTogglingProxy(true);
+    setNotice(null);
+    setError(null);
+    try {
+      const data = await api.put<UserWeChatConfig>('/api/config/user-im/wechat', { bypassProxy: newBypass });
+      setConfig(data);
+      setNotice(newBypass ? '已切换为直连模式（绕过代理）' : '已切换为代理模式');
+    } catch (err) {
+      setError(getErrorMessage(err, '切换直连模式失败'));
+    } finally {
+      setTogglingProxy(false);
+    }
+  };
+
   const handleDisconnect = async () => {
     setDisconnecting(true);
     setError(null);
@@ -80,6 +97,8 @@ export function WeChatChannelCard({ setNotice, setError }: WeChatChannelCardProp
     await loadConfig();
   };
 
+  const bypassProxy = config?.bypassProxy ?? true;
+
   return (
     <>
       <div className="rounded-xl border border-border bg-card overflow-hidden">
@@ -88,7 +107,7 @@ export function WeChatChannelCard({ setNotice, setError }: WeChatChannelCardProp
             <span className={`inline-block w-2 h-2 rounded-full ${config?.connected ? 'bg-emerald-500' : 'bg-slate-300'}`} />
             <div>
               <h3 className="text-sm font-semibold text-slate-800">微信</h3>
-              <p className="text-xs text-slate-500 mt-0.5">通过微信接收和回复消息</p>
+              <p className="text-xs text-slate-500 mt-0.5">通过微信 iLink Bot 接收和回复消息</p>
             </div>
           </div>
           <ToggleSwitch checked={enabled} disabled={loading || toggling} onChange={handleToggle} />
@@ -99,43 +118,81 @@ export function WeChatChannelCard({ setNotice, setError }: WeChatChannelCardProp
             <div className="text-sm text-slate-500">加载中...</div>
           ) : (
             <>
-              {/* Connection status */}
+              {/* Connected state */}
               {config?.connected ? (
-                <div className="flex items-center justify-between rounded-lg bg-emerald-50 px-4 py-3">
-                  <div>
-                    <div className="text-sm font-medium text-emerald-700">已连接</div>
+                <div className="space-y-3">
+                  <div className="rounded-lg bg-emerald-50 px-4 py-3 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Smartphone className="size-4 text-emerald-600" />
+                        <span className="text-sm font-medium text-emerald-700">已连接</span>
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleDisconnect}
+                        disabled={disconnecting}
+                        className="text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
+                      >
+                        {disconnecting ? <Loader2 className="size-3.5 animate-spin" /> : <LogOut className="size-3.5" />}
+                        退出登录
+                      </Button>
+                    </div>
                     {config.ilinkBotId && (
-                      <div className="text-xs text-emerald-600 mt-0.5">Bot ID: {config.ilinkBotId}</div>
+                      <div className="text-xs text-emerald-600">
+                        Bot ID: <span className="font-mono">{config.ilinkBotId}</span>
+                      </div>
+                    )}
+                    {config.botTokenMasked && (
+                      <div className="text-xs text-emerald-600">
+                        Token: <span className="font-mono">{config.botTokenMasked}</span>
+                      </div>
                     )}
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDisconnect}
-                    disabled={disconnecting}
-                    className="text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
-                  >
-                    {disconnecting ? <Loader2 className="size-3.5 animate-spin" /> : <LogOut className="size-3.5" />}
-                    退出登录
-                  </Button>
                 </div>
               ) : (
                 <div className="space-y-3">
+                  {/* Expired session hint */}
                   {config?.hasBotToken && (
                     <div className="flex items-center justify-between rounded-lg bg-amber-50 px-4 py-3">
                       <div className="text-sm text-amber-700">Session 已过期，请重新扫码登录</div>
                     </div>
                   )}
-                  <Button onClick={() => setQrDialogOpen(true)}>
-                    <QrCode className="size-4" />
-                    扫码登录
-                  </Button>
-                  <p className="text-xs text-slate-400">
-                    点击扫码登录，使用微信扫描二维码完成绑定
-                  </p>
+
+                  {/* QR login button */}
+                  <div className="flex flex-col items-center gap-3 py-4 rounded-lg border border-dashed border-slate-200 bg-slate-50/50">
+                    <QrCode className="size-10 text-slate-400" />
+                    <div className="text-center">
+                      <p className="text-sm text-slate-600 font-medium">扫码绑定微信</p>
+                      <p className="text-xs text-slate-400 mt-1">点击下方按钮获取二维码，使用微信扫码完成绑定</p>
+                    </div>
+                    <Button onClick={() => setQrDialogOpen(true)} className="mt-1">
+                      <QrCode className="size-4" />
+                      扫码登录
+                    </Button>
+                  </div>
                 </div>
               )}
 
+              {/* Direct connection toggle */}
+              <div className="flex items-center justify-between rounded-lg bg-slate-50 px-4 py-3">
+                <div className="flex items-start gap-2">
+                  <Shield className="size-4 text-blue-500 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-sm text-slate-700">直连模式</p>
+                    <p className="text-xs text-slate-400 mt-0.5">
+                      {bypassProxy
+                        ? '绕过 HTTP 代理直连微信服务，适合国内网络环境'
+                        : '通过系统代理访问微信服务'}
+                    </p>
+                  </div>
+                </div>
+                <ToggleSwitch
+                  checked={bypassProxy}
+                  disabled={togglingProxy}
+                  onChange={handleBypassProxyToggle}
+                />
+              </div>
             </>
           )}
         </div>


### PR DESCRIPTION
## 问题描述

微信 iLink Bot 使用的域名（`ilinkai.weixin.qq.com`、`novac2c.cdn.weixin.qq.com`）是国内服务，通过海外代理无法访问。之前需要手动操作 `NO_PROXY` 环境变量来绕过代理，流程不够友好。

## 实现方案

在微信设置卡片中增加"直连模式"开关，用户可在 Web UI 一键切换直连/代理模式。

### `src/config.ts`
- 新增 `WECHAT_NO_PROXY_DOMAINS` 常量和 `updateWeChatNoProxy()` 函数，动态管理 `NO_PROXY` 环境变量
- 启动时默认开启直连模式

### `src/runtime-config.ts`
- `UserWeChatConfig` 接口新增 `bypassProxy` 字段（默认 `true`）
- 读写配置时透传该字段

### `src/schemas.ts`
- `WeChatConfigSchema` 新增 `bypassProxy` 可选字段

### `src/routes/config.ts`
- GET/PUT `/api/config/user-im/wechat` 接口支持 `bypassProxy` 字段
- PUT 时调用 `updateWeChatNoProxy()` 动态更新环境变量

### `web/src/components/settings/WeChatChannelCard.tsx`
- 微信卡片底部新增"直连模式"开关（`ToggleSwitch`）
- 已连接状态和未连接状态的 UI 布局优化