### PR TITLE
fix: preserve context on session resume failure + prevent IPC race crash

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -253,6 +253,13 @@ class MessageStream {
   private done = false;
 
   push(text: string, images?: Array<{ data: string; mimeType?: string }>): string[] {
+    // Guard: reject push after stream has ended to prevent writing to a closed SDK transport.
+    // This can happen when an IPC message arrives between the for-await loop exit and
+    // the ipcPolling=false cleanup (race condition).
+    if (this.done) {
+      return ['Stream already ended, message will be processed in the next query'];
+    }
+
     const rejectedReasons: string[] = [];
     let filteredImages = images;
 
@@ -293,6 +300,10 @@ class MessageStream {
     });
     this.waiting?.();
     return rejectedReasons;
+  }
+
+  get ended(): boolean {
+    return this.done;
   }
 
   end(): void {
@@ -561,6 +572,52 @@ function createPreCompactHook(
 
     return {};
   };
+}
+
+/**
+ * Extract recent conversation history from a session's JSONL transcript.
+ * Used when session resume fails to inject context into the fresh session's prompt.
+ */
+function extractSessionHistory(oldSessionId: string, currentPrompt: string): string | null {
+  try {
+    const configDir = process.env.CLAUDE_CONFIG_DIR
+      || path.join(process.env.HOME || '/home/node', '.claude');
+    // SDK stores transcripts at: <configDir>/projects/<encoded-cwd>/<sessionId>.jsonl
+    // where encoded-cwd replaces '/' with '-'
+    const encodedCwd = WORKSPACE_GROUP.replace(/\//g, '-');
+    const transcriptPath = path.join(configDir, 'projects', encodedCwd, `${oldSessionId}.jsonl`);
+
+    if (!fs.existsSync(transcriptPath)) {
+      log(`Session transcript not found at ${transcriptPath}`);
+      return null;
+    }
+
+    const content = fs.readFileSync(transcriptPath, 'utf-8');
+    const messages = parseTranscript(content);
+    if (messages.length === 0) return null;
+
+    // Take the last N messages for context (similar to RECOVERY_HISTORY_LIMIT in index.ts)
+    const HISTORY_LIMIT = 20;
+    const recentMessages = messages.slice(-HISTORY_LIMIT);
+
+    const historyLines = recentMessages.map((m) => {
+      const role = m.role === 'user' ? 'User' : 'HappyClaw';
+      const truncated = m.content.length > 500 ? m.content.slice(0, 500) + '…' : m.content;
+      // Strip lone surrogates to avoid API JSON errors
+      const cleaned = truncated.replace(/[\uD800-\uDFFF]/g, '');
+      return `[${role}] ${cleaned}`;
+    });
+
+    log(`Extracted ${recentMessages.length} messages from old session ${oldSessionId} for context injection`);
+
+    return '<system_context>\n' +
+      '会话恢复失败，当前为新会话。以下是之前的对话记录，供你了解上下文（请基于这些上下文继续对话）：\n\n' +
+      historyLines.join('\n') +
+      '\n</system_context>\n\n';
+  } catch (err) {
+    log(`Failed to extract session history: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
 }
 
 function parseTranscript(content: string): ParsedMessage[] {
@@ -1038,6 +1095,17 @@ async function runQuery(
     // gets silently consumed, leaving queryInFlight=true on the host forever (bug #259).
     if (!emitOutput) {
       return; // No setTimeout needed — watcher will trigger next check on file change
+    }
+
+    // Guard: don't drain IPC messages if the stream has already ended.
+    // Messages arriving after the for-await loop exits but before ipcPolling=false
+    // would be consumed from IPC (deleted) but rejected by stream.push(),
+    // causing them to be lost. Leave them for waitForIpcMessage() to pick up.
+    if (stream.ended) {
+      log('Stream already ended, skipping IPC drain (messages will be picked up by waitForIpcMessage)');
+      ipcPolling = false;
+      ipcQueryWatcher.close();
+      return;
     }
 
     const { messages } = drainIpcInput();
@@ -1678,8 +1746,18 @@ async function main(): Promise<void> {
       }
 
       // Session resume 失败（SDK 无法恢复旧会话）：清除 session，以新会话重试
+      // 同时从旧会话的 JSONL 转录中提取最近对话历史，注入到 prompt 中，
+      // 避免新会话完全丢失上下文（类似 recoveryGroups 机制）。
       if (queryResult.sessionResumeFailed) {
         log(`Session resume failed, retrying with fresh session (old: ${sessionId})`);
+        // Extract recent history from the old session transcript before clearing
+        if (sessionId) {
+          const historyContext = extractSessionHistory(sessionId, prompt);
+          if (historyContext) {
+            prompt = historyContext + prompt;
+            log(`Injected session history context into prompt for fresh session retry`);
+          }
+        }
         sessionId = undefined;
         latestSessionId = undefined;
         resumeAt = undefined;

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -578,7 +578,7 @@ function createPreCompactHook(
  * Extract recent conversation history from a session's JSONL transcript.
  * Used when session resume fails to inject context into the fresh session's prompt.
  */
-function extractSessionHistory(oldSessionId: string, currentPrompt: string): string | null {
+function extractSessionHistory(oldSessionId: string): string | null {
   try {
     const configDir = process.env.CLAUDE_CONFIG_DIR
       || path.join(process.env.HOME || '/home/node', '.claude');
@@ -603,8 +603,8 @@ function extractSessionHistory(oldSessionId: string, currentPrompt: string): str
     const historyLines = recentMessages.map((m) => {
       const role = m.role === 'user' ? 'User' : 'HappyClaw';
       const truncated = m.content.length > 500 ? m.content.slice(0, 500) + '…' : m.content;
-      // Strip lone surrogates to avoid API JSON errors
-      const cleaned = truncated.replace(/[\uD800-\uDFFF]/g, '');
+      // Strip lone surrogates (unpaired) to avoid API JSON errors, preserving valid surrogate pairs (emoji etc.)
+      const cleaned = truncated.replace(/(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g, '');
       return `[${role}] ${cleaned}`;
     });
 
@@ -1752,7 +1752,7 @@ async function main(): Promise<void> {
         log(`Session resume failed, retrying with fresh session (old: ${sessionId})`);
         // Extract recent history from the old session transcript before clearing
         if (sessionId) {
-          const historyContext = extractSessionHistory(sessionId, prompt);
+          const historyContext = extractSessionHistory(sessionId);
           if (historyContext) {
             prompt = historyContext + prompt;
             log(`Injected session history context into prompt for fresh session retry`);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -253,9 +253,10 @@ class MessageStream {
   private done = false;
 
   push(text: string, images?: Array<{ data: string; mimeType?: string }>): string[] {
-    // Guard: reject push after stream has ended to prevent writing to a closed SDK transport.
-    // This can happen when an IPC message arrives between the for-await loop exit and
-    // the ipcPolling=false cleanup (race condition).
+    // 预防性 invariant：stream.done=true 后不应再有 caller 调用 push（pollIpcDuringQuery
+    // 已通过 stream.ended 守护拦住主路径）。此守护防止上游重构（例如 SDK write-pump 在
+    // transport.close() 后仍 drain 残留消息）或未来新增的 push 调用点引入崩溃，避免
+    // 写入已关闭的 SDK transport 触发 "ProcessTransport is not ready for writing"。
     if (this.done) {
       return ['Stream already ended, message will be processed in the next query'];
     }
@@ -596,9 +597,9 @@ function extractSessionHistory(oldSessionId: string): string | null {
     const messages = parseTranscript(content);
     if (messages.length === 0) return null;
 
-    // Take the last N messages for context (similar to RECOVERY_HISTORY_LIMIT in index.ts)
-    const HISTORY_LIMIT = 20;
-    const recentMessages = messages.slice(-HISTORY_LIMIT);
+    // Take the last N messages for context (aligned with RECOVERY_HISTORY_LIMIT in src/index.ts)
+    const RECOVERY_HISTORY_LIMIT = 20;
+    const recentMessages = messages.slice(-RECOVERY_HISTORY_LIMIT);
 
     const historyLines = recentMessages.map((m) => {
       const role = m.role === 'user' ? 'User' : 'HappyClaw';
@@ -1097,10 +1098,10 @@ async function runQuery(
       return; // No setTimeout needed — watcher will trigger next check on file change
     }
 
-    // Guard: don't drain IPC messages if the stream has already ended.
-    // Messages arriving after the for-await loop exits but before ipcPolling=false
-    // would be consumed from IPC (deleted) but rejected by stream.push(),
-    // causing them to be lost. Leave them for waitForIpcMessage() to pick up.
+    // 预防性 invariant：当前所有 stream.end() 路径（sentinel handlers / interrupt-before-query
+    // / immediate-interrupt）都在同一同步 tick 把 ipcPolling=false，理论上 !ipcPolling 早退
+    // 已覆盖 stream.ended=true 的情况；此守护保留作为未来重构时的 invariant 断言，
+    // 避免后续改动引入"流已关闭但 polling 未停"的竞态窗口（消息会被 drain 后又被 stream.push 拒绝丢失）。
     if (stream.ended) {
       log('Stream already ended, skipping IPC drain (messages will be picked up by waitForIpcMessage)');
       ipcPolling = false;
@@ -1715,6 +1716,10 @@ async function main(): Promise<void> {
   const MAX_OVERFLOW_RETRIES = 3;
   let consecutiveCompactions = 0;
   const MAX_CONSECUTIVE_COMPACTIONS = 3;
+  // 暂存的会话历史上下文：当 auto-continue 阶段发生 sessionResumeFailed 时，
+  // 历史无法直接拼到 auto-continue prompt（因为 fall-through 等下一条 IPC 消息后才重启 query），
+  // 需要在下一轮主循环 query 之前消费它，避免新会话完全丢失上下文。
+  let pendingHistoryContext: string | null = null;
   try {
     while (true) {
       // 清理残留的 _interrupt sentinel（空闲期间写入的中断信号不应影响下一次 query）。
@@ -1722,6 +1727,16 @@ async function main(): Promise<void> {
       // pollIpcDuringQuery 会在查询结果后检测到并正确退出容器。
       try { fs.unlinkSync(IPC_INPUT_INTERRUPT_SENTINEL); } catch { /* ignore */ }
       clearInterruptRequested();
+
+      // 消费 auto-continue 阶段暂存的 history context（如果存在）。
+      // 对应 sessionResumeFailed 在 auto-continue 路径上的镜像处理：
+      // 此时 sessionId 已被清空，pendingHistoryContext 是从旧 JSONL 转录中
+      // 提取的最近对话历史，需在 fresh session 启动前注入到 prompt 前面。
+      if (pendingHistoryContext) {
+        prompt = pendingHistoryContext + prompt;
+        log('Injected pending session history context (from auto-continue resume failure) into prompt');
+        pendingHistoryContext = null;
+      }
 
       log(`Starting query (session: ${sessionId || 'new'}, resumeAt: ${resumeAt || 'latest'})...`);
 
@@ -1947,6 +1962,17 @@ async function main(): Promise<void> {
           // auto-continue is a standalone call we must check them explicitly).
           if (autoContResult.sessionResumeFailed) {
             log('WARN: Session resume failed during auto-continue, clearing session');
+            // 镜像主循环 sessionResumeFailed 的 history 注入逻辑：
+            // 在清空 sessionId 之前从旧 JSONL 转录中提取最近对话历史，
+            // 暂存到 pendingHistoryContext，下一轮主循环 query 会在用户消息前消费它。
+            // 与主循环不同，此处无法直接拼到 prompt（auto-continue 已结束，需等待下一条 IPC 消息）。
+            if (sessionId) {
+              const historyContext = extractSessionHistory(sessionId);
+              if (historyContext) {
+                pendingHistoryContext = historyContext;
+                log('Stashed session history context for next user-initiated query');
+              }
+            }
             sessionId = undefined;
             latestSessionId = undefined;
             resumeAt = undefined;


### PR DESCRIPTION
## Summary

Fixes two bugs in `container/agent-runner/src/index.ts` that caused a conversation to break mid-chat:

- **Session resume failure loses all context**: When the Claude SDK fails to resume a session (e.g. corrupted `resumeAt` UUID), the agent-runner creates a fresh session but discards all prior conversation history. Now extracts the last 20 messages from the old session's JSONL transcript and injects them as `<system_context>` into the new session's prompt, similar to the existing `recoveryGroups` mechanism used during service restarts.

- **IPC race condition crash**: When a user message arrives between the for-await query loop exit and the `ipcPolling=false` cleanup, `stream.push()` writes to an already-closed SDK `ProcessTransport`, causing an unhandled `ProcessTransport is not ready for writing` error that crashes the agent-runner. Fixed by:
  - Adding a `done` guard in `MessageStream.push()` to reject writes after `end()`
  - Adding a `stream.ended` check in `pollIpcDuringQuery()` to skip draining IPC messages when the stream is closed, leaving them for `waitForIpcMessage()` to pick up

## Root cause

Observed in production: user was chatting about Claude Code's Monitor feature via WeChat. Mid-conversation, session resume failed (synthetic UUID `11abd3b6-...-000000000001`), context was lost, agent misinterpreted the topic, and then crashed on the next message due to the IPC race condition. The crash caused a port-conflict restart loop.

## Test plan

- [ ] Verify session resume failure path: kill a session's JSONL mid-conversation, confirm history is injected into the fresh session
- [ ] Verify IPC race condition: send rapid messages during query completion, confirm no crash
- [ ] Verify normal conversation flow is unaffected
- [ ] Verify emoji in conversation history are preserved (lone surrogate stripping only)