### PR TITLE
修复: Mermaid 语法错误降级代码块在暗黑模式下显示白色背景

### DIFF
--- a/web/src/components/chat/MermaidDiagram.tsx
+++ b/web/src/components/chat/MermaidDiagram.tsx
@@ -146,10 +146,10 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
             )}
           </button>
         </div>
-        <div className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded-t-lg px-3 py-1">
+        <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-t-lg px-3 py-1">
           Mermaid 语法错误，已降级为代码展示
         </div>
-        <pre className="!bg-[#f6f8fa] rounded-b-lg p-4 overflow-x-auto">
+        <pre className="!bg-[#f6f8fa] dark:!bg-[#1e1e1e] rounded-b-lg p-4 overflow-x-auto">
           <code className="language-mermaid">{code}</code>
         </pre>
       </div>


### PR DESCRIPTION
## 问题描述

暗黑模式下，Mermaid 图表语法错误降级为代码展示时，提示条和代码块显示为白色背景，与暗黑主题不协调。

**根因**：`MermaidDiagram.tsx` 的 error 分支中，提示条硬编码了亮色样式（`bg-amber-50`、`text-amber-600`、`border-amber-200`），代码块硬编码了 `!bg-[#f6f8fa]`，均未添加 `dark:` 变体。

## 修复方案

### `web/src/components/chat/MermaidDiagram.tsx`

- 提示条添加 `dark:text-amber-400`、`dark:bg-amber-950/50`、`dark:border-amber-800`
- 降级代码块添加 `dark:!bg-[#1e1e1e]`

## Test plan

- [ ] 切换到暗黑模式
- [ ] 发送一段错误的 Mermaid 语法（如 `graph INVALID`）
- [ ] 确认降级后的提示条和代码块背景色与暗黑主题协调
- [ ] 确认亮色模式下行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)