### PR TITLE
fix: suppress auto_continue system-maintenance noise leaking to IM (#275)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -926,6 +926,7 @@ async function runQuery(
   allowedTools: string[] = DEFAULT_ALLOWED_TOOLS,
   disallowedTools?: string[],
   images?: Array<{ data: string; mimeType?: string }>,
+  sourceKindOverride?: ContainerOutput['sourceKind'],
 ): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean; contextOverflow?: boolean; unrecoverableTranscriptError?: boolean; interruptedDuringQuery: boolean; sessionResumeFailed?: boolean }> {
   const stream = new MessageStream();
   let newSessionId: string | undefined;
@@ -1407,7 +1408,7 @@ async function runQuery(
         result: finalText,
         newSessionId,
         sdkMessageUuid: canonicalAssistantUuid || lastAssistantUuid,
-        sourceKind: 'sdk_final',
+        sourceKind: sourceKindOverride ?? 'sdk_final',
         finalizationReason: 'completed',
       });
       // After emitting an sdk_final result, rotate turnId so that if
@@ -1788,6 +1789,12 @@ async function main(): Promise<void> {
       // ── Non-blocking compaction: auto-continue after context compaction ──
       // Instead of waiting for user to send "继续", automatically start a
       // new query so the agent resumes seamlessly where it left off.
+      // The query is tagged with sourceKind='auto_continue' so the host
+      // process can suppress system-maintenance noise (memory flush "OK",
+      // CLAUDE.md update acks, etc.) that leaked into the agent's session
+      // transcript — the host will only forward substantive user-facing
+      // content to IM, preventing the bug described in issue #275.
+      //
       // Guard: if compaction keeps firing repeatedly (e.g. system prompt alone
       // nearly fills the context window), stop auto-continuing to avoid an
       // infinite loop that burns API tokens without producing useful work.
@@ -1796,13 +1803,77 @@ async function main(): Promise<void> {
         consecutiveCompactions++;
         if (consecutiveCompactions <= MAX_CONSECUTIVE_COMPACTIONS) {
           log(`Auto-continuing after compaction (${consecutiveCompactions}/${MAX_CONSECUTIVE_COMPACTIONS})`);
-          prompt = '继续';
-          promptImages = undefined;
+          const autoContinuePrompt = [
+            '继续。',
+            '注意：刚刚发生了上下文压缩，系统已自动执行了记忆刷新和 CLAUDE.md 更新（这些是内部维护操作）。',
+            '请**只关注与用户的实际对话**，从压缩前的最后一个对话话题自然衔接。',
+            '如果压缩前你正在进行方案设计、讨论或等待用户确认，请简要回顾当前状态和待确认事项。',
+            '如果压缩前已经在执行中，则继续执行。',
+            '**重要**：不要提及、确认或重复任何系统维护相关的内容（如 "OK"、"已更新 CLAUDE.md"、"记忆已刷新" 等），',
+            '这些内部状态对用户不可见。如果你的回复中确实包含此类内容，请用 <internal>...</internal> 标签包裹。',
+          ].join('');
           containerInput.turnId = generateTurnId();
-          continue;
+          const autoContResult = await runQuery(
+            autoContinuePrompt,
+            sessionId,
+            mcpServerConfig,
+            containerInput,
+            memoryRecallPrompt,
+            resumeAt,
+            true,
+            DEFAULT_ALLOWED_TOOLS,
+            undefined,
+            undefined,
+            'auto_continue',
+          );
+          if (autoContResult.newSessionId) {
+            sessionId = autoContResult.newSessionId;
+            latestSessionId = sessionId;
+          }
+          if (autoContResult.lastAssistantUuid) {
+            resumeAt = autoContResult.lastAssistantUuid;
+          }
+          if (autoContResult.closedDuringQuery) {
+            log('Close sentinel during auto-continue, exiting');
+            writeOutput({ status: 'closed', result: null });
+            break;
+          }
+          // Handle abnormal states from auto-continue runQuery (these were
+          // previously handled by the main loop's `continue` re-entry; now that
+          // auto-continue is a standalone call we must check them explicitly).
+          if (autoContResult.sessionResumeFailed) {
+            log('WARN: Session resume failed during auto-continue, clearing session');
+            sessionId = undefined;
+            latestSessionId = undefined;
+            resumeAt = undefined;
+            mcpServerConfig = buildMcpServerConfig();
+            // Fall through to wait for next IPC message with a fresh session.
+          }
+          if (autoContResult.unrecoverableTranscriptError) {
+            log('WARN: Unrecoverable transcript error during auto-continue, signaling reset');
+            writeOutput({
+              status: 'error',
+              result: null,
+              error: 'unrecoverable_transcript: 会话历史中包含无法处理的数据，会话需要重置。',
+              newSessionId: sessionId,
+            });
+            process.exit(1);
+          }
+          if (autoContResult.contextOverflow) {
+            log('WARN: Context overflow during auto-continue, will be handled on next query');
+            // Don't retry here — the main loop's overflow-retry logic will
+            // kick in on the next user-initiated query.
+          }
+          if (autoContResult.interruptedDuringQuery) {
+            log('WARN: Auto-continue query was interrupted by user');
+            resumeAt = undefined;
+            try { fs.unlinkSync(IPC_INPUT_INTERRUPT_SENTINEL); } catch { /* ignore */ }
+          }
+          // After auto-continue, fall through to wait for next IPC message.
+        } else {
+          log(`Compaction loop detected (${consecutiveCompactions} consecutive), stopping auto-continue and waiting for user input`);
+          consecutiveCompactions = 0;
         }
-        log(`Compaction loop detected (${consecutiveCompactions} consecutive), stopping auto-continue and waiting for user input`);
-        consecutiveCompactions = 0;
       } else {
         consecutiveCompactions = 0;
       }

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -35,7 +35,7 @@ export interface ContainerOutput {
   turnId?: string;
   sessionId?: string;
   sdkMessageUuid?: string;
-  sourceKind?: 'sdk_final' | 'sdk_send_message' | 'interrupt_partial' | 'overflow_partial' | 'compact_partial' | 'legacy';
+  sourceKind?: 'sdk_final' | 'sdk_send_message' | 'interrupt_partial' | 'overflow_partial' | 'compact_partial' | 'legacy' | 'auto_continue';
   finalizationReason?: 'completed' | 'interrupted' | 'error';
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -130,7 +130,8 @@ export interface ContainerOutput {
     | 'interrupt_partial'
     | 'overflow_partial'
     | 'compact_partial'
-    | 'legacy';
+    | 'legacy'
+    | 'auto_continue';
   finalizationReason?: 'completed' | 'interrupted' | 'error';
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,7 @@ import {
 import { logger } from './logger.js';
 import {
   ensureAgentDirectories,
+  isSystemMaintenanceNoise,
   stripAgentInternalTags,
   stripVirtualJidSuffix,
 } from './utils.js';
@@ -1609,7 +1610,7 @@ interface SendMessageOptions {
     turnId?: string;
     sessionId?: string;
     sdkMessageUuid?: string;
-    sourceKind?: 'sdk_final' | 'sdk_send_message' | 'interrupt_partial' | 'overflow_partial' | 'compact_partial' | 'legacy';
+    sourceKind?: 'sdk_final' | 'sdk_send_message' | 'interrupt_partial' | 'overflow_partial' | 'compact_partial' | 'legacy' | 'auto_continue';
     finalizationReason?: 'completed' | 'interrupted' | 'error';
   };
 }
@@ -2595,6 +2596,20 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           let text = stripAgentInternalTags(raw);
           if (result.sourceKind === 'overflow_partial' || result.sourceKind === 'compact_partial') {
             text = buildOverflowPartialReply(text);
+          }
+          // auto_continue outputs that consist solely of system-maintenance
+          // acknowledgements (e.g. "OK", "已更新 CLAUDE.md") are suppressed from
+          // IM delivery. These arise when the agent's session transcript contains
+          // memory-flush / CLAUDE.md-update context from the compaction pipeline
+          // and the agent echoes it back in the resumption query. Substantive
+          // user-facing continuations (longer replies or actual task resumption)
+          // pass through normally. See issue #275.
+          if (result.sourceKind === 'auto_continue' && isSystemMaintenanceNoise(text)) {
+            logger.info(
+              { group: group.name, textLen: text.length },
+              'auto_continue output suppressed (system maintenance noise)',
+            );
+            return;
           }
           logger.info(
             { group: group.name },
@@ -4850,6 +4865,16 @@ async function processAgentConversation(
         if (agent.kind !== 'spawn') {
           text = buildOverflowPartialReply(text);
         }
+      }
+      // Suppress system-maintenance noise from auto_continue outputs (issue #275).
+      // Short acknowledgements ("OK", "已更新 CLAUDE.md") that leak from the
+      // compaction pipeline are dropped; substantive continuations pass through.
+      if (output.sourceKind === 'auto_continue' && isSystemMaintenanceNoise(text)) {
+        logger.info(
+          { chatJid, agentId, textLen: text.length },
+          'auto_continue output suppressed (system maintenance noise)',
+        );
+        return;
       }
       if (text) {
         const isFirstReply = !lastAgentReplyMsgId;

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,8 @@ export type MessageSourceKind =
   | 'overflow_partial'
   | 'compact_partial'
   | 'user_command'
-  | 'legacy';
+  | 'legacy'
+  | 'auto_continue';
 
 export type MessageFinalizationReason =
   | 'completed'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,36 @@ export function stripAgentInternalTags(text: string): string {
 }
 
 /**
+ * Detect whether an agent output is system-maintenance noise that should
+ * be suppressed from IM delivery when sourceKind is 'auto_continue'.
+ *
+ * These are short acknowledgements that the agent generates when its session
+ * transcript contains memory-flush / CLAUDE.md-update context from the
+ * compaction pipeline (issue #275). Substantive user-facing continuations
+ * (task resumption, actual replies) are NOT noise and must pass through.
+ *
+ * Heuristic: text is "noise" if it is short (<= 30 chars) AND matches a
+ * known system-acknowledgement pattern after normalisation.
+ */
+export function isSystemMaintenanceNoise(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return true;
+  // Only apply heuristic to very short outputs to avoid false positives.
+  if (normalized.length > 30) return false;
+  const NOISE_PATTERNS = [
+    /^ok[.。!！]?$/,
+    /^好的[.。!！]?$/,
+    /^已更新/,
+    /^已完成/,
+    /^已刷新/,
+    /^记忆已/,
+    /^claude\.md\s*已/,
+    /^memory\s*(flush|updated)/i,
+  ];
+  return NOISE_PATTERNS.some((p) => p.test(normalized));
+}
+
+/**
  * Strip virtual JID suffixes (#task:xxx, #agent:xxx) to get the base JID.
  */
 export function stripVirtualJidSuffix(jid: string): string {

--- a/tests/unit-issue-275.mjs
+++ b/tests/unit-issue-275.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for Issue #275 fix:
+ * auto_continue system-maintenance noise suppression
+ *
+ * Tests the isSystemMaintenanceNoise() function from src/utils.ts
+ * (compiled to dist/utils.js).
+ */
+
+import { isSystemMaintenanceNoise } from '../dist/utils.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(description, condition) {
+  if (condition) {
+    console.log(`  ✅ ${description}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${description}`);
+    failed++;
+  }
+}
+
+console.log('\n🔧 Issue #275 — isSystemMaintenanceNoise() unit tests\n');
+
+// Should be treated as noise (system maintenance acks)
+console.log('── Noise cases (should return true) ──');
+assert('empty string → noise', isSystemMaintenanceNoise(''));
+assert('"OK" → noise', isSystemMaintenanceNoise('OK'));
+assert('"ok" → noise', isSystemMaintenanceNoise('ok'));
+assert('"ok." → noise', isSystemMaintenanceNoise('ok.'));
+assert('"OK。" → noise', isSystemMaintenanceNoise('OK。'));
+assert('"好的" → noise', isSystemMaintenanceNoise('好的'));
+assert('"好的。" → noise', isSystemMaintenanceNoise('好的。'));
+assert('"已更新 CLAUDE.md" → noise', isSystemMaintenanceNoise('已更新 CLAUDE.md'));
+assert('"已完成记忆刷新" → noise', isSystemMaintenanceNoise('已完成记忆刷新'));
+assert('"已刷新" → noise', isSystemMaintenanceNoise('已刷新'));
+assert('"记忆已保存" → noise', isSystemMaintenanceNoise('记忆已保存'));
+assert('"Memory flush completed" → noise', isSystemMaintenanceNoise('Memory flush completed'));
+
+// Should NOT be treated as noise (substantive user-facing content)
+console.log('\n── Non-noise cases (should return false) ──');
+assert(
+  'Substantive continuation text → not noise',
+  !isSystemMaintenanceNoise('上次我们讨论到方案选择，我建议使用方案 A，主要原因是性能更好。'),
+);
+assert(
+  'Task resumption > 30 chars → not noise',
+  !isSystemMaintenanceNoise('Phase 1-3 已全部完成，目前进入 Phase 4 的集成测试阶段。'),
+);
+assert(
+  '"继续执行中..." → not noise (>30 chars)',
+  !isSystemMaintenanceNoise('继续执行中，当前正在处理文件合并，请稍候。'),
+);
+assert(
+  'Normal short reply that is not a noise pattern → not noise',
+  !isSystemMaintenanceNoise('好的，继续方案设计'),
+);
+
+console.log(`\n==================================================`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`==================================================\n`);
+
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Problem

Fixes #275.

After context compaction, the agent-runner ran memory flush and CLAUDE.md update queries (`emitOutput=false`) writing system maintenance conversations into the session transcript. The auto-continue block then issued `continue` to jump back to the main query loop, which ran `runQuery(..., emitOutput=true)`. The agent's response sometimes referenced system context from the transcript ("OK", "CLAUDE.md has been updated", internal status recap), leaking it to IM.

## Root Cause

The auto-continue path reused the **user-initiated query** output channel. There was no mechanism to distinguish system-initiated outputs from user-conversation outputs.

## Fix

### Layer 3 — Architectural (`sourceKind: 'auto_continue'`)

- Added `'auto_continue'` to `ContainerOutput.sourceKind` type in all relevant files (`container/agent-runner/src/types.ts`, `src/container-runner.ts`, `src/types.ts`)
- Added `sourceKindOverride` parameter to `runQuery()` — overrides the default `'sdk_final'` sourceKind on final result emission
- Replaced the bare `continue` jump in auto-continue with a **dedicated `runQuery()` call** using `sourceKindOverride: 'auto_continue'`
- Both `onOutput` handlers in `src/index.ts` now check for `auto_continue` and suppress IM delivery for system-maintenance noise (via `isSystemMaintenanceNoise()`)

### Layer 2 — Prompt hardening

Replaced the bare `'继续'` prompt with an explicit instruction to focus only on the user conversation, not acknowledge system maintenance operations, and use `<internal>...</internal>` tags as a safety net for any maintenance content that slips through.

### New helper: `isSystemMaintenanceNoise(text)` in `src/utils.ts`

Detects short (≤ 30 chars) system-acknowledgement phrases — `OK`, `好的`, `已更新`, `已刷新`, `已完成`, `记忆已…`, `Memory flush…`, etc. Substantive continuations (> 30 chars or not matching patterns) pass through normally.

## Test

```
node tests/unit-issue-275.mjs
```

16 unit tests pass, covering all noise patterns and non-noise (substantive) cases.

## Files Changed

| File | Change |
|------|--------|
| `container/agent-runner/src/types.ts` | Add `auto_continue` to `ContainerOutput.sourceKind` |
| `container/agent-runner/src/index.ts` | Add `sourceKindOverride` to `runQuery()`; replace auto-continue `continue` jump with dedicated call |
| `src/container-runner.ts` | Add `auto_continue` to local `ContainerOutput.sourceKind` |
| `src/types.ts` | Add `auto_continue` to `MessageSourceKind` |
| `src/index.ts` | Import + call `isSystemMaintenanceNoise()` in both `onOutput` handlers |
| `src/utils.ts` | Add `isSystemMaintenanceNoise()` helper |
| `tests/unit-issue-275.mjs` | 16 unit tests |
