### PR TITLE
功能: 在提供商卡片展示 OAuth 用量信息（5h/7d/7dS）

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -73,7 +73,7 @@ import {
   saveUserDingTalkConfig,
   updateAllSessionCredentials,
 } from '../runtime-config.js';
-import type { ClaudeOAuthCredentials } from '../runtime-config.js';
+import type { ClaudeOAuthCredentials, CachedOAuthUsage, OAuthUsageResponse } from '../runtime-config.js';
 import type { AuthUser, RegisteredGroup } from '../types.js';
 import { hasPermission } from '../permissions.js';
 import { logger } from '../logger.js';
@@ -194,6 +194,54 @@ setInterval(() => {
     if (flow.expiresAt < now) oauthFlows.delete(key);
   }
 }, 60_000);
+
+// --- OAuth Usage Cache ---
+
+const OAUTH_USAGE_API = 'https://api.anthropic.com/api/oauth/usage';
+const USAGE_CACHE_TTL_MS = 3 * 60 * 1000; // 3 minutes
+const usageCache = new Map<string, CachedOAuthUsage>();
+
+async function fetchOAuthUsage(providerId: string): Promise<CachedOAuthUsage> {
+  const cached = usageCache.get(providerId);
+  if (cached && Date.now() - cached.fetchedAt < USAGE_CACHE_TTL_MS) {
+    return cached;
+  }
+
+  const providers = getProviders();
+  const provider = providers.find((p) => p.id === providerId);
+  if (!provider?.claudeOAuthCredentials) {
+    throw new Error('Provider has no OAuth credentials');
+  }
+
+  const resp = await fetch(OAUTH_USAGE_API, {
+    headers: {
+      Authorization: `Bearer ${provider.claudeOAuthCredentials.accessToken}`,
+      'anthropic-beta': 'oauth-2025-04-20',
+    },
+  });
+
+  if (!resp.ok) {
+    // Return stale cache if available, otherwise throw
+    if (cached) {
+      const stale: CachedOAuthUsage = { ...cached, error: `HTTP ${resp.status}` };
+      usageCache.set(providerId, stale);
+      return stale;
+    }
+    throw new Error(`Usage API returned ${resp.status}`);
+  }
+
+  const raw = (await resp.json()) as Record<string, unknown>;
+  const data: OAuthUsageResponse = {
+    five_hour: raw.five_hour as OAuthUsageResponse['five_hour'],
+    seven_day: raw.seven_day as OAuthUsageResponse['seven_day'],
+    seven_day_opus: raw.seven_day_opus as OAuthUsageResponse['seven_day_opus'],
+    seven_day_sonnet: raw.seven_day_sonnet as OAuthUsageResponse['seven_day_sonnet'],
+  };
+
+  const result: CachedOAuthUsage = { data, fetchedAt: Date.now() };
+  usageCache.set(providerId, result);
+  return result;
+}
 
 // --- Routes ---
 
@@ -472,6 +520,24 @@ configRoutes.get(
     const balancing = getBalancingConfig();
     providerPool.refreshFromConfig(enabledProviders, balancing);
     return c.json({ statuses: providerPool.getHealthStatuses() });
+  },
+);
+
+// ─── GET /claude/providers/:id/usage — OAuth 用量数据 ─────
+configRoutes.get(
+  '/claude/providers/:id/usage',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const { id } = c.req.param();
+    try {
+      const usage = await fetchOAuthUsage(id);
+      return c.json(usage);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      logger.warn({ err, providerId: id }, 'Failed to fetch OAuth usage');
+      return c.json({ error: msg }, 400);
+    }
   },
 );
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -103,6 +103,24 @@ export interface ClaudeOAuthCredentials {
   subscriptionType?: string; // e.g. 'max', 'pro' — written to .credentials.json if present
 }
 
