### PR TITLE
修复: 多 bot re-route 保护改为渠道级精确检测 (#304 拆分 1/2)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5646,9 +5646,14 @@ async function ensureDockerRunning(): Promise<void> {
  * Build the onNewChat callback for IM connections.
  * Feishu/Telegram chats auto-register to the user's home group folder.
  *
- * When the same Feishu app is transferred between users (e.g., admin disables
+ * When the same IM app is transferred between users (e.g., admin disables
  * their channel and a member enables the same credentials), existing chats
  * are re-routed to the new user's home folder on first message receipt.
+ *
+ * In multi-bot setups where the same human talks to multiple bots (each owned
+ * by a different HappyClaw user), re-routing is skipped — the chat stays with
+ * its original owner as long as that owner still has an active connection on
+ * the **same channel type** (feishu/telegram/qq/wechat).
  */
 function buildOnNewChat(
   userId: string,
@@ -5678,27 +5683,58 @@ function buildOnNewChat(
       }
 
       // Different user's connection now owns this IM app.
-      // Re-route the chat to the current user's home folder.
-      // This handles the common case where the same Feishu app credentials
-      // are moved from one user to another (e.g., admin → member for testing).
+      // Two possible scenarios:
+      //   1. Credential transfer: admin disables their Feishu channel, member
+      //      enables the same appId → re-route chat to the new user.
+      //   2. Multi-bot setup: same human talks to multiple bots, each owned by
+      //      a different HappyClaw user → do NOT re-route.
+      //
+      // Distinguish by checking whether the previous owner still has an active
+      // connection on the SAME channel type.  Checking all channel types would
+      // produce false positives (e.g., admin's Telegram is still online while
+      // their Feishu app was transferred → skip re-route incorrectly).
       if (!existing.is_home) {
-        const previousFolder = existing.folder;
         const previousOwner = existing.created_by;
-        existing.folder = homeFolder;
-        existing.created_by = userId;
-        setRegisteredGroup(chatJid, existing);
-        registeredGroups[chatJid] = existing;
-        logger.info(
-          {
-            chatJid,
-            chatName,
-            userId,
-            homeFolder,
-            previousFolder,
-            previousOwner,
-          },
-          'Re-routed IM chat to new user (IM credentials transferred)',
-        );
+        const channelType = getChannelType(chatJid);
+        const previousOwnerStillConnected = channelType
+          ? imManager
+              .getConnectedChannelTypes(previousOwner)
+              .includes(channelType)
+          : false;
+
+        if (previousOwnerStillConnected) {
+          // Multi-bot: previous owner still has the same channel type active
+          logger.debug(
+            {
+              chatJid,
+              chatName,
+              userId,
+              channelType,
+              existingOwner: previousOwner,
+              existingFolder: existing.folder,
+            },
+            'Skipped IM chat re-route (previous owner still connected on same channel type)',
+          );
+        } else {
+          // Credential transfer: previous owner no longer connected on this channel
+          const previousFolder = existing.folder;
+          existing.folder = homeFolder;
+          existing.created_by = userId;
+          setRegisteredGroup(chatJid, existing);
+          registeredGroups[chatJid] = existing;
+          logger.info(
+            {
+              chatJid,
+              chatName,
+              userId,
+              homeFolder,
+              previousFolder,
+              previousOwner,
+              channelType,
+            },
+            'Re-routed IM chat to new user (IM credentials transferred)',
+          );
+        }
       }
       return;
     }


### PR DESCRIPTION
## 问题描述

关联 #304 review 反馈。原 PR 中 `previousOwnerStillConnected` 检测逻辑检查的是 previousOwner 是否有**任意** IM 连接在线，而问题发生在**连接级别**而非用户级别。

**反例**：admin 同时开了 Feishu bot A + Telegram bot，member 开了 Feishu bot B。当 admin 关掉 Feishu bot A（凭据迁移），admin 的 Telegram 仍在线 → `previousOwnerStillConnected = true` → Feishu 群消息不会 re-route，凭据迁移失效。

## 修复方案

### `src/index.ts`

- 使用 `getChannelType(chatJid)` 判断当前聊天所属渠道类型（feishu/telegram/qq/wechat）
- 改用 `imManager.getConnectedChannelTypes(previousOwner)` 获取 previousOwner 的所有在线渠道类型
- 仅检查 previousOwner 在**同类型渠道**上是否仍有连接，而非任意渠道
- 自动覆盖所有已注册渠道类型（包括 WeChat），无需逐个枚举 `isXxxConnected()`