### PR TITLE
fix: skip PreCompact hook when triggered by sub-agent compact (#321)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -491,6 +491,20 @@ function createPreCompactHook(
     const transcriptPath = preCompact.transcript_path;
     const sessionId = preCompact.session_id;
 
+    // ── Skip sub-agent compaction ──
+    // The SDK fires PreCompact hooks at process level, meaning sub-agent
+    // compactions (e.g. a haiku web-researcher hitting its 167K threshold)
+    // also trigger this hook on the main agent. BaseHookInput.agent_id is
+    // present *only* when the hook fires from within a sub-agent, so we can
+    // use it as a reliable guard.  Without this check, every sub-agent
+    // compact would: archive the (unchanged) main-agent transcript, set
+    // hadCompaction = true, and trigger a needless auto-continue + memory
+    // flush — see issue #321.
+    if (preCompact.agent_id) {
+      log(`PreCompact: skipping sub-agent compact (agent_id=${preCompact.agent_id})`);
+      return {};
+    }
+
     // ── Flush accumulated streaming text as compact_partial ──
     // This ensures users see the partial response even after compaction.
     const partialText = deps.getFullText();


### PR DESCRIPTION
## 问题

Sub-agent（如 haiku web-researcher）compact 时，SDK 会在进程级触发所有已注册的 `PreCompact` hook，包括主 Agent 的 hook。这导致：

- **重复归档**：主 Agent 上下文未变，却被反复归档（9 份内容相同的文件）
- **误触发 auto-continue**：`hadCompaction` 被错误置为 `true`，主 Agent 不必要地 auto-continue
- **无效内存刷新**：home 容器的 `needsMemoryFlush` 被误置位
- **用户困惑**：频繁收到上下文压缩通知，实际主 Agent 上下文远未满

详见 Issue #321。

## 修复方案

在 `createPreCompactHook()` 返回的回调函数最前面，检查 `BaseHookInput.agent_id` 字段。

根据 SDK（v0.2.86）类型定义：
```
/** Subagent identifier. Present only when the hook fires from within a subagent.
 *  Absent for the main thread. Use this field to distinguish subagent calls
 *  from main-thread calls. */
agent_id?: string;
```

当 `agent_id` 存在时，表示 compact 来自 sub-agent，直接返回 `{}`，跳过归档、`hadCompaction` 置位和内存刷新。

## 变更

```
container/agent-runner/src/index.ts
```

在 `createPreCompactHook` 的 callback 开头添加了 14 行保护逻辑：

```typescript
// ── Skip sub-agent compaction ──
if (preCompact.agent_id) {
  log(`PreCompact: skipping sub-agent compact (agent_id=${preCompact.agent_id})`);
  return {};
}
```

## 验证

- TypeScript 类型检查通过（`tsc --noEmit`，SDK 0.2.86 types）
- `agent_id` 字段为 SDK 官方 `BaseHookInput` 属性，行为有文档保证
- 主 Agent 触发的 compact（无 `agent_id`）走原有完整逻辑，不受影响

Closes #321