### PR TITLE
fix: 优雅关闭超时过短导致进程被强制终止

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6722,7 +6722,7 @@ async function main(): Promise<void> {
         logger.warn({ err }, 'Error shutting down web server'),
       ),
       queue
-        .shutdown(1500)
+        .shutdown(30000)
         .catch((err) => logger.warn({ err }, 'Error shutting down queue')),
     ]);
 


### PR DESCRIPTION
## 问题描述

关闭服务时(如宿主机重启/关机发送 SIGTERM),如果 GroupQueue 中还有活跃的 host agent 在运行,1500ms 的优雅关闭宽限期不足以等待其正常完成,导致进程被强制 kill,make start 报 exit 1。

## 崩溃机制详解

### 关闭流程（关闭信号 → 进程退出）

```
SIGTERM 收到
  ↓
abortAllStreamingSessions()     ← 立刻中止所有流式输出
  ↓
imManager.disconnectAll()       ← 断开 IM 连接
  ↓
queue.shutdown(1500)            ← 等待最多 1.5 秒让容器/进程自行关闭
  ↓
如果 1.5 秒后还有活跃的容器/进程：
  → force stop（强制 kill）
  ↓
process.exit(0) / process.exit(1)
```

### 问题所在

Host agent 的生命周期不受 GroupQueue 直接管理。来看一次实际发生的案例:

| 时间 | 事件 |
|------|------|
| 03:00:14 | host agent spawn（开始运行）|
| 03:01:33 | SIGTERM 收到（开始优雅关闭）|
| 03:01:33 | abortAllStreamingSessions + disconnectAll |
| 03:01:33 | queue.shutdown(1500) 开始等待 |
| 03:01:34 | host agent 还在运行...（1 秒过去）|
| 03:01:35 | 1500ms 到期, activeCount > 0 → force stop |

实际上 host agent 在 03:01:34 就正常结束了,但 1500ms 太短,等不到它。

### 为什么 make start 报 exit 1

`make start` 中 `node dist/index.js` 的退出码是 1（因为 force stop 路径）。Make 把非零退出码当作错误报告,所以显示为"crash"。

## 修复方案

将 shutdown timeout 从 1500ms 增加到 30000ms,与容器空闲超时(IDLE_TIMEOUT)一致,给活跃容器足够的时间完成优雅关闭。

正常情况下,GroupQueue 发送 _close sentinel 后,agent 会在秒级响应关闭信号。30 秒是充足的缓冲,既避免过短导致的 force kill,也避免过长导致的关闭延迟。

```diff
- queue.shutdown(1500)
+ queue.shutdown(30000)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)