### PR TITLE
功能: IM 群组自动注册开关 + 新群组默认 require_mention

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -38,8 +38,8 @@ interface FeishuFileInfo {
 
 export interface ConnectOptions {
   onReady: () => void;
-  /** 收到消息后调用，让调用方自动注册未知的飞书聊天 */
-  onNewChat?: (chatJid: string, chatName: string) => void;
+  /** 收到消息后调用，让调用方自动注册未知的飞书聊天。返回 false 表示拒绝该聊天，消息将被丢弃 */
+  onNewChat?: (chatJid: string, chatName: string) => boolean;
   /** 热重连时设置：丢弃 create_time 早于此时间戳（epoch ms）的消息，避免处理渠道关闭期间的堆积消息 */
   ignoreMessagesBefore?: number;
   /** 斜杠指令回调（如 /clear），返回回复文本或 null */
@@ -909,7 +909,14 @@ export function createFeishuConnection(
     const resolvedChatName = chatType === 'p2p' ? '飞书私聊' : '飞书群聊';
 
     // 先注册会话，确保 resolveGroupFolder 能正确解析 folder（含首条文件消息场景）
-    onNewChat?.(chatJid, resolvedChatName);
+    // onNewChat 返回 false 表示该聊天被拒绝（如 autoRegisterIMChats 关闭时的未注册群组）
+    if (onNewChat && !onNewChat(chatJid, resolvedChatName)) {
+      logger.debug(
+        { chatJid, messageId },
+        'Dropped message: chat not registered and auto-registration disabled',
+      );
+      return;
+    }
 
     let attachmentsJson: string | undefined;
 
@@ -1942,8 +1949,8 @@ let _defaultInstance: FeishuConnection | null = null;
 
 export interface ConnectFeishuOptions {
   onReady: () => void;
-  /** 收到消息后调用，让主模块自动注册未知的飞书聊天到主容器 */
-  onNewChat?: (chatJid: string, chatName: string) => void;
+  /** 收到消息后调用，让主模块自动注册未知的飞书聊天到主容器。返回 false 表示拒绝 */
+  onNewChat?: (chatJid: string, chatName: string) => boolean;
   /** 热重连时设置：丢弃 create_time 早于此时间戳（epoch ms）的消息，避免处理渠道关闭期间的堆积消息 */
   ignoreMessagesBefore?: number;
 }

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -34,7 +34,7 @@ import {
 
 export interface IMChannelConnectOpts {
   onReady: () => void;
-  onNewChat: (chatJid: string, chatName: string) => void;
+  onNewChat: (chatJid: string, chatName: string) => boolean;
   onMessage?: (chatJid: string, text: string, senderName: string) => void;
   ignoreMessagesBefore?: number;
   isChatAuthorized?: (jid: string) => boolean;

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -318,7 +318,7 @@ class IMConnectionManager {
   async connectUserFeishu(
     userId: string,
     config: FeishuConnectConfig,
-    onNewChat: (chatJid: string, chatName: string) => void,
+    onNewChat: (chatJid: string, chatName: string) => boolean,
     options?: ConnectFeishuOptions,
   ): Promise<boolean> {
     if (!config.appId || !config.appSecret) {
@@ -354,7 +354,7 @@ class IMConnectionManager {
   async connectUserTelegram(
     userId: string,
     config: TelegramConnectConfig,
-    onNewChat: (chatJid: string, chatName: string) => void,
+    onNewChat: (chatJid: string, chatName: string) => boolean,
     isChatAuthorized?: (jid: string) => boolean,
     onPairAttempt?: (
       jid: string,
@@ -406,7 +406,7 @@ class IMConnectionManager {
   async connectUserQQ(
     userId: string,
     config: QQConnectConfig,
-    onNewChat: (chatJid: string, chatName: string) => void,
+    onNewChat: (chatJid: string, chatName: string) => boolean,
     isChatAuthorized?: (jid: string) => boolean,
     onPairAttempt?: (
       jid: string,
@@ -464,7 +464,7 @@ class IMConnectionManager {
   async connectUserWeChat(
     userId: string,
     config: WeChatConnectConfig,
-    onNewChat: (chatJid: string, chatName: string) => void,
+    onNewChat: (chatJid: string, chatName: string) => boolean,
     options?: {
       ignoreMessagesBefore?: number;
       onCommand?: (chatJid: string, command: string) => Promise<string | null>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4347,6 +4347,7 @@ async function processTaskIpc(
           containerConfig: data.containerConfig,
           created_by: sourceEntry?.created_by,
           executionMode: execMode,
+          require_mention: true,
         });
       } else {
         logger.warn(
@@ -5637,15 +5638,15 @@ async function ensureDockerRunning(): Promise<void> {
 function buildOnNewChat(
   userId: string,
   homeFolder: string,
-): (chatJid: string, chatName: string) => void {
+): (chatJid: string, chatName: string) => boolean {
   return (chatJid, chatName) => {
     const existing = registeredGroups[chatJid];
     if (existing) {
       // Already owned by this user — nothing to do
-      if (existing.created_by === userId) return;
+      if (existing.created_by === userId) return true;
 
       // Don't override groups with explicit IM routing configured.
-      if (existing.target_agent_id || existing.target_main_jid) return;
+      if (existing.target_agent_id || existing.target_main_jid) return true;
 
       // Backfill missing created_by without changing folder binding.
       // Legacy IM groups may have NULL created_by after migration;
@@ -5658,7 +5659,7 @@ function buildOnNewChat(
           { chatJid, chatName, userId, folder: existing.folder },
           'Backfilled created_by for IM chat (preserved existing folder)',
         );
-        return;
+        return true;
       }
 
       // Different user's connection now owns this IM app.
@@ -5684,18 +5685,31 @@ function buildOnNewChat(
           'Re-routed IM chat to new user (IM credentials transferred)',
         );
       }
-      return;
+      return true;
     }
+
+    // Check if auto-registration is enabled
+    const { autoRegisterIMChats } = getSystemSettings();
+    if (!autoRegisterIMChats) {
+      logger.info(
+        { chatJid, chatName, userId },
+        'Rejected new IM chat: autoRegisterIMChats is disabled',
+      );
+      return false;
+    }
+
     registerGroup(chatJid, {
       name: chatName,
       folder: homeFolder,
       added_at: new Date().toISOString(),
       created_by: userId,
+      require_mention: true,
     });
     logger.info(
       { chatJid, chatName, userId, homeFolder },
       'Auto-registered IM chat',
     );
+    return true;
   };
 }
 

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -52,7 +52,7 @@ export interface QQConnectionConfig {
 
 export interface QQConnectOpts {
   onReady?: () => void;
-  onNewChat: (jid: string, name: string) => void;
+  onNewChat: (jid: string, name: string) => boolean;
   isChatAuthorized: (jid: string) => boolean;
   ignoreMessagesBefore?: number;
   onPairAttempt?: (

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3365,6 +3365,8 @@ export interface SystemSettings {
   // Skills auto-sync
   skillAutoSyncEnabled: boolean;
   skillAutoSyncIntervalMinutes: number;
+  // IM auto-registration
+  autoRegisterIMChats: boolean;
   // Billing
   billingEnabled: boolean;
   billingMode: 'wallet_first';
@@ -3385,6 +3387,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   scriptTimeout: 60000,
   skillAutoSyncEnabled: false,
   skillAutoSyncIntervalMinutes: 10,
+  autoRegisterIMChats: true,
   billingEnabled: false,
   billingMode: 'wallet_first',
   billingMinStartBalanceUsd: 0.01,
@@ -3463,6 +3466,10 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       raw.skillAutoSyncIntervalMinutes >= 1
         ? raw.skillAutoSyncIntervalMinutes
         : DEFAULT_SYSTEM_SETTINGS.skillAutoSyncIntervalMinutes,
+    autoRegisterIMChats:
+      typeof raw.autoRegisterIMChats === 'boolean'
+        ? raw.autoRegisterIMChats
+        : DEFAULT_SYSTEM_SETTINGS.autoRegisterIMChats,
     billingEnabled:
       typeof raw.billingEnabled === 'boolean'
         ? raw.billingEnabled
@@ -3529,6 +3536,9 @@ function buildEnvFallbackSettings(): SystemSettings {
       process.env.SKILL_AUTO_SYNC_INTERVAL_MINUTES,
       DEFAULT_SYSTEM_SETTINGS.skillAutoSyncIntervalMinutes,
     ),
+    autoRegisterIMChats:
+      process.env.AUTO_REGISTER_IM_CHATS !== 'false' &&
+      DEFAULT_SYSTEM_SETTINGS.autoRegisterIMChats,
     billingEnabled:
       process.env.BILLING_ENABLED === 'true' ||
       DEFAULT_SYSTEM_SETTINGS.billingEnabled,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -221,6 +221,7 @@ export const SystemSettingsSchema = z.object({
   scriptTimeout: z.number().int().min(5000).max(600000).optional(),
   skillAutoSyncEnabled: z.boolean().optional(),
   skillAutoSyncIntervalMinutes: z.number().int().min(1).max(1440).optional(),
+  autoRegisterIMChats: z.boolean().optional(),
   billingEnabled: z.boolean().optional(),
   billingMode: z.literal('wallet_first').optional(),
   billingMinStartBalanceUsd: z.number().min(0).max(1000000).optional(),

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -23,8 +23,8 @@ export interface TelegramConnectionConfig {
 
 export interface TelegramConnectOpts {
   onReady?: () => void;
-  /** 收到消息后调用，让调用方自动注册未知的 Telegram 聊天 */
-  onNewChat: (jid: string, name: string) => void;
+  /** 收到消息后调用，让调用方自动注册未知的 Telegram 聊天。返回 false 表示拒绝 */
+  onNewChat: (jid: string, name: string) => boolean;
   /** 检查聊天是否已注册（已在 registered_groups 中） */
   isChatAuthorized: (jid: string) => boolean;
   /** 配对尝试回调：验证码并注册聊天，返回是否成功 */

--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -74,7 +74,7 @@ export interface WeChatConnectionConfig {
 
 export interface WeChatConnectOpts {
   onReady?: () => void;
-  onNewChat: (jid: string, name: string) => void;
+  onNewChat: (jid: string, name: string) => boolean;
   ignoreMessagesBefore?: number;
   onCommand?: (chatJid: string, command: string) => Promise<string | null>;
   resolveGroupFolder?: (jid: string) => string | undefined;

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -133,6 +133,7 @@ export function SystemSettingsSection({ setNotice, setError }: SystemSettingsSec
 
   const [settings, setSettings] = useState<SystemSettings | null>(null);
   const [displayValues, setDisplayValues] = useState<Record<string, number>>({});
+  const [autoRegisterIMChats, setAutoRegisterIMChats] = useState(true);
   const [billingEnabled, setBillingEnabled] = useState(false);
   const [billingMinStartBalanceUsd, setBillingMinStartBalanceUsd] = useState(0.01);
   const [billingCurrency, setBillingCurrency] = useState('USD');
@@ -157,6 +158,7 @@ export function SystemSettingsSection({ setNotice, setError }: SystemSettingsSec
           display[f.key] = f.toDisplay(data[f.key] as number);
         }
         setDisplayValues(display);
+        setAutoRegisterIMChats(data.autoRegisterIMChats ?? true);
         setBillingEnabled(data.billingEnabled ?? false);
         setBillingMinStartBalanceUsd(data.billingMinStartBalanceUsd ?? 0.01);
         setBillingCurrency(data.billingCurrency ?? 'USD');
@@ -202,6 +204,7 @@ export function SystemSettingsSection({ setNotice, setError }: SystemSettingsSec
     setNotice(null);
     try {
       const payload: Partial<SystemSettings> = {
+        autoRegisterIMChats,
         billingEnabled,
         billingMode: 'wallet_first',
         billingMinStartBalanceUsd,
@@ -221,6 +224,7 @@ export function SystemSettingsSection({ setNotice, setError }: SystemSettingsSec
         display[f.key] = f.toDisplay(data[f.key] as number);
       }
       setDisplayValues(display);
+      setAutoRegisterIMChats(data.autoRegisterIMChats ?? true);
       setBillingEnabled(data.billingEnabled ?? false);
       setBillingMinStartBalanceUsd(data.billingMinStartBalanceUsd ?? 0.01);
       setBillingCurrency(data.billingCurrency ?? 'USD');
@@ -284,6 +288,25 @@ export function SystemSettingsSection({ setNotice, setError }: SystemSettingsSec
             </p>
           </div>
         ))}
+      </div>
+
+      {/* IM 设置 */}
+      <div className="border-t border-border pt-6 space-y-5">
+        <h3 className="text-sm font-semibold text-foreground">IM 消息</h3>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="block text-sm font-medium text-foreground">自动注册新 IM 群组</label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              关闭后，来自未注册飞书/Telegram/QQ 群组的消息将被静默忽略，不会自动创建工作区
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={autoRegisterIMChats}
+            onChange={setAutoRegisterIMChats}
+            aria-label="自动注册新 IM 群组"
+          />
+        </div>
       </div>
 
       {/* 计费设置 */}

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -104,6 +104,7 @@ export interface SystemSettings {
   scriptTimeout: number;
   skillAutoSyncEnabled: boolean;
   skillAutoSyncIntervalMinutes: number;
+  autoRegisterIMChats: boolean;
   billingEnabled: boolean;
   billingMode: 'wallet_first';
   billingMinStartBalanceUsd: number;


### PR DESCRIPTION
- 新增 autoRegisterIMChats 系统设置，关闭后未注册的 IM 群组消息将被静默忽略
- onNewChat 回调统一改为返回 boolean，false 表示拒绝该聊天
- 新自动注册的 IM 群组和 register_group 创建的群组默认 require_mention: true
- 前端设置页新增 IM 消息区域，提供自动注册开关