### PR TITLE
fix: 优雅关闭超时过短导致进程被强制终止

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6722,7 +6722,7 @@ async function main(): Promise<void> {
         logger.warn({ err }, 'Error shutting down web server'),
       ),
       queue
-        .shutdown(1500)
+        .shutdown(30000)
         .catch((err) => logger.warn({ err }, 'Error shutting down queue')),
     ]);
 


### PR DESCRIPTION
## 问题描述

关闭服务时(如宿主机重启/关机发送 SIGTERM),如果 GroupQueue 中还有活跃的 host agent 在运行,1500ms 的优雅关闭宽限期不足以等待其正常完成,导致进程被强制 kill,make start 报 exit 1。

## 根因

`src/index.ts:6725` 硬编码了 1500ms 的关闭超时:

```diff
- queue.shutdown(1500)
+ queue.shutdown(30000)
```

当定时任务在 03:00 触发启动 host agent 后,如果宿主机在 03:01 发送 SIGTERM,此时 agent 还在运行中。1500ms 后(03:01:35)GroupQueue 会强制终止 agent,但 agent 在 03:01:34 其实已经正常完成了——只是稍微超过了 1500ms 的死线。

## 修复方案

将 shutdown timeout 从 1500ms 增加到 30000ms,与容器空闲超时(IDLE_TIMEOUT)一致,给活跃容器足够的时间完成优雅关闭。

正常情况下,GroupQueue 发送 _close sentinel 后,agent 会在秒级响应关闭信号。30 秒是充足的缓冲,既避免过短导致的 force kill,也避免过长导致的关闭延迟。

关联 #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)