### PR TITLE
修复: 补齐 Web + 飞书 StreamEvent 处理覆盖度

### DIFF
--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -440,6 +440,7 @@ function buildAuxiliaryElements(aux: AuxiliaryState): {
 function buildStreamingCard(
   text: string,
   state: 'streaming' | 'completed' | 'aborted',
+  footerNote?: string,
 ): object {
   const { title, contentElements: elements } = buildCardContent(text, splitAtParagraphs);
 
@@ -462,6 +463,13 @@ function buildStreamingCard(
     elements.push({
       tag: 'note',
       elements: [{ tag: 'plain_text', content: noteMap[state] }],
+    });
+  }
+
+  if (footerNote) {
+    elements.push({
+      tag: 'note',
+      elements: [{ tag: 'plain_text', content: footerNote }],
     });
   }
 
@@ -499,6 +507,7 @@ function buildSchema2Card(
   titlePrefix = '',
   overrideTitle?: string,
   auxiliaryState?: AuxiliaryState,
+  footerNote?: string,
 ): object {
   const { title, contentElements } = buildCardContent(
     text,
@@ -531,6 +540,14 @@ function buildSchema2Card(
     });
   }
 
+  if (footerNote) {
+    elements.push({
+      tag: 'markdown',
+      content: footerNote,
+      text_size: 'notation',
+    });
+  }
+
   return {
     schema: '2.0',
     config: {
@@ -543,6 +560,26 @@ function buildSchema2Card(
     },
     body: { elements },
   };
+}
+
+// ─── Usage Note Formatter ─────────────────────────────────────
+
+function formatUsageNote(usage: {
+  inputTokens: number;
+  outputTokens: number;
+  costUSD: number;
+  durationMs: number;
+  numTurns: number;
+}): string {
+  const fmt = (n: number) =>
+    n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
+  const parts: string[] = [];
+  parts.push(`${fmt(usage.inputTokens)} / ${fmt(usage.outputTokens)} tokens`);
+  if (usage.costUSD > 0) parts.push(`$${usage.costUSD.toFixed(4)}`);
+  if (usage.durationMs > 0)
+    parts.push(`${(usage.durationMs / 1000).toFixed(1)}s`);
+  if (usage.numTurns > 1) parts.push(`${usage.numTurns} turns`);
+  return `💰 ${parts.join(' · ')}`;
 }
 
 // ─── Streaming Mode Card Builder ──────────────────────────────
@@ -1037,6 +1074,10 @@ class MultiCardManager {
     this.onCardCreated = onCardCreated;
   }
 
+  getCardCount(): number {
+    return this.cards.length;
+  }
+
   /**
    * Create the first card and send it as a message.
    * Returns the initial messageId.
@@ -1069,6 +1110,7 @@ class MultiCardManager {
     text: string,
     state: 'streaming' | 'completed' | 'aborted',
     auxiliaryState?: AuxiliaryState,
+    footerNote?: string,
   ): Promise<void> {
     const titlePrefix = this.cardIndex > 0 ? '(续) ' : '';
 
@@ -1081,7 +1123,8 @@ class MultiCardManager {
         })()
       : 0;
     const fixedCount = (state === 'streaming' ? 1 : 0)        // button
-                     + (SCHEMA2_NOTE_MAP[state] ? 1 : 0);     // note
+                     + (SCHEMA2_NOTE_MAP[state] ? 1 : 0)      // note
+                     + (footerNote ? 1 : 0);                   // footer
     const totalElements = contentElements.length + auxCount + fixedCount;
 
     if (totalElements > this.MAX_ELEMENTS && state === 'streaming') {
@@ -1094,7 +1137,7 @@ class MultiCardManager {
     const currentCard = this.cards[this.cards.length - 1];
     if (!currentCard) return;
 
-    const cardJson = buildSchema2Card(text, state, titlePrefix, undefined, auxiliaryState);
+    const cardJson = buildSchema2Card(text, state, titlePrefix, undefined, auxiliaryState, footerNote);
 
     // Byte size check (Feishu limit ~30KB, use 25KB safety margin)
     const cardSize = Buffer.byteLength(JSON.stringify(cardJson), 'utf-8');
@@ -1426,6 +1469,50 @@ export class StreamingCardController {
       // Revert state so abort() doesn't bail on the 'completed' check
       this.state = prevState;
       throw err;
+    }
+  }
+
+  /**
+   * Patch a completed card to append a usage note at the bottom.
+   * Called AFTER complete() because agent-runner emits usage after the final result.
+   */
+  async patchUsageNote(usage: {
+    inputTokens: number;
+    outputTokens: number;
+    costUSD: number;
+    durationMs: number;
+    numTurns: number;
+  }): Promise<void> {
+    if (this.state !== 'completed') return;
+
+    const note = formatUsageNote(usage);
+    if (!note) return;
+
+    try {
+      if (this.backendMode === 'streaming' && this.streamingBackend) {
+        const cardJson = buildSchema2Card(
+          this.accumulatedText,
+          'completed',
+          '',
+          undefined,
+          undefined,
+          note,
+        );
+        // Skip if card was split during finalization — rebuilding a single card
+        // would overwrite the first card with full text while continuation cards remain.
+        const cardSize = Buffer.byteLength(JSON.stringify(cardJson), 'utf-8');
+        if (cardSize > CARD_SIZE_LIMIT) return;
+        await this.streamingBackend.updateCardFull(cardJson);
+      } else if (this.messageId || this.multiCard) {
+        // For CardKit v1 / legacy: skip if multiCard has split content
+        if (this.multiCard && this.multiCard.getCardCount() > 1) return;
+        await this.patchCard('completed', note);
+      }
+    } catch (err) {
+      logger.debug(
+        { err, chatId: this.chatId },
+        'Streaming card: patchUsageNote failed (non-fatal)',
+      );
     }
   }
 
@@ -1832,12 +1919,13 @@ export class StreamingCardController {
 
   private async patchCard(
     displayState: 'streaming' | 'completed' | 'aborted',
+    footerNote?: string,
   ): Promise<void> {
     if (this.useCardKit && this.multiCard) {
       // CardKit v1 path — pass auxiliary state for rich display
       const auxState = displayState === 'streaming' ? this.getAuxiliaryState() : undefined;
       try {
-        await this.multiCard.commitContent(this.accumulatedText, displayState, auxState);
+        await this.multiCard.commitContent(this.accumulatedText, displayState, auxState, footerNote);
         this.flushCtrl.markFlushed(this.accumulatedText.length);
         this.patchFailCount = 0;
       } catch (err) {
@@ -1852,7 +1940,7 @@ export class StreamingCardController {
       // Legacy message.patch path (no auxiliary content)
       if (!this.messageId) return;
 
-      const card = buildStreamingCard(this.accumulatedText, displayState);
+      const card = buildStreamingCard(this.accumulatedText, displayState, footerNote);
       const content = JSON.stringify(card);
 
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,19 @@ function feedStreamEventToCard(
       // Update hook state (no card push needed — card already shows hook indicator)
       session.setHook({ hookName: se.hookName || '', hookEvent: se.hookEvent || '' });
       break;
+    case 'mode_change':
+      if (se.permissionMode === 'plan') {
+        session.setSystemStatus('📋 Plan 模式');
+      } else if (se.permissionMode) {
+        session.setSystemStatus(null);
+      }
+      break;
+    case 'usage':
+      if (se.usage) session.patchUsageNote(se.usage);
+      break;
+    case 'init':
+      // Internal signal, no card display needed
+      break;
   }
 }
 

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -711,6 +711,13 @@ function applyStreamEvent(
       }
       break;
     }
+    case 'usage':
+      // Token usage is handled at handleStreamEvent level (direct message table update).
+      // No streaming state mutation needed.
+      break;
+    case 'init':
+      // Internal signal, no UI handling needed.
+      break;
   }
 }
 


### PR DESCRIPTION
## 背景

HappyClaw 的 Agent 执行时通过 16 种 `StreamEventType`（定义在 `shared/stream-event.ts`）向 Web 和飞书推送实时进度。对两个渠道做了系统性对比调研后，发现以下遗漏：

| StreamEventType | Web 前端 | 飞书卡片 | 影响 |
|-----------------|---------|---------|------|
| `mode_change` | ⚠️ ChatView 层处理，applyStreamEvent 空壳 | ❌ **完全缺失** | Agent 进入 plan mode 时飞书用户看不到任何反馈，以为卡住 |
| `usage` | ⚠️ handleStreamEvent 直接写消息表，applyStreamEvent 无 case | ❌ **卡片无展示**（仅 DB 持久化） | 飞书用户无法看到 token 成本/耗时 |
| `init` | ❌ 无 case | ❌ 无 case | 内部信令，影响小，但 switch 不完整 |

其余 13 种事件类型（text_delta、thinking_delta、tool_use_start/end、tool_progress、hook_*、task_*、todo_update、status）两端均已正确处理。

## 关键时序约束

agent-runner 的发射顺序（`container/agent-runner/src/index.ts:1359-1412`）：
1. **先** emit `{status: 'success', result: finalText}` → 主进程调用 `streamingSession.complete(text)` → 卡片 finalize
2. **后** emit `{status: 'stream', streamEvent: {eventType: 'usage'}}` → `feedStreamEventToCard()` 接收

因此 usage 事件到达时飞书卡片已处于 `state='completed'`。需要**后置补丁**机制（complete 之后再 patch 一次卡片）。不能调换发射顺序，否则 Web 前端在 `handleStreamEvent` 中找不到目标消息写 `token_usage`。

## 修复方案

### 1. 飞书 `mode_change` 支持

`src/index.ts` — `feedStreamEventToCard()` 新增 case，复用已有的 `setSystemStatus()` 方法：
- `permissionMode === 'plan'` → 辅助区显示 `📋 Plan 模式`
- 其他值 → 清除状态指示
- 卡片 finalize 时辅助区自动清除，无需额外处理

### 2. 飞书 `usage` 后置补丁

`src/feishu-streaming-card.ts` 四处改动：

- **`formatUsageNote()`** — 格式化 usage 为 `💰 1.2K / 800 tokens · $0.003 · 5.2s` 格式
- **`buildSchema2Card()` / `buildStreamingCard()` / `commitContent()`** — 增加可选 `footerNote` 参数，在卡片底部追加 notation 大小的脚注
- **`StreamingCardController.patchUsageNote()`** — 在 `state='completed'` 后重建卡片 JSON 并追加 usage 脚注，调用飞书 API 做一次最终补丁
- **`MultiCardManager.getCardCount()`** — 新增 getter，供分卡检测使用

**分卡场景防护**：长回复（>25KB）在 `complete()` 时会被拆分为多张卡片。`patchUsageNote()` 在 streaming 路径检查 `CARD_SIZE_LIMIT`，CardKit 路径检查 `getCardCount() > 1`，超限则跳过补丁，避免覆盖分卡内容。失败时 try/catch 兜底，记录 debug 日志。

### 3. Web `applyStreamEvent` 补齐

`web/src/stores/chat.ts` — 添加 `usage` 和 `init` 的显式空 case，附注释说明处理路径。纯架构完整性改动，不影响运行时行为。

## 涉及文件

| 文件 | 改动 |
|------|------|
| `src/feishu-streaming-card.ts` | +92 行：formatUsageNote、footerNote 参数链、patchUsageNote 方法、getCardCount、分卡防护 |
| `src/index.ts` | +13 行：feedStreamEventToCard 添加 mode_change / usage / init 三个 case |
| `web/src/stores/chat.ts` | +7 行：applyStreamEvent 添加 usage / init 两个空 case |

## Test plan

- [ ] `make typecheck` 通过（已验证 ✅）
- [ ] 飞书发消息触发 Agent → 回复完成后卡片底部出现 `💰 tokens · $cost · 耗时`
- [ ] 飞书发消息触发 plan mode → 辅助区显示 `📋 Plan 模式`，退出后消失
- [ ] 长回复（分卡场景）→ usage 补丁被跳过，不破坏已有分卡结构
- [ ] Web 端所有 StreamEvent 类型行为无回归