### PR TITLE
feat: 定时任务执行结果系统级推送到 IM 渠道

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -638,6 +638,7 @@ export function initDatabase(): void {
   ensureColumn('scheduled_tasks', 'execution_type', "TEXT DEFAULT 'agent'");
   ensureColumn('scheduled_tasks', 'script_command', 'TEXT');
   ensureColumn('scheduled_tasks', 'notify_channels', 'TEXT');
+  ensureColumn('scheduled_tasks', 'notify_im', 'INTEGER');
   ensureColumn('scheduled_tasks', 'execution_mode', 'TEXT');
   ensureColumn('scheduled_tasks', 'workspace_jid', 'TEXT');
   ensureColumn('scheduled_tasks', 'workspace_folder', 'TEXT');
@@ -1817,8 +1818,8 @@ export function createTask(
 ): void {
   db.prepare(
     `
-    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, execution_type, script_command, execution_mode, next_run, status, created_at, created_by, notify_channels)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO scheduled_tasks (id, group_folder, chat_jid, prompt, schedule_type, schedule_value, context_mode, execution_type, script_command, execution_mode, next_run, status, created_at, created_by, notify_channels, notify_im)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
   ).run(
     task.id,
@@ -1836,6 +1837,7 @@ export function createTask(
     task.created_at,
     task.created_by ?? null,
     task.notify_channels != null ? JSON.stringify(task.notify_channels) : null,
+    task.notify_im != null ? (task.notify_im ? 1 : 0) : null,
   );
 }
 
@@ -1850,6 +1852,12 @@ function mapTaskRow(row: unknown): ScheduledTask {
     }
   } else if (r.notify_channels === undefined) {
     r.notify_channels = null;
+  }
+  // Normalize notify_im: SQLite stores as 0/1 integer or NULL
+  if (r.notify_im === null || r.notify_im === undefined) {
+    r.notify_im = null;
+  } else {
+    r.notify_im = r.notify_im !== 0;
   }
   // Normalize new nullable fields
   if (r.execution_mode === undefined) r.execution_mode = null;
@@ -1894,6 +1902,7 @@ export function updateTask(
       | 'next_run'
       | 'status'
       | 'notify_channels'
+      | 'notify_im'
     >
   >,
 ): void {
@@ -1939,6 +1948,10 @@ export function updateTask(
   if (updates.notify_channels !== undefined) {
     fields.push('notify_channels = ?');
     values.push(updates.notify_channels != null ? JSON.stringify(updates.notify_channels) : null);
+  }
+  if (updates.notify_im !== undefined) {
+    fields.push('notify_im = ?');
+    values.push(updates.notify_im != null ? (updates.notify_im ? 1 : 0) : null);
   }
 
   if (fields.length === 0) return;

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -29,6 +29,7 @@ import {
   getTaskById,
   getUserById,
   getUserHomeGroup,
+  getJidsByFolder,
   logTaskRun,
   logTaskRunStart,
   updateTaskRunLog,
@@ -39,6 +40,7 @@ import {
 } from './db.js';
 import { GroupQueue } from './group-queue.js';
 import { logger } from './logger.js';
+import { imManager } from './im-manager.js';
 import { resolveTaskOwner } from './task-utils.js';
 import { removeFlowArtifacts } from './file-manager.js';
 import { hasScriptCapacity, runScript } from './script-runner.js';
@@ -477,6 +479,45 @@ async function runTask(
 
     // Safety net: finalize run log if not already done by onOutput callback
     finalizeRunLog();
+
+    // Push task execution result to the owner's IM channel.
+    // notify_im defaults to true (null = not set = enabled).
+    const notifyIm = task.notify_im !== false;
+    if (notifyIm && workspaceGroup.created_by) {
+      const ownerId = workspaceGroup.created_by;
+      const homeGroup = getUserHomeGroup(ownerId);
+      if (homeGroup) {
+        // Find an IM-routable JID for the owner's home group
+        const homeJids = getJidsByFolder(homeGroup.folder);
+        const imJid = homeJids.find(
+          (j) => imManager.isChannelAvailableForJid(j),
+        );
+        if (imJid) {
+          const taskLabel = task.prompt.split('\n')[0].trim().slice(0, 40);
+          let notifyText: string;
+          if (error) {
+            const durationSec = Math.round((lastOutputTime - startTime) / 1000);
+            notifyText =
+              `⚠️ 定时任务执行失败\n` +
+              `📋 任务：${taskLabel}\n` +
+              `❌ 错误：${error.slice(0, 300)}\n` +
+              `⏱ 耗时：${durationSec}s`;
+          } else {
+            const summary = result ? result.slice(0, 200) : '（无输出）';
+            notifyText =
+              `✅ 定时任务执行完成\n` +
+              `📋 任务：${taskLabel}\n` +
+              `📝 结果：${summary}`;
+          }
+          imManager.sendMessage(imJid, notifyText).catch((err) => {
+            logger.warn(
+              { taskId: task.id, imJid, err },
+              'Failed to send task IM notification',
+            );
+          });
+        }
+      }
+    }
   }
 
   // manualRun: preserve original next_run schedule

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,8 @@ export interface ScheduledTask {
   created_at: string;
   created_by?: string;
   notify_channels?: string[] | null;
+  /** Push task result to the owner's IM channel after each run. Defaults to true. */
+  notify_im?: boolean | null;
 }
 
 export interface TaskRunLog {


### PR DESCRIPTION
## 解决 Issue

Closes #334

## 问题背景

定时任务改用 `context_mode: isolated` 后，任务执行过程和结果只存在于独立工作区，用户需要主动打开 Web 端才能查看，对 IM 用户不友好。

## 实现方案

在 `task-scheduler.ts` 的 `runTask()` `finally` 块中，任务执行完毕后自动将执行摘要推送到任务 owner 的主会话所绑定的 IM 渠道。

### 核心逻辑

1. 通过 `getUserHomeGroup(ownerId)` 找到 owner 的主会话
2. 通过 `getJidsByFolder()` + `imManager.isChannelAvailableForJid()` 找到可用的 IM 路由 JID
3. 使用 `imManager.sendMessage()` 推送通知（fire-and-forget，失败仅记录 warn 日志，不影响主流程）

### 通知格式

**成功：**
```
✅ 定时任务执行完成
📋 任务：<任务第一行前40字>
📝 结果：<result前200字符>
```

**失败：**
```
⚠️ 定时任务执行失败
📋 任务：<任务第一行前40字>
❌ 错误：<error前300字符>
⏱ 耗时：Xs
```

## 新增字段：`notify_im`

在 `ScheduledTask` 类型、DB schema 和 `updateTask` 中新增 `notify_im: boolean | null` 字段：

- `null`（默认）= 开启通知
- `true` = 明确开启
- `false` = 关闭（适合高频任务）

DB 通过 `ensureColumn` 自动迁移，无需手动执行 SQL。

## 变更文件

- `src/types.ts` — `ScheduledTask` 接口新增 `notify_im` 字段
- `src/db.ts` — DB 迁移、`mapTaskRow` 解析、`createTask` INSERT、`updateTask` 更新
- `src/task-scheduler.ts` — `runTask()` finally 块加入 IM 通知逻辑

## 测试

- TypeScript 编译无错误（`tsc --noEmit`）
- 现有测试全部通过（`npm test`）