### PR TITLE
修复: OAuth credentials 补全 scopes 默认值 + subscriptionType 可配置 (#304 拆分 2/2)

### DIFF
--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -91,6 +91,7 @@ export interface ClaudeOAuthCredentials {
   refreshToken: string;
   expiresAt: number; // Unix timestamp (ms)
   scopes: string[];
+  subscriptionType?: string; // e.g. 'max', 'pro' — written to .credentials.json if present
 }
 
 export interface ClaudeProviderConfig {
@@ -590,6 +591,9 @@ function decryptSecrets(secrets: EncryptedSecrets): SecretPayload {
         refreshToken: creds.refreshToken,
         expiresAt: typeof creds.expiresAt === 'number' ? creds.expiresAt : 0,
         scopes: Array.isArray(creds.scopes) ? (creds.scopes as string[]) : [],
+        ...(typeof creds.subscriptionType === 'string'
+          ? { subscriptionType: creds.subscriptionType }
+          : {}),
       };
     }
   }
@@ -2746,14 +2750,29 @@ export function writeCredentialsFile(
   const creds = config.claudeOAuthCredentials;
   if (!creds) return;
 
-  const credentialsData = {
-    claudeAiOauth: {
-      accessToken: creds.accessToken,
-      refreshToken: creds.refreshToken,
-      expiresAt: creds.expiresAt,
-      scopes: creds.scopes,
-    },
+  // Claude CLI requires scopes to recognize the token as valid.
+  // Fall back to a sensible default when the stored credentials lack scopes
+  // (e.g. tokens imported before scopes were captured).
+  const DEFAULT_SCOPES = [
+    'user:inference',
+    'user:profile',
+    'user:sessions:claude_code',
+  ];
+  const scopes = creds.scopes?.length ? creds.scopes : DEFAULT_SCOPES;
+
+  const claudeAiOauth: Record<string, unknown> = {
+    accessToken: creds.accessToken,
+    refreshToken: creds.refreshToken,
+    expiresAt: creds.expiresAt,
+    scopes,
   };
+  // Only include subscriptionType when explicitly configured — avoids
+  // misleading Claude CLI when the actual subscription tier is unknown.
+  if (creds.subscriptionType) {
+    claudeAiOauth.subscriptionType = creds.subscriptionType;
+  }
+
+  const credentialsData = { claudeAiOauth };
 
   const filePath = path.join(sessionDir, '.credentials.json');
   const tmp = `${filePath}.tmp`;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -324,6 +324,7 @@ export const ClaudeOAuthCredentialsSchema = z.object({
   refreshToken: z.string().min(1),
   expiresAt: z.number(),
   scopes: z.array(z.string()).default([]),
+  subscriptionType: z.string().optional(),
 });
 
 export const ClaudeSecretsSchema = z


### PR DESCRIPTION
## 问题描述

关联 #304 review 反馈。原 PR 中存在两个问题：

1. `scopes` 为空时未填充默认值，可能导致 Claude CLI 无法识别 token
2. `subscriptionType: 'max'` 硬编码，非 Max 订阅用户可能出现非预期行为

## 修复方案

### `src/runtime-config.ts`

- `writeCredentialsFile()` 中 scopes 为空时 fallback 到默认值 `['user:inference', 'user:profile', 'user:sessions:claude_code']`
- `subscriptionType` 改为可选字段，仅在用户显式配置时写入 `.credentials.json`，不再硬编码
- `ClaudeOAuthCredentials` 接口新增可选 `subscriptionType` 字段
- 从存储配置解析时同步读取 `subscriptionType`

### `src/schemas.ts`

- `ClaudeOAuthCredentialsSchema` 新增 `subscriptionType: z.string().optional()`

## 关于 env 权限问题

原 PR 中将 env 文件权限从 0o600 放宽到 0o644 的改动已移除。`entrypoint.sh` 以 root 运行 `source`，env 变量通过 `runuser` 继承给 node 用户，0o600 不构成权限问题，无需修改。