+export interface OAuthUsageBucket {
+  utilization: number; // 0-100
+  resets_at: string; // ISO 8601
+}
+
+export interface OAuthUsageResponse {
+  five_hour: OAuthUsageBucket | null;
+  seven_day: OAuthUsageBucket | null;
+  seven_day_opus: OAuthUsageBucket | null;
+  seven_day_sonnet: OAuthUsageBucket | null;
+}
+
+export interface CachedOAuthUsage {
+  data: OAuthUsageResponse;
+  fetchedAt: number; // Unix timestamp ms
+  error?: string;
+}
+
 export interface ClaudeProviderConfig {
   anthropicBaseUrl: string;
   anthropicAuthToken: string;

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import type { ProviderWithHealth, ProviderHealthStatus } from './types';
+import { UsageBars } from './UsageBars';
 
 interface ProviderListProps {
   providers: ProviderWithHealth[];
@@ -257,6 +258,11 @@ export function ProviderList({
                       <Activity className="w-3 h-3 inline mr-0.5" />
                       {health.activeSessionCount} 活跃会话
                     </div>
+                  )}
+
+                  {/* OAuth 用量 */}
+                  {provider.hasClaudeOAuthCredentials && (
+                    <UsageBars providerId={provider.id} />
                   )}
                 </div>
               );

--- a/web/src/components/settings/UsageBars.tsx
+++ b/web/src/components/settings/UsageBars.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '@/api/client';
+import type { CachedOAuthUsage, OAuthUsageBucket } from './types';
+
+const POLL_INTERVAL_MS = 3 * 60 * 1000; // 3 minutes
+
+function barColor(utilization: number): string {
+  if (utilization >= 80) return 'bg-red-500';
+  if (utilization >= 50) return 'bg-amber-500';
+  return 'bg-emerald-500';
+}
+
+function formatResetTime(resetsAt: string): string {
+  const diff = new Date(resetsAt).getTime() - Date.now();
+  if (diff <= 0) return '现在';
+
+  const totalMinutes = Math.floor(diff / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+
+  if (days > 0) {
+    return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
+function UsageColumn({
+  label,
+  bucket,
+}: {
+  label: string;
+  bucket: OAuthUsageBucket;
+}) {
+  const pct = Math.round(bucket.utilization);
+  return (
+    <div className="flex items-center gap-1.5 flex-1 min-w-0 justify-center">
+      <span className="text-[11px] font-medium text-muted-foreground shrink-0">
+        {label}
+      </span>
+      <div className="w-16 h-1.5 rounded-full bg-muted overflow-hidden shrink-0">
+        <div
+          className={`h-full rounded-full transition-all ${barColor(pct)}`}
+          style={{ width: `${Math.min(pct, 100)}%` }}
+        />
+      </div>
+      <span className="text-[11px] font-mono text-muted-foreground shrink-0">
+        {pct}%
+      </span>
+      <span className="text-[10px] text-muted-foreground/60 shrink-0">
+        {formatResetTime(bucket.resets_at)}
+      </span>
+    </div>
+  );
+}
+
+export function UsageBars({ providerId }: { providerId: string }) {
+  const [usage, setUsage] = useState<CachedOAuthUsage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchUsage = async () => {
+      try {
+        const data = await api.get<CachedOAuthUsage>(
+          `/api/config/claude/providers/${providerId}/usage`,
+        );
+        if (!cancelled) setUsage(data);
+      } catch {
+        // Silent — usage is optional
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchUsage();
+    timerRef.current = setInterval(fetchUsage, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [providerId]);
+
+  if (loading || !usage?.data) return null;
+
+  const buckets: { label: string; bucket: OAuthUsageBucket }[] = [];
+  if (usage.data.five_hour) buckets.push({ label: '5h', bucket: usage.data.five_hour });
+  if (usage.data.seven_day) buckets.push({ label: '7d', bucket: usage.data.seven_day });
+  if (usage.data.seven_day_sonnet) buckets.push({ label: '7dS', bucket: usage.data.seven_day_sonnet });
+
+  if (buckets.length === 0) return null;
+
+  return (
+    <div className="mt-1.5 ml-4 flex items-center divide-x divide-border">
+      {buckets.map((b) => (
+        <UsageColumn key={b.label} label={b.label} bucket={b.bucket} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -106,6 +106,26 @@ export interface SystemSettings {
   billingCurrencyRate: number;
 }
 
+// ─── OAuth Usage ────────────────────────────────────────────
+
+export interface OAuthUsageBucket {
+  utilization: number;
+  resets_at: string;
+}
+
+export interface OAuthUsageResponse {
+  five_hour: OAuthUsageBucket | null;
+  seven_day: OAuthUsageBucket | null;
+  seven_day_opus: OAuthUsageBucket | null;
+  seven_day_sonnet: OAuthUsageBucket | null;
+}
+
+export interface CachedOAuthUsage {
+  data: OAuthUsageResponse;
+  fetchedAt: number;
+  error?: string;
+}
+
 export type SettingsTab = 'claude' | 'registration' | 'appearance' | 'system' | 'profile' | 'my-channels' | 'security' | 'groups' | 'memory' | 'skills' | 'mcp-servers' | 'agent-definitions' | 'users' | 'about' | 'bindings' | 'usage' | 'monitor';
 
 export function getErrorMessage(err: unknown, fallback: string): string {


### PR DESCRIPTION
## 问题描述

Claude 提供商列表缺少用量信息，无法直观了解各账号的 5 小时/7 天限流窗口使用情况。
<img width="1530" height="334" alt="image" src="https://github.com/user-attachments/assets/46f20d3a-971d-4ee9-8b44-424c26309708" />

## 实现方案

通过 Anthropic OAuth usage API (`GET /api/oauth/usage`) 获取用量数据，在提供商卡片底部展示。

### `src/runtime-config.ts`
- 新增 `OAuthUsageBucket`、`OAuthUsageResponse`、`CachedOAuthUsage` 类型定义

### `src/routes/config.ts`
- 新增 `GET /claude/providers/:id/usage` 路由
- 服务端 3 分钟缓存，429 时降级返回过期缓存

### `web/src/components/settings/UsageBars.tsx`（新文件）
- 页面加载时请求一次，每 3 分钟轮询
- 横排三栏布局（5h / 7d / 7dS），栏间竖线分隔
- 颜色编码：<50% 绿色，50-80% 琥珀色，≥80% 红色
- 加载/错误时静默不显示

### `web/src/components/settings/ProviderList.tsx`
- 在卡片底部为有 OAuth 凭据的提供商渲染 `UsageBars`

### `web/src/components/settings/types.ts`
- 前端对应的类型定义