### PR TITLE
feat: 宿主机模式支持可配置的 externalClaudeDir（Skills/Agents/Rules）

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1046,11 +1046,81 @@ export async function runHostAgent(
 
     // 项目级 skills
     const projectRoot = process.cwd();
+
+    // 外部 Claude Code 目录 skills（最低优先级，先链接）
+    const { externalClaudeDir } = getSystemSettings();
+    const resolvedExternalClaudeDir = externalClaudeDir
+      ? externalClaudeDir.startsWith('~')
+        ? path.join(
+            process.env.HOME || '/root',
+            externalClaudeDir.slice(externalClaudeDir.startsWith('~/') ? 2 : 1),
+          )
+        : externalClaudeDir
+      : null;
+
+    if (resolvedExternalClaudeDir) {
+      linkSkillEntries(path.join(resolvedExternalClaudeDir, 'skills'));
+    }
+
     linkSkillEntries(path.join(projectRoot, 'container', 'skills'));
     // 用户级 skills（覆盖同名项目级）
     const ownerId = group.created_by;
     if (ownerId) {
       linkSkillEntries(path.join(DATA_DIR, 'skills', ownerId));
+    }
+
+    // 链接外部 Agents（最低优先级：只链接在 session agents/ 中不存在的 .md 文件）
+    if (resolvedExternalClaudeDir) {
+      const externalAgentsDir = path.join(resolvedExternalClaudeDir, 'agents');
+      if (fs.existsSync(externalAgentsDir)) {
+        const sessionAgentsDir = path.join(groupSessionsDir, 'agents');
+        fs.mkdirSync(sessionAgentsDir, { recursive: true });
+        try {
+          for (const entry of fs.readdirSync(externalAgentsDir, {
+            withFileTypes: true,
+          })) {
+            if (
+              !entry.isFile() && !entry.isSymbolicLink()
+            ) continue;
+            if (!entry.name.endsWith('.md')) continue;
+            const linkPath = path.join(sessionAgentsDir, entry.name);
+            // Only link if not already present (lowest priority — don't override HappyClaw agents)
+            if (!fs.existsSync(linkPath)) {
+              try {
+                fs.symlinkSync(
+                  path.join(externalAgentsDir, entry.name),
+                  linkPath,
+                );
+              } catch {
+                /* ignore */
+              }
+            }
+          }
+        } catch (agentErr) {
+          logger.warn(
+            { folder: group.folder, err: agentErr },
+            '宿主机模式外部 agents 符号链接失败',
+          );
+        }
+      }
+    }
+
+    // 链接外部 Rules（最低优先级：只在 session rules/ 不存在时链接）
+    if (resolvedExternalClaudeDir) {
+      const externalRulesDir = path.join(resolvedExternalClaudeDir, 'rules');
+      if (fs.existsSync(externalRulesDir)) {
+        const sessionRulesDir = path.join(groupSessionsDir, 'rules');
+        if (!fs.existsSync(sessionRulesDir)) {
+          try {
+            fs.symlinkSync(externalRulesDir, sessionRulesDir);
+          } catch (rulesErr) {
+            logger.warn(
+              { folder: group.folder, err: rulesErr },
+              '宿主机模式外部 rules 符号链接失败',
+            );
+          }
+        }
+      }
     }
   } catch (err) {
     logger.warn(

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3386,6 +3386,10 @@ export interface SystemSettings {
   billingMinStartBalanceUsd: number;
   billingCurrency: string;
   billingCurrencyRate: number;
+  // External Claude Code directory (host mode): optional path to ~/.claude or custom dir.
+  // When set, Skills/Agents/Rules from this directory are symlinked into the session at
+  // lowest priority (HappyClaw-native resources always win). Empty/unset = no change.
+  externalClaudeDir?: string;
 }
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -3496,6 +3500,10 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       typeof raw.billingCurrencyRate === 'number' && raw.billingCurrencyRate > 0
         ? raw.billingCurrencyRate
         : DEFAULT_SYSTEM_SETTINGS.billingCurrencyRate,
+    externalClaudeDir:
+      typeof raw.externalClaudeDir === 'string' && raw.externalClaudeDir
+        ? raw.externalClaudeDir
+        : undefined,
   };
 }
 
@@ -3558,6 +3566,7 @@ function buildEnvFallbackSettings(): SystemSettings {
       process.env.BILLING_CURRENCY_RATE,
       DEFAULT_SYSTEM_SETTINGS.billingCurrencyRate,
     ),
+    externalClaudeDir: process.env.EXTERNAL_CLAUDE_DIR || undefined,
   };
 }
 
@@ -3640,6 +3649,10 @@ export function saveSystemSettings(
       DEFAULT_SYSTEM_SETTINGS.billingMinStartBalanceUsd;
   if (merged.billingMinStartBalanceUsd > 1000000)
     merged.billingMinStartBalanceUsd = 1000000;
+  // externalClaudeDir: keep as-is (empty string → normalize to undefined)
+  if (merged.externalClaudeDir !== undefined && merged.externalClaudeDir.trim() === '') {
+    merged.externalClaudeDir = undefined;
+  }
 
   fs.mkdirSync(CLAUDE_CONFIG_DIR, { recursive: true });
   const tmp = `${SYSTEM_SETTINGS_FILE}.tmp`;


### PR DESCRIPTION
## Summary

Implements the feature requested in #354.

Adds an optional `externalClaudeDir` field to `SystemSettings` that lets users point HappyClaw host-mode at their local `~/.claude/` (or any custom path). When configured, host agent symlinks Skills, Agents, and Rules from that directory into the session isolated `.claude/` directory at lowest priority.

## Changes

### src/runtime-config.ts
- Add `externalClaudeDir?: string` to `SystemSettings` interface
- Read from file in `readSystemSettingsFromFile()`
- Read from `EXTERNAL_CLAUDE_DIR` env var in `buildEnvFallbackSettings()`
- Normalize empty string to `undefined` in `saveSystemSettings()`

### src/container-runner.ts
- In `runHostAgent()`: when `externalClaudeDir` is set, resolve `~` prefix and symlink:
  - `{externalClaudeDir}/skills/` entries at lowest priority (before container/skills and user skills)
  - `{externalClaudeDir}/agents/*.md` to session `.claude/agents/` (only if not already present)
  - `{externalClaudeDir}/rules/` to session `.claude/rules/` (only if not already present)

## Behavior

- **Default: no change** — `externalClaudeDir` is `undefined` by default
- **Opt-in**: user sets path in system settings (or `EXTERNAL_CLAUDE_DIR` env var), only then does linking happen
- **Priority**: external resources are lowest priority; HappyClaw-native resources always win
  - Skills: external linked first, then overridden by container/skills and user skills
  - Agents: external .md files only linked if no same-named file already exists in session
  - Rules: external rules/ only linked if session rules/ doesn't already exist
- **Container mode unaffected**: logic is host-mode only (`runHostAgent()`)
- **`~` expansion**: paths starting with `~/` are resolved against `process.env.HOME`

Closes #354