### PR TITLE
修复: 多 admin 独立主容器 — 每个 admin bot 拥有独立工作区

### DIFF
--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "*",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "cron-parser": "^5.0.0",
         "zod": "^4.0.0"
       },
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.81",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.81.tgz",
-      "integrity": "sha512-CBeebgibBEN/DWOQGZN67vhuTG55RbI1hlsFSSoZ4uA/Io3lw04eHTE2ISCmdbqyJaefYTt6GKZei1nP0TQMNw==",
+      "version": "0.2.83",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.83.tgz",
+      "integrity": "sha512-O8g56htGMxrwbjCbqUqRBMNC0O98B7SkPnfQC7vmo3w2DVnUrBj3qat/IBLB8SI4sjVSZHeJrcK7+ozsCzStSw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -14,6 +14,7 @@ import os from 'os';
 import path from 'path';
 
 import { CONTAINER_IMAGE, DATA_DIR, GROUPS_DIR } from './config.js';
+import { isAdminHomeGroup } from './db.js';
 import { logger } from './logger.js';
 import {
   loadMountAllowlist,
@@ -479,7 +480,7 @@ export async function runContainerAgent(
 
   try {
     // Determine if this is an admin home container (full privileges)
-    const isAdminHome = !!group.is_home && group.folder === 'main';
+    const isAdminHome = isAdminHomeGroup(group);
     // Per-user skills: always mount if the group has an owner
     const shouldMountUserSkills = !!group.created_by;
     const mounts = buildVolumeMounts(

--- a/src/db.ts
+++ b/src/db.ts
@@ -2297,36 +2297,42 @@ export function getGroupsByTargetMainJid(
 export function getUserHomeGroup(
   userId: string,
 ): (RegisteredGroup & { jid: string }) | undefined {
-  // First try exact match: is_home=1 AND created_by=userId
-  let row = db
+  // Exact match: is_home=1 AND created_by=userId.
+  // Each user (admin or member) owns exactly one home group.
+  // In multi-admin setups, only the primary admin (who created web:main)
+  // uses folder=main; other admins get their own home-{userId}.
+  const row = db
     .prepare(
       'SELECT * FROM registered_groups WHERE is_home = 1 AND created_by = ?',
     )
     .get(userId) as RegisteredGroupRow | undefined;
-
-  // Fallback for admin users: all admins share web:main (folder=main).
-  // If no exact match, check if the user is an admin and web:main exists.
-  if (!row) {
-    const user = db
-      .prepare("SELECT role FROM users WHERE id = ? AND status = 'active'")
-      .get(userId) as { role: string } | undefined;
-    if (user?.role === 'admin') {
-      row = db
-        .prepare(
-          "SELECT * FROM registered_groups WHERE jid = 'web:main' AND is_home = 1",
-        )
-        .get() as RegisteredGroupRow | undefined;
-    }
-  }
 
   if (!row) return undefined;
   return parseGroupRow(row);
 }
 
 /**
+ * Check whether a registered group is an admin's home container.
+ * In multi-admin setups the primary admin uses folder='main' while secondary
+ * admins use folder='home-{userId}', but both are admin home containers with
+ * host-mode execution and elevated privileges.
+ */
+export function isAdminHomeGroup(group: RegisteredGroup): boolean {
+  if (!group.is_home) return false;
+  if (group.folder === 'main') return true;
+  if (!group.created_by) return false;
+  const owner = db
+    .prepare("SELECT role FROM users WHERE id = ? AND status = 'active'")
+    .get(group.created_by) as { role: string } | undefined;
+  return owner?.role === 'admin';
+}
+
+/**
  * Ensure a user has a home group. If not, create one.
- * Admin gets folder='main' with executionMode='host'.
- * Member gets folder='home-{userId}' with executionMode='container'.
+ * The first admin gets folder='main' (web:main) with executionMode='host'.
+ * Subsequent admins get folder='home-{userId}' with executionMode='host',
+ * so each admin bot has its own independent workspace.
+ * Members get folder='home-{userId}' with executionMode='container'.
  * Returns the JID of the home group.
  */
 export function ensureUserHomeGroup(
@@ -2339,40 +2345,42 @@ export function ensureUserHomeGroup(
 
   const now = new Date().toISOString();
   const isAdmin = role === 'admin';
-  const jid = isAdmin ? 'web:main' : `web:home-${userId}`;
-  const folder = isAdmin ? 'main' : `home-${userId}`;
 
-  // For admin: check if web:main already exists (created by another admin)
-  // In that case, reuse it rather than overwriting created_by
+  // Determine JID and folder.
+  // For admin: use web:main only if it doesn't exist yet or has no owner.
+  // If web:main is already owned by another admin, create home-{userId} instead.
+  let jid: string;
+  let folder: string;
   if (isAdmin) {
-    const existingMain = getRegisteredGroup(jid);
-    if (existingMain) {
-      // web:main already exists.
-      // Ensure is_home, created_by, and executionMode are correct for owner-based routing.
-      const patched = { ...existingMain };
-      let changed = false;
-      if (!patched.is_home) {
-        patched.is_home = true;
-        changed = true;
+    const existingMain = getRegisteredGroup('web:main');
+    if (!existingMain) {
+      // First admin — claim web:main
+      jid = 'web:main';
+      folder = 'main';
+    } else if (!existingMain.created_by) {
+      // Legacy web:main with no owner — claim it
+      const patched = { ...existingMain, created_by: userId, is_home: true, executionMode: 'host' as const };
+      setRegisteredGroup('web:main', patched);
+      ensureChatExists('web:main');
+      return 'web:main';
+    } else if (existingMain.created_by === userId) {
+      // Already owned by this user (shouldn't happen since getUserHomeGroup checks)
+      if (!existingMain.is_home) {
+        setRegisteredGroup('web:main', { ...existingMain, is_home: true });
       }
-      if (!patched.created_by) {
-        patched.created_by = userId;
-        changed = true;
-      }
-      // Admin home container must use host mode
-      if (patched.executionMode !== 'host') {
-        patched.executionMode = 'host';
-        changed = true;
-      }
-      if (changed) {
-        setRegisteredGroup(jid, patched);
-      }
-      ensureChatExists(jid);
-      return jid;
+      ensureChatExists('web:main');
+      return 'web:main';
+    } else {
+      // web:main is owned by another admin — create independent home
+      jid = `web:home-${userId}`;
+      folder = `home-${userId}`;
     }
+  } else {
+    jid = `web:home-${userId}`;
+    folder = `home-${userId}`;
   }
 
-  const name = username ? `${username} Home` : isAdmin ? 'Main' : 'Home';
+  const name = username ? `${username} Home` : (jid === 'web:main' ? 'Main' : 'Home');
 
   const group: RegisteredGroup = {
     name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   deleteTask,
   ensureChatExists,
   ensureUserHomeGroup,
+  isAdminHomeGroup,
   getAllChats,
   getAllRegisteredGroups,
   getAllSessions,
@@ -1810,15 +1811,15 @@ function loadState(): void {
   }
 
   // Enforce execution mode on all is_home groups:
-  // - admin home → host mode
+  // - admin home → host mode (regardless of folder name)
   // - member home → container mode
   for (const [jid, group] of Object.entries(registeredGroups)) {
     if (!group.is_home) continue;
 
-    // Determine expected mode based on the owner's role
-    // Admin home groups use host mode, member home groups use container mode
-    const isAdminHome = group.folder === MAIN_GROUP_FOLDER;
-    const expectedMode = isAdminHome ? 'host' : 'container';
+    // Determine expected mode based on the owner's role.
+    // In multi-admin setups, secondary admins have folder=home-{userId}
+    // but still need host mode (same as the primary admin on folder=main).
+    const expectedMode = isAdminHomeGroup(group) ? 'host' : 'container';
 
     if (group.executionMode !== expectedMode) {
       group.executionMode = expectedMode;
@@ -3146,7 +3147,7 @@ async function runAgent(
 ): Promise<{ status: 'success' | 'error' | 'closed'; error?: string }> {
   const isHome = !!group.is_home;
   // For the agent-runner: isMain means this is an admin home container (full privileges)
-  const isAdminHome = isHome && group.folder === MAIN_GROUP_FOLDER;
+  const isAdminHome = isAdminHomeGroup(group);
   const sessionId = sessions[group.folder];
 
   // Update tasks snapshot for container to read (filtered by group)
@@ -3626,9 +3627,9 @@ function startIpcWatcher(): void {
       const sourceGroupEntry = Object.values(registeredGroups).find(
         (g) => g.folder === sourceGroup,
       );
-      const isAdminHome = !!(
-        sourceGroupEntry?.is_home && sourceGroup === MAIN_GROUP_FOLDER
-      );
+      const isAdminHome = sourceGroupEntry
+        ? isAdminHomeGroup(sourceGroupEntry)
+        : false;
       const isHome = !!sourceGroupEntry?.is_home;
 
       // Collect all IPC roots: main group dir + agents/*/ + tasks-run/*/
@@ -4627,7 +4628,7 @@ async function processAgentConversation(
   }
 
   const isHome = !!effectiveGroup.is_home;
-  const isAdminHome = isHome && effectiveGroup.folder === MAIN_GROUP_FOLDER;
+  const isAdminHome = isAdminHomeGroup(effectiveGroup);
 
   // Update agent status → running
   updateAgentStatus(agentId, 'running');

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -24,6 +24,7 @@ import {
   getDueTasks,
   getTaskById,
   getUserById,
+  isAdminHomeGroup,
   logTaskRun,
   updateTaskAfterRun,
 } from './db.js';
@@ -201,7 +202,7 @@ async function runTask(
 
   // Update tasks snapshot for container to read (filtered by group)
   const isHome = !!group.is_home;
-  const isAdminHome = isHome && task.group_folder === MAIN_GROUP_FOLDER;
+  const isAdminHome = isAdminHomeGroup(group);
   const tasks = getAllTasks();
   writeTasksSnapshot(
     task.group_folder,


### PR DESCRIPTION
## 问题描述

在多 admin 多 bot 部署场景中（如从 OpenClaw 迁移），所有 admin 共享 `folder=main` 工作区。当非主 admin 的飞书 bot 收到消息时，消息被路由到 core bot 的 `main` 工作区，导致会话内容串台。

**根因**：`getUserHomeGroup()` 对 admin 有 fallback 逻辑，所有 admin 都回退到 `web:main`；`ensureUserHomeGroup()` 也让所有 admin 共享 `main`。

## 修复方案

### `src/db.ts`

- **`getUserHomeGroup()`**：移除 admin fallback 到 `web:main` 的逻辑，每个用户必须有自己的 `is_home` 记录
- **`ensureUserHomeGroup()`**：当 `web:main` 已被其他 admin 占用时，新 admin 创建 `home-{userId}` 独立主容器（`executionMode='host'`）
- **新增 `isAdminHomeGroup()`**：基于 owner role 判断是否为 admin 主容器，替代 `folder === 'main'` 硬编码判断

### `src/index.ts`

- `loadState()` 执行模式强制逻辑改用 `isAdminHomeGroup()`，确保非主 admin 的 `home-{userId}` 也使用 `host` 模式
- 所有 `isAdminHome` 判断改为 `isAdminHomeGroup(group)`

### `src/container-runner.ts`

- 容器启动时的 `isAdminHome` 判断改用 `isAdminHomeGroup()`

### `src/task-scheduler.ts`

- 定时任务的 `isAdminHome` 判断改用 `isAdminHomeGroup()`

## 兼容性

- **向后兼容**：第一个 admin 仍使用 `web:main` + `folder=main`，单 admin 部署无影响
- **仅影响多 admin 场景**：后续 admin 自动获得独立 `home-{userId}` 主容器
- 配合 #307（渠道级 re-route 保护）可完整解决多 bot 共存问题