### PR TITLE
fix: address review findings for OAuth usage display (#341)

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -200,6 +200,17 @@ setInterval(() => {
 const OAUTH_USAGE_API = 'https://api.anthropic.com/api/oauth/usage';
 const USAGE_CACHE_TTL_MS = 3 * 60 * 1000; // 3 minutes
 const usageCache = new Map<string, CachedOAuthUsage>();
+const inFlightUsageRequests = new Map<string, Promise<CachedOAuthUsage>>();
+
+// Periodic cleanup of stale usage cache entries
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of usageCache) {
+    if (now - entry.fetchedAt >= USAGE_CACHE_TTL_MS) {
+      usageCache.delete(key);
+    }
+  }
+}, 60_000);
 
 async function fetchOAuthUsage(providerId: string): Promise<CachedOAuthUsage> {
   const cached = usageCache.get(providerId);
@@ -207,40 +218,56 @@ async function fetchOAuthUsage(providerId: string): Promise<CachedOAuthUsage> {
     return cached;
   }
 
+  // Deduplicate concurrent requests for the same provider
+  const inFlight = inFlightUsageRequests.get(providerId);
+  if (inFlight) return inFlight;
+
   const providers = getProviders();
   const provider = providers.find((p) => p.id === providerId);
-  if (!provider?.claudeOAuthCredentials) {
+  if (!provider) {
+    throw new Error('Provider not found');
+  }
+  if (!provider.claudeOAuthCredentials) {
     throw new Error('Provider has no OAuth credentials');
   }
 
-  const resp = await fetch(OAUTH_USAGE_API, {
-    headers: {
-      Authorization: `Bearer ${provider.claudeOAuthCredentials.accessToken}`,
-      'anthropic-beta': 'oauth-2025-04-20',
-    },
-  });
+  const requestPromise = (async () => {
+    try {
+      const resp = await fetch(OAUTH_USAGE_API, {
+        headers: {
+          Authorization: `Bearer ${provider.claudeOAuthCredentials!.accessToken}`,
+          'anthropic-beta': 'oauth-2025-04-20',
+        },
+      });
 
-  if (!resp.ok) {
-    // Return stale cache if available, otherwise throw
-    if (cached) {
-      const stale: CachedOAuthUsage = { ...cached, error: `HTTP ${resp.status}` };
-      usageCache.set(providerId, stale);
-      return stale;
+      if (!resp.ok) {
+        // Return stale cache if available, otherwise throw
+        if (cached) {
+          const stale: CachedOAuthUsage = { ...cached, error: `HTTP ${resp.status}` };
+          usageCache.set(providerId, stale);
+          return stale;
+        }
+        throw new Error(`Usage API returned ${resp.status}`);
+      }
+
+      const raw = (await resp.json()) as Record<string, unknown>;
+      const data: OAuthUsageResponse = {
+        five_hour: raw.five_hour as OAuthUsageResponse['five_hour'],
+        seven_day: raw.seven_day as OAuthUsageResponse['seven_day'],
+        seven_day_opus: raw.seven_day_opus as OAuthUsageResponse['seven_day_opus'],
+        seven_day_sonnet: raw.seven_day_sonnet as OAuthUsageResponse['seven_day_sonnet'],
+      };
+
+      const result: CachedOAuthUsage = { data, fetchedAt: Date.now() };
+      usageCache.set(providerId, result);
+      return result;
+    } finally {
+      inFlightUsageRequests.delete(providerId);
     }
-    throw new Error(`Usage API returned ${resp.status}`);
-  }
+  })();
 
-  const raw = (await resp.json()) as Record<string, unknown>;
-  const data: OAuthUsageResponse = {
-    five_hour: raw.five_hour as OAuthUsageResponse['five_hour'],
-    seven_day: raw.seven_day as OAuthUsageResponse['seven_day'],
-    seven_day_opus: raw.seven_day_opus as OAuthUsageResponse['seven_day_opus'],
-    seven_day_sonnet: raw.seven_day_sonnet as OAuthUsageResponse['seven_day_sonnet'],
-  };
-
-  const result: CachedOAuthUsage = { data, fetchedAt: Date.now() };
-  usageCache.set(providerId, result);
-  return result;
+  inFlightUsageRequests.set(providerId, requestPromise);
+  return requestPromise;
 }
 
 // --- Routes ---

--- a/web/src/components/settings/UsageBars.tsx
+++ b/web/src/components/settings/UsageBars.tsx
@@ -93,6 +93,7 @@ export function UsageBars({ providerId }: { providerId: string }) {
   const buckets: { label: string; bucket: OAuthUsageBucket }[] = [];
   if (usage.data.five_hour) buckets.push({ label: '5h', bucket: usage.data.five_hour });
   if (usage.data.seven_day) buckets.push({ label: '7d', bucket: usage.data.seven_day });
+  if (usage.data.seven_day_opus) buckets.push({ label: '7dO', bucket: usage.data.seven_day_opus });
   if (usage.data.seven_day_sonnet) buckets.push({ label: '7dS', bucket: usage.data.seven_day_sonnet });
 
   if (buckets.length === 0) return null;


### PR DESCRIPTION
## 问题描述
修复 PR #341 的 4 个 review 问题：

1. **usageCache 无上限** — 添加 60s 定期清理机制，避免内存泄漏
2. **并发请求无去重** — 引入 inFlightUsageRequests Map 避免重复请求
3. **seven_day_opus 桶未渲染** — 补充 7dO 标签渲染
4. **错误信息误导** — 拆分 provider 存在性与 OAuth 凭据检查

## 修改内容

### src/routes/config.ts
- 添加 `inFlightUsageRequests` Map 作为 in-flight 请求缓存
- 添加 `setInterval` 定期清理过期 usageCache 条目
- `fetchOAuthUsage` 先检查 in-flight 请求，存在则返回同一 Promise
- 拆分 provider 存在性检查（`Provider not found`）与凭据检查（`Provider has no OAuth credentials`）

### web/src/components/settings/UsageBars.tsx
- 补充 `seven_day_opus` 桶渲染，标签为 `7dO`

## Test plan
- [x] make typecheck 通过