### PR TITLE
修复: 流式卡片完成后未清除 ack reaction 的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1881,11 +1881,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const directImReply = getChannelType(chatJid) !== null;
   let replySourceImJid: string | null = null;
   if (!directImReply) {
-    // chatJid is a web channel — check if ALL messages share the same IM source
-    const firstSourceJid = missedMessages[0]?.source_jid || chatJid;
+    // chatJid is a web channel — check if ALL user messages share the same IM source.
+    // Ignore agent replies (sender='happyclaw-agent') to avoid false negatives when
+    // agent replies are included in missedMessages context.
+    const userMessages = missedMessages.filter((m) => m.sender !== 'happyclaw-agent');
+    const firstSourceJid = userMessages[0]?.source_jid || chatJid;
     const allSameImSource =
       getChannelType(firstSourceJid) !== null &&
-      missedMessages.every((m) => (m.source_jid || chatJid) === firstSourceJid);
+      userMessages.every((m) => (m.source_jid || chatJid) === firstSourceJid);
     if (allSameImSource) {
       replySourceImJid = firstSourceJid;
     }
@@ -2414,7 +2417,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 streamingCardHandledIM = true;
                 // Streaming card replaced the normal sendMessage path,
                 // so clear the ack reaction that would normally be cleared in sendMessage.
-                imManager.clearAckReaction(chatJid);
+                // Use replySourceImJid (original IM JID) — chatJid may be normalized to web:xxx
+                imManager.clearAckReaction(replySourceImJid || chatJid);
                 logger.debug(
                   { chatJid },
                   'Streaming card completed with final text',
@@ -2538,7 +2542,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     await setTyping(chatJid, false);
     // Always clear ack reaction in finally — covers error/interrupt/abort paths
     // where the normal sendMessage (which clears it) is never called.
-    imManager.clearAckReaction(chatJid);
+    // Use replySourceImJid (original IM JID) — chatJid may be normalized to web:xxx
+    imManager.clearAckReaction(replySourceImJid || chatJid);
     if (idleTimer) clearTimeout(idleTimer);
     activeRouteUpdaters.delete(effectiveGroup.folder);
     activeImReplyRoutes.delete(effectiveGroup.folder);


### PR DESCRIPTION
## 问题描述

流式卡片完成后，飞书消息的 ack reaction（✅）未被正确清除。

## 修复方案

### `src/index.ts`
- 修复 `replySourceImJid` 判断逻辑，过滤掉 agent 回复消息，避免因 agent 消息干扰导致判断失败
- 在流式卡片完成和 finally 块中使用正确的 IM JID（`replySourceImJid`）清除 ack reaction
- 避免因 `chatJid` 被规范化为 `web:xxx` 导致清除失败