### PR TITLE
fix: remove cross-workspace fallback in broadcastToOwnerIMChannels (#273)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3393,13 +3393,11 @@ function startIpcWatcher(): void {
       if (sentChannelTypes.has(channelType)) continue;
       // Filter by notify_channels if specified (null = all channels)
       if (notifyChannels && !notifyChannels.includes(channelType)) continue;
-      const target =
-        ownerGroups.find(
-          (g) =>
-            getChannelType(g.jid) === channelType &&
-            g.folder === sourceFolder,
-        ) ||
-        ownerGroups.find((g) => getChannelType(g.jid) === channelType);
+      const target = ownerGroups.find(
+        (g) =>
+          getChannelType(g.jid) === channelType &&
+          g.folder === sourceFolder,
+      );
       if (target) {
         sendFn(target.jid);
         sentChannelTypes.add(channelType);


### PR DESCRIPTION
## 问题

Fixes #273

`broadcastToOwnerIMChannels()` 中的两级查找策略会导致工作区 A 的消息泄漏到工作区 B 的 IM 群组中：

```typescript
// Before (有问题)
const target =
  ownerGroups.find(
    (g) =>
      getChannelType(g.jid) === channelType &&
      g.folder === sourceFolder,
  ) ||
  ownerGroups.find((g) => getChannelType(g.jid) === channelType); // ← 忽略了 folder 限制
```

当 `sourceFolder` 没有绑定对应 channelType 的 IM 群组时，fallback 会匹配该用户名下**任意工作区**的同类型 IM JID，违反了工作区隔离原则。

## 修复

移除 fallback，仅保留 same-folder 精确匹配：

```typescript
// After (修复后)
const target = ownerGroups.find(
  (g) =>
    getChannelType(g.jid) === channelType &&
    g.folder === sourceFolder,
);
```

如果 `sourceFolder` 没有绑定该 channelType 的 IM 群组，则不发送——这是符合预期的行为。

## 影响范围

- `src/index.ts` 中的 `broadcastToOwnerIMChannels()` 函数
- 两个调用点均受保护：`send_message` IPC（L3529）和 `send_image` IPC（L3636）