### PR TITLE
feat: 对话标签栏支持拖拽排序

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/inter": "^5.2.8",
         "@tanstack/react-virtual": "^3.0.0",
         "@xterm/addon-fit": "^0.11.0",
@@ -1756,6 +1759,59 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
       "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.57.1",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,9 @@
     "generate-icons": "node scripts/generate-icons.js"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/inter": "^5.2.8",
     "@tanstack/react-virtual": "^3.0.0",
     "@xterm/addon-fit": "^0.11.0",
@@ -46,12 +49,12 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "shadcn": "^4.0.8",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
-    "vite-plugin-pwa": "^1.2.0",
-    "shadcn": "^4.0.8"
+    "vite-plugin-pwa": "^1.2.0"
   },
   "license": "MIT",
   "repository": {

--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -1,5 +1,8 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { Plus, X, Link, MessageSquare, Pencil, Trash2 } from 'lucide-react';
+import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, horizontalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { AgentInfo } from '../../types';
 
 interface AgentTabBarProps {
@@ -12,6 +15,8 @@ interface AgentTabBarProps {
   onBindIm?: (agentId: string) => void;
   /** Show bind button on main conversation tab (non-home workspaces) */
   onBindMainIm?: () => void;
+  /** Called when conversations are reordered via drag-and-drop */
+  onReorder?: (orderedIds: string[]) => void;
 }
 
 const tabClass = (active: boolean) =>
@@ -78,7 +83,80 @@ function ContextMenuOverlay({ menu, onRename, onDelete, onClose }: {
   );
 }
 
-export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onRenameAgent, onCreateConversation, onBindIm, onBindMainIm }: AgentTabBarProps) {
+function SortableTab({ agent, isActive, onSelect, onContextMenu, onTouchStart, onTouchEnd, onBindIm, onDeleteAgent }: {
+  agent: AgentInfo;
+  isActive: boolean;
+  onSelect: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onBindIm?: (agentId: string) => void;
+  onDeleteAgent: (agentId: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: agent.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+  const hasLinked = agent.linked_im_groups && agent.linked_im_groups.length > 0;
+
+  // Merge dnd-kit listeners with custom touch handlers for long-press context menu
+  const mergedOnTouchStart = (e: React.TouchEvent) => {
+    listeners?.onTouchStart?.(e as unknown as TouchEvent);
+    onTouchStart(e);
+  };
+  const mergedOnTouchEnd = () => {
+    onTouchEnd();
+  };
+  const mergedOnTouchMove = () => {
+    onTouchEnd(); // cancel long-press on move
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className={`${tabClass(isActive)} flex items-center gap-1.5 group`}
+      onClick={onSelect}
+      onContextMenu={onContextMenu}
+      onTouchStart={mergedOnTouchStart}
+      onTouchEnd={mergedOnTouchEnd}
+      onTouchMove={mergedOnTouchMove}
+    >
+      {agent.status === 'running' && (
+        <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
+      )}
+      {hasLinked && (
+        <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
+          <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />
+        </span>
+      )}
+      <span className="truncate max-w-[120px]">{agent.name}</span>
+      {onBindIm && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
+          className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+          title="绑定 IM 群组"
+        >
+          <Link className="w-3 h-3" />
+        </button>
+      )}
+      <button
+        onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
+        title="关闭对话"
+      >
+        <X className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
+
+export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onRenameAgent, onCreateConversation, onBindIm, onBindMainIm, onReorder }: AgentTabBarProps) {
   // Spawn agents are rendered inline in the main chat, not as separate tabs
   const conversations = useMemo(() => agents.filter(a => a.kind === 'conversation'), [agents]);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
@@ -90,6 +168,31 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onR
       if (longPressTimer.current) clearTimeout(longPressTimer.current);
     };
   }, []);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
