### PR TITLE
修复: 定时任务 Agent 不使用 send_message 导致消息未送达用户

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1617,7 +1617,13 @@ async function main(): Promise<void> {
   let prompt = containerInput.prompt;
   let promptImages = containerInput.images;
   if (containerInput.isScheduledTask) {
-    prompt = `[定时任务 - 以下内容由系统自动发送，并非来自用户或群组的直接消息。]\n\n重要：你正在定时任务模式下运行。你的最终输出不会自动发送给用户。你必须使用 mcp__happyclaw__send_message 工具来发送消息，否则用户将收不到任何内容。\n\n${prompt}`;
+    const scheduledTaskPrefixLines = [
+      '[定时任务 - 以下内容由系统自动发送，并非来自用户或群组的直接消息。]',
+      '',
+      '重要：你正在定时任务模式下运行。你的最终输出不会自动发送给用户。你必须使用 mcp__happyclaw__send_message 工具来发送消息，否则用户将收不到任何内容。',
+    ];
+    const scheduledTaskPrefix = scheduledTaskPrefixLines.join('\n');
+    prompt = scheduledTaskPrefix + '\n\n' + prompt;
   }
   const pendingDrain = drainIpcInput();
   if (pendingDrain.messages.length > 0) {


### PR DESCRIPTION
## 问题描述

定时任务（执行方式=Agent）成功运行并产生了正确的结果文本，但用户在 Web / 飞书 / 微信等渠道上收不到任何消息。

### 根因

Agent 类型的定时任务中，`query()` 的最终返回值 **不会** 被自动发送给用户（`task-scheduler.ts` 注释：`// Messages are sent via MCP tool (IPC), result text is just logged`）。Agent 必须主动调用 `send_message` MCP 工具才能将消息送达用户。

但定时任务注入给 Agent 的 prompt 前缀只有：

```
[定时任务 - 以下内容由系统自动发送，并非来自用户或群组的直接消息。]
```

没有告知 Agent 必须使用 `send_message`，而全局 CLAUDE.md 中写的是"你的输出会发送给用户"，导致 Agent 误以为直接回复即可。

### 影响

所有 Agent 类型定时任务的执行结果只记录在执行日志中，无法送达用户的任何通知渠道。

## 修复方案

### `container/agent-runner/src/index.ts`

在定时任务的 prompt 前缀中增加明确指示，告知 Agent 必须使用 `mcp__happyclaw__send_message` 工具发送消息，否则用户将收不到任何内容。
