### PR TITLE
功能: 宿主机模式支持可配置的外部 Skills/Agents/Rules 路径 (#354)

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1009,9 +1009,9 @@ export async function runHostAgent(
   const hostMcpServers = group.created_by ? loadUserMcpServers(group.created_by) : {};
   ensureSettingsJson(settingsFile, hostMcpServers);
 
-  // 4. Skills 自动链接到 session 目录
-  // 链接顺序：项目级 → 用户级(覆盖同名项目级)
-  // 用户的所有 skills 在所有工作区中生效
+  // 4. Skills/Agents/Rules 自动链接到 session 目录
+  // 链接顺序：外部(最低) → 项目级 → 用户级(最高，覆盖同名)
+  const { externalClaudeDir: extClaudeDir } = getSystemSettings();
   try {
     const skillsDir = path.join(groupSessionsDir, 'skills');
     fs.mkdirSync(skillsDir, { recursive: true });
@@ -1044,6 +1044,10 @@ export async function runHostAgent(
       }
     };
 
+    // 外部 Claude Code skills（最低优先级）
+    if (extClaudeDir) {
+      linkSkillEntries(path.join(extClaudeDir, 'skills'));
+    }
     // 项目级 skills
     const projectRoot = process.cwd();
     linkSkillEntries(path.join(projectRoot, 'container', 'skills'));
@@ -1057,6 +1061,70 @@ export async function runHostAgent(
       { folder: group.folder, err },
       '宿主机模式 skills 符号链接失败',
     );
+  }
+
+  // 4b. 外部 Agents 自动链接到 session 目录
+  // 将 externalClaudeDir/agents/ 下的文件 symlink 到 session agents/ 目录
+  // 不覆盖 HappyClaw 内置的 agent（由 SDK agents 选项注册）
+  if (extClaudeDir) {
+    try {
+      const externalAgentsDir = path.join(extClaudeDir, 'agents');
+      if (fs.existsSync(externalAgentsDir)) {
+        const agentsDir = path.join(groupSessionsDir, 'agents');
+        fs.mkdirSync(agentsDir, { recursive: true });
+        for (const entry of fs.readdirSync(externalAgentsDir, {
+          withFileTypes: true,
+        })) {
+          if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+          const linkPath = path.join(agentsDir, entry.name);
+          try {
+            if (!fs.existsSync(linkPath)) {
+              fs.symlinkSync(
+                path.join(externalAgentsDir, entry.name),
+                linkPath,
+              );
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { folder: group.folder, err },
+        '宿主机模式外部 agents 符号链接失败',
+      );
+    }
+
+    // 4c. 外部 Rules 自动链接到 session 目录
+    try {
+      const externalRulesDir = path.join(extClaudeDir, 'rules');
+      if (fs.existsSync(externalRulesDir)) {
+        const rulesDir = path.join(groupSessionsDir, 'rules');
+        fs.mkdirSync(rulesDir, { recursive: true });
+        for (const entry of fs.readdirSync(externalRulesDir, {
+          withFileTypes: true,
+        })) {
+          if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+          const linkPath = path.join(rulesDir, entry.name);
+          try {
+            if (!fs.existsSync(linkPath)) {
+              fs.symlinkSync(
+                path.join(externalRulesDir, entry.name),
+                linkPath,
+              );
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { folder: group.folder, err },
+        '宿主机模式外部 rules 符号链接失败',
+      );
+    }
   }
 
   // 5. 构建环境变量

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { ASSISTANT_NAME, DATA_DIR } from './config.js';
@@ -3386,6 +3387,8 @@ export interface SystemSettings {
   billingMinStartBalanceUsd: number;
   billingCurrency: string;
   billingCurrencyRate: number;
+  // External Claude Code config directory (host mode only)
+  externalClaudeDir: string;
 }
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -3405,6 +3408,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   billingMinStartBalanceUsd: 0.01,
   billingCurrency: 'USD',
   billingCurrencyRate: 1,
+  externalClaudeDir: '',
 };
 
 function parseIntEnv(envVar: string | undefined, fallback: number): number {
@@ -3496,6 +3500,10 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       typeof raw.billingCurrencyRate === 'number' && raw.billingCurrencyRate > 0
         ? raw.billingCurrencyRate
         : DEFAULT_SYSTEM_SETTINGS.billingCurrencyRate,
+    externalClaudeDir:
+      typeof raw.externalClaudeDir === 'string'
+        ? raw.externalClaudeDir
+        : DEFAULT_SYSTEM_SETTINGS.externalClaudeDir,
   };
 }
 
@@ -3558,6 +3566,8 @@ function buildEnvFallbackSettings(): SystemSettings {
       process.env.BILLING_CURRENCY_RATE,
       DEFAULT_SYSTEM_SETTINGS.billingCurrencyRate,
     ),
+    externalClaudeDir:
+      process.env.EXTERNAL_CLAUDE_DIR || DEFAULT_SYSTEM_SETTINGS.externalClaudeDir,
   };
 }
 
@@ -3635,6 +3645,14 @@ export function saveSystemSettings(
   if (merged.skillAutoSyncIntervalMinutes > 1440)
     merged.skillAutoSyncIntervalMinutes = 1440; // max 24h
   merged.billingMode = 'wallet_first';
+  // Normalize externalClaudeDir: trim whitespace, resolve ~ to homedir
+  if (merged.externalClaudeDir) {
+    let dir = merged.externalClaudeDir.trim();
+    if (dir.startsWith('~/')) {
+      dir = path.join(os.homedir(), dir.slice(2));
+    }
+    merged.externalClaudeDir = dir;
+  }
   if (merged.billingMinStartBalanceUsd < 0)
     merged.billingMinStartBalanceUsd =
       DEFAULT_SYSTEM_SETTINGS.billingMinStartBalanceUsd;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -237,6 +237,7 @@ export const SystemSettingsSchema = z.object({
   billingMinStartBalanceUsd: z.number().min(0).max(1000000).optional(),
   billingCurrency: z.string().min(1).max(10).optional(),
   billingCurrencyRate: z.number().min(0.0001).max(1000000).optional(),
+  externalClaudeDir: z.string().max(1024).optional(),
 });
 
 export const AppearanceConfigSchema = z.object({

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -137,6 +137,7 @@ export function SystemSettingsSection() {
   const [billingMinStartBalanceUsd, setBillingMinStartBalanceUsd] = useState(0.01);
   const [billingCurrency, setBillingCurrency] = useState('USD');
   const [billingCurrencyRate, setBillingCurrencyRate] = useState(1);
+  const [externalClaudeDir, setExternalClaudeDir] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -161,6 +162,7 @@ export function SystemSettingsSection() {
         setBillingMinStartBalanceUsd(data.billingMinStartBalanceUsd ?? 0.01);
         setBillingCurrency(data.billingCurrency ?? 'USD');
         setBillingCurrencyRate(data.billingCurrencyRate ?? 1);
+        setExternalClaudeDir(data.externalClaudeDir ?? '');
       } catch (err) {
         toast.error(getErrorMessage(err, '加载系统参数失败'));
       } finally {
@@ -205,6 +207,7 @@ export function SystemSettingsSection() {
         billingMinStartBalanceUsd,
         billingCurrency,
         billingCurrencyRate,
+        externalClaudeDir,
       };
       for (const f of fields) {
         const val = displayValues[f.key];
@@ -223,6 +226,7 @@ export function SystemSettingsSection() {
       setBillingMinStartBalanceUsd(data.billingMinStartBalanceUsd ?? 0.01);
       setBillingCurrency(data.billingCurrency ?? 'USD');
       setBillingCurrencyRate(data.billingCurrencyRate ?? 1);
+      setExternalClaudeDir(data.externalClaudeDir ?? '');
       // 刷新计费状态，更新导航栏可见性
       loadBillingStatus();
       toast.success('系统参数已保存，新参数将对后续启动的容器/进程生效');
@@ -282,6 +286,27 @@ export function SystemSettingsSection() {
             </p>
           </div>
         ))}
+      </div>
+
+      {/* 外部 Claude Code 配置 */}
+      <div className="border-t border-border pt-6 space-y-5">
+        <h3 className="text-sm font-semibold text-foreground">宿主机模式集成</h3>
+        <div>
+          <Label className="mb-1">
+            外部 Claude Code 配置目录
+          </Label>
+          <Input
+            type="text"
+            value={externalClaudeDir}
+            onChange={(e) => setExternalClaudeDir(e.target.value)}
+            placeholder="例如 ~/.claude"
+            className="max-w-80"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            填入本地 Claude Code 配置目录路径后，宿主机模式将自动链接该目录下的 Skills、Agents 和
+            Rules。留空则不关联（默认行为不变）。
+          </p>
+        </div>
       </div>
 
       {/* 计费设置 */}

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -104,6 +104,7 @@ export interface SystemSettings {
   billingMinStartBalanceUsd: number;
   billingCurrency: string;
   billingCurrencyRate: number;
+  externalClaudeDir: string;
 }
 
 // ─── OAuth Usage ────────────────────────────────────────────


### PR DESCRIPTION
## 问题描述

关闭 #354。

宿主机模式下 `CLAUDE_CONFIG_DIR` 被重定向到隔离目录，导致用户本地 `~/.claude/` 下的 Skills、Agents、Rules 全部不可见，体验割裂。

## 实现方案

新增 `SystemSettings.externalClaudeDir` 配置项，用户在 Web 设置页填入本地 Claude Code 配置目录路径后，宿主机模式启动时自动将该目录下的资源符号链接到会话目录。

### `src/runtime-config.ts`
- `SystemSettings` 接口新增 `externalClaudeDir: string`（默认空字符串）
- `readSystemSettingsFromFile()` / `buildEnvFallbackSettings()` 增加读取逻辑
- `saveSystemSettings()` 增加路径规范化（trim、`~/` 展开）
- 支持环境变量 `EXTERNAL_CLAUDE_DIR` fallback

### `src/schemas.ts`
- `SystemSettingsSchema` 新增 `externalClaudeDir: z.string().max(1024).optional()`

### `src/container-runner.ts` — `runHostAgent()`
- **Skills**：外部目录作为最低优先级链接源（外部 → 项目级 → 用户级），高优先级覆盖同名
- **Agents**：将 `{externalClaudeDir}/agents/` 下的文件 symlink 到 session 目录，不覆盖已有文件
- **Rules**：将 `{externalClaudeDir}/rules/` 下的文件 symlink 到 session 目录，不覆盖已有文件

### 前端
- `web/src/components/settings/types.ts` — `SystemSettings` 类型同步新增字段
- `web/src/components/settings/SystemSettingsSection.tsx` — 新增「宿主机模式集成」区域，提供文本输入框

### 行为保证
- 默认为空，不改变现有行为
- 不影响容器模式（容器模式通过卷挂载控制，逻辑独立）
- 不影响多用户隔离

🤖 Generated with [Claude Code](https://claude.com/claude-code)