### PR TITLE
修复: 多 bot 共存时 IM 聊天被错误 re-route 的问题

### DIFF
--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "*",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "cron-parser": "^5.0.0",
         "zod": "^4.0.0"
       },
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.81",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.81.tgz",
-      "integrity": "sha512-CBeebgibBEN/DWOQGZN67vhuTG55RbI1hlsFSSoZ4uA/Io3lw04eHTE2ISCmdbqyJaefYTt6GKZei1nP0TQMNw==",
+      "version": "0.2.83",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.83.tgz",
+      "integrity": "sha512-O8g56htGMxrwbjCbqUqRBMNC0O98B7SkPnfQC7vmo3w2DVnUrBj3qat/IBLB8SI4sjVSZHeJrcK7+ozsCzStSw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -623,6 +623,16 @@ class IMConnectionManager {
     return conn?.channels.get('wechat')?.isConnected() ?? false;
   }
 
+  /**
+   * Check if a user has an active connection for a specific channel type.
+   * Used by multi-bot re-route detection to check at the channel level
+   * rather than the user level.
+   */
+  isChannelConnected(userId: string, channelType: string): boolean {
+    const conn = this.connections.get(userId);
+    return conn?.channels.get(channelType)?.isConnected() ?? false;
+  }
+
   /** Check if any user has an active WeChat connection */
   isAnyWeChatConnected(): boolean {
     for (const conn of this.connections.values()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5677,13 +5677,37 @@ function buildOnNewChat(
         return;
       }
 
-      // Different user's connection now owns this IM app.
-      // Re-route the chat to the current user's home folder.
-      // This handles the common case where the same Feishu app credentials
-      // are moved from one user to another (e.g., admin → member for testing).
+      // Different user's connection received a message for this chat.
+      // Determine whether this is a multi-bot setup (both users have
+      // active connections for this channel type) or a credential transfer
+      // (previous owner disconnected this channel type).
+      const channelType = getChannelType(chatJid);
+      const previousOwner = existing.created_by;
+      const previousOwnerStillConnected =
+        channelType !== null &&
+        imManager.isChannelConnected(previousOwner, channelType);
+
+      if (previousOwnerStillConnected) {
+        // Multi-bot setup: the previous owner still has an active connection
+        // for the same channel type. Do NOT re-route — each bot should keep
+        // its own chats.
+        logger.debug(
+          {
+            chatJid,
+            chatName,
+            userId,
+            previousOwner,
+            channelType,
+          },
+          'Multi-bot detected: previous owner still connected on same channel, skipping re-route',
+        );
+        return;
+      }
+
+      // Credential transfer: previous owner no longer has this channel type
+      // connected. Re-route the chat to the current user's home folder.
       if (!existing.is_home) {
         const previousFolder = existing.folder;
-        const previousOwner = existing.created_by;
         existing.folder = homeFolder;
         existing.created_by = userId;
         setRegisteredGroup(chatJid, existing);
@@ -5696,6 +5720,7 @@ function buildOnNewChat(
             homeFolder,
             previousFolder,
             previousOwner,
+            channelType,
           },
           'Re-routed IM chat to new user (IM credentials transferred)',
         );


### PR DESCRIPTION
## 问题描述

关闭 #304 中提出的核心问题（re-route 检测的抽象层次不对）。

当多个 HappyClaw 用户各自运行不同的飞书 bot，同一个人与所有 bot 对话时，`buildOnNewChat` 会将所有聊天错误路由到最后处理消息的用户的 home folder，破坏 bot 隔离。

## 修复方案

采纳 #304 review 中 @riba2534 的建议，实现**渠道级精确检测**：

### `src/im-manager.ts`
- 新增 `isChannelConnected(userId, channelType)` 通用方法，检查指定用户在指定渠道类型上是否有活跃连接

### `src/index.ts`
- `buildOnNewChat` 中，当检测到不同用户时：
  1. 通过 `getChannelType(chatJid)` 获取渠道类型（feishu/telegram/qq/wechat）
  2. 检查 previousOwner **在同类型渠道上**是否仍有活跃连接
  3. 仍连接 → 多 bot 共存场景，**跳过 re-route**
  4. 已断开 → 凭据迁移场景，**正常 re-route**

### 解决 review 中提到的问题

- ✅ **渠道级检测**：不再检查用户是否有"任意"连接，而是检查同类型渠道连接（解决 admin 关掉 Feishu 但 Telegram 仍在线导致误判的问题）
- ✅ **WeChat 覆盖**：使用通用 `getChannelType()` + `isChannelConnected()`，自动覆盖所有渠道类型
- ✅ **不涉及 env 权限和 OAuth 字段**：这两个独立问题按建议拆分，本 PR 仅聚焦 re-route 逻辑

## Test plan

- [ ] Setup: 2+ 用户配置不同飞书 app，同一个人分别与两个 bot 私聊
- [ ] 验证消息留在各自用户的 home workspace，不会被 re-route
- [ ] 验证凭据迁移仍有效：禁用 user A 的飞书 → user B 启用相同 appId → 聊天正确 re-route 到 user B
- [ ] 验证 admin 关掉 Feishu 但 Telegram 仍在线时，Feishu 聊天能正确 re-route（不被 Telegram 连接误判）

🤖 Generated with [Claude Code](https://claude.com/claude-code)