### PR TITLE
修复: 阻断 compaction auto-continue 无限循环

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1618,6 +1618,8 @@ async function main(): Promise<void> {
   let resumeAt: string | undefined;
   let overflowRetryCount = 0;
   const MAX_OVERFLOW_RETRIES = 3;
+  let consecutiveCompactions = 0;
+  const MAX_CONSECUTIVE_COMPACTIONS = 3;
   try {
     while (true) {
       // 清理残留的 _interrupt sentinel（空闲期间写入的中断信号不应影响下一次 query）。
@@ -1654,6 +1656,7 @@ async function main(): Promise<void> {
         sessionId = undefined;
         latestSessionId = undefined;
         resumeAt = undefined;
+        consecutiveCompactions = 0;
         // Rebuild MCP server to avoid "Already connected to a transport" error
         mcpServerConfig = buildMcpServerConfig();
         continue;
@@ -1734,6 +1737,7 @@ async function main(): Promise<void> {
           break;
         }
         clearInterruptRequested();
+        consecutiveCompactions = 0;
         prompt = nextMessage.text;
         promptImages = nextMessage.images;
         containerInput.turnId = generateTurnId();
@@ -1741,7 +1745,8 @@ async function main(): Promise<void> {
       }
 
       // Memory Flush: run an extra query to let agent save durable memories (home containers only)
-      if (needsMemoryFlush && isHome) {
+      // Skip flush when already in a compaction loop — context is too full for productive work.
+      if (needsMemoryFlush && isHome && consecutiveCompactions === 0) {
         needsMemoryFlush = false;
         log('Running memory flush query after compaction...');
 
@@ -1783,13 +1788,23 @@ async function main(): Promise<void> {
       // ── Non-blocking compaction: auto-continue after context compaction ──
       // Instead of waiting for user to send "继续", automatically start a
       // new query so the agent resumes seamlessly where it left off.
+      // Guard: if compaction keeps firing repeatedly (e.g. system prompt alone
+      // nearly fills the context window), stop auto-continuing to avoid an
+      // infinite loop that burns API tokens without producing useful work.
       if (hadCompaction) {
         hadCompaction = false;
-        log('Auto-continuing after compaction (non-blocking)');
-        prompt = '继续';
-        promptImages = undefined;
-        containerInput.turnId = generateTurnId();
-        continue;
+        consecutiveCompactions++;
+        if (consecutiveCompactions <= MAX_CONSECUTIVE_COMPACTIONS) {
+          log(`Auto-continuing after compaction (${consecutiveCompactions}/${MAX_CONSECUTIVE_COMPACTIONS})`);
+          prompt = '继续';
+          promptImages = undefined;
+          containerInput.turnId = generateTurnId();
+          continue;
+        }
+        log(`Compaction loop detected (${consecutiveCompactions} consecutive), stopping auto-continue and waiting for user input`);
+        consecutiveCompactions = 0;
+      } else {
+        consecutiveCompactions = 0;
       }
 
       log('Query ended, waiting for next IPC message...');


### PR DESCRIPTION
## 问题描述

当系统 prompt 较大（CLAUDE.md + HEARTBEAT.md + 记忆系统 + MCP 工具定义等占满大部分上下文窗口）时，compaction 后的 auto-continue 机制会陷入无限循环：

1. 用户消息处理完毕 → 上下文接近 token 限制 → SDK 触发 compaction
2. `hadCompaction = true` → auto-continue 自动发送 `"继续"` 作为下一轮 query
3. `"继续"` + 大系统 prompt 立即再次溢出 → 又一次 compaction → `hadCompaction = true`
4. 回到步骤 2，形成无限循环

### 现象

- Agent 每 ~100 秒（API 调用延迟）输出一次无意义的空回复（如 "有什么新的问题可以随时问我"）
- 持续消耗 API tokens（实测观察到 50+ 次无效 compaction）
- IM 渠道可能收到大量重复消息

### 根因

`container/agent-runner/src/index.ts` 的 compaction auto-continue 逻辑（原 #229 引入）没有对连续 compaction 做上限保护。当系统 prompt 本身就接近 context window 容量时，任何 query（哪怕只有 "继续" 两个字）都会立即触发下一次 compaction。

## 修复方案

### 核心: `container/agent-runner/src/index.ts`

**1. 新增 `consecutiveCompactions` 计数器（阈值 3）**

```typescript
let consecutiveCompactions = 0;
const MAX_CONSECUTIVE_COMPACTIONS = 3;
```

- 每次 compaction 后 auto-continue 时递增
- 超过阈值后停止 auto-continue，转为等待用户输入或 idle timeout 关闭
- 收到真正的用户消息（非 compaction 产生的 "继续"）时重置为 0

**2. compaction 循环中跳过 memory flush query**

```typescript
if (needsMemoryFlush && isHome && consecutiveCompactions === 0) {
```

当已检测到连续 compaction 时，跳过 memory flush query。原因：上下文已满时 flush query 无法产生有效的记忆写入工作，只会额外消耗一次 API 调用（每轮循环从 1 次变成 2 次）。

**3. 在 interrupt / session-resume-failed 路径中重置计数器**

用户触发的 interrupt 和 session 重建都意味着"重新开始"，计数器应归零，避免后续正常 compaction 被误判为循环。

### 行为对比

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 系统 prompt 过大 | 无限循环，无限消耗 tokens | 最多 3 次 auto-continue 后停止 |
| 正常长任务（偶尔 compaction） | 自动 "继续"（正常） | 不受影响（3 次内） |
| compaction 后 memory flush | 每轮 flush 额外消耗 1 次 API | 循环中跳过 flush |
| 用户 interrupt 后新消息 | 计数器不重置，可能误判 | 计数器归零，正常工作 |

## 测试

- [x] `npx tsc --noEmit` 通过
- [ ] 部署后用大 CLAUDE.md 的工作区发消息，验证循环在 3 次后停止
- [ ] 验证正常长任务的 compaction auto-continue 不受影响