### PR TITLE
功能: 定时任务执行日志支持 running 状态实时追踪

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2027,6 +2027,42 @@ export function logTaskRun(log: TaskRunLog): void {
   );
 }
 
+export function logTaskRunStart(taskId: string): number {
+  const result = db
+    .prepare(
+      `
+    INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error)
+    VALUES (?, ?, 0, 'running', NULL, NULL)
+  `,
+    )
+    .run(taskId, new Date().toISOString());
+  return Number(result.lastInsertRowid);
+}
+
+export function updateTaskRunLog(
+  id: number,
+  updates: { duration_ms: number; status: 'success' | 'error'; result: string | null; error: string | null },
+): void {
+  db.prepare(
+    `
+    UPDATE task_run_logs SET duration_ms = ?, status = ?, result = ?, error = ?
+    WHERE id = ?
+  `,
+  ).run(updates.duration_ms, updates.status, updates.result, updates.error, id);
+}
+
+export function cleanupStaleRunningLogs(): number {
+  const result = db
+    .prepare(
+      `
+    UPDATE task_run_logs SET status = 'error', error = 'Process crashed before completion'
+    WHERE status = 'running'
+  `,
+    )
+    .run();
+  return result.changes;
+}
+
 export function cleanupOldTaskRunLogs(retentionDays = 30): number {
   const cutoff = new Date(
     Date.now() - retentionDays * 24 * 60 * 60 * 1000,

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -22,12 +22,15 @@ import {
   addGroupMember,
   getAllTasks,
   cleanupOldTaskRunLogs,
+  cleanupStaleRunningLogs,
   ensureChatExists,
   getDueTasks,
   getTaskById,
   getUserById,
   getUserHomeGroup,
   logTaskRun,
+  logTaskRunStart,
+  updateTaskRunLog,
   setRegisteredGroup,
   updateChatName,
   updateTaskAfterRun,
@@ -235,6 +238,7 @@ async function runTask(
 
   runningTaskIds.add(task.id);
   const startTime = Date.now();
+  const runLogId = logTaskRunStart(task.id);
 
   // Ensure task has a dedicated workspace (Agent tasks only)
   const workspace = ensureTaskWorkspace(task, deps);
@@ -246,9 +250,7 @@ async function runTask(
       { taskId: task.id, workspaceJid: workspace.jid },
       'Workspace group not found after creation',
     );
-    logTaskRun({
-      task_id: task.id,
-      run_at: new Date().toISOString(),
+    updateTaskRunLog(runLogId, {
       duration_ms: Date.now() - startTime,
       status: 'error',
       result: null,
@@ -286,9 +288,7 @@ async function runTask(
           },
           'Billing access denied, blocking scheduled task',
         );
-        logTaskRun({
-          task_id: task.id,
-          run_at: new Date().toISOString(),
+        updateTaskRunLog(runLogId, {
           duration_ms: Date.now() - startTime,
           status: 'error',
           result: null,
@@ -333,6 +333,24 @@ async function runTask(
   // Track the time of last meaningful output from the agent.
   // duration_ms should measure actual work time, not include idle wait.
   let lastOutputTime = startTime;
+  let runLogFinalized = false;
+
+  const finalizeRunLog = () => {
+    if (runLogFinalized) return;
+    runLogFinalized = true;
+    runningTaskIds.delete(task.id);
+    const durationMs = lastOutputTime - startTime;
+    updateTaskRunLog(runLogId, {
+      duration_ms: durationMs,
+      status: error ? 'error' : 'success',
+      result,
+      error,
+    });
+    // Send _close sentinel so the idle agent process exits promptly,
+    // freeing the queue slot for the next run.
+    if (idleTimer) clearTimeout(idleTimer);
+    deps.queue.closeStdin(effectiveJid);
+  };
 
   // Use persistent session for task workspace
   const sessions = deps.getSessions();
@@ -399,6 +417,11 @@ async function runTask(
           error = streamedOutput.error || 'Unknown error';
           lastOutputTime = Date.now();
         }
+        // Finalize run log on first non-stream output (success/error/closed).
+        // Don't wait for the process to exit — idle timeout can be very long.
+        if (streamedOutput.status !== 'stream') {
+          finalizeRunLog();
+        }
       },
       ownerHomeFolder,
     );
@@ -413,6 +436,9 @@ async function runTask(
       result = output.result;
       lastOutputTime = Date.now();
     }
+
+    // Finalize if not already done by onOutput callback
+    finalizeRunLog();
 
     logger.info(
       { taskId: task.id, durationMs: lastOutputTime - startTime },
@@ -440,19 +466,10 @@ async function runTask(
         /* ignore */
       }
     }
+
+    // Safety net: finalize run log if not already done by onOutput callback
+    finalizeRunLog();
   }
-
-  // Use lastOutputTime instead of Date.now() to exclude idle wait time
-  const durationMs = lastOutputTime - startTime;
-
-  logTaskRun({
-    task_id: task.id,
-    run_at: new Date().toISOString(),
-    duration_ms: durationMs,
-    status: error ? 'error' : 'success',
-    result,
-    error,
-  });
 
   // manualRun: preserve original next_run schedule
   const nextRun = options?.manualRun ? task.next_run : computeNextRun(task);
@@ -475,6 +492,7 @@ async function runScriptTask(
 
   runningTaskIds.add(task.id);
   const startTime = Date.now();
+  const runLogId = logTaskRunStart(task.id);
 
   logger.info(
     { taskId: task.id, group: task.group_folder, executionType: 'script' },
@@ -500,9 +518,7 @@ async function runScriptTask(
             },
             'Billing access denied, blocking script task',
           );
-          logTaskRun({
-            task_id: task.id,
-            run_at: new Date().toISOString(),
+          updateTaskRunLog(runLogId, {
             duration_ms: Date.now() - startTime,
             status: 'error',
             result: null,
@@ -525,9 +541,7 @@ async function runScriptTask(
       { taskId: task.id },
       'Script task has no script_command, skipping',
     );
-    logTaskRun({
-      task_id: task.id,
-      run_at: new Date().toISOString(),
+    updateTaskRunLog(runLogId, {
       duration_ms: Date.now() - startTime,
       status: 'error',
       result: null,
@@ -581,9 +595,7 @@ async function runScriptTask(
 
   const durationMs = Date.now() - startTime;
 
-  logTaskRun({
-    task_id: task.id,
-    run_at: new Date().toISOString(),
+  updateTaskRunLog(runLogId, {
     duration_ms: durationMs,
     status: error ? 'error' : 'success',
     result,
@@ -610,6 +622,18 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
     return;
   }
   schedulerRunning = true;
+
+  // Clean up stale state from previous process crash
+  runningTaskIds.clear();
+  try {
+    const cleaned = cleanupStaleRunningLogs();
+    if (cleaned > 0) {
+      logger.info({ cleaned }, 'Cleaned up stale running task logs from previous session');
+    }
+  } catch (err) {
+    logger.error({ err }, 'Failed to cleanup stale running task logs');
+  }
+
   logger.info('Scheduler loop started');
 
   const loop = async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,7 +135,7 @@ export interface TaskRunLog {
   task_id: string;
   run_at: string;
   duration_ms: number;
-  status: 'success' | 'error';
+  status: 'running' | 'success' | 'error';
   result: string | null;
   error: string | null;
 }

--- a/web/src/components/tasks/TaskDetail.tsx
+++ b/web/src/components/tasks/TaskDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, Pencil, X } from 'lucide-react';
-import { ScheduledTask, useTasksStore } from '../../stores/tasks';
+import { Check, Pencil, RefreshCw, X } from 'lucide-react';
+import { ScheduledTask, TaskRunLog, useTasksStore } from '../../stores/tasks';
 import { showToast } from '../../utils/toast';
 import { INTERVAL_UNITS, formatInterval, decomposeInterval, toggleNotifyChannel } from '../../utils/task-utils';
 import { useConnectedChannels } from '../../hooks/useConnectedChannels';
@@ -17,10 +17,49 @@ interface TaskDetailProps {
   task: ScheduledTask;
 }
 
+const LOG_STATUS_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  running: { bg: 'bg-blue-100', text: 'text-blue-700', label: '运行中' },
+  success: { bg: 'bg-green-100', text: 'text-green-700', label: '成功' },
+  error: { bg: 'bg-red-100', text: 'text-red-700', label: '失败' },
+};
+
+function RunLogStatusBadge({ status }: { status: string }) {
+  const style = LOG_STATUS_STYLES[status] || { bg: 'bg-muted', text: 'text-muted-foreground', label: status };
+  return (
+    <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${style.bg} ${style.text}`}>
+      {style.label}
+    </span>
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
+}
+
 export function TaskDetail({ task }: TaskDetailProps) {
-  const { updateTask } = useTasksStore();
+  const { updateTask, loadLogs, logs } = useTasksStore();
 
   const connectedChannels = useConnectedChannels();
+  const taskLogs = logs[task.id] || [];
+  const [logsLoading, setLogsLoading] = useState(false);
+
+  useEffect(() => {
+    loadLogs(task.id);
+  }, [task.id, loadLogs]);
+
+  const handleRefreshLogs = async () => {
+    setLogsLoading(true);
+    try {
+      await loadLogs(task.id);
+    } finally {
+      setLogsLoading(false);
+    }
+  };
 
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -439,6 +478,64 @@ export function TaskDetail({ task }: TaskDetailProps) {
             renderNotifyChannelsBadges()
           )}
         </div>
+      </div>
+
+      {/* Execution Logs */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <div className="text-sm text-muted-foreground">执行日志</div>
+          <button
+            onClick={handleRefreshLogs}
+            disabled={logsLoading}
+            className="p-1 text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
+            title="刷新日志"
+          >
+            <RefreshCw className={`w-4 h-4 ${logsLoading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+
+        {taskLogs.length === 0 ? (
+          <p className="text-xs text-muted-foreground">暂无执行记录</p>
+        ) : (
+          <div className="border border-border rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-brand-50 text-primary text-xs">
+                  <th className="text-left px-4 py-2 font-medium">运行时间</th>
+                  <th className="text-left px-4 py-2 font-medium">耗时</th>
+                  <th className="text-left px-4 py-2 font-medium">状态</th>
+                  <th className="text-left px-4 py-2 font-medium">结果</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {taskLogs.map((log: TaskRunLog) => (
+                  <tr key={log.id}>
+                    <td className="px-4 py-2.5 text-foreground whitespace-nowrap">
+                      {formatDate(log.run_at)}
+                    </td>
+                    <td className="px-4 py-2.5 text-foreground whitespace-nowrap">
+                      {log.status === 'running' ? '-' : formatDuration(log.duration_ms)}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <RunLogStatusBadge status={log.status} />
+                    </td>
+                    <td className="px-4 py-2.5 text-foreground truncate max-w-xs" title={log.error || log.result || ''}>
+                      {log.error ? (
+                        <span className="text-red-600">{log.error.slice(0, 100)}</span>
+                      ) : log.result ? (
+                        log.result.slice(0, 100)
+                      ) : log.status === 'running' ? (
+                        <span className="text-muted-foreground">执行中...</span>
+                      ) : (
+                        ''
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/stores/tasks.ts
+++ b/web/src/stores/tasks.ts
@@ -28,7 +28,7 @@ export interface TaskRunLog {
   task_id: string;
   run_at: string;
   duration_ms: number;
-  status: 'success' | 'error';
+  status: 'running' | 'success' | 'error';
   result?: string | null;
   error?: string | null;
 }


### PR DESCRIPTION
## 问题描述

改造前，定时任务的执行日志（`task_run_logs`）仅在任务完成后写入一条 success/error 记录，无法在运行期间反映任务状态。此外，前端 `TaskDetail` 组件虽然 store 中有 `loadLogs` 方法，但从未调用，执行日志表格缺失。

## 实现方案

任务开始时立即插入一条 `status='running'` 的记录，任务完成后更新为 success/error。

### `src/types.ts`
- `TaskRunLog.status` 新增 `'running'` 联合成员

### `src/db.ts`
- 新增 `logTaskRunStart(taskId)`: 插入 running 记录，返回 row id
- 新增 `updateTaskRunLog(id, updates)`: 按 id 更新状态、耗时、结果
- 新增 `cleanupStaleRunningLogs()`: 服务启动时将残留 running 记录标记为 error（应对进程崩溃）

### `src/task-scheduler.ts`
- `runTask()` / `runScriptTask()` 改为开头 `logTaskRunStart()`，各退出路径调用 `updateTaskRunLog()`
- 引入 `finalizeRunLog()` 闭包，确保幂等（仅执行一次）：
  - 在 `onOutput` 回调收到第一个非 stream 输出时立即 finalize，避免 agent idle 等待期（最长 30min）日志停留 running
  - finalize 时同步从 `runningTaskIds` 移除并发送 `_close` sentinel，释放 queue slot 使任务可立即重新触发
  - `finally` 块保留 `finalizeRunLog()` 作为兜底
- `startSchedulerLoop()` 启动时清空 `runningTaskIds` 并调用 `cleanupStaleRunningLogs()`

### `web/src/stores/tasks.ts`
- `TaskRunLog.status` 新增 `'running'`

### `web/src/components/tasks/TaskDetail.tsx`
- 补充执行日志表格（运行时间/耗时/状态/结果四列，与原有设计一致）
- 状态列支持 running（蓝色）/ success（绿色）/ error（红色）三种 badge
- 带刷新按钮，展开任务详情时自动加载

## 效果截图

### 任务运行中
<img width="1098" height="361" alt="image" src="https://github.com/user-attachments/assets/fb6fd666-1572-4159-875b-de3351181348" />

### 任务完成后
<img width="1106" height="395" alt="image" src="https://github.com/user-attachments/assets/4b05f2e3-9c31-4b3c-af2c-7cd743ce8f97" />
