### PR TITLE
修复: 1M 上下文窗口在 SDK auto-compact 中未生效 (#261)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -43,7 +43,7 @@ const WORKSPACE_IPC = process.env.HAPPYCLAW_WORKSPACE_IPC || '/workspace/ipc';
 
 // 模型配置：支持别名（opus/sonnet/haiku）或完整模型 ID
 // 别名自动解析为最新版本，如 opus → Opus 4.6
-const CLAUDE_MODEL = process.env.ANTHROPIC_MODEL || 'opus';
+const CLAUDE_MODEL = process.env.ANTHROPIC_MODEL || 'opus[1m]';
 
 const IPC_INPUT_DIR = path.join(WORKSPACE_IPC, 'input');
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
@@ -1150,6 +1150,12 @@ async function runQuery(
     return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery };
   }
 
+  // Set autocompact window to 530K → threshold ≈ 500K tokens
+  // (works with 1M context: 'opus' resolves to 'opus[1m]' in SDK)
+  if (!process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW) {
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '530000';
+  }
+
   try {
     const q = query({
     prompt: stream,
@@ -1167,6 +1173,17 @@ async function runQuery(
       permissionMode: currentPermissionMode,
       allowDangerouslySkipPermissions: true,
       agentProgressSummaries: true,
+      settings: {
+        hooks: {
+          PreCompact: [{
+            hooks: [{
+              type: 'command' as const,
+              command: 'echo "This conversation has a 500K token compact threshold. Generate a VERY detailed and comprehensive summary. Include ALL code snippets, file paths, function signatures, error messages, and exact user instructions verbatim. The summary should be 3x-5x longer than a typical compact summary to preserve maximum context from this large conversation window."',
+              timeout: 5,
+            }],
+          }],
+        },
+      },
       settingSources: ['project', 'user'],
       includePartialMessages: true,
       mcpServers: {


### PR DESCRIPTION
## 问题描述

关联 #261。PR #262 添加了 `betas: ['context-1m-2025-08-07']` 让 API 支持 1M context，但 **SDK 内部的 auto-compact 阈值计算不看 `betas`，只检查模型名是否含 `[1m]` 后缀**，导致所有工作区实际仍在 ~167K tokens 时触发压缩。

### 根因

SDK `cli.js` 中的关键函数：

```javascript
function jG(model) {
    return /\[1m\]/i.test(model);  // 只检查模型名
}

function sM(model) {
    if (jG(model)) return 1e6;     // 含 [1m] → 1M
    return JX1(model).max_input_tokens;  // opus → 200K
}

// auto-compact 阈值
effectiveWindow = min(modelContextWindow, CLAUDE_CODE_AUTO_COMPACT_WINDOW) - 20000
// min(200K, 530K) = 200K → 阈值 = 200K - 33K = 167K
```

### 验证数据

某工作区一次对话中 7 次压缩（1 小时内），compact agent 收到的最大内容约 350KB（~170K tokens），与 167K 阈值吻合。

## 修复方案

### `container/agent-runner/src/index.ts`

1. **模型 fallback 从 `'opus'` 改为 `'opus[1m]'`**：让 SDK 的 `jG()` 识别为 1M 模型，`sM()` 返回 1M
2. **设置 `CLAUDE_CODE_AUTO_COMPACT_WINDOW=530000`**：实际阈值 = `min(1M, 530K) - 33K ≈ 497K tokens`
3. **添加 PreCompact settings hook**：500K 窗口的压缩摘要需要更详尽，通过 hook 提示生成 3-5x 长度的摘要

🤖 Generated with [Claude Code](https://claude.com/claude-code)