### PR TITLE
修复: isolated 定时任务被重复执行两次

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -147,7 +147,7 @@ function getNewMessagesStmt(jidCount: number): any {
        WHERE (timestamp > ? OR (timestamp = ? AND id > ?))
          AND chat_jid IN (${placeholders})
          AND is_from_me = 0
-         AND COALESCE(source_kind, '') != 'user_command'
+         AND COALESCE(source_kind, '') NOT IN ('user_command', 'scheduled_task_prompt')
        ORDER BY timestamp ASC, id ASC`,
     );
     _newMsgStmtCache.set(jidCount, s);


### PR DESCRIPTION
## 问题描述

`context_mode: isolated` 的定时任务在 cron 触发时会被执行**两次**，产出两组重复文件。

## 根因

`runTask()` 执行 isolated 任务时，调用 `storePromptMessage()` 将 prompt 存为 `source_kind: 'scheduled_task_prompt'` 的消息（用于前端展示对话历史）。但 `getNewMessages()` 的 SQL 查询只过滤了 `user_command`，没有过滤 `scheduled_task_prompt`。

消息循环将这条 prompt 当作新的用户消息捡起，任务完成后 `drainGroup()` 启动新容器再次执行同样的内容。

**执行链**：
1. scheduler `enqueueTask()` → 第一次执行
2. `runTask()` 内 `storePromptMessage()` 存消息到 DB
3. 消息循环 `getNewMessages()` 捡起这条消息
4. `sendMessage()` 返回 `no_active`（任务正在跑）→ `pendingMessages=true`
5. 任务完成 → `drainGroup()` → `runForGroup()` → 第二次执行

## 修复方案

### `src/db.ts`

在 `getNewMessagesStmt` 的 SQL 查询中，将 `scheduled_task_prompt` 加入过滤条件：

```sql
-- 修改前
AND COALESCE(source_kind, '') != 'user_command'

-- 修改后
AND COALESCE(source_kind, '') NOT IN ('user_command', 'scheduled_task_prompt')
```

`scheduled_task_prompt` 消息只用于前端展示任务对话历史，不应被消息循环当作新的待处理消息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)