### PR TITLE
修复: IPC send_message/send_image 回复路由到错误 IM 渠道

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3710,7 +3710,14 @@ function startIpcWatcher(): void {
                   const effectiveChatJid = ipcAgentId
                     ? `${data.chatJid}#agent:${ipcAgentId}`
                     : data.chatJid;
+                  // Suppress auto IM send when we have a tracked route — the route
+                  // is authoritative and may differ from the stale data.chatJid
+                  // (set at agent start, never updated on IM channel switch).
+                  // Fall back to default auto-send when no route is tracked
+                  // (edge case: race during agent shutdown).
+                  const hasTrackedRoute = !ipcAgentId && activeImReplyRoutes.has(sourceGroup);
                   await sendMessage(effectiveChatJid, data.text, {
+                    sendToIM: hasTrackedRoute ? false : undefined,
                     messageMeta: {
                       sourceKind: 'sdk_send_message',
                     },
@@ -3721,11 +3728,7 @@ function startIpcWatcher(): void {
                   // processAgentConversation's wrappedOnOutput callback.
                   if (!ipcAgentId) {
                     const ipcImRoute = activeImReplyRoutes.get(sourceGroup);
-                    if (
-                      ipcImRoute &&
-                      getChannelType(data.chatJid) === null &&
-                      ipcImRoute !== data.chatJid
-                    ) {
+                    if (ipcImRoute) {
                       const localImages = extractLocalImImagePaths(
                         data.text,
                         sourceGroup,
@@ -3735,8 +3738,9 @@ function startIpcWatcher(): void {
 
                     // Scheduled task: broadcast to all connected IM channels of the owner
                     if (data.isScheduledTask && sourceGroupEntry?.created_by) {
+                      // Only include JIDs we actually sent to (not the potentially stale data.chatJid)
                       const alreadySent = new Set<string>(
-                        [data.chatJid, ipcImRoute].filter(Boolean) as string[],
+                        [ipcImRoute].filter(Boolean) as string[],
                       );
                       const taskLocalImages = extractLocalImImagePaths(
                         data.text,
@@ -3794,12 +3798,15 @@ function startIpcWatcher(): void {
                     const fileName = data.fileName || undefined;
 
                     // Conversation agents: skip IM forwarding (handled in wrappedOnOutput).
-                    // Non-agent: route to IM via activeImReplyRoutes.
+                    // Non-agent: use activeImReplyRoutes (authoritative, tracks route changes).
+                    // Fall back to data.chatJid only when no route is tracked (race during shutdown).
                     const imgImRoute = ipcAgentId
                       ? null
-                      : getChannelType(data.chatJid) !== null
-                        ? data.chatJid
-                        : activeImReplyRoutes.get(sourceGroup) ?? null;
+                      : activeImReplyRoutes.has(sourceGroup)
+                        ? activeImReplyRoutes.get(sourceGroup) ?? null
+                        : getChannelType(data.chatJid) !== null
+                          ? data.chatJid
+                          : null;
                     if (imgImRoute) {
                       await retryImOperation('send_image', imgImRoute, () =>
                         imManager.sendImage(imgImRoute, imageBuffer, mimeType, caption, fileName),


### PR DESCRIPTION
## 问题描述

当多个 IM 渠道（如微信 + 飞书）共享同一工作区（folder）时，agent 通过 `send_message` MCP 工具发送的回复会路由到**启动 agent 的渠道**而非**最近提问的渠道**。

**复现路径**：
1. 微信发消息 → agent 启动，`ctx.chatJid = "wechat:xxx"`
2. Agent 回复微信 ✓
3. Agent 保持运行（idle timeout 内）
4. 飞书发消息 → IPC 注入到运行中的 agent，路由更新为飞书 ✓
5. Agent 处理飞书问题，调用 `send_message` MCP 工具
6. **期望**：回复发到飞书  **实际**：回复发到微信

### 根因

1. **`container/agent-runner/src/mcp-tools.ts:167`** — `send_message` MCP 工具硬编码 `chatJid: ctx.chatJid`，agent 启动时设置，IPC 注入新消息后不更新
2. **`src/index.ts` IPC handler** — IM 转发条件 `getChannelType(data.chatJid) === null` 仅对 web 渠道生效。当 `data.chatJid` 已是 IM JID 时条件为 false，跳过转发到正确渠道

路由更新逻辑（`activeRouteUpdaters` / `activeImReplyRoutes`）本身工作正常，但 IPC handler 的 `send_message` 和 `send_image` 路径没有参考它。

## 修复方案

只修改 `src/index.ts`，两处：

### `send_message` IPC handler

- 当 `activeImReplyRoutes` 有追踪路由时（`has(sourceGroup) = true`），用 `sendToIM: false` 抑制 `sendMessage()` 的自动 IM 发送，统一由 `sendImWithFailTracking(ipcImRoute)` 发到正确渠道
- 无追踪路由时（`has(sourceGroup) = false`，agent 退出竞态窗口），回退到原始 auto-send 行为
- `alreadySent` 集合只包含实际发送的 JID，避免定时任务广播误跳过渠道

### `send_image` IPC handler

- 同样优先使用 `activeImReplyRoutes`，无追踪路由时回退到 `data.chatJid`

### 边界情况

| 场景 | 行为 |
|------|------|
| 正常 IM 回复（无切换） | `sendImWithFailTracking` 发到正确渠道 |
| IM 渠道切换（微信→飞书） | 不发微信，发飞书 ✓ |
| 路由清空（web 注入 IM 会话） | 不发 IM，仅 web 显示 |
| agent 退出竞态窗口 | 回退到 auto-send（安全网） |
| conversation agent | `ipcAgentId` 非空，跳过 IM 转发块，不受影响 |
| 定时任务广播 | `alreadySent` 只含实际发送的 JID，广播正常 |

## 已验证

微信先发消息启动 agent → 飞书后发消息 IPC 注入 → agent 回复成功发到飞书、微信未收到误发消息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)