### PR TITLE
修复: 实现定时任务 group 上下文模式

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -639,6 +639,71 @@ async function runScriptTask(
   updateTaskAfterRun(task.id, nextRun, resultSummary);
 }
 
+/**
+ * Group context mode: inject task prompt as a regular message into the source workspace.
+ * The message is processed by the existing message pipeline (IPC if running, new container if idle).
+ */
+async function runGroupModeTask(
+  task: ScheduledTask,
+  deps: SchedulerDependencies,
+  targetGroupJid: string,
+  manualRun = false,
+): Promise<void> {
+  const startTime = Date.now();
+
+  try {
+    // Resolve task owner for sender attribution
+    const owner = task.created_by ? getUserById(task.created_by) : null;
+    const senderName = owner?.display_name || owner?.username || '定时任务';
+
+    if (!deps.storePromptMessage) {
+      throw new Error('storePromptMessage dependency not available');
+    }
+
+    // Store prompt as a user message in the source workspace chat
+    deps.storePromptMessage(
+      targetGroupJid,
+      owner?.id || 'system',
+      senderName,
+      task.prompt,
+    );
+
+    // Trigger normal message processing for the source workspace
+    deps.queue.enqueueMessageCheck(targetGroupJid);
+
+    logger.info(
+      { taskId: task.id, targetGroupJid, contextMode: 'group' },
+      'Group-mode task injected into source workspace',
+    );
+
+    logTaskRun({
+      task_id: task.id,
+      run_at: new Date().toISOString(),
+      duration_ms: Date.now() - startTime,
+      status: 'success',
+      result: '已注入到源工作区',
+      error: null,
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    logger.error({ taskId: task.id, error }, 'Group-mode task injection failed');
+
+    logTaskRun({
+      task_id: task.id,
+      run_at: new Date().toISOString(),
+      duration_ms: Date.now() - startTime,
+      status: 'error',
+      result: null,
+      error,
+    });
+  }
+
+  // Update next_run (manualRun preserves original schedule)
+  const nextRun = manualRun ? task.next_run : computeNextRun(task);
+  const resultSummary = '已注入到源工作区';
+  updateTaskAfterRun(task.id, nextRun, resultSummary);
+}
+
 let schedulerRunning = false;
 const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 let lastCleanupTime = 0;
@@ -757,9 +822,16 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
               'Unhandled error in runScriptTask',
             );
           });
+        } else if (currentTask.context_mode === 'group') {
+          // Group mode: inject prompt into source workspace as a regular message
+          runGroupModeTask(currentTask, deps, targetGroupJid).catch((err) => {
+            logger.error(
+              { taskId: currentTask.id, err },
+              'Unhandled error in runGroupModeTask',
+            );
+          });
         } else {
-          // Each agent task has a dedicated workspace; use workspace JID or
-          // fallback to targetGroupJid for queue serialization key
+          // Isolated mode (default): each agent task has a dedicated workspace
           const taskQueueJid = currentTask.workspace_jid
             ? `${currentTask.workspace_jid}#task:${currentTask.id}`
             : `${targetGroupJid}#task:${currentTask.id}`;
@@ -807,6 +879,10 @@ export function triggerTaskNow(
       return { success: false, error: 'Script concurrency limit reached' };
     runScriptTask(task, deps, targetGroupJid, true).catch((err) =>
       logger.error({ taskId, err }, 'Manual script task failed'),
+    );
+  } else if (task.context_mode === 'group') {
+    runGroupModeTask(task, deps, targetGroupJid, true).catch((err) =>
+      logger.error({ taskId, err }, 'Manual group-mode task failed'),
     );
   } else {
     const opts: RunTaskOptions = { manualRun: true, taskRunId: task.id };


### PR DESCRIPTION
## 问题描述

关联 #337。

定时任务的 `context_mode` 字段（`group` / `isolated`）在数据库层面已设计完成，但 `task-scheduler.ts` 中的调度循环从未读取该字段。无论用户选择 `group` 还是 `isolated`，所有 agent 类型的定时任务都走同一条路径：

```
runTask() → ensureTaskWorkspace() → 创建独立的 task-{id} 工作区 → 新容器执行
```

**用户现象**：在工作区 `c_group` 中通过飞书设置了一个美股播报定时任务（`context_mode=group`），期望任务在该工作区内执行（共享 session、skills、对话历史），但实际每次都启动一个全新的独立工作区。

**根因**：调度循环的 `else` 分支（agent 任务）没有区分 `context_mode`，统一走 `isolated` 路径。

## 修复方案

在 `script` 和 `isolated`（默认）之间插入 `group` 模式分支，复用现有消息处理管道：

### `src/task-scheduler.ts`

- 新增 `runGroupModeTask()` 函数：
  - 将任务 prompt 通过 `storePromptMessage()` 存为源工作区的一条用户消息
  - 调用 `queue.enqueueMessageCheck(targetGroupJid)` 触发正常消息处理流程
  - 如果源工作区容器正在运行 → IPC 注入；如果空闲 → 启动容器处理
  - 注入失败时 `logTaskRun` 记录 `error` 状态（而非静默失败）
  - `storePromptMessage` 不可用时提前抛错
- 调度循环（`startSchedulerLoop`）和手动触发（`triggerTaskNow`）两处均添加 `context_mode === 'group'` 分支
- `isolated` 模式的现有逻辑**完全不变**，零回归风险

### 已知限制

- **task run log 记录的是消息注入时刻**，而非任务实际执行完成时间（因为 group 模式下任务变为"一条普通消息"，由正常消息流程驱动执行）
- 如果源工作区正在处理其他消息，任务 prompt 会排队等待

### 替代方案

| 方案 | 思路 | 优劣 |
|------|------|------|
| **✅ 消息注入（本 PR）** | prompt → `storePromptMessage` + `enqueueMessageCheck` | 改动最小（1 文件 +78/-2），复用已验证的消息管道，无新机制 |
| IPC 直接注入 | 写入 `data/ipc/{folder}/input/` | 需要容器已在运行，否则消息丢失；不如 `enqueueMessageCheck` 健壮 |
| 复用源工作区走 `enqueueTask` | 修改 `runTask()` 跳过 `ensureTaskWorkspace()` | 保留执行追踪能力，但需改动 `runTask` 内部大量逻辑，回归风险高 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)