### PR TITLE
fix: prevent IM chat re-routing in multi-bot setups

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -358,10 +358,10 @@ function buildVolumeMounts(
     const envFilePath = path.join(envDir, 'env');
     const quotedLines = shellQuoteEnvLines(envLines);
     fs.writeFileSync(envFilePath, quotedLines.join('\n') + '\n', {
-      mode: 0o600,
+      mode: 0o644,
     });
     try {
-      fs.chmodSync(envFilePath, 0o600);
+      fs.chmodSync(envFilePath, 0o644);
     } catch (err) {
       logger.warn(
         { group: group.name, err },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5649,6 +5649,10 @@ async function ensureDockerRunning(): Promise<void> {
  * When the same Feishu app is transferred between users (e.g., admin disables
  * their channel and a member enables the same credentials), existing chats
  * are re-routed to the new user's home folder on first message receipt.
+ *
+ * In multi-bot setups where the same human talks to multiple bots (each owned
+ * by a different HappyClaw user), re-routing is skipped — the chat stays with
+ * its original owner as long as that owner still has an active IM connection.
  */
 function buildOnNewChat(
   userId: string,
@@ -5678,27 +5682,53 @@ function buildOnNewChat(
       }
 
       // Different user's connection now owns this IM app.
-      // Re-route the chat to the current user's home folder.
-      // This handles the common case where the same Feishu app credentials
-      // are moved from one user to another (e.g., admin → member for testing).
+      // Two possible scenarios:
+      //   1. Credential transfer: admin disables their Feishu channel, member
+      //      enables the same appId → re-route chat to the new user.
+      //   2. Multi-bot setup: same human talks to multiple bots, each owned by
+      //      a different HappyClaw user → do NOT re-route.
+      //
+      // Distinguish by checking whether the previous owner still has an active
+      // IM connection.  If they do, both users run their own bot and we must
+      // preserve existing ownership.  If they don't, it's a credential transfer.
       if (!existing.is_home) {
-        const previousFolder = existing.folder;
-        const previousOwner = existing.created_by;
-        existing.folder = homeFolder;
-        existing.created_by = userId;
-        setRegisteredGroup(chatJid, existing);
-        registeredGroups[chatJid] = existing;
-        logger.info(
-          {
-            chatJid,
-            chatName,
-            userId,
-            homeFolder,
-            previousFolder,
-            previousOwner,
-          },
-          'Re-routed IM chat to new user (IM credentials transferred)',
-        );
+        const previousOwner = existing.created_by!;
+        const previousOwnerStillConnected =
+          imManager.isFeishuConnected(previousOwner) ||
+          imManager.isTelegramConnected(previousOwner) ||
+          imManager.isQQConnected(previousOwner);
+
+        if (previousOwnerStillConnected) {
+          // Multi-bot: both users have active IM connections — keep original ownership
+          logger.debug(
+            {
+              chatJid,
+              chatName,
+              userId,
+              existingOwner: previousOwner,
+              existingFolder: existing.folder,
+            },
+            'Skipped IM chat re-route (previous owner still has active IM connection)',
+          );
+        } else {
+          // Credential transfer: previous owner disconnected — re-route to new user
+          const previousFolder = existing.folder;
+          existing.folder = homeFolder;
+          existing.created_by = userId;
+          setRegisteredGroup(chatJid, existing);
+          registeredGroups[chatJid] = existing;
+          logger.info(
+            {
+              chatJid,
+              chatName,
+              userId,
+              homeFolder,
+              previousFolder,
+              previousOwner,
+            },
+            'Re-routed IM chat to new user (IM credentials transferred)',
+          );
+        }
       }
       return;
     }

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -2746,12 +2746,21 @@ export function writeCredentialsFile(
   const creds = config.claudeOAuthCredentials;
   if (!creds) return;
 
+  // Claude CLI requires scopes and subscriptionType to recognize the token as valid
+  const defaultScopes = [
+    'user:file_upload',
+    'user:inference',
+    'user:mcp_servers',
+    'user:profile',
+    'user:sessions:claude_code',
+  ];
   const credentialsData = {
     claudeAiOauth: {
       accessToken: creds.accessToken,
       refreshToken: creds.refreshToken,
       expiresAt: creds.expiresAt,
-      scopes: creds.scopes,
+      scopes: creds.scopes?.length ? creds.scopes : defaultScopes,
+      subscriptionType: 'max',
     },
   };
 


### PR DESCRIPTION
## Summary

- **Multi-bot re-route fix**: When multiple HappyClaw users each run their own Feishu bot and the same human talks to all of them, `buildOnNewChat` would incorrectly re-route all chats to the last user's home folder. Now checks whether the previous chat owner still has an active IM connection before re-routing:
  - Previous owner still connected → multi-bot setup, **skip re-route**
  - Previous owner disconnected → credential transfer, **re-route as before**
- **Container env file permissions**: Changed env file mode from `0o600` to `0o644` so the container's `node` user (uid 1000) can read the mounted env file (fixes `Permission denied` on container startup)
- **OAuth credentials completeness**: `writeCredentialsFile()` now includes `scopes` and `subscriptionType` fields — Claude CLI requires these to recognize the token as valid (was returning "Not logged in" without them)

## Use case

A single person runs 4 Feishu bots (e.g., general assistant, content ops, video director, content planner), each owned by a different HappyClaw user. Without this fix, all private chats get re-routed to whichever user's connection processes the message last, breaking bot isolation.

## Test plan

- [ ] Setup: 2+ users with different Feishu apps, same human talks to both bots
- [ ] Verify messages stay in their respective user's home workspace
- [ ] Verify credential transfer still works (disable user A's Feishu, enable same appId on user B → chat re-routes)
- [ ] Verify container startup with env file works (no Permission denied)
- [ ] Verify OAuth token is recognized by Claude CLI (no "Not logged in")

🤖 Generated with [Claude Code](https://claude.com/claude-code)