### PR TITLE
修复: 多处组件暗黑模式颜色适配缺失

### DIFF
--- a/web/src/components/chat/MermaidDiagram.tsx
+++ b/web/src/components/chat/MermaidDiagram.tsx
@@ -146,10 +146,10 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
             )}
           </button>
         </div>
-        <div className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded-t-lg px-3 py-1">
+        <div className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-t-lg px-3 py-1">
           Mermaid 语法错误，已降级为代码展示
         </div>
-        <pre className="!bg-[#f6f8fa] rounded-b-lg p-4 overflow-x-auto">
+        <pre className="!bg-[#f6f8fa] dark:!bg-[#1e1e1e] rounded-b-lg p-4 overflow-x-auto">
           <code className="language-mermaid">{code}</code>
         </pre>
       </div>

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -331,11 +331,11 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
                   }}
                 >
                   <div className="flex items-center gap-3 my-6 px-4">
-                    <div className="flex-1 border-t border-amber-300" />
-                    <span className="text-xs text-amber-600 whitespace-pre-wrap">
+                    <div className="flex-1 border-t border-amber-300 dark:border-amber-700" />
+                    <span className="text-xs text-amber-600 dark:text-amber-400 whitespace-pre-wrap">
                       {item.content}
                     </span>
-                    <div className="flex-1 border-t border-amber-300" />
+                    <div className="flex-1 border-t border-amber-300 dark:border-amber-700" />
                   </div>
                 </div>
               );
@@ -382,12 +382,12 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
                   }}
                 >
                   <div className="flex items-center gap-3 my-6 px-4">
-                    <div className="flex-1 border-t border-red-300" />
-                    <span className="text-xs text-red-600 whitespace-pre-wrap flex items-center gap-1">
+                    <div className="flex-1 border-t border-red-300 dark:border-red-800" />
+                    <span className="text-xs text-red-600 dark:text-red-400 whitespace-pre-wrap flex items-center gap-1">
                       <AlertTriangle size={14} />
                       {item.content}
                     </span>
-                    <div className="flex-1 border-t border-red-300" />
+                    <div className="flex-1 border-t border-red-300 dark:border-red-800" />
                   </div>
                 </div>
               );
@@ -477,7 +477,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
           <button
             type="button"
             onClick={onInterrupt}
-            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs text-muted-foreground hover:text-red-600 bg-card/90 backdrop-blur-sm hover:bg-red-50 rounded-full border border-border shadow-sm transition-colors cursor-pointer"
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs text-muted-foreground hover:text-red-600 dark:hover:text-red-400 bg-card/90 backdrop-blur-sm hover:bg-red-50 dark:hover:bg-red-950/30 rounded-full border border-border shadow-sm transition-colors cursor-pointer"
           >
             <Square className="w-3 h-3" />
             中断


### PR DESCRIPTION
## 问题描述

暗黑模式下多个聊天组件使用了硬编码的亮色系颜色值，缺少 `dark:` Tailwind 变体，导致在深色背景上对比度不足或视觉效果异常。

## 修复方案

### `web/src/components/chat/MermaidDiagram.tsx`
- Mermaid 语法错误降级代码展示时，错误提示条和代码块背景缺少暗黑适配
- 添加 `dark:text-amber-400`、`dark:bg-amber-950/50`、`dark:border-amber-800` 到错误提示条
- 添加 `dark:!bg-[#1e1e1e]` 到代码块背景

### `web/src/components/chat/MessageList.tsx`
- 系统消息分隔线 `border-amber-300` / `text-amber-600` 在深色背景上对比度不足
  - 添加 `dark:border-amber-700` 和 `dark:text-amber-400`
- 错误消息分隔线 `border-red-300` / `text-red-600` 同样缺少暗黑变体
  - 添加 `dark:border-red-800` 和 `dark:text-red-400`
- 中断按钮 hover 态 `hover:bg-red-50` / `hover:text-red-600` 在暗黑模式下不协调
  - 添加 `dark:hover:bg-red-950/30` 和 `dark:hover:text-red-400`

## 审查说明

经过对 `web/src/` 下全部前端组件的完整审查，其他使用硬编码颜色的场景（如 TerminalPanel 的深色终端主题、ShareCardRenderer 的分享图片固定亮色主题）均为有意设计，不在此次修复范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)