### PR TITLE
修复: MCP schedule_task 的 context_mode 默认值与 Web API 不一致

### DIFF
--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -472,9 +472,9 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
           ),
         context_mode: z
           .enum(['group', 'isolated'])
-          .default('group')
+          .default('isolated')
           .describe(
-            '(agent mode only) group=runs with chat history, isolated=fresh session',
+            '(agent mode only) isolated=fresh session (recommended), group=runs with chat history (may block on active sessions)',
           ),
         target_group_jid: z
           .string()
@@ -573,7 +573,7 @@ SCHEDULE VALUE FORMAT (all times are LOCAL timezone):
           prompt: args.prompt || '',
           schedule_type: args.schedule_type,
           schedule_value: args.schedule_value,
-          context_mode: args.context_mode || 'group',
+          context_mode: args.context_mode || 'isolated',
           execution_type: execType,
           targetJid,
           createdBy: ctx.groupFolder,


### PR DESCRIPTION
## 问题描述

MCP `schedule_task` 工具的 `context_mode` 默认值为 `group`，而 Web API (`routes/tasks.ts`) 默认值为 `isolated`，两个创建路径不一致。

`group` 模式的定时任务会与用户消息共享同一个 agent-runner 进程。当用户活跃时，定时任务无法及时执行——任务被推入 `pendingTasks` 队列，需要等待 runner 自然退出后才能通过 `drainGroup()` 执行。

实测中观察到：用户空闲 1.5 小时，但 15:30 的定时任务始终未执行，因为 agent-runner 进程一直存活。

## 修复方案

### `container/agent-runner/src/mcp-tools.ts`
- `context_mode` 的 `.default()` 从 `'group'` 改为 `'isolated'`，与 Web API 保持一致
- fallback 默认值从 `args.context_mode || 'group'` 改为 `args.context_mode || 'isolated'`
- 更新 describe 文本，标注 `isolated` 为推荐选项，`group` 可能阻塞