### PR TITLE
优化: systemPromptAppend 瘦身，去除 user-profile 重复注入 (#377)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -106,16 +106,8 @@ const SECURITY_RULES_PATH = path.join(
 );
 const SECURITY_RULES = fs.readFileSync(SECURITY_RULES_PATH, 'utf-8');
 
-// globalClaudeMd 截断保护：防止用户 CLAUDE.md 过大导致系统提示词膨胀
-const GLOBAL_CLAUDE_MD_MAX_CHARS = 8000;
-
-/** Head+Tail 截断：保留头 75% + 尾 25%，中间标记已截断 */
-function truncateWithHeadTail(content: string, maxChars: number): string {
-  if (content.length <= maxChars) return content;
-  const headSize = Math.floor(maxChars * 0.75);
-  const tailSize = Math.max(0, maxChars - headSize - 30);
-  return content.slice(0, headSize) + '\n\n[...内容过长，已截断...]\n\n' + content.slice(-tailSize);
-}
+// HEARTBEAT.md 截断上限（仅作用于 fresh session 的近期工作提示）
+const HEARTBEAT_MAX_CHARS = 2048;
 
 /** 按渠道生成格式指南（仅 IM 渠道需要，Web 前端原生支持 Markdown + Mermaid） */
 function buildChannelGuidelines(channel: string): string {
@@ -1060,19 +1052,17 @@ async function runQuery(
 
   const processor = new StreamEventProcessor(emit, log);
 
-  // Build system prompt: memory recall guidance + global CLAUDE.md (for non-admin-home)
+  // Build system prompt: memory recall guidance + guidelines.
+  //
+  // NOTE: Global CLAUDE.md (at WORKSPACE_GLOBAL/CLAUDE.md) is NOT manually injected
+  // into systemPromptAppend. Home containers expose WORKSPACE_GLOBAL via
+  // `additionalDirectories`, which triggers the SDK's CLAUDE.md auto-discovery.
+  // Manually wrapping it in <user-profile> caused the same content to appear
+  // twice in the prompt — once from auto-discovery and once from the wrapper.
+  // Non-home containers intentionally exclude WORKSPACE_GLOBAL from
+  // `additionalDirectories` so the global CLAUDE.md is not loaded at all,
+  // preventing context pollution across isolated tasks.
   const { isHome, isAdminHome } = normalizeHomeFlags(containerInput);
-  const globalClaudeMdPath = path.join(WORKSPACE_GLOBAL, 'CLAUDE.md');
-
-  // Home containers: inject full global CLAUDE.md for immediate context.
-  // Non-home containers: global CLAUDE.md is accessible via filesystem (mounted readonly)
-  // but NOT injected into system prompt to avoid context pollution that causes
-  // the agent to "continue" unrelated previous work.
-  let globalClaudeMd = '';
-  if (isHome && fs.existsSync(globalClaudeMdPath)) {
-    globalClaudeMd = fs.readFileSync(globalClaudeMdPath, 'utf-8');
-    globalClaudeMd = truncateWithHeadTail(globalClaudeMd, GLOBAL_CLAUDE_MD_MAX_CHARS);
-  }
   const outputGuidelines = [
     '',
     '## 输出格式',
@@ -1097,17 +1087,19 @@ async function runQuery(
     '且 agent-browser 可用，立即改用 agent-browser 通过真实浏览器访问。不要反复重试 WebFetch。',
   ].join('\n');
 
-  // Read HEARTBEAT.md (recent work summary) — only for home containers.
-  // Non-home containers are task-isolated and should not see unrelated work history,
-  // which can mislead the agent into "continuing" previous tasks instead of
-  // focusing on the user's current message.
+  // Read HEARTBEAT.md (recent work summary) — only for home containers on a FRESH
+  // session. Resumed sessions already carry the prior conversation history, so the
+  // heartbeat summary is redundant and wastes cache tokens on every turn.
+  // Non-home containers are task-isolated and should not see unrelated work history.
   let heartbeatContent = '';
-  if (isHome) {
+  if (isHome && !sessionId) {
     const heartbeatPath = path.join(WORKSPACE_GLOBAL, 'HEARTBEAT.md');
     if (fs.existsSync(heartbeatPath)) {
       try {
         const raw = fs.readFileSync(heartbeatPath, 'utf-8');
-        const truncated = raw.length > 2048 ? raw.slice(0, 2048) + '\n\n[...截断]' : raw;
+        const truncated = raw.length > HEARTBEAT_MAX_CHARS
+          ? raw.slice(0, HEARTBEAT_MAX_CHARS) + '\n\n[...截断]'
+          : raw;
         heartbeatContent = [
           '',
           '## 近期工作参考（仅供背景了解）',
@@ -1174,22 +1166,21 @@ async function runQuery(
   const channel = getChannelFromJid(containerInput.chatJid);
   const channelGuidelines = buildChannelGuidelines(channel);
 
+  // NOTE: user-level global CLAUDE.md used to be injected here as a <user-profile>
+  // block. It is intentionally no longer included — the SDK already auto-discovers
+  // it via `additionalDirectories: [WORKSPACE_GLOBAL, ...]` on home containers.
+  // See the comment above normalizeHomeFlags() for details.
   const systemPromptAppend = [
-    // L1: Identity — 用户身份与偏好（仅主容器注入）
-    globalClaudeMd && `<user-profile>\n${globalClaudeMd}\n</user-profile>`,
-
-    // L2: Behavior — 核心行为约束（始终注入所有容器）
+    // L1: Behavior — 核心行为约束（始终注入所有容器）
     `<behavior>\n${interactionGuidelines}\n</behavior>`,
     `<security>\n${SECURITY_RULES}\n</security>`,
 
-    // L3: Context — 记忆系统与工作背景
+    // L2: Context — 记忆系统与近期工作背景（<recent-work> 仅在 fresh session 注入）
     `<memory-system>\n${memoryRecall}\n</memory-system>`,
     heartbeatContent && `<recent-work>\n${heartbeatContent}\n</recent-work>`,
 
-    // L4: Reference — 输出格式与工具使用指南
-    `<output-format>\n${outputGuidelines}\n</output-format>`,
-    `<web-access>\n${webFetchGuidelines}\n</web-access>`,
-    `<background-tasks>\n${backgroundTaskGuidelines}\n</background-tasks>`,
+    // L3: Operation guidelines — 合并输出 / 网页访问 / 后台任务为单个 block，降低结构开销
+    `<guidelines>\n${outputGuidelines}\n${webFetchGuidelines}\n${backgroundTaskGuidelines}\n</guidelines>`,
     channelGuidelines && `<channel-format>\n${channelGuidelines}\n</channel-format>`,
 
     // Override: Sub-Agent 行为覆盖


### PR DESCRIPTION
## 问题描述

关联 #377 — Phase 1: systemPromptAppend 瘦身。

通过检查当前运行的 Agent 会话的 system prompt，发现用户级全局 `CLAUDE.md` 的内容**同时以两种机制被加载**，导致完全相同的文本在 system prompt 中出现两次：

1. **Claude Agent SDK 的自动发现**：home 容器通过 `additionalDirectories: [WORKSPACE_GLOBAL, WORKSPACE_MEMORY]` 暴露用户全局目录，SDK 会自动发现其中的 `CLAUDE.md` 并以 `Contents of .../CLAUDE.md (project instructions, checked into the codebase)` 的形式注入系统提示词
2. **Agent Runner 的手动注入**：`container/agent-runner/src/index.ts:1179` 又把同一份 `globalClaudeMd` 包在 `<user-profile>` 标签里拼到 `systemPromptAppend`

两份内容**完全一致**（可在任意 home 容器的 system prompt 中目测验证），但都会进入 cache，每请求浪费 ~2KB（≈ 500 tokens）。

此外还发现两个相关的可优化点：

- `<recent-work>` 基于 `HEARTBEAT.md` 生成，cap 2KB，原本**每轮都注入**。但 resumed session 的对话历史中早已包含这段内容，是冗余。
- `<output-format>`、`<web-access>`、`<background-tasks>` 三个段落都是非常短的操作指引，每段独立包一对 XML 标签，有结构上的开销。

## 修复方案 / 实现方案

### `container/agent-runner/src/index.ts`

#### 1. 移除 `<user-profile>` 手动注入

删除 `globalClaudeMd` 的读取逻辑以及 `systemPromptAppend` 中的 `<user-profile>` 条目。用户全局 `CLAUDE.md` 继续通过 SDK 自动发现加载，行为一致。

同步删除不再使用的 `GLOBAL_CLAUDE_MD_MAX_CHARS` 常量和 `truncateWithHeadTail` 函数（避免留下死代码）。

> 截断保护被一并移除是有意的：原先的 cap 只作用于手动注入的那一份副本，SDK 自动发现加载的那一份从来都没有被截断过，所以 cap 实际上并没有为整体体积提供保护，只是让相同内容的两份副本中的一份看起来"更小"。用户全局 `CLAUDE.md` 本身的体积应由用户自己维护。

#### 2. `<recent-work>` 按会话状态条件注入

把 `heartbeatContent` 的读取条件从 `if (isHome)` 改为 `if (isHome && !sessionId)`，即仅在 fresh session（首轮建会话）时注入。resumed session 的历史消息已经带着这部分上下文。

#### 3. 合并三段短指引为单一 `<guidelines>` block

把 `<output-format>`、`<web-access>`、`<background-tasks>` 合并为一个 `<guidelines>` block，内部依旧用 Markdown 二级标题做区分，不修改任何内容文案。

#### 4. 引入 `HEARTBEAT_MAX_CHARS = 2048` 常量

原先截断长度直接硬编码为 2048，抽出为常量方便后续调整和文档化。

## 单次请求 systemPromptAppend 体积收益

以实际用户（全局 `CLAUDE.md` 1993 B, `HEARTBEAT.md` 3961 B）为例：

| 场景 | 改动前 | 改动后 | 节省 |
|---|---:|---:|---:|
| Fresh session（home + feishu） | ~3.5 KB | ~2.4 KB | ~1.1 KB（31%） |
| Resumed session（home + feishu） | ~3.5 KB | ~2.3 KB | ~1.2 KB（33%） |

> 注意：以上只测 `systemPromptAppend` 本身。全量 system prompt 还包含 SDK `preset: 'claude_code'` + 所有被 `settingSources: ['project', 'user']` 发现的 `CLAUDE.md` 文件，这些不在本 PR 范围内。

按 #377 给出的当日基线（174 requests，其中绝大部分为 resumed session），`<user-profile>` 去重本身估算节省 ~87K tokens/day cache read。这是本 PR 的"确定收益"。

## 行为对比

| 观察点 | 改动前 | 改动后 |
|---|---|---|
| Home 容器能读到用户全局 CLAUDE.md | ✅（两条路径） | ✅（一条路径 — SDK 自动发现） |
| Non-home 容器能否读到用户全局 CLAUDE.md | ❌（显式不注入 + 不在 additionalDirectories） | ❌（同前） |
| Fresh session 收到 `<recent-work>` | ✅ | ✅ |
| Resumed session 收到 `<recent-work>` | ✅（冗余） | ❌（历史里已有） |
| `<output-format>` / `<web-access>` / `<background-tasks>` 内容 | 分三段 XML | 合并为 `<guidelines>` |

## 验证

- `make typecheck` — ✅ 后端 + 前端 + agent-runner 全通过
- `make test` — ✅ 39 tests passed
- `make build` — ✅ 三子项目构建成功

### 待部署后验证的行为

- [ ] 新建会话（首轮）能正确看到 `<recent-work>`
- [ ] 继续已有会话（resume）不再看到 `<recent-work>`
- [ ] 启动 home 容器后，可以通过 `memory_search` / `memory_get` 等工具正常访问用户级全局记忆（证明 SDK 自动发现路径工作正常）
- [ ] 查看 `usage_daily_summary` 观察次日 cache_read 每请求均值的变化

## 后续 PR

- **Phase 2**：CLAUDE.md 精简（46KB → ~8KB 顶层 + 按需文档），需单独 Issue 评审每项被迁移的内容
- **Phase 3**：对话压缩与上下文管理（主动 compaction + 工具输出摘要 + MCP 工具按场景裁剪）