### PR TITLE
修复: 容器内 agent-runner 找不到 prompts/security-rules.md 导致崩溃

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -44,6 +44,8 @@ chown -R node:node /home/node/.claude/skills 2>/dev/null || true
 # Compile TypeScript (agent-runner source may be hot-mounted from host)
 cd /app && npx tsc --outDir /tmp/dist 2>&1 >&2
 ln -s /app/node_modules /tmp/dist/node_modules
+# Link non-TS assets so compiled code can resolve relative paths (e.g. ../prompts/)
+ln -sfn /app/prompts /tmp/prompts
 chmod -R a-w /tmp/dist
 
 # Buffer stdin to file (container requires EOF to flush stdin pipe)


### PR DESCRIPTION
## 问题描述

关联 commit `6da7ec4`（重构: 代码质量审查 — 去重、提取共享模块、迁移语义化 token）。

该提交将安全守则从 `index.ts` 内联字符串提取到独立文件 `container/agent-runner/prompts/security-rules.md`，代码通过 `import.meta.url` 相对路径读取。但 `entrypoint.sh` 未同步更新，导致 **所有 container 模式的会话启动即崩溃**，指数退避重试 5 次后放弃。

**错误信息**：
```
Error: ENOENT: no such file or directory, open '/tmp/prompts/security-rules.md'
    at file:///tmp/dist/index.js:78:27
```

**根因**：`entrypoint.sh` 将 TypeScript 编译到 `/tmp/dist/`，运行时 `import.meta.url` 为 `file:///tmp/dist/index.js`，`path.join(dirname, '..', 'prompts', 'security-rules.md')` 解析到 `/tmp/prompts/security-rules.md`。但 `prompts/` 目录只存在于 `/app/prompts/`（Dockerfile `COPY agent-runner/ ./`），`/tmp/` 下不存在。

宿主机模式不受影响（直接运行编译后代码，路径正确）。

## 修复方案

### `container/entrypoint.sh`

在 tsc 编译后、chmod 锁定前，添加符号链接将 `/tmp/prompts` 指向 `/app/prompts`：

```bash
ln -sfn /app/prompts /tmp/prompts
```

- `ln -sfn` 幂等，多次执行安全
- `chmod -R a-w /tmp/dist` 不影响符号链接穿透（读取使用目标权限）
- 搜索确认 `security-rules.md` 是 agent-runner 中唯一通过 `import.meta.url` 相对路径读取的非 TS 资源，无其他遗漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)