### PR TITLE
fix: 统一所有工作区的 deviceId，共享宿主机 ~/.claude.json

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -52,6 +52,44 @@ import {
  * Required env flags for settings.json — 每次容器/进程启动时强制写入，不可被用户覆盖。
  * 合并模式：仅覆盖这些 key，保留用户自定义的其他 key。
  */
+/**
+ * 宿主机的 ~/.claude.json 路径。
+ * 所有工作区共享此文件，确保 deviceId (userID) 一致。
+ * 即使 HappyClaw 项目删除重建，此文件始终存在于宿主机上。
+ */
+function getHostClaudeJsonPath(): string {
+  return path.join(os.homedir(), '.claude.json');
+}
+
+/**
+ * 确保宿主机 ~/.claude.json 存在。
+ * 如不存在则创建空 JSON，Claude Code 首次运行时会自动生成 userID。
+ */
+function ensureHostClaudeJson(): string {
+  const p = getHostClaudeJsonPath();
+  if (!fs.existsSync(p)) {
+    fs.writeFileSync(p, '{}', { mode: 0o600 });
+  }
+  return p;
+}
+
+/**
+ * 确保 localPath 是指向 targetPath 的 symlink。
+ * 如果 localPath 是普通文件或指向错误目标的 symlink，替换它。
+ */
+function ensureSymlinkTo(localPath: string, targetPath: string): void {
+  try {
+    const st = fs.lstatSync(localPath);
+    if (st.isSymbolicLink() && fs.readlinkSync(localPath) === targetPath) {
+      return; // 已经是正确的 symlink
+    }
+    fs.unlinkSync(localPath); // 普通文件或错误 symlink，删除
+  } catch {
+    // 文件不存在，继续创建
+  }
+  fs.symlinkSync(targetPath, localPath);
+}
+
 const REQUIRED_SETTINGS_ENV: Record<string, string> = {
   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '0',
   CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
@@ -278,6 +316,14 @@ function buildVolumeMounts(
   mounts.push({
     hostPath: groupSessionsDir,
     containerPath: '/home/node/.claude',
+    readonly: false,
+  });
+
+  // Bind mount 宿主机 ~/.claude.json，所有容器共享同一个 deviceId
+  const hostJson = ensureHostClaudeJson();
+  mounts.push({
+    hostPath: hostJson,
+    containerPath: '/home/node/.claude.json',
     readonly: false,
   });
 
@@ -900,6 +946,10 @@ export async function runHostAgent(
       )
     : path.join(DATA_DIR, 'sessions', group.folder, '.claude');
   fs.mkdirSync(groupSessionsDir, { recursive: true });
+
+  // Symlink .claude.json 到宿主机 ~/.claude.json，确保 deviceId 一致
+  const localJson = path.join(groupSessionsDir, '.claude.json');
+  ensureSymlinkTo(localJson, ensureHostClaudeJson());
 
   // 3. 写入 settings.json（合并模式，不覆盖已有用户配置）
   // Load user's global MCP servers (same logic as Docker mode).


### PR DESCRIPTION
## 背景

通过对 Claude Code 泄露源码的逆向分析，发现 Claude Code 会为每个独立的 `~/.claude.json` 生成一个 64 字符的随机 `userID` 作为永久设备指纹（deviceId），并在所有遥测事件（Datadog、BigQuery）和 GrowthBook 用户画像中上报给 Anthropic 服务端。

## 相关调研文档

- 必要性与可行性分析：https://bytedance.larkoffice.com/docx/RNzndk402oSUyxx2RKScQjrfn4d

## 问题

HappyClaw 通过 `CLAUDE_CONFIG_DIR` 为每个工作区做目录隔离（`settings.json`、`.credentials.json` 等各自独立，这是合理的）。但副作用是 `.claude.json` 也被隔离了：

- **宿主机模式**：每个工作区在 `data/sessions/{folder}/.claude/.claude.json` 生成独立的 `userID`
- **Docker 模式**：`.claude.json` 在容器内 `/home/node/.claude.json`（不在挂载卷内），容器销毁后丢失，每次重建都生成新的 `userID`

结果是同一个 OAuth 账号关联了大量不同的 deviceId，对 Anthropic 服务端来说这等同于「一个账号在几十台不同设备上使用」，可能触发风控系统的异常检测（"一号多用"信号）。

## 修复方案

以宿主机的 `~/.claude.json` 作为唯一的设备身份文件，所有工作区共享这一份：

- **Docker 模式**：bind mount 宿主机 `~/.claude.json` 到容器内 `/home/node/.claude.json`
- **宿主机模式**：在 `{groupSessionsDir}/.claude.json` 创建指向宿主机 `~/.claude.json` 的 symlink

如果宿主机 `~/.claude.json` 不存在，自动创建空 `{}`，Claude Code 首次运行时会自动填充 `userID`。

## 效果

- 所有工作区看起来像「一台设备开了多个终端窗口」，而非「多台不同设备」
- 目录隔离不受影响：`settings.json`（MCP 配置）、`.credentials.json`（OAuth token）、`telemetry/` 等保持每个工作区独立
- 即使 HappyClaw 项目删除重建，设备身份始终保持一致（因为 `~/.claude.json` 在宿主机 HOME 目录下）

## 改动

仅修改 `src/container-runner.ts`，新增约 50 行：

1. `getHostClaudeJsonPath()` / `ensureHostClaudeJson()` — 共享文件路径管理
2. `ensureSymlinkTo()` — 幂等的 symlink 创建工具函数
3. Docker 模式：在 `.claude` 目录挂载之后，追加 `~/.claude.json` 的 bind mount
4. 宿主机模式：在 `groupSessionsDir` 创建后，创建 `.claude.json` -> `~/.claude.json` 的 symlink
