### PR TITLE
fix: route IM slash commands to bound workspace

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,15 +50,18 @@ function clearSessionFiles(folder: string, agentId?: string): void {
 // ─── Core reset ─────────────────────────────────────────────────
 
 export async function executeSessionReset(
-  chatJid: string,
+  baseChatJid: string,
   folder: string,
   deps: CommandDeps,
   agentId?: string,
 ): Promise<void> {
+  const targetJid = agentId
+    ? `${baseChatJid}#agent:${agentId}`
+    : baseChatJid;
+
   if (agentId) {
     // Agent-specific reset: only stop the agent's virtual JID process
-    const virtualJid = `web:${folder}#agent:${agentId}`;
-    await deps.queue.stopGroup(virtualJid, { force: true });
+    await deps.queue.stopGroup(targetJid, { force: true });
   } else {
     // Main session reset: stop all processes for this folder
     const siblingJids = getJidsByFolder(folder);
@@ -77,7 +80,6 @@ export async function executeSessionReset(
   }
 
   // 4. Insert context_reset divider message into the correct JID
-  const targetJid = agentId ? `web:${folder}#agent:${agentId}` : chatJid;
   const dividerMessageId = crypto.randomUUID();
   const timestamp = new Date().toISOString();
   ensureChatExists(targetJid);
@@ -104,8 +106,7 @@ export async function executeSessionReset(
   // 5. Advance lastAgentTimestamp so old messages before the reset are not
   //    re-sent to the next fresh agent session.
   if (agentId) {
-    const virtualJid = `web:${folder}#agent:${agentId}`;
-    deps.setLastAgentTimestamp(virtualJid, { timestamp, id: dividerMessageId });
+    deps.setLastAgentTimestamp(targetJid, { timestamp, id: dividerMessageId });
   } else {
     const siblingJids = getJidsByFolder(folder);
     for (const siblingJid of siblingJids) {
@@ -116,5 +117,8 @@ export async function executeSessionReset(
     }
   }
 
-  logger.info({ chatJid, folder, agentId }, 'Session reset via /clear command');
+  logger.info(
+    { baseChatJid, targetJid, folder, agentId },
+    'Session reset via /clear command',
+  );
 }

--- a/src/im-command-utils.ts
+++ b/src/im-command-utils.ts
@@ -99,6 +99,14 @@ export interface LocationInfo {
   replyPolicy: string | null;
 }
 
+export interface BoundChatTarget {
+  baseChatJid: string;
+  targetChatJid: string;
+  folder: string;
+  agentId: string | null;
+  locationLine: string;
+}
+
 export interface RegisteredGroupLike {
   folder: string;
   name: string;
@@ -146,6 +154,55 @@ export function resolveLocationInfo(
     : null;
 
   return { locationLine, folder, replyPolicy };
+}
+
+/**
+ * Resolve the real chat target for IM slash commands.
+ *
+ * Non-main workspaces use random web JIDs (`web:<uuid>`), so commands must not
+ * reconstruct targets from `folder`. They need the actual bound workspace JID.
+ */
+export function resolveBoundChatTarget(
+  sourceChatJid: string,
+  group: RegisteredGroupLike,
+  getRegisteredGroup: (jid: string) => RegisteredGroupLike | undefined,
+  getAgent: (id: string) => AgentLike | undefined,
+  findGroupNameByFolder: (folder: string) => string,
+): BoundChatTarget {
+  if (group.target_agent_id) {
+    const agent = getAgent(group.target_agent_id);
+    const parent = agent ? getRegisteredGroup(agent.chat_jid) : undefined;
+    const workspaceName =
+      parent?.name || findGroupNameByFolder(parent?.folder || group.folder);
+    const baseChatJid = agent?.chat_jid || sourceChatJid;
+    return {
+      baseChatJid,
+      targetChatJid: `${baseChatJid}#agent:${group.target_agent_id}`,
+      folder: parent?.folder || group.folder,
+      agentId: group.target_agent_id,
+      locationLine: `${workspaceName} / ${agent?.name || group.target_agent_id}`,
+    };
+  }
+
+  if (group.target_main_jid) {
+    const target = getRegisteredGroup(group.target_main_jid);
+    return {
+      baseChatJid: group.target_main_jid,
+      targetChatJid: group.target_main_jid,
+      folder: target?.folder || group.folder,
+      agentId: null,
+      locationLine: `${target?.name || group.target_main_jid} / 主对话`,
+    };
+  }
+
+  const workspaceName = findGroupNameByFolder(group.folder);
+  return {
+    baseChatJid: sourceChatJid,
+    targetChatJid: sourceChatJid,
+    folder: group.folder,
+    agentId: null,
+    locationLine: `${workspaceName} / 主对话`,
+  };
 }
 
 // ─── System Status Formatting ─────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ import {
   formatContextMessages,
   formatWorkspaceList,
   formatSystemStatus,
+  resolveBoundChatTarget,
   resolveLocationInfo,
   type WorkspaceInfo,
 } from './im-command-utils.js';
@@ -1020,27 +1021,38 @@ async function handleClearCommand(chatJid: string): Promise<string> {
   const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
   if (!group) return '未找到当前工作区';
 
-  const agentId = group.target_agent_id || undefined;
-  // IM 群绑定工作区主对话时，使用工作区 JID 清除上下文，
-  // 确保 divider 插入到工作区消息流（Web 端可见）。
-  const effectiveJid =
-    group.target_main_jid && !agentId ? group.target_main_jid : chatJid;
+  const target = resolveBoundChatTarget(
+    chatJid,
+    group,
+    (jid) => registeredGroups[jid] ?? getRegisteredGroup(jid),
+    getAgent,
+    findGroupNameByFolder,
+  );
 
   try {
     await executeSessionReset(
-      effectiveJid,
-      group.folder,
+      target.baseChatJid,
+      target.folder,
       {
         queue,
         sessions,
         broadcast: broadcastNewMessage,
         setLastAgentTimestamp: setCursors,
       },
-      agentId,
+      target.agentId ?? undefined,
     );
     return '已清除对话上下文 ✓';
   } catch (err) {
-    logger.error({ chatJid, agentId, err }, 'handleCommand /clear failed');
+    logger.error(
+      {
+        chatJid,
+        targetChatJid: target.targetChatJid,
+        targetFolder: target.folder,
+        agentId: target.agentId,
+        err,
+      },
+      'handleCommand /clear failed',
+    );
     return '清除上下文失败，请稍后重试';
   }
 }
@@ -1502,22 +1514,24 @@ function resolveSpawnWorkspace(
   let homeChatJid: string;
   let homeGroup: RegisteredGroup;
 
-  if (group.target_main_jid) {
-    const target =
-      registeredGroups[group.target_main_jid] ??
-      getRegisteredGroup(group.target_main_jid);
-    if (!target) return '绑定的工作区不存在';
-    homeChatJid = group.target_main_jid;
-    homeGroup = target;
-  } else if (group.target_agent_id) {
-    const agentInfo = getAgent(group.target_agent_id);
-    if (!agentInfo) return '绑定的 Agent 不存在';
-    const parent =
-      registeredGroups[agentInfo.chat_jid] ??
-      getRegisteredGroup(agentInfo.chat_jid);
-    if (!parent) return '绑定 Agent 所属的工作区不存在';
-    homeChatJid = agentInfo.chat_jid;
-    homeGroup = parent;
+  if (group.target_main_jid || group.target_agent_id) {
+    const target = resolveBoundChatTarget(
+      baseJid,
+      group,
+      (jid) => registeredGroups[jid] ?? getRegisteredGroup(jid),
+      getAgent,
+      findGroupNameByFolder,
+    );
+    const targetGroup =
+      registeredGroups[target.baseChatJid] ??
+      getRegisteredGroup(target.baseChatJid);
+    if (!targetGroup) {
+      return group.target_agent_id
+        ? '绑定 Agent 所属的工作区不存在'
+        : '绑定的工作区不存在';
+    }
+    homeChatJid = target.baseChatJid;
+    homeGroup = targetGroup;
   } else if (baseJid.startsWith('web:')) {
     homeChatJid = baseJid;
     homeGroup = group;

--- a/tests/im-command-utils.test.ts
+++ b/tests/im-command-utils.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  resolveBoundChatTarget,
+  type RegisteredGroupLike,
+  type AgentLike,
+} from '../src/im-command-utils.js';
+
+const deleteSessionMock = vi.fn();
+const getJidsByFolderMock = vi.fn();
+const storeMessageDirectMock = vi.fn();
+const ensureChatExistsMock = vi.fn();
+
+vi.mock('../src/db.js', () => ({
+  deleteSession: deleteSessionMock,
+  getJidsByFolder: getJidsByFolderMock,
+  storeMessageDirect: storeMessageDirectMock,
+  ensureChatExists: ensureChatExistsMock,
+}));
+
+vi.mock('../src/config.js', () => ({
+  DATA_DIR: '/tmp/happyclaw-test',
+}));
+
+describe('resolveBoundChatTarget', () => {
+  const registeredGroups = new Map<string, RegisteredGroupLike>([
+    [
+      'web:graduation-jid',
+      {
+        name: 'graduation',
+        folder: 'flow-graduation',
+      },
+    ],
+  ]);
+
+  const agents = new Map<string, AgentLike>([
+    [
+      'agent-1234',
+      {
+        name: 'Thesis Agent',
+        chat_jid: 'web:graduation-jid',
+      },
+    ],
+  ]);
+
+  const getRegisteredGroup = (jid: string) => registeredGroups.get(jid);
+  const getAgent = (id: string) => agents.get(id);
+  const findGroupNameByFolder = (folder: string) =>
+    folder === 'home-u1' ? 'Home' : folder;
+
+  test('uses the real bound workspace jid for main-conversation bindings', () => {
+    const target = resolveBoundChatTarget(
+      'feishu:chat-1',
+      {
+        name: 'Feishu Chat',
+        folder: 'home-u1',
+        target_main_jid: 'web:graduation-jid',
+      },
+      getRegisteredGroup,
+      getAgent,
+      findGroupNameByFolder,
+    );
+
+    expect(target).toEqual({
+      baseChatJid: 'web:graduation-jid',
+      targetChatJid: 'web:graduation-jid',
+      folder: 'flow-graduation',
+      agentId: null,
+      locationLine: 'graduation / 主对话',
+    });
+  });
+
+  test('uses the agent parent workspace jid for agent bindings', () => {
+    const target = resolveBoundChatTarget(
+      'feishu:chat-1',
+      {
+        name: 'Feishu Chat',
+        folder: 'home-u1',
+        target_agent_id: 'agent-1234',
+      },
+      getRegisteredGroup,
+      getAgent,
+      findGroupNameByFolder,
+    );
+
+    expect(target).toEqual({
+      baseChatJid: 'web:graduation-jid',
+      targetChatJid: 'web:graduation-jid#agent:agent-1234',
+      folder: 'flow-graduation',
+      agentId: 'agent-1234',
+      locationLine: 'graduation / Thesis Agent',
+    });
+  });
+});
+
+describe('executeSessionReset', () => {
+  beforeEach(() => {
+    deleteSessionMock.mockReset();
+    getJidsByFolderMock.mockReset();
+    storeMessageDirectMock.mockReset();
+    ensureChatExistsMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  test('resets a bound conversation agent under the real workspace jid', async () => {
+    const { executeSessionReset } = await import('../src/commands.js');
+    const stopGroup = vi.fn(async () => {});
+    const broadcast = vi.fn();
+    const setLastAgentTimestamp = vi.fn();
+    const sessions = { 'flow-graduation': 'session-1' } as Record<
+      string,
+      string
+    >;
+
+    await executeSessionReset(
+      'web:graduation-jid',
+      'flow-graduation',
+      {
+        queue: { stopGroup },
+        sessions,
+        broadcast,
+        setLastAgentTimestamp,
+      },
+      'agent-1234',
+    );
+
+    expect(stopGroup).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+      { force: true },
+    );
+    expect(ensureChatExistsMock).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+    );
+    expect(setLastAgentTimestamp).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+      expect.objectContaining({
+        chat_jid: 'web:graduation-jid#agent:agent-1234',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- resolve IM slash-command targets from the actual bound workspace or conversation agent JID instead of reconstructing `web:${folder}`
- fix `/clear` and `/sw` so non-main workspace bindings run against the bound workspace rather than falling back to the main workspace
- add regression tests covering bound main-conversation routing, bound agent routing, and agent session reset target JIDs

## Test Plan
- npm run typecheck
- npm test -- --run