+
+  const conversationIds = useMemo(() => conversations.map(a => a.id), [conversations]);
+
+  const handleDragStart = useCallback(() => {
+    // Cancel long-press context menu timer when drag starts
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = conversations.findIndex(a => a.id === active.id);
+    const newIndex = conversations.findIndex(a => a.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    const reordered = arrayMove(conversations, oldIndex, newIndex);
+    onReorder?.(reordered.map(a => a.id));
+  }, [conversations, onReorder]);
 
   // Show bar if there are agents OR if creation is available
   if (conversations.length === 0 && !onCreateConversation) return null;
@@ -146,47 +249,24 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onR
           )}
         </div>
 
-        {/* Conversation tabs — same visual level as main */}
-        {conversations.map((agent) => {
-          const hasLinked = agent.linked_im_groups && agent.linked_im_groups.length > 0;
-          return (
-            <div
-              key={agent.id}
-              className={`${tabClass(activeTab === agent.id)} flex items-center gap-1.5 group`}
-              onClick={() => onSelectTab(agent.id)}
-              onContextMenu={(e) => handleContextMenu(e, agent)}
-              onTouchStart={(e) => handleTouchStart(agent, e)}
-              onTouchEnd={handleTouchEnd}
-              onTouchMove={handleTouchEnd}
-            >
-              {agent.status === 'running' && (
-                <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
-              )}
-              {hasLinked && (
-                <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
-                  <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />
-                </span>
-              )}
-              <span className="truncate max-w-[120px]">{agent.name}</span>
-              {onBindIm && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
-                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-                  title="绑定 IM 群组"
-                >
-                  <Link className="w-3 h-3" />
-                </button>
-              )}
-              <button
-                onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-                title="关闭对话"
-              >
-                <X className="w-3 h-3" />
-              </button>
-            </div>
-          );
-        })}
+        {/* Conversation tabs — draggable, same visual level as main */}
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <SortableContext items={conversationIds} strategy={horizontalListSortingStrategy}>
+            {conversations.map((agent) => (
+              <SortableTab
+                key={agent.id}
+                agent={agent}
+                isActive={activeTab === agent.id}
+                onSelect={() => onSelectTab(agent.id)}
+                onContextMenu={(e) => handleContextMenu(e, agent)}
+                onTouchStart={(e) => handleTouchStart(agent, e)}
+                onTouchEnd={handleTouchEnd}
+                onBindIm={onBindIm}
+                onDeleteAgent={onDeleteAgent}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
 
         {/* Create conversation button */}
         {onCreateConversation && (

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -105,6 +105,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const agentStreaming = useChatStore(s => s.agentStreaming);
   const createConversation = useChatStore(s => s.createConversation);
   const renameConversation = useChatStore(s => s.renameConversation);
+  const reorderConversations = useChatStore(s => s.reorderConversations);
   const loadAgentMessages = useChatStore(s => s.loadAgentMessages);
   const refreshAgentMessages = useChatStore(s => s.refreshAgentMessages);
   const sendAgentMessage = useChatStore(s => s.sendAgentMessage);
@@ -529,6 +530,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
         onCreateConversation={() => setShowNewConversation(true)}
         onBindIm={setBindingAgentId}
         onBindMainIm={!isHome ? () => setBindingAgentId(MAIN_BINDING) : undefined}
+        onReorder={(orderedIds) => reorderConversations(groupJid, orderedIds)}
       />
 
       {/* Main Content: Messages + Sidebar */}

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -208,6 +208,7 @@ interface ChatState {
   deleteAgentAction: (jid: string, agentId: string) => Promise<boolean>;
   setActiveAgentTab: (jid: string, agentId: string | null) => void;
   // Conversation agent actions
+  reorderConversations: (jid: string, orderedIds: string[]) => void;
   createConversation: (jid: string, name: string, description?: string) => Promise<AgentInfo | null>;
   renameConversation: (jid: string, agentId: string, name: string) => Promise<boolean>;
   loadAgentMessages: (jid: string, agentId: string, loadMore?: boolean) => Promise<void>;
@@ -1834,8 +1835,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
           nextSdkTaskAliases[alias] = target;
         }
 
+        // Apply saved conversation order from localStorage
+        let orderedAgents = visibleAgents;
+        try {
+          const savedOrder = localStorage.getItem(`happyclaw-agent-order-${jid}`);
+          if (savedOrder) {
+            const ids: string[] = JSON.parse(savedOrder);
+            const idIndex = new Map(ids.map((id, i) => [id, i]));
+            orderedAgents = [...visibleAgents].sort((a, b) => {
+              const ai = idIndex.get(a.id);
+              const bi = idIndex.get(b.id);
+              if (ai === undefined && bi === undefined) return 0;
+              if (ai === undefined) return 1;
+              if (bi === undefined) return -1;
+              return ai - bi;
+            });
+          }
+        } catch { /* ignore */ }
+
         return {
-          agents: { ...s.agents, [jid]: visibleAgents },
+          agents: { ...s.agents, [jid]: orderedAgents },
           sdkTasks: nextSdkTasks,
           sdkTaskAliases: nextSdkTaskAliases,
           agentStreaming: nextAgentStreaming,
@@ -1893,6 +1912,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   // -- Conversation agent actions --
+
+  reorderConversations: (jid, orderedIds) => {
+    set((s) => {
+      const current = s.agents[jid] || [];
+      const idIndex = new Map(orderedIds.map((id, i) => [id, i]));
+      const sorted = [...current].sort((a, b) => {
+        const ai = idIndex.get(a.id);
+        const bi = idIndex.get(b.id);
+        if (ai === undefined && bi === undefined) return 0;
+        if (ai === undefined) return 1;
+        if (bi === undefined) return -1;
+        return ai - bi;
+      });
+      return { agents: { ...s.agents, [jid]: sorted } };
+    });
+    // Persist to localStorage
+    try {
+      localStorage.setItem(`happyclaw-agent-order-${jid}`, JSON.stringify(orderedIds));
+    } catch { /* ignore */ }
+  },
 
   createConversation: async (jid, name, description?) => {
     try {


### PR DESCRIPTION
## 问题描述

工作区内的对话标签栏（AgentTabBar）不支持拖拽排序，用户无法自定义对话标签的排列顺序。

## 实现方案

使用 `@dnd-kit` 实现对话标签的水平拖拽排序，主对话固定不可拖拽。

### `web/src/components/chat/AgentTabBar.tsx`
- 新增 `SortableTab` 组件，包裹原有标签渲染逻辑，集成 `useSortable` hook
- 使用 `DndContext` + `SortableContext` + `horizontalListSortingStrategy` 包裹对话标签列表
- 桌面端：`PointerSensor`（拖拽 5px 激活）
- 移动端：`TouchSensor`（长按 200ms 激活拖拽），与原有长按 500ms 右键菜单互不冲突
- `onDragStart` 时取消长按菜单计时器，防止拖拽中弹出菜单

### `web/src/stores/chat.ts`
- 新增 `reorderConversations(jid, orderedIds)` action，重排 agents 数组并持久化到 localStorage
- `loadAgents` 加载时自动从 localStorage 恢复保存的排序顺序
- 新增的对话自动追加到列表末尾

### `web/src/components/chat/ChatView.tsx`
- 传递 `onReorder` 回调给 `AgentTabBar`

### 依赖
- 新增 `@dnd-kit/core`、`@dnd-kit/sortable`、`@dnd-kit/utilities`

## Test plan
- [ ] 桌面端：拖拽对话标签可交换位置，刷新后顺序保持
- [ ] 移动端：长按 200ms 后可拖拽排序，轻触仍为选中
- [ ] 移动端：长按 500ms 弹出右键菜单（重命名/删除）不受拖拽影响
- [ ] 主对话标签始终固定在最左侧，不可拖拽
- [ ] 新建对话自动出现在列表末尾
- [ ] 删除对话后排序仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)