### PR TITLE
feat: Discord IM 通道支持

### DIFF
--- a/container/agent-runner/src/channel-prefixes.ts
+++ b/container/agent-runner/src/channel-prefixes.ts
@@ -5,6 +5,7 @@ export const CHANNEL_PREFIXES: Record<string, string> = {
   qq: 'qq:',
   wechat: 'wechat:',
   dingtalk: 'dingtalk:',
+  discord: 'discord:',
 };
 
 /** Determine the channel type from a JID string. Returns 'web' for unrecognized prefixes. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "better-sqlite3": "^11.8.1",
         "cron-parser": "^5.5.0",
         "dingtalk-stream": "2.1.6-beta.1",
+        "discord.js": "^14.26.2",
         "grammy": "^1.40.0",
         "hono": "^4.11.9",
         "node-pty": "^1.1.0",
@@ -98,6 +99,171 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmmirror.com/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmmirror.com/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmmirror.com/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmmirror.com/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -105,6 +271,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1296,6 +1463,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmmirror.com/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmmirror.com/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1384,7 +1584,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1501,6 +1700,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmmirror.com/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2167,6 +2376,42 @@
         "axios": "^1.4.0",
         "debug": "^4.3.4",
         "ws": "^8.13.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.45",
+      "resolved": "https://registry.npmmirror.com/discord-api-types/-/discord-api-types-0.38.45.tgz",
+      "integrity": "sha512-DiI01i00FPv6n+hXcFkFxK8Y/rFRpKs6U6aP32N4T73nTbj37Eua3H/95TBpLktLWB6xnLXhYDGvyLq6zzYY2w==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.2",
+      "resolved": "https://registry.npmmirror.com/discord.js/-/discord.js-14.26.2.tgz",
+      "integrity": "sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/dunder-proto": {
@@ -2871,7 +3116,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3325,6 +3569,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.identity": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
@@ -3341,6 +3591,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -3366,6 +3622,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmmirror.com/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3739,7 +4001,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4840,6 +5101,12 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4852,7 +5119,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4932,6 +5198,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -4968,7 +5243,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5266,7 +5540,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "better-sqlite3": "^11.8.1",
     "cron-parser": "^5.5.0",
     "dingtalk-stream": "2.1.6-beta.1",
+    "discord.js": "^14.26.2",
     "grammy": "^1.40.0",
     "hono": "^4.11.9",
     "node-pty": "^1.1.0",

--- a/shared/channel-prefixes.ts
+++ b/shared/channel-prefixes.ts
@@ -5,6 +5,7 @@ export const CHANNEL_PREFIXES: Record<string, string> = {
   qq: 'qq:',
   wechat: 'wechat:',
   dingtalk: 'dingtalk:',
+  discord: 'discord:',
 };
 
 /** Determine the channel type from a JID string. Returns 'web' for unrecognized prefixes. */

--- a/src/channel-prefixes.ts
+++ b/src/channel-prefixes.ts
@@ -5,6 +5,7 @@ export const CHANNEL_PREFIXES: Record<string, string> = {
   qq: 'qq:',
   wechat: 'wechat:',
   dingtalk: 'dingtalk:',
+  discord: 'discord:',
 };
 
 /** Determine the channel type from a JID string. Returns 'web' for unrecognized prefixes. */

--- a/src/discord-streaming-edit.ts
+++ b/src/discord-streaming-edit.ts
@@ -1,0 +1,690 @@
+/**
+ * Discord Streaming Edit Controller
+ *
+ * Implements the same public API as DingTalkStreamingCardController so that
+ * `feedStreamEventToCard()` can drive it without modification.
+ *
+ * Discord message edit lifecycle:
+ *   1. channel.send() — create initial placeholder message
+ *   2. message.edit() — throttled streaming updates (500ms)
+ *   3. message.edit() — final content (may split into multiple messages if >2000 chars)
+ *
+ * Discord limits each message to 2000 characters. When content exceeds this,
+ * the controller finalises the current message and sends continuation messages,
+ * preserving code fence state across splits.
+ */
+
+import type {
+  TextChannel,
+  DMChannel,
+  NewsChannel,
+  Message,
+} from 'discord.js';
+import { logger } from './logger.js';
+
+// ─── Constants ───────────────────────────────────────────────
+
+const STREAM_UPDATE_INTERVAL = 500; // ms
+const DISCORD_MSG_LIMIT = 2000;
+const MAX_THINKING_CHARS = 500;
+const MAX_TOOLS_DISPLAY = 5;
+const MAX_TOOL_SUMMARY_CHARS = 60;
+const MAX_RECENT_EVENTS = 5;
+
+type StreamingState =
+  | 'idle'
+  | 'creating'
+  | 'streaming'
+  | 'completed'
+  | 'aborted'
+  | 'error';
+
+// ─── Controller ──────────────────────────────────────────────
+
+export class DiscordStreamingEditController {
+  private state: StreamingState = 'idle';
+  private channel: TextChannel | DMChannel | NewsChannel;
+  private onCardCreated?: (messageId: string) => void;
+  private fallbackSend: ((text: string) => Promise<void>) | null;
+
+  // Message state — we may need multiple messages if text exceeds 2000 chars
+  private messages: Message[] = [];
+  private accumulatedText = '';
+
+  // Throttle
+  private lastUpdateTime = 0;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Auxiliary flush throttle
+  private auxFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastAuxFlushTime = 0;
+  private static readonly AUX_FLUSH_INTERVAL = 1500; // ms
+
+  // Auxiliary state (thinking, tools, status)
+  private thinking = false;
+  private thinkingText = '';
+  private systemStatus: string | null = null;
+  private tools = new Map<
+    string,
+    {
+      name: string;
+      status: 'running' | 'complete' | 'error';
+      startTime: number;
+      summary?: string;
+    }
+  >();
+  private recentEvents: string[] = [];
+
+  // Fallback flag
+  private fallbackUsed = false;
+  // Creation guard
+  private messageCreationPromise: Promise<void> | null = null;
+
+  constructor(
+    channel: TextChannel | DMChannel | NewsChannel,
+    opts?: {
+      onCardCreated?: (messageId: string) => void;
+      fallbackSend?: (text: string) => Promise<void>;
+    },
+  ) {
+    this.channel = channel;
+    this.onCardCreated = opts?.onCardCreated;
+    this.fallbackSend = opts?.fallbackSend ?? null;
+  }
+
+  // ─── Lifecycle ─────────────────────────────────────────────
+
+  isActive(): boolean {
+    return (
+      this.state === 'idle' ||
+      this.state === 'creating' ||
+      this.state === 'streaming'
+    );
+  }
+
+  append(text: string): void {
+    if (!this.isActive()) return;
+    this.accumulatedText = text; // Full replacement (same as DingTalk pattern)
+    this.thinkingText = ''; // Clear reasoning once real text arrives
+    this.thinking = false; // No longer in active thinking phase
+    this.scheduleFlush();
+  }
+
+  async complete(finalText: string): Promise<void> {
+    if (this.state === 'completed' || this.state === 'aborted') return;
+    this.accumulatedText = finalText;
+    this.clearFlushTimer();
+
+    // If there's no text at all, skip message creation entirely
+    if (!finalText.trim()) {
+      this.state = 'completed';
+      return;
+    }
+
+    logger.info(
+      {
+        state: this.state,
+        hasMessages: this.messages.length > 0,
+        textLen: finalText.length,
+      },
+      'Discord streaming edit complete() called',
+    );
+
+    // Ensure message exists before finalizing
+    try {
+      await this.ensureMessage();
+    } catch (err: any) {
+      logger.warn(
+        { err: err.message },
+        'Discord ensureMessage failed in complete()',
+      );
+      await this.tryFallback(finalText);
+      this.state = 'completed';
+      return;
+    }
+
+    if (this.messages.length === 0) {
+      logger.warn(
+        { state: this.state },
+        'Discord complete(): no messages after ensureMessage, using fallback',
+      );
+      await this.tryFallback(finalText);
+      this.state = 'completed';
+      return;
+    }
+
+    try {
+      // Clear auxiliary state for final render — only keep reply body
+      this.thinkingText = '';
+      this.thinking = false;
+
+      // Split and send final content (clean, no aux prefix)
+      await this.splitAndSend(finalText);
+      this.state = 'completed';
+      logger.info(
+        { messageCount: this.messages.length },
+        'Discord streaming edit completed',
+      );
+    } catch (err: any) {
+      logger.warn(
+        { err: err.message },
+        'Discord streaming edit finalize failed, degrading',
+      );
+      await this.tryFallback(finalText);
+      this.state = 'error';
+    }
+  }
+
+  async abort(reason?: string): Promise<void> {
+    if (this.state === 'completed' || this.state === 'aborted') return;
+    this.clearFlushTimer();
+
+    const displayText = this.accumulatedText
+      ? this.accumulatedText +
+        `\n\n> ⚠️ 已中断: ${reason ?? '用户取消'}`
+      : `⚠️ 已中断: ${reason ?? '用户取消'}`;
+
+    if (this.messages.length === 0) {
+      this.state = 'aborted';
+      return;
+    }
+
+    try {
+      const lastMsg = this.messages[this.messages.length - 1];
+      const truncated = displayText.slice(
+        -(DISCORD_MSG_LIMIT),
+      );
+      await lastMsg.edit(truncated);
+    } catch (err: any) {
+      logger.debug(
+        { err: err.message },
+        'Discord streaming edit abort update failed',
+      );
+    }
+    this.state = 'aborted';
+  }
+
+  dispose(): void {
+    this.clearFlushTimer();
+  }
+
+  // ─── Auxiliary display (prepended as markdown) ─────────────
+
+  setThinking(): void {
+    this.thinking = true;
+    if (this.messages.length === 0 && this.state === 'idle') {
+      // Trigger message creation early so user sees placeholder
+      this.state = 'creating';
+      this.ensureMessage().catch(() => {
+        this.state = 'error';
+      });
+    }
+  }
+
+  appendThinking(text: string): void {
+    this.thinkingText += text;
+    if (this.thinkingText.length > MAX_THINKING_CHARS) {
+      this.thinkingText =
+        '...' + this.thinkingText.slice(-(MAX_THINKING_CHARS - 3));
+    }
+    this.thinking = true;
+    if (this.messages.length === 0 && this.state === 'idle') {
+      this.state = 'creating';
+      this.ensureMessage().catch(() => {
+        this.state = 'error';
+      });
+    } else if (this.state === 'streaming') {
+      this.scheduleAuxFlush();
+    }
+  }
+
+  setSystemStatus(status: string | null): void {
+    this.systemStatus = status;
+    if (this.state === 'streaming') this.scheduleAuxFlush();
+  }
+
+  setHook(_hook: { hookName: string; hookEvent: string } | null): void {
+    // Hooks are less meaningful in Discord — skip rendering
+  }
+
+  setTodos(
+    _todos: Array<{ id: string; content: string; status: string }>,
+  ): void {
+    // Todos are too verbose for Discord messages — skip
+  }
+
+  pushRecentEvent(text: string): void {
+    this.recentEvents.push(text);
+    if (this.recentEvents.length > MAX_RECENT_EVENTS) {
+      this.recentEvents = this.recentEvents.slice(-MAX_RECENT_EVENTS);
+    }
+    // Piggyback on other flush events — don't trigger standalone flush
+  }
+
+  startTool(toolId: string, toolName: string): void {
+    this.tools.set(toolId, {
+      name: toolName,
+      status: 'running',
+      startTime: Date.now(),
+    });
+    if (this.state === 'streaming') this.scheduleAuxFlush();
+  }
+
+  endTool(toolId: string, isError: boolean): void {
+    const tc = this.tools.get(toolId);
+    if (tc) {
+      tc.status = isError ? 'error' : 'complete';
+      this.purgeOldTools();
+      if (this.state === 'streaming') this.scheduleAuxFlush();
+    }
+  }
+
+  updateToolSummary(toolId: string, summary: string): void {
+    const tc = this.tools.get(toolId);
+    if (tc) {
+      tc.summary = summary;
+      if (this.state === 'streaming') this.scheduleAuxFlush();
+    }
+  }
+
+  getToolInfo(toolId: string): { name: string } | undefined {
+    return this.tools.get(toolId);
+  }
+
+  async patchUsageNote(_usage: {
+    inputTokens: number;
+    outputTokens: number;
+    costUSD: number;
+    durationMs: number;
+    numTurns: number;
+  }): Promise<void> {
+    // Usage notes are not meaningful for Discord messages — no-op
+  }
+
+  getAllMessageIds(): string[] {
+    return this.messages.map((m) => m.id);
+  }
+
+  // ─── Auxiliary Build ────────────────────────────────────────
+
+  /**
+   * Build auxiliary prefix (thinking + tools + status) to prepend to content.
+   * Renders as compact markdown above the main response text.
+   */
+  private buildAuxPrefix(): string {
+    const parts: string[] = [];
+
+    // 1. System status
+    if (this.systemStatus) {
+      parts.push(`⏳ ${this.systemStatus}`);
+    }
+
+    // 2. Thinking / Reasoning
+    if (this.thinkingText) {
+      const label = this.thinking ? '💭 **Reasoning...**' : '💭 **Reasoned**';
+      const truncated =
+        this.thinkingText.length > MAX_THINKING_CHARS
+          ? '...' + this.thinkingText.slice(-(MAX_THINKING_CHARS - 3))
+          : this.thinkingText;
+      const quoted = truncated
+        .split('\n')
+        .map((l) => `> ${l}`)
+        .join('\n');
+      parts.push(`${label}\n${quoted}`);
+    } else if (this.thinking) {
+      parts.push('💭 **Thinking...**');
+    }
+
+    // 3. Active tools
+    const now = Date.now();
+    const display: Array<{
+      name: string;
+      status: string;
+      elapsed: string;
+      summary?: string;
+    }> = [];
+    for (const [, tc] of this.tools) {
+      if (display.length >= MAX_TOOLS_DISPLAY) break;
+      const elapsed = DiscordStreamingEditController.formatElapsed(
+        now - tc.startTime,
+      );
+      display.push({
+        name: tc.name,
+        status: tc.status,
+        elapsed,
+        summary: tc.summary,
+      });
+    }
+    if (display.length > 0) {
+      const lines = display.map((d) => {
+        const icon =
+          d.status === 'running'
+            ? '🔄'
+            : d.status === 'complete'
+              ? '✅'
+              : '❌';
+        const summary = d.summary
+          ? `  ${d.summary.length > MAX_TOOL_SUMMARY_CHARS ? d.summary.slice(0, MAX_TOOL_SUMMARY_CHARS) + '...' : d.summary}`
+          : '';
+        return `${icon} \`${d.name}\` (${d.elapsed})${summary}`;
+      });
+      parts.push(lines.join('\n'));
+    }
+
+    // 4. Recent events
+    if (this.recentEvents.length > 0) {
+      const eventLines = this.recentEvents.map((e) => `- ${e}`);
+      parts.push(`📝 **调用轨迹**\n${eventLines.join('\n')}`);
+    }
+
+    return parts.length > 0 ? parts.join('\n\n') + '\n\n---\n\n' : '';
+  }
+
+  /** Format elapsed time */
+  private static formatElapsed(ms: number): string {
+    if (ms < 1000) return `${ms}ms`;
+    const sec = ms / 1000;
+    if (sec < 60) return `${sec.toFixed(1)}s`;
+    const min = Math.floor(sec / 60);
+    return `${min}m ${Math.floor(sec % 60)}s`;
+  }
+
+  /** Purge completed/error tools older than 30s */
+  private purgeOldTools(): void {
+    const cutoff = Date.now() - 30_000;
+    for (const [id, tc] of this.tools) {
+      if (tc.status !== 'running' && tc.startTime < cutoff) {
+        this.tools.delete(id);
+      }
+    }
+  }
+
+  /** Schedule auxiliary-only flush (throttled) */
+  private scheduleAuxFlush(): void {
+    if (this.auxFlushTimer) return;
+    const elapsed = Date.now() - this.lastAuxFlushTime;
+    const delay = Math.max(
+      0,
+      DiscordStreamingEditController.AUX_FLUSH_INTERVAL - elapsed,
+    );
+    this.auxFlushTimer = setTimeout(() => {
+      this.auxFlushTimer = null;
+      // Guard: don't flush after complete/abort
+      if (this.state === 'completed' || this.state === 'aborted') return;
+      this.lastAuxFlushTime = Date.now();
+      // Push combined content (aux prefix + main text)
+      const content = this.buildAuxPrefix() + this.accumulatedText;
+      this.editLastMessage(content).catch((err: any) => {
+        logger.debug({ err: err.message }, 'Discord aux flush failed');
+      });
+    }, delay);
+  }
+
+  // ─── Internal: message creation ────────────────────────────
+
+  private async ensureMessage(): Promise<void> {
+    if (this.messages.length > 0) return;
+
+    // If message creation is already in progress, await it
+    if (this.messageCreationPromise) {
+      await this.messageCreationPromise;
+      return;
+    }
+
+    this.state = 'creating';
+    this.messageCreationPromise = (async () => {
+      try {
+        const msg = await this.channel.send('💭 思考中...');
+        this.messages.push(msg);
+        this.state = 'streaming';
+        if (this.onCardCreated) this.onCardCreated(msg.id);
+      } catch (err: any) {
+        logger.warn(
+          { err: err.message },
+          'Discord initial message creation failed',
+        );
+        this.state = 'error';
+      } finally {
+        this.messageCreationPromise = null;
+      }
+    })();
+
+    try {
+      await this.messageCreationPromise;
+    } catch {
+      // Already handled inside the promise
+    }
+  }
+
+  // ─── Internal: streaming ────────────────────────────────────
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+
+    const elapsed = Date.now() - this.lastUpdateTime;
+    const delay = Math.max(0, STREAM_UPDATE_INTERVAL - elapsed);
+
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.doFlush().catch((err: any) => {
+        logger.debug({ err: err.message }, 'Discord streaming edit flush failed');
+      });
+    }, delay);
+  }
+
+  private async doFlush(): Promise<void> {
+    // Guard: don't flush after complete/abort (race with in-flight timer callbacks)
+    if (this.state === 'completed' || this.state === 'aborted') return;
+
+    if (!this.accumulatedText.trim() && !this.thinking && !this.systemStatus) {
+      return;
+    }
+
+    // If message creation failed, use fallback
+    if (this.state === 'error') {
+      await this.tryFallback(this.accumulatedText);
+      return;
+    }
+
+    await this.ensureMessage();
+
+    if (this.messages.length === 0) {
+      await this.tryFallback(this.accumulatedText);
+      return;
+    }
+
+    const content = this.buildAuxPrefix() + this.accumulatedText;
+
+    // During streaming, if content exceeds limit, truncate from the beginning
+    // (full split only happens on complete())
+    if (content.length > DISCORD_MSG_LIMIT) {
+      const truncated =
+        '...' + content.slice(-(DISCORD_MSG_LIMIT - 3));
+      await this.editLastMessage(truncated);
+    } else {
+      await this.editLastMessage(content);
+    }
+
+    this.lastUpdateTime = Date.now();
+  }
+
+  private clearFlushTimer(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.auxFlushTimer) {
+      clearTimeout(this.auxFlushTimer);
+      this.auxFlushTimer = null;
+    }
+  }
+
+  /**
+   * Edit the last message in the chain. discord.js handles rate limits
+   * internally via its built-in queue, so we don't need manual retry logic.
+   */
+  private async editLastMessage(content: string): Promise<void> {
+    if (this.messages.length === 0) return;
+    const lastMsg = this.messages[this.messages.length - 1];
+    try {
+      await lastMsg.edit(content || '\u200b'); // Zero-width space if empty
+    } catch (err: any) {
+      logger.debug(
+        { err: err.message, messageId: lastMsg.id },
+        'Discord message edit failed',
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Split final text into 2000-char chunks preserving code fences,
+   * editing existing messages and sending new ones as needed.
+   */
+  private async splitAndSend(fullContent: string): Promise<void> {
+    const chunks = splitWithCodeFences(fullContent, DISCORD_MSG_LIMIT);
+    let firstError: Error | null = null;
+
+    for (let i = 0; i < chunks.length; i++) {
+      if (i < this.messages.length) {
+        // Edit existing message
+        try {
+          await this.messages[i].edit(chunks[i]);
+        } catch (err: any) {
+          logger.warn(
+            { err: err.message, index: i },
+            'Discord message edit failed during split',
+          );
+          if (!firstError) firstError = err;
+        }
+      } else {
+        // Send new continuation message
+        try {
+          const msg = await this.channel.send(chunks[i]);
+          this.messages.push(msg);
+        } catch (err: any) {
+          logger.warn(
+            { err: err.message, index: i },
+            'Discord continuation message send failed',
+          );
+          if (!firstError) firstError = err;
+          break;
+        }
+      }
+    }
+
+    // Propagate the first error so complete() can fallback
+    if (firstError) throw firstError;
+  }
+
+  private async tryFallback(text: string): Promise<void> {
+    if (this.fallbackUsed || !this.fallbackSend) return;
+    this.fallbackUsed = true;
+    try {
+      await this.fallbackSend(text);
+    } catch (err: any) {
+      logger.warn({ err: err.message }, 'Discord fallback send also failed');
+    }
+  }
+}
+
+// ─── Code fence-aware text splitting ─────────────────────────
+
+/**
+ * Split text into chunks of at most `limit` characters, preserving code fences.
+ *
+ * When a split occurs inside a fenced code block (``` ... ```), the current
+ * chunk is closed with ``` and the next chunk reopens with ```lang.
+ */
+function splitWithCodeFences(text: string, limit: number): string[] {
+  if (text.length <= limit) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  let insideCodeBlock = false;
+  let codeFenceLang = '';
+
+  while (remaining.length > 0) {
+    if (remaining.length <= limit) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Find a good split point — prefer splitting at newlines near the limit
+    let splitAt = limit;
+
+    // Reserve space for potential closing/opening fences
+    const reservedChars = insideCodeBlock ? 8 : 0; // "```\n" = 4, "```lang\n" ≈ up to ~20
+    const effectiveLimit = limit - reservedChars;
+
+    // Look for a newline near the effective limit (search within last 200 chars)
+    const searchStart = Math.max(0, effectiveLimit - 200);
+    const searchRegion = remaining.slice(searchStart, effectiveLimit);
+    const lastNewline = searchRegion.lastIndexOf('\n');
+    if (lastNewline !== -1) {
+      splitAt = searchStart + lastNewline + 1; // Split after the newline
+    } else {
+      splitAt = effectiveLimit;
+    }
+
+    // Ensure we always make progress
+    if (splitAt <= 0) splitAt = effectiveLimit > 0 ? effectiveLimit : limit;
+
+    let chunk = remaining.slice(0, splitAt);
+
+    // Track code fence state within this chunk
+    const fenceState = trackCodeFences(chunk, insideCodeBlock, codeFenceLang);
+
+    if (fenceState.insideCodeBlock) {
+      // We're splitting inside a code block — close it
+      chunk = chunk + '\n```';
+      insideCodeBlock = true;
+      codeFenceLang = fenceState.lang;
+    } else {
+      insideCodeBlock = false;
+      codeFenceLang = '';
+    }
+
+    chunks.push(chunk);
+    remaining = remaining.slice(splitAt);
+
+    // If we were inside a code block, reopen it in the next chunk
+    if (insideCodeBlock && remaining.length > 0) {
+      const opener = codeFenceLang ? '```' + codeFenceLang + '\n' : '```\n';
+      remaining = opener + remaining;
+    }
+  }
+
+  return chunks;
+}
+
+/**
+ * Simple state machine to track whether we end up inside a code fence
+ * after processing the given text.
+ */
+function trackCodeFences(
+  text: string,
+  initiallyInside: boolean,
+  initialLang: string,
+): { insideCodeBlock: boolean; lang: string } {
+  let inside = initiallyInside;
+  let lang = initialLang;
+
+  // Match lines that start with ``` (with optional language tag)
+  const fenceRegex = /^(`{3,})(.*)?$/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = fenceRegex.exec(text)) !== null) {
+    if (!inside) {
+      // Opening fence
+      inside = true;
+      lang = (match[2] || '').trim();
+    } else {
+      // Closing fence
+      inside = false;
+      lang = '';
+    }
+  }
+
+  return { insideCodeBlock: inside, lang };
+}

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,0 +1,956 @@
+/**
+ * Discord Bot Connection Factory
+ *
+ * Implements Discord bot connection using discord.js:
+ * - Gateway WebSocket for receiving events
+ * - Message deduplication (LRU 1000 / 30min TTL)
+ * - Guild channel and DM support
+ * - Attachment handling (images as base64, files saved to disk)
+ * - Long message splitting (2000 char limit, code fence preservation)
+ * - Ack reaction (eyes emoji on user messages)
+ *
+ * Reference: https://discord.js.org/
+ */
+import crypto from 'crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  Client,
+  GatewayIntentBits,
+  Events,
+  Partials,
+  AttachmentBuilder,
+  ChannelType,
+} from 'discord.js';
+import type {
+  Message,
+  TextChannel,
+  DMChannel,
+  NewsChannel,
+  TextBasedChannel,
+} from 'discord.js';
+import {
+  storeChatMetadata,
+  storeMessageDirect,
+  updateChatName,
+} from './db.js';
+import { notifyNewImMessage } from './message-notifier.js';
+import { broadcastNewMessage } from './web.js';
+import { logger } from './logger.js';
+import { saveDownloadedFile, MAX_FILE_SIZE } from './im-downloader.js';
+import { detectImageMimeType } from './image-detector.js';
+import { splitTextChunks } from './im-utils.js';
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const MSG_DEDUP_MAX = 1000;
+const MSG_DEDUP_TTL = 30 * 60 * 1000; // 30min
+const DISCORD_MSG_LIMIT = 2000; // Discord message character limit
+// Same 5MB threshold as other channels — only inline base64 for small images
+const IMAGE_MAX_BASE64_SIZE = 5 * 1024 * 1024;
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface DiscordConnectionConfig {
+  botToken: string;
+}
+
+export interface DiscordConnectOpts {
+  onReady?: () => void;
+  onNewChat: (jid: string, name: string) => void;
+  isChatAuthorized?: (jid: string) => boolean;
+  ignoreMessagesBefore?: number;
+  onCommand?: (
+    chatJid: string,
+    command: string,
+    senderImId?: string,
+  ) => Promise<string | null>;
+  resolveGroupFolder?: (jid: string) => string | undefined;
+  resolveEffectiveChatJid?: (
+    chatJid: string,
+  ) => { effectiveJid: string; agentId: string | null } | null;
+  onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+  onBotAddedToGroup?: (chatJid: string, chatName: string) => void;
+  onBotRemovedFromGroup?: (chatJid: string) => void;
+  shouldProcessGroupMessage?: (
+    chatJid: string,
+    senderImId?: string,
+  ) => boolean;
+  isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
+}
+
+export interface DiscordConnection {
+  connect(opts: DiscordConnectOpts): Promise<boolean>;
+  disconnect(): Promise<void>;
+  sendMessage(
+    chatId: string,
+    text: string,
+    localImagePaths?: string[],
+  ): Promise<void>;
+  sendImage(
+    chatId: string,
+    imageBuffer: Buffer,
+    mimeType: string,
+    caption?: string,
+    fileName?: string,
+  ): Promise<void>;
+  sendFile(chatId: string, filePath: string, fileName: string): Promise<void>;
+  setTyping(chatId: string, isTyping: boolean): Promise<void>;
+  clearAckReaction(chatId: string): void;
+  isConnected(): boolean;
+  getLastMessageId?(chatId: string): string | undefined;
+  createStreamingSession?(
+    chatId: string,
+    onCardCreated?: (messageId: string) => void,
+  ): Promise<
+    | import('./discord-streaming-edit.js').DiscordStreamingEditController
+    | undefined
+  >;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/**
+ * Parse a Discord chat ID (JID) to determine the type and extract the snowflake ID.
+ * discord:{channelId} → guild channel
+ * discord:dm:{userId} → DM channel
+ */
+function parseChatId(
+  chatId: string,
+): { type: 'guild' | 'dm'; id: string } | null {
+  // Full JID form: discord:dm:{userId} or discord:{channelId}
+  if (chatId.startsWith('discord:dm:'))
+    return { type: 'dm', id: chatId.slice(11) };
+  if (chatId.startsWith('discord:'))
+    return { type: 'guild', id: chatId.slice(8) };
+  // Bare ID form (after extractChatId strips prefix): dm:{userId} or raw snowflake
+  if (chatId.startsWith('dm:'))
+    return { type: 'dm', id: chatId.slice(3) };
+  // Bare snowflake — assume guild channel
+  if (/^\d+$/.test(chatId))
+    return { type: 'guild', id: chatId };
+  return null;
+}
+
+/**
+ * Split text into chunks respecting Discord's 2000-character limit.
+ * Preserves code fence integrity: if a split happens inside a fenced code block,
+ * close it before the split and reopen after.
+ */
+function splitDiscordChunks(text: string): string[] {
+  // Reserve space for fence open/close markers that may be added:
+  // opening: ```lang\n (up to ~15 chars), closing: \n``` (4 chars)
+  const FENCE_OVERHEAD = 20;
+  const raw = splitTextChunks(text, DISCORD_MSG_LIMIT - FENCE_OVERHEAD);
+  if (raw.length <= 1) return raw;
+
+  const result: string[] = [];
+  let insideCodeBlock = false;
+  let currentLang = '';
+
+  for (let i = 0; i < raw.length; i++) {
+    let chunk = raw[i];
+
+    // If previous chunk ended inside a code block, reopen at the start
+    if (insideCodeBlock) {
+      chunk = '```' + currentLang + '\n' + chunk;
+    }
+
+    // Count code fences in this chunk to track open/close state
+    const fenceMatches = chunk.match(/^```(\w*)/gm) || [];
+    let localFenceCount = 0;
+    let lastLang = currentLang;
+    for (const fence of fenceMatches) {
+      localFenceCount++;
+      // Extract language from opening fences
+      const langMatch = fence.match(/^```(\w+)/);
+      if (langMatch && localFenceCount % 2 === 1) {
+        lastLang = langMatch[1];
+      }
+    }
+
+    // An odd total fence count means the chunk ends with an unclosed block
+    const totalFences = (insideCodeBlock ? 1 : 0) + localFenceCount;
+    const endsOpen = totalFences % 2 === 1;
+
+    if (endsOpen && i < raw.length - 1) {
+      // Close the code block at the end of this chunk
+      chunk = chunk + '\n```';
+      insideCodeBlock = true;
+      currentLang = lastLang;
+    } else {
+      insideCodeBlock = false;
+      currentLang = '';
+    }
+
+    result.push(chunk);
+  }
+
+  return result;
+}
+
+/**
+ * Download an attachment from a URL and return a Buffer.
+ * Returns null on failure or if the file exceeds MAX_FILE_SIZE.
+ */
+async function downloadAttachment(url: string): Promise<Buffer | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    if (buffer.length > MAX_FILE_SIZE) return null;
+    return buffer;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Factory Function ───────────────────────────────────────────
+
+export function createDiscordConnection(
+  config: DiscordConnectionConfig,
+): DiscordConnection {
+  let discordClient: Client | null = null;
+  let stopping = false;
+  let readyFired = false;
+
+  // Message deduplication — LRU Map, 1000 entries, 30min TTL
+  const msgCache = new Map<string, number>();
+
+  // Last message ID per chat (for reply context)
+  const lastMessageIds = new Map<string, string>();
+
+  // Ack reaction per chat: { messageId, channelId }
+  const ackReactionByChat = new Map<
+    string,
+    { messageId: string; channelId: string }
+  >();
+
+  function isDuplicate(msgId: string): boolean {
+    const now = Date.now();
+    // Map preserves insertion order; stop at first non-expired entry
+    for (const [id, ts] of msgCache.entries()) {
+      if (now - ts > MSG_DEDUP_TTL) {
+        msgCache.delete(id);
+      } else {
+        break;
+      }
+    }
+    if (msgCache.size >= MSG_DEDUP_MAX) {
+      const firstKey = msgCache.keys().next().value;
+      if (firstKey) msgCache.delete(firstKey);
+    }
+    return msgCache.has(msgId);
+  }
+
+  function markSeen(msgId: string): void {
+    // delete + set to refresh insertion order (move to end)
+    msgCache.delete(msgId);
+    msgCache.set(msgId, Date.now());
+  }
+
+  // ─── Channel Resolution ──────────────────────────────────
+
+  /**
+   * Resolve a Discord TextBasedChannel from a chatId string.
+   * Handles both guild channels and DMs.
+   */
+  async function resolveChannel(
+    chatId: string,
+  ): Promise<TextChannel | DMChannel | NewsChannel | null> {
+    const parsed = parseChatId(chatId);
+    if (!parsed || !discordClient) return null;
+    try {
+      if (parsed.type === 'dm') {
+        const user = await discordClient.users.fetch(parsed.id);
+        return await user.createDM();
+      }
+      const channel = await discordClient.channels.fetch(parsed.id);
+      if (channel?.isTextBased()) {
+        return channel as TextChannel | NewsChannel;
+      }
+      return null;
+    } catch (err) {
+      logger.warn({ err, chatId }, 'Discord: failed to resolve channel');
+      return null;
+    }
+  }
+
+  // ─── Ack Reaction ─────────────────────────────────────────
+
+  /**
+   * Add an eyes emoji reaction to a user's message as ack confirmation.
+   */
+  async function attachAckReaction(
+    msg: Message,
+    jid: string,
+  ): Promise<void> {
+    try {
+      await msg.react('\u{1F440}'); // eyes emoji
+      ackReactionByChat.set(jid, {
+        messageId: msg.id,
+        channelId: msg.channelId,
+      });
+      logger.debug({ msgId: msg.id, jid }, 'Discord ack reaction attached');
+    } catch (err) {
+      logger.debug(
+        { err, msgId: msg.id, jid },
+        'Discord ack reaction attach failed',
+      );
+    }
+  }
+
+  /**
+   * Remove the eyes emoji reaction from the stored message for a chat.
+   * Silent on failure — the emoji is non-critical.
+   */
+  async function recallAckReaction(chatId: string): Promise<void> {
+    const stored = ackReactionByChat.get(chatId);
+    if (!stored) return;
+    ackReactionByChat.delete(chatId);
+    try {
+      if (!discordClient?.user) return;
+      const channel = await discordClient.channels.fetch(stored.channelId);
+      if (channel?.isTextBased()) {
+        const textChannel = channel as TextBasedChannel;
+        const msg = await textChannel.messages.fetch(stored.messageId);
+        const reaction = msg.reactions.cache.find(
+          (r) => r.emoji.name === '\u{1F440}',
+        );
+        if (reaction) {
+          await reaction.users.remove(discordClient.user.id);
+        }
+      }
+    } catch {
+      // Non-critical: emoji will remain but won't break anything
+    }
+  }
+
+  // ─── Message Handling ─────────────────────────────────────
+
+  async function handleMessage(
+    msg: Message,
+    opts: DiscordConnectOpts,
+  ): Promise<void> {
+    try {
+      // Skip bot messages
+      if (msg.author.bot) return;
+
+      const msgId = msg.id;
+
+      // Dedup check
+      if (isDuplicate(msgId)) {
+        logger.debug({ msgId }, 'Discord dropped: duplicate');
+        return;
+      }
+      markSeen(msgId);
+
+      // Skip stale messages from before connection (hot-reload scenario)
+      if (opts.ignoreMessagesBefore && msg.createdTimestamp) {
+        if (msg.createdTimestamp < opts.ignoreMessagesBefore) {
+          logger.debug(
+            {
+              msgId,
+              msgTime: msg.createdTimestamp,
+              ignoreBefore: opts.ignoreMessagesBefore,
+            },
+            'Discord dropped: stale message',
+          );
+          return;
+        }
+      }
+
+      // Determine channel type and construct JID
+      const isDM =
+        msg.channel.type === ChannelType.DM ||
+        msg.channel.type === ChannelType.GroupDM;
+      const jid = isDM
+        ? `discord:dm:${msg.author.id}`
+        : `discord:${msg.channelId}`;
+
+      const senderName = msg.member?.displayName || msg.author.displayName || msg.author.username;
+      const chatName = isDM
+        ? senderName
+        : (msg.channel as TextChannel).name || `Discord #${msg.channelId}`;
+      const senderImId = msg.author.id;
+
+      // Store last message ID for reply context
+      lastMessageIds.set(jid, msgId);
+
+      // Register chat early (before mention gate) so that
+      // shouldProcessGroupMessage can find the group in registeredGroups.
+      // Without this, first-time guild channel messages are always dropped
+      // because shouldProcessGroupMessage returns false for unknown groups.
+      storeChatMetadata(jid, new Date().toISOString());
+      updateChatName(jid, chatName);
+      opts.onNewChat(jid, chatName);
+
+      // Guild channel: check group filtering (must check actual @mention first)
+      if (!isDM) {
+        const isBotMentioned = discordClient?.user
+          ? msg.mentions.has(discordClient.user)
+          : false;
+
+        // Gate 1: require_mention mode — only process if bot was @mentioned
+        if (opts.shouldProcessGroupMessage) {
+          const shouldProcess = opts.shouldProcessGroupMessage(jid, senderImId);
+          if (!shouldProcess && !isBotMentioned) {
+            logger.debug(
+              { jid },
+              'Discord group message dropped (mention required but bot not @mentioned)',
+            );
+            return;
+          }
+        }
+        // Gate 2: owner_mentioned mode — only process if sender is owner or bot was @mentioned
+        if (opts.isGroupOwnerMessage) {
+          const isOwner = opts.isGroupOwnerMessage(jid, senderImId);
+          if (!isOwner && !isBotMentioned) {
+            logger.debug(
+              { jid, senderImId },
+              'Discord group message dropped (owner_mentioned mode)',
+            );
+            return;
+          }
+        }
+      }
+
+      // Authorization check — before downloading any attachments to avoid
+      // resource consumption from unauthorized channels
+      if (opts.isChatAuthorized && !opts.isChatAuthorized(jid)) {
+        logger.debug({ jid }, 'Discord chat not authorized');
+        return;
+      }
+
+      // Extract content, stripping bot mentions
+      let content = msg.content;
+      if (!isDM && discordClient?.user) {
+        // Remove bot mention patterns: <@123456> or <@!123456>
+        content = content.replace(/<@!?\d+>/g, '').trim();
+      }
+
+      // Process attachments
+      let attachmentsJson: string | undefined;
+      const imageAttachments: { type: 'image'; data: string; mimeType: string }[] = [];
+
+      for (const attachment of msg.attachments.values()) {
+        const contentType = attachment.contentType || '';
+        const isImage = contentType.startsWith('image/');
+        const attachUrl = attachment.url;
+        const attachName = attachment.name || `file_${Date.now()}`;
+
+        if (isImage) {
+          // Download image for base64 and disk save
+          const buffer = await downloadAttachment(attachUrl);
+          if (buffer) {
+            const mimeType = detectImageMimeType(buffer) || contentType;
+
+            // Inline as base64 if under threshold
+            if (buffer.length <= IMAGE_MAX_BASE64_SIZE) {
+              imageAttachments.push({
+                type: 'image',
+                data: buffer.toString('base64'),
+                mimeType,
+              });
+            }
+
+            // Save to disk
+            const groupFolder = opts.resolveGroupFolder?.(jid);
+            if (groupFolder) {
+              try {
+                const ext = mimeType.split('/')[1] || 'jpg';
+                const filename = `img_${Date.now()}.${ext}`;
+                const savedPath = await saveDownloadedFile(
+                  groupFolder,
+                  'discord',
+                  filename,
+                  buffer,
+                );
+                if (!content) {
+                  content = `[图片: ${savedPath}]`;
+                } else {
+                  content += `\n[图片: ${savedPath}]`;
+                }
+              } catch (err) {
+                logger.warn({ err }, 'Failed to save Discord image to disk');
+                if (!content) content = '[图片]';
+              }
+            } else {
+              if (!content) content = '[图片]';
+            }
+          }
+        } else {
+          // Non-image file: download and save to workspace
+          const buffer = await downloadAttachment(attachUrl);
+          if (buffer) {
+            const groupFolder = opts.resolveGroupFolder?.(jid);
+            if (groupFolder) {
+              try {
+                const savedPath = await saveDownloadedFile(
+                  groupFolder,
+                  'discord',
+                  attachName,
+                  buffer,
+                );
+                if (!content) {
+                  content = `[文件: ${savedPath}]`;
+                } else {
+                  content += `\n[文件: ${savedPath}]`;
+                }
+              } catch (err) {
+                logger.warn({ err }, 'Failed to save Discord file to disk');
+                if (!content) content = `[文件: ${attachName}]`;
+              }
+            } else {
+              if (!content) content = `[文件: ${attachName}]`;
+            }
+          }
+        }
+      }
+
+      if (imageAttachments.length > 0) {
+        attachmentsJson = JSON.stringify(imageAttachments);
+      }
+
+      // Skip empty messages
+      if (!content && !attachmentsJson) {
+        return;
+      }
+
+      // Handle slash commands
+      const slashMatch = content.match(/^\/(\S+)(?:\s+(.*))?$/i);
+      if (slashMatch && opts.onCommand) {
+        const cmdBody = (
+          slashMatch[1] + (slashMatch[2] ? ' ' + slashMatch[2] : '')
+        ).trim();
+        try {
+          const reply = await opts.onCommand(jid, cmdBody, senderImId);
+          if (reply) {
+            const channel = await resolveChannel(jid);
+            if (channel) {
+              const chunks = splitDiscordChunks(reply);
+              for (const chunk of chunks) {
+                await channel.send(chunk);
+              }
+            }
+            return;
+          }
+        } catch (err) {
+          logger.error({ jid, err }, 'Discord slash command failed');
+          return;
+        }
+      }
+
+      // Route and store message
+      const agentRouting = opts.resolveEffectiveChatJid?.(jid);
+      const targetJid = agentRouting?.effectiveJid ?? jid;
+
+      const id = crypto.randomUUID();
+      const timestamp = new Date(msg.createdTimestamp).toISOString();
+      const senderId = `discord:${msg.author.id}`;
+      storeChatMetadata(targetJid, timestamp);
+      storeMessageDirect(id, targetJid, senderId, senderName, content, timestamp, false, {
+        attachments: attachmentsJson,
+        sourceJid: jid,
+      });
+
+      broadcastNewMessage(
+        targetJid,
+        {
+          id,
+          chat_jid: targetJid,
+          source_jid: jid,
+          sender: senderId,
+          sender_name: senderName,
+          content,
+          timestamp,
+          attachments: attachmentsJson,
+          is_from_me: false,
+        },
+        agentRouting?.agentId ?? undefined,
+      );
+
+      // Ack reaction: confirm receipt with eyes emoji
+      attachAckReaction(msg, jid).catch(() => {});
+
+      notifyNewImMessage();
+
+      if (agentRouting?.agentId) {
+        opts.onAgentMessage?.(jid, agentRouting.agentId);
+        logger.info(
+          { jid, effectiveJid: targetJid, agentId: agentRouting.agentId },
+          'Discord message routed to agent',
+        );
+      } else {
+        logger.info(
+          { jid, sender: senderName, msgId },
+          'Discord message stored',
+        );
+      }
+    } catch (err) {
+      logger.error({ err }, 'Error handling Discord message');
+    }
+  }
+
+  // ─── Connection Interface ─────────────────────────────────
+
+  async function sendMessage(
+    chatId: string,
+    text: string,
+    localImagePaths?: string[],
+  ): Promise<void> {
+    const channel = await resolveChannel(chatId);
+    if (!channel) {
+      logger.error({ chatId }, 'Discord sendMessage: failed to resolve channel');
+      return;
+    }
+
+    const chunks = splitDiscordChunks(text);
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      // Attach images to the first chunk only
+      if (i === 0 && localImagePaths && localImagePaths.length > 0) {
+        const files: AttachmentBuilder[] = [];
+        for (const imgPath of localImagePaths) {
+          try {
+            const buffer = await fs.readFile(imgPath);
+            const name = path.basename(imgPath);
+            files.push(new AttachmentBuilder(buffer, { name }));
+          } catch (err) {
+            logger.warn(
+              { err, imgPath },
+              'Discord sendMessage: failed to read local image',
+            );
+          }
+        }
+        if (files.length > 0) {
+          await channel.send({ content: chunk, files });
+        } else {
+          await channel.send(chunk);
+        }
+      } else {
+        await channel.send(chunk);
+      }
+    }
+  }
+
+  const connection: DiscordConnection = {
+    async connect(opts: DiscordConnectOpts): Promise<boolean> {
+      if (!config.botToken) {
+        logger.info('Discord botToken not configured, skipping');
+        return false;
+      }
+
+      stopping = false;
+      readyFired = false;
+
+      try {
+        discordClient = new Client({
+          intents: [
+            GatewayIntentBits.Guilds,
+            GatewayIntentBits.GuildMessages,
+            GatewayIntentBits.DirectMessages,
+            GatewayIntentBits.MessageContent,
+            GatewayIntentBits.GuildMessageReactions,
+          ],
+          partials: [Partials.Channel, Partials.Message],
+        });
+
+        // Ready event
+        discordClient.once(Events.ClientReady, async (readyClient) => {
+          logger.info(
+            { botTag: readyClient.user.tag },
+            'Discord bot connected',
+          );
+          readyFired = true;
+          opts.onReady?.();
+
+          // Register HappyClaw slash commands as Discord Application Commands
+          try {
+            await readyClient.application.commands.set([
+              { name: 'clear', description: '清除当前对话的会话上下文' },
+              { name: 'list', description: '查看所有工作区和对话列表' },
+              { name: 'status', description: '查看当前工作区/对话状态' },
+              { name: 'recall', description: '总结最近的对话内容' },
+              {
+                name: 'require_mention',
+                description: '切换群聊响应模式（需要 @Bot 才响应）',
+                options: [{
+                  name: 'enabled',
+                  description: 'true 或 false',
+                  type: 3, // STRING
+                  required: true,
+                  choices: [
+                    { name: 'true - 需要 @Bot', value: 'true' },
+                    { name: 'false - 全量响应', value: 'false' },
+                  ],
+                }],
+              },
+            ]);
+            // Clear guild-level commands (remove any stale ones from other apps)
+            for (const guild of readyClient.guilds.cache.values()) {
+              try { await guild.commands.set([]); } catch {}
+            }
+            logger.info('Discord application commands registered');
+          } catch (err: any) {
+            logger.warn({ err: err.message }, 'Failed to register application commands');
+          }
+        });
+
+        // Slash command interactions (Discord Application Commands)
+        discordClient.on(Events.InteractionCreate, async (interaction) => {
+          if (!interaction.isChatInputCommand()) return;
+          if (stopping) return;
+
+          const isDM = !interaction.guildId;
+          const jid = isDM
+            ? `discord:dm:${interaction.user.id}`
+            : `discord:${interaction.channelId}`;
+
+          // Build command string matching HappyClaw's text command format
+          let cmdBody = interaction.commandName;
+          const enabledOpt = interaction.options.getString('enabled');
+          if (enabledOpt) cmdBody += ' ' + enabledOpt;
+
+          try {
+            await interaction.deferReply();
+            const reply = await opts.onCommand?.(jid, cmdBody, interaction.user.id);
+            if (reply) {
+              // Discord interaction replies have 2000 char limit
+              const truncated = reply.length > 2000 ? reply.slice(0, 1997) + '...' : reply;
+              await interaction.editReply(truncated);
+            } else {
+              await interaction.editReply('命令已执行');
+            }
+          } catch (err: any) {
+            logger.error({ jid, cmd: cmdBody, err: err.message }, 'Discord slash command failed');
+            try {
+              await interaction.editReply('命令执行失败');
+            } catch {}
+          }
+        });
+
+        // Message create event — use raw event as primary to ensure DM delivery,
+        // then resolve the Message object from cache or API
+        discordClient.on('raw', async (packet: { t: string; d: any }) => {
+          if (packet.t !== 'MESSAGE_CREATE') return;
+          if (stopping) return;
+          try {
+            const data = packet.d;
+            // Skip bot messages early (before resolving full Message)
+            if (data.author?.bot) return;
+
+            // Try to get the Message from the discord.js cache
+            const channelId = data.channel_id;
+            let channel = discordClient!.channels.cache.get(channelId) ?? undefined;
+            if (!channel) {
+              try {
+                channel = (await discordClient!.channels.fetch(channelId)) ?? undefined;
+              } catch {
+                logger.warn({ channelId }, 'Discord: could not fetch channel for raw MESSAGE_CREATE');
+                return;
+              }
+            }
+            if (!channel || !channel.isTextBased()) return;
+
+            let msg: Message;
+            try {
+              msg = await (channel as TextBasedChannel).messages.fetch(data.id);
+            } catch {
+              logger.warn({ msgId: data.id }, 'Discord: could not fetch message from raw event');
+              return;
+            }
+
+            await handleMessage(msg, opts);
+          } catch (err) {
+            logger.error({ err }, 'Error in Discord raw message handler');
+          }
+        });
+
+        // Guild create (bot added to a new server) — log only, don't register
+        // phantom JID since our JIDs are channel-level (discord:{channelId}),
+        // not guild-level. Channels will auto-register on first message.
+        discordClient.on(Events.GuildCreate, (guild) => {
+          logger.info(
+            { guildId: guild.id, guildName: guild.name },
+            'Discord bot added to guild (channels auto-register on first message)',
+          );
+        });
+
+        // Guild delete (bot removed from a server) — log only
+        discordClient.on(Events.GuildDelete, (guild) => {
+          logger.info(
+            { guildId: guild.id },
+            'Discord bot removed from guild',
+          );
+        });
+
+        // Login and wait for ClientReady before returning
+        // (login() resolves before ClientReady fires, so isConnected()
+        // would return false if we returned immediately after login)
+        const readyPromise = new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            reject(new Error('Discord ClientReady timeout (15s)'));
+          }, 15000);
+          discordClient!.once(Events.ClientReady, () => {
+            clearTimeout(timeout);
+            resolve();
+          });
+        });
+        await discordClient.login(config.botToken);
+        await readyPromise;
+        return true;
+      } catch (err) {
+        logger.error({ err }, 'Discord initial connection failed');
+        discordClient = null;
+        return false;
+      }
+    },
+
+    async disconnect(): Promise<void> {
+      stopping = true;
+      if (discordClient) {
+        try {
+          discordClient.destroy();
+        } catch (err) {
+          logger.debug({ err }, 'Error disconnecting Discord client');
+        }
+        discordClient = null;
+      }
+      readyFired = false;
+      msgCache.clear();
+      lastMessageIds.clear();
+      ackReactionByChat.clear();
+      logger.info('Discord bot disconnected');
+    },
+
+    sendMessage,
+
+    async sendImage(
+      chatId: string,
+      imageBuffer: Buffer,
+      mimeType: string,
+      caption?: string,
+      fileName?: string,
+    ): Promise<void> {
+      const channel = await resolveChannel(chatId);
+      if (!channel) {
+        logger.error({ chatId }, 'Discord sendImage: failed to resolve channel');
+        throw new Error(`Discord sendImage: unknown chat ${chatId}`);
+      }
+
+      const fname = fileName || `image.${mimeType.split('/')[1] || 'png'}`;
+      const attachment = new AttachmentBuilder(imageBuffer, { name: fname });
+
+      if (caption) {
+        await channel.send({ content: caption, files: [attachment] });
+      } else {
+        await channel.send({ files: [attachment] });
+      }
+      logger.info({ chatId, fileName: fname }, 'Discord image sent');
+    },
+
+    async sendFile(
+      chatId: string,
+      filePath: string,
+      fileName: string,
+    ): Promise<void> {
+      const channel = await resolveChannel(chatId);
+      if (!channel) {
+        logger.error({ chatId }, 'Discord sendFile: failed to resolve channel');
+        throw new Error(`Discord sendFile: unknown chat ${chatId}`);
+      }
+
+      let fileBuffer: Buffer;
+      try {
+        fileBuffer = await fs.readFile(filePath);
+      } catch (err) {
+        logger.error(
+          { err, filePath },
+          'Discord sendFile: failed to read file',
+        );
+        throw new Error(`Discord sendFile: failed to read file ${filePath}`);
+      }
+
+      if (fileBuffer.length === 0) {
+        throw new Error('Discord sendFile: empty file');
+      }
+
+      const attachment = new AttachmentBuilder(fileBuffer, { name: fileName });
+      await channel.send({ files: [attachment] });
+      logger.info({ chatId, fileName }, 'Discord file sent');
+    },
+
+    async setTyping(chatId: string, isTyping: boolean): Promise<void> {
+      if (!isTyping) return;
+      try {
+        const channel = await resolveChannel(chatId);
+        if (channel) {
+          await channel.sendTyping();
+        }
+      } catch (err) {
+        logger.debug({ err, chatId }, 'Discord setTyping failed');
+      }
+    },
+
+    clearAckReaction(chatId: string): void {
+      recallAckReaction(chatId).catch(() => {});
+    },
+
+    isConnected(): boolean {
+      return discordClient !== null && !stopping && readyFired;
+    },
+
+    getLastMessageId(chatId: string): string | undefined {
+      return lastMessageIds.get(chatId);
+    },
+
+    async createStreamingSession(
+      chatId: string,
+      onCardCreated?: (messageId: string) => void,
+    ): Promise<
+      | import('./discord-streaming-edit.js').DiscordStreamingEditController
+      | undefined
+    > {
+      const parsed = parseChatId(chatId);
+      if (!parsed || !discordClient) return undefined;
+
+      const channel =
+        parsed.type === 'dm'
+          ? await (async () => {
+              try {
+                const user = await discordClient!.users.fetch(parsed.id);
+                return await user.createDM();
+              } catch {
+                return null;
+              }
+            })()
+          : await (async () => {
+              try {
+                const ch = await discordClient!.channels.fetch(parsed.id);
+                if (ch?.isTextBased()) return ch as TextChannel | NewsChannel;
+                return null;
+              } catch {
+                return null;
+              }
+            })();
+
+      if (!channel) return undefined;
+
+      const { DiscordStreamingEditController } = await import(
+        './discord-streaming-edit.js'
+      );
+      return new DiscordStreamingEditController(
+        channel as TextChannel | DMChannel,
+        {
+          onCardCreated,
+          fallbackSend: (text: string) => sendMessage(chatId, text),
+        },
+      );
+    },
+  };
+
+  return connection;
+}

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -29,6 +29,11 @@ import {
   type DingTalkConnection,
   type DingTalkConnectionConfig,
 } from './dingtalk.js';
+import {
+  createDiscordConnection,
+  type DiscordConnection,
+  type DiscordConnectionConfig,
+} from './discord.js';
 import { logger } from './logger.js';
 import type { FeishuMessageMeta } from './types.js';
 import {
@@ -36,12 +41,14 @@ import {
   type StreamingCardOptions,
 } from './feishu-streaming-card.js';
 import type { DingTalkStreamingCardController } from './dingtalk-streaming-card.js';
+import type { DiscordStreamingEditController } from './discord-streaming-edit.js';
 import { CHANNEL_PREFIXES } from './channel-prefixes.js';
 
-/** Union type for any streaming card controller (Feishu or DingTalk) */
+/** Union type for any streaming card controller (Feishu, DingTalk, or Discord) */
 export type StreamingSession =
   | StreamingCardController
-  | DingTalkStreamingCardController;
+  | DingTalkStreamingCardController
+  | DiscordStreamingEditController;
 
 // ─── Unified Interface ──────────────────────────────────────────
 
@@ -644,5 +651,105 @@ export function createDingTalkChannel(
     },
   };
 
+  return channel;
+}
+
+// ─── Discord Adapter ────────────────────────────────────────────
+
+export function createDiscordChannel(
+  config: DiscordConnectionConfig,
+  opts?: { streamingMode?: 'edit' | 'off' },
+): IMChannel {
+  const streamingEnabled = opts?.streamingMode === 'edit';
+  let inner: DiscordConnection | null = null;
+  let typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
+
+  const channel: IMChannel = {
+    channelType: 'discord',
+
+    async connect(opts: IMChannelConnectOpts): Promise<boolean> {
+      inner = createDiscordConnection(config);
+      try {
+        const ok = await inner.connect({
+          onReady: opts.onReady,
+          onNewChat: opts.onNewChat,
+          isChatAuthorized: opts.isChatAuthorized,
+          ignoreMessagesBefore: opts.ignoreMessagesBefore,
+          onCommand: opts.onCommand,
+          resolveGroupFolder: opts.resolveGroupFolder,
+          resolveEffectiveChatJid: opts.resolveEffectiveChatJid,
+          onAgentMessage: opts.onAgentMessage,
+          onBotAddedToGroup: opts.onBotAddedToGroup,
+          onBotRemovedFromGroup: opts.onBotRemovedFromGroup,
+          shouldProcessGroupMessage: opts.shouldProcessGroupMessage,
+          isGroupOwnerMessage: opts.isGroupOwnerMessage,
+        });
+        return ok;
+      } catch (err) {
+        logger.warn({ err }, 'Discord channel connect failed');
+        inner = null;
+        return false;
+      }
+    },
+
+    async disconnect(): Promise<void> {
+      // Clear all typing intervals
+      for (const [, interval] of typingIntervals) clearInterval(interval);
+      typingIntervals.clear();
+      if (inner) {
+        await inner.disconnect();
+        inner = null;
+      }
+    },
+
+    async sendMessage(chatId, text, localImagePaths?) {
+      if (!inner) return;
+      await inner.sendMessage(chatId, text, localImagePaths);
+    },
+
+    async sendFile(chatId, filePath, fileName) {
+      if (!inner) return;
+      await inner.sendFile(chatId, filePath, fileName);
+    },
+
+    async sendImage(chatId, imageBuffer, mimeType, caption?, fileName?) {
+      if (!inner) return;
+      await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
+    },
+
+    async setTyping(chatId, isTyping) {
+      if (!inner) return;
+      if (isTyping) {
+        // Discord typing indicator lasts 10s, repeat every 9s
+        if (!typingIntervals.has(chatId)) {
+          await inner.setTyping(chatId, true);
+          const interval = setInterval(async () => {
+            try { if (inner) await inner.setTyping(chatId, true); } catch {}
+          }, 9000);
+          typingIntervals.set(chatId, interval);
+        }
+      } else {
+        const interval = typingIntervals.get(chatId);
+        if (interval) {
+          clearInterval(interval);
+          typingIntervals.delete(chatId);
+        }
+      }
+    },
+
+    clearAckReaction(chatId) {
+      inner?.clearAckReaction(chatId);
+    },
+
+    isConnected() {
+      return inner?.isConnected() ?? false;
+    },
+
+    async createStreamingSession(chatId, onCardCreated?) {
+      if (!streamingEnabled) return undefined;
+      if (!inner?.createStreamingSession) return undefined;
+      return inner.createStreamingSession(chatId, onCardCreated);
+    },
+  };
   return channel;
 }

--- a/src/im-downloader.ts
+++ b/src/im-downloader.ts
@@ -20,7 +20,7 @@ export class FileTooLargeError extends Error {
  */
 export async function saveDownloadedFile(
   groupFolder: string,
-  channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk',
+  channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
   originalFilename: string,
   buffer: Buffer,
 ): Promise<string> {

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -15,12 +15,14 @@ import {
   createQQChannel,
   createWeChatChannel,
   createDingTalkChannel,
+  createDiscordChannel,
 } from './im-channel.js';
 import { parseFeishuRouteTarget, type FeishuConnectionConfig } from './feishu.js';
 import type { TelegramConnectionConfig } from './telegram.js';
 import type { QQConnectionConfig } from './qq.js';
 import type { WeChatConnectionConfig } from './wechat.js';
 import type { DingTalkConnectionConfig } from './dingtalk.js';
+import type { DiscordConnectionConfig } from './discord.js';
 import type { StreamingSession } from './im-channel.js';
 import { getRegisteredGroup, getJidsByFolder } from './db.js';
 import { getUserDingTalkConfig } from './runtime-config.js';
@@ -63,6 +65,12 @@ export interface DingTalkConnectConfig {
   clientId: string;
   clientSecret: string;
   enabled?: boolean;
+}
+
+export interface DiscordConnectConfig {
+  botToken: string;
+  enabled?: boolean;
+  streamingMode?: 'edit' | 'off';
 }
 
 export interface ConnectFeishuOptions {
@@ -252,7 +260,7 @@ class IMConnectionManager {
     onCardCreated?: (messageId: string) => void,
   ): Promise<StreamingSession | undefined> {
     const channelType = getChannelType(jid);
-    if (channelType !== 'feishu' && channelType !== 'dingtalk')
+    if (channelType !== 'feishu' && channelType !== 'dingtalk' && channelType !== 'discord')
       return undefined;
 
     // Check DingTalk streaming mode: if text mode, skip streaming session creation
@@ -588,6 +596,51 @@ class IMConnectionManager {
   }
 
   /**
+   * Connect a Discord instance for a specific user.
+   */
+  async connectUserDiscord(
+    userId: string,
+    config: DiscordConnectConfig,
+    onNewChat: (chatJid: string, chatName: string) => void,
+    options?: {
+      ignoreMessagesBefore?: number;
+      isChatAuthorized?: (jid: string) => boolean;
+      onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+      resolveGroupFolder?: (jid: string) => string | undefined;
+      resolveEffectiveChatJid?: (chatJid: string) => { effectiveJid: string; agentId: string | null } | null;
+      onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+      onBotAddedToGroup?: (chatJid: string, chatName: string) => void;
+      onBotRemovedFromGroup?: (chatJid: string) => void;
+      shouldProcessGroupMessage?: (chatJid: string, senderImId?: string) => boolean;
+      isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
+    },
+  ): Promise<boolean> {
+    if (!config.botToken) return false;
+    const channel = createDiscordChannel(
+      { botToken: config.botToken },
+      { streamingMode: config.streamingMode ?? 'off' },
+    );
+    return this.connectChannel(userId, 'discord', channel, {
+      onReady: () => logger.info({ userId }, 'User Discord bot connected'),
+      onNewChat,
+      ignoreMessagesBefore: options?.ignoreMessagesBefore,
+      isChatAuthorized: options?.isChatAuthorized,
+      onCommand: options?.onCommand,
+      resolveGroupFolder: options?.resolveGroupFolder,
+      resolveEffectiveChatJid: options?.resolveEffectiveChatJid,
+      onAgentMessage: options?.onAgentMessage,
+      onBotAddedToGroup: options?.onBotAddedToGroup,
+      onBotRemovedFromGroup: options?.onBotRemovedFromGroup,
+      shouldProcessGroupMessage: options?.shouldProcessGroupMessage,
+      isGroupOwnerMessage: options?.isGroupOwnerMessage,
+    });
+  }
+
+  async disconnectUserDiscord(userId: string): Promise<void> {
+    await this.disconnectChannel(userId, 'discord');
+  }
+
+  /**
    * Send a message to a Feishu chat.
    * @deprecated Use sendMessage(jid, text) which auto-routes.
    */
@@ -700,6 +753,11 @@ class IMConnectionManager {
   isDingTalkConnected(userId: string): boolean {
     const conn = this.connections.get(userId);
     return conn?.channels.get('dingtalk')?.isConnected() ?? false;
+  }
+
+  isDiscordConnected(userId: string): boolean {
+    const conn = this.connections.get(userId);
+    return conn?.channels.get('discord')?.isConnected() ?? false;
   }
 
   /** Get the Feishu channel for a user (for direct access like syncGroups) */

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ import {
   getUserQQConfig,
   getUserWeChatConfig,
   getUserDingTalkConfig,
+  getUserDiscordConfig,
   getSystemSettings,
   saveUserFeishuConfig,
   saveUserTelegramConfig,
@@ -133,6 +134,7 @@ import type {
   QQConnectConfig,
   WeChatConnectConfig,
   DingTalkConnectConfig,
+  DiscordConnectConfig,
 } from './im-manager.js';
 import { GroupQueue } from './group-queue.js';
 import { startSchedulerLoop, triggerTaskNow } from './task-scheduler.js';
@@ -6864,6 +6866,7 @@ async function connectUserIMChannels(
   qqConfig?: QQConnectConfig | null,
   wechatConfig?: WeChatConnectConfig | null,
   dingtalkConfig?: DingTalkConnectConfig | null,
+  discordConfig?: DiscordConnectConfig | null,
   ignoreMessagesBefore?: number,
 ): Promise<{
   feishu: boolean;
@@ -6871,6 +6874,7 @@ async function connectUserIMChannels(
   qq: boolean;
   wechat: boolean;
   dingtalk: boolean;
+  discord: boolean;
 }> {
   const onNewChat = buildOnNewChat(userId, homeFolder);
   const resolveGroupFolder = (chatJid: string): string | undefined => {
@@ -6886,6 +6890,7 @@ async function connectUserIMChannels(
   let qq = false;
   let wechat = false;
   let dingtalk = false;
+  let discord = false;
 
   if (
     feishuConfig &&
@@ -7000,7 +7005,30 @@ async function connectUserIMChannels(
     );
   }
 
-  return { feishu, telegram, qq, wechat, dingtalk };
+  if (
+    discordConfig &&
+    discordConfig.enabled !== false &&
+    discordConfig.botToken
+  ) {
+    discord = await imManager.connectUserDiscord(
+      userId,
+      discordConfig,
+      onNewChat,
+      {
+        ignoreMessagesBefore,
+        onCommand: handleCommand,
+        resolveGroupFolder,
+        resolveEffectiveChatJid,
+        onAgentMessage,
+        onBotAddedToGroup,
+        onBotRemovedFromGroup,
+        shouldProcessGroupMessage,
+        isGroupOwnerMessage,
+      },
+    );
+  }
+
+  return { feishu, telegram, qq, wechat, dingtalk, discord };
 }
 
 function movePathWithFallback(src: string, dst: string): void {
@@ -7406,7 +7434,7 @@ async function main(): Promise<void> {
   // Reload a per-user IM channel (hot-reload on user-im config save)
   const reloadUserIMConfig = async (
     userId: string,
-    channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk',
+    channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
   ): Promise<boolean> => {
     const homeGroup = getUserHomeGroup(userId);
     if (!homeGroup) {
@@ -7546,6 +7574,35 @@ async function main(): Promise<void> {
       }
       logger.info({ userId }, 'User DingTalk channel disabled via hot-reload');
       return false;
+    } else if (channel === 'discord') {
+      await imManager.disconnectUserDiscord(userId);
+      const config = getUserDiscordConfig(userId);
+      if (config && config.enabled !== false && config.botToken) {
+        const connected = await imManager.connectUserDiscord(
+          userId,
+          config,
+          onNewChat,
+          {
+            ignoreMessagesBefore,
+            onCommand: handleCommand,
+            resolveGroupFolder: (chatJid: string) =>
+              resolveEffectiveFolder(chatJid),
+            resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
+            onAgentMessage: buildOnAgentMessage(),
+            onBotAddedToGroup: buildOnNewChat(userId, homeFolder),
+            onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
+            shouldProcessGroupMessage,
+            isGroupOwnerMessage,
+          },
+        );
+        logger.info(
+          { userId, connected },
+          'User Discord connection hot-reloaded',
+        );
+        return connected;
+      }
+      logger.info({ userId }, 'User Discord channel disabled via hot-reload');
+      return false;
     } else {
       // WeChat
       await imManager.disconnectUserWeChat(userId);
@@ -7616,6 +7673,8 @@ async function main(): Promise<void> {
       imManager.isWeChatConnected(userId),
     isUserDingTalkConnected: (userId: string) =>
       imManager.isDingTalkConnected(userId),
+    isUserDiscordConnected: (userId: string) =>
+      imManager.isDiscordConnected(userId),
     processAgentConversation,
     getFeishuChatInfo: (userId: string, chatId: string) =>
       imManager.getFeishuChatInfo(userId, chatId),
@@ -7937,6 +7996,7 @@ async function main(): Promise<void> {
     const userQQ = getUserQQConfig(user.id);
     const userWeChat = getUserWeChatConfig(user.id);
     const userDingTalk = getUserDingTalkConfig(user.id);
+    const userDiscord = getUserDiscordConfig(user.id);
 
     // Determine effective Feishu config: per-user > global (admin only)
     let effectiveFeishu: FeishuConnectConfig | null = null;
@@ -8008,12 +8068,23 @@ async function main(): Promise<void> {
       };
     }
 
+    // Determine effective Discord config: per-user only (no global fallback)
+    let effectiveDiscord: DiscordConnectConfig | null = null;
+    if (userDiscord && userDiscord.botToken) {
+      effectiveDiscord = {
+        botToken: userDiscord.botToken,
+        enabled: userDiscord.enabled,
+        streamingMode: userDiscord.streamingMode,
+      };
+    }
+
     if (
       !effectiveFeishu &&
       !effectiveTelegram &&
       !effectiveQQ &&
       !effectiveWeChat &&
-      !effectiveDingTalk
+      !effectiveDingTalk &&
+      !effectiveDiscord
     )
       continue;
 
@@ -8026,6 +8097,7 @@ async function main(): Promise<void> {
         effectiveQQ,
         effectiveWeChat,
         effectiveDingTalk,
+        effectiveDiscord,
         Date.now(),
       );
       if (result.feishu) anyFeishuConnected = true;
@@ -8037,6 +8109,7 @@ async function main(): Promise<void> {
           qq: result.qq,
           wechat: result.wechat,
           dingtalk: result.dingtalk,
+          discord: result.discord,
         },
         'User IM channels connected',
       );

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -24,6 +24,7 @@ import {
   QQConfigSchema,
   WeChatConfigSchema,
   DingTalkConfigSchema,
+  DiscordConfigSchema,
   RegistrationConfigSchema,
   AppearanceConfigSchema,
   SystemSettingsSchema,
@@ -72,6 +73,8 @@ import {
   saveUserWeChatConfig,
   getUserDingTalkConfig,
   saveUserDingTalkConfig,
+  getUserDiscordConfig,
+  saveUserDiscordConfig,
   updateAllSessionCredentials,
 } from '../runtime-config.js';
 import type {
@@ -101,7 +104,7 @@ const configRoutes = new Hono<{ Variables: Variables }>();
  */
 function countOtherEnabledImChannels(
   userId: string,
-  excludeChannel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk',
+  excludeChannel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
 ): number {
   let count = 0;
   if (excludeChannel !== 'feishu' && getUserFeishuConfig(userId)?.enabled)
@@ -112,6 +115,8 @@ function countOtherEnabledImChannels(
     count++;
   if (excludeChannel !== 'qq' && getUserQQConfig(userId)?.enabled) count++;
   if (excludeChannel !== 'dingtalk' && getUserDingTalkConfig(userId)?.enabled)
+    count++;
+  if (excludeChannel !== 'discord' && getUserDiscordConfig(userId)?.enabled)
     count++;
   return count;
 }
@@ -1295,6 +1300,7 @@ configRoutes.get('/user-im/status', authMiddleware, (c) => {
     qq: deps?.isUserQQConnected?.(user.id) ?? false,
     wechat: deps?.isUserWeChatConnected?.(user.id) ?? false,
     dingtalk: deps?.isUserDingTalkConnected?.(user.id) ?? false,
+    discord: deps?.isUserDiscordConnected?.(user.id) ?? false,
   });
 });
 
@@ -2034,6 +2040,166 @@ configRoutes.post('/user-im/dingtalk/test', authMiddleware, async (c) => {
     const message =
       err instanceof Error ? err.message : 'Connection test failed';
     logger.warn({ err }, 'DingTalk connection test failed');
+    return c.json({ error: message }, 400);
+  }
+});
+
+// ─── Per-user Discord IM config ──────────────────────────────────
+
+configRoutes.get('/user-im/discord', authMiddleware, (c) => {
+  const user = c.get('user') as AuthUser;
+  try {
+    const config = getUserDiscordConfig(user.id);
+    const connected = deps?.isUserDiscordConnected?.(user.id) ?? false;
+    if (!config) {
+      return c.json({
+        hasBotToken: false,
+        botTokenMasked: null,
+        enabled: false,
+        streamingMode: 'off',
+        updatedAt: null,
+        connected,
+      });
+    }
+    return c.json({
+      hasBotToken: !!config.botToken,
+      botTokenMasked: config.botToken
+        ? config.botToken.slice(0, 4) + '***' + config.botToken.slice(-4)
+        : null,
+      enabled: config.enabled ?? false,
+      streamingMode: config.streamingMode ?? 'off',
+      updatedAt: config.updatedAt,
+      connected,
+    });
+  } catch (err) {
+    logger.error({ err }, 'Failed to load user Discord config');
+    return c.json({ error: 'Failed to load Discord config' }, 500);
+  }
+});
+
+configRoutes.put('/user-im/discord', authMiddleware, async (c) => {
+  const user = c.get('user') as AuthUser;
+  const body = await c.req.json().catch(() => ({}));
+  const validation = DiscordConfigSchema.safeParse(body);
+  if (!validation.success) {
+    return c.json(
+      { error: 'Invalid request body', details: validation.error.format() },
+      400,
+    );
+  }
+
+  // Billing: check IM channel limit when enabling
+  if (validation.data.enabled === true && isBillingEnabled()) {
+    const current = getUserDiscordConfig(user.id);
+    if (!current?.enabled) {
+      const limit = checkImChannelLimit(
+        user.id,
+        user.role,
+        countOtherEnabledImChannels(user.id, 'discord'),
+      );
+      if (!limit.allowed) {
+        return c.json({ error: limit.reason }, 403);
+      }
+    }
+  }
+
+  const current = getUserDiscordConfig(user.id);
+  const next = {
+    botToken: current?.botToken || '',
+    enabled: current?.enabled ?? true,
+    streamingMode: current?.streamingMode ?? ('off' as const),
+  };
+
+  if (typeof validation.data.botToken === 'string') {
+    const token = validation.data.botToken.trim();
+    if (token) next.botToken = token;
+  } else if (validation.data.clearBotToken === true) {
+    next.botToken = '';
+  }
+  if (typeof validation.data.enabled === 'boolean') {
+    next.enabled = validation.data.enabled;
+  } else if (!current && next.botToken) {
+    next.enabled = true;
+  }
+  if (typeof validation.data.streamingMode === 'string') {
+    next.streamingMode = validation.data.streamingMode;
+  }
+
+  try {
+    const saved = saveUserDiscordConfig(user.id, next);
+
+    // Hot-reload: reconnect user's Discord channel
+    if (deps?.reloadUserIMConfig) {
+      try {
+        await deps.reloadUserIMConfig(user.id, 'discord');
+      } catch (err) {
+        logger.warn({ err, userId: user.id }, 'Failed to hot-reload Discord');
+      }
+    }
+
+    const connected = deps?.isUserDiscordConnected?.(user.id) ?? false;
+    return c.json({
+      hasBotToken: !!saved.botToken,
+      botTokenMasked: saved.botToken
+        ? saved.botToken.slice(0, 4) + '***' + saved.botToken.slice(-4)
+        : null,
+      enabled: saved.enabled ?? false,
+      streamingMode: saved.streamingMode ?? 'off',
+      updatedAt: saved.updatedAt,
+      connected,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid config';
+    logger.warn({ err }, 'Invalid Discord config');
+    return c.json({ error: message }, 400);
+  }
+});
+
+configRoutes.post('/user-im/discord/test', authMiddleware, async (c) => {
+  const user = c.get('user') as AuthUser;
+  const config = getUserDiscordConfig(user.id);
+
+  if (!config?.botToken) {
+    return c.json({ error: 'Discord Bot Token not configured' }, 400);
+  }
+
+  try {
+    // Test by creating a temporary Client and logging in
+    const { Client, GatewayIntentBits } = await import('discord.js');
+    const testClient = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+    const result = await Promise.race([
+      new Promise<{ success: true; bot_username: string; bot_name: string }>(
+        (resolve, reject) => {
+          testClient.once('ready', () => {
+            const username = testClient.user?.username || 'unknown';
+            const name = testClient.user?.displayName || username;
+            testClient.destroy();
+            resolve({ success: true, bot_username: username, bot_name: name });
+          });
+          testClient.once('error', (err) => {
+            testClient.destroy();
+            reject(err);
+          });
+          testClient.login(config.botToken).catch((err) => {
+            testClient.destroy();
+            reject(err);
+          });
+        },
+      ),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => {
+          testClient.destroy();
+          reject(new Error('Connection test timed out (10s)'));
+        }, 10000),
+      ),
+    ]);
+
+    return c.json(result);
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Connection test failed';
+    logger.warn({ err }, 'Discord connection test failed');
     return c.json({ error: message }, 400);
   }
 });

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3048,6 +3048,25 @@ interface DingTalkSecretPayload {
   clientSecret: string;
 }
 
+export interface UserDiscordConfig {
+  botToken: string;
+  enabled?: boolean;
+  streamingMode?: 'edit' | 'off';
+  updatedAt: string | null;
+}
+
+interface StoredDiscordProviderConfigV1 {
+  version: 1;
+  enabled?: boolean;
+  streamingMode?: 'edit' | 'off';
+  updatedAt: string;
+  secret: EncryptedSecrets;
+}
+
+interface DiscordSecretPayload {
+  botToken: string;
+}
+
 interface StoredQQProviderConfigV1 {
   version: 1;
   appId: string;
@@ -3376,6 +3395,62 @@ export function saveUserDingTalkConfig(
   const dir = userImDir(userId);
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, 'dingtalk.json');
+  const tmp = `${filePath}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmp, filePath);
+  return normalized;
+}
+
+// ========== Discord User IM Config ==========
+
+export function getUserDiscordConfig(
+  userId: string,
+): UserDiscordConfig | null {
+  const filePath = path.join(userImDir(userId), 'discord.json');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (parsed.version !== 1) return null;
+
+    const stored = parsed as unknown as StoredDiscordProviderConfigV1;
+    const secret = decryptChannelSecret<DiscordSecretPayload>(stored.secret);
+    return {
+      botToken: secret.botToken,
+      enabled: stored.enabled,
+      streamingMode: stored.streamingMode === 'edit' ? 'edit' : 'off',
+      updatedAt: stored.updatedAt || null,
+    };
+  } catch (err) {
+    logger.warn({ err, userId }, 'Failed to read user Discord config');
+    return null;
+  }
+}
+
+export function saveUserDiscordConfig(
+  userId: string,
+  next: Omit<UserDiscordConfig, 'updatedAt'>,
+): UserDiscordConfig {
+  const normalized: UserDiscordConfig = {
+    botToken: normalizeSecret(next.botToken, 'botToken'),
+    enabled: next.enabled,
+    streamingMode: next.streamingMode === 'edit' ? 'edit' : 'off',
+    updatedAt: new Date().toISOString(),
+  };
+
+  const payload: StoredDiscordProviderConfigV1 = {
+    version: 1,
+    enabled: normalized.enabled,
+    streamingMode: normalized.streamingMode,
+    updatedAt: normalized.updatedAt || new Date().toISOString(),
+    secret: encryptChannelSecret<DiscordSecretPayload>({
+      botToken: normalized.botToken,
+    }),
+  };
+
+  const dir = userImDir(userId);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, 'discord.json');
   const tmp = `${filePath}.tmp`;
   fs.writeFileSync(tmp, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
   fs.renameSync(tmp, filePath);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,7 +17,7 @@ export const TaskPatchSchema = z.object({
   status: z.enum(['active', 'paused']).optional(),
   next_run: z.string().optional(),
   notify_channels: z
-    .array(z.enum(['feishu', 'telegram', 'qq', 'wechat', 'dingtalk']))
+    .array(z.enum(['feishu', 'telegram', 'qq', 'wechat', 'dingtalk', 'discord']))
     .nullable()
     .optional(),
 });
@@ -39,7 +39,7 @@ export const TaskCreateSchema = z
     execution_mode: z.enum(['host', 'container']).optional(),
     script_command: z.string().max(4096).optional(),
     notify_channels: z
-      .array(z.enum(['feishu', 'telegram', 'qq', 'wechat', 'dingtalk']))
+      .array(z.enum(['feishu', 'telegram', 'qq', 'wechat', 'dingtalk', 'discord']))
       .nullable()
       .optional(),
   })
@@ -717,6 +717,22 @@ export const DingTalkConfigSchema = z
       typeof data.clientId === 'string' ||
       typeof data.clientSecret === 'string' ||
       data.clearClientSecret === true ||
+      typeof data.enabled === 'boolean' ||
+      typeof data.streamingMode === 'string',
+    { message: 'At least one config field must be provided' },
+  );
+
+export const DiscordConfigSchema = z
+  .object({
+    botToken: z.string().max(2000).optional(),
+    clearBotToken: z.boolean().optional(),
+    enabled: z.boolean().optional(),
+    streamingMode: z.enum(['edit', 'off']).optional(),
+  })
+  .refine(
+    (data) =>
+      typeof data.botToken === 'string' ||
+      data.clearBotToken === true ||
       typeof data.enabled === 'boolean' ||
       typeof data.streamingMode === 'string',
     { message: 'At least one config field must be provided' },

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -43,7 +43,7 @@ export interface WebDeps {
   }) => Promise<boolean>;
   reloadUserIMConfig?: (
     userId: string,
-    channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk',
+    channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
   ) => Promise<boolean>;
   isFeishuConnected?: () => boolean;
   isTelegramConnected?: () => boolean;
@@ -52,6 +52,7 @@ export interface WebDeps {
   isUserQQConnected?: (userId: string) => boolean;
   isUserWeChatConnected?: (userId: string) => boolean;
   isUserDingTalkConnected?: (userId: string) => boolean;
+  isUserDiscordConnected?: (userId: string) => boolean;
   processAgentConversation?: (
     chatJid: string,
     agentId: string,

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -77,7 +77,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
       ? window.matchMedia('(min-width: 1024px)').matches
       : true,
   );
-  const [imStatus, setImStatus] = useState<{ feishu: boolean; telegram: boolean } | null>(null);
+  const [imStatus, setImStatus] = useState<Record<string, boolean> | null>(null);
   const [imBannerDismissed, setImBannerDismissed] = useState(() =>
     localStorage.getItem('im-banner-dismissed') === '1',
   );
@@ -148,7 +148,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
     if (!isOwnHome) { setImStatus(null); return; }
     let active = true;
     const fetchStatus = () => {
-      api.get<{ feishu: boolean; telegram: boolean }>('/api/config/user-im/status')
+      api.get<Record<string, boolean>>('/api/config/user-im/status')
         .then((data) => { if (active) setImStatus(data); })
         .catch(() => {});
     };
@@ -504,7 +504,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                 </span>
               </>
             )}
-            {isOwnHome && imStatus && (imStatus.feishu || imStatus.telegram) && (
+            {isOwnHome && imStatus && Object.entries(imStatus).some(([, v]) => v) && (
               <>
                 <span className="text-muted-foreground/40">·</span>
                 {imStatus.feishu && (
@@ -517,6 +517,12 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                   <span className="inline-flex items-center gap-0.5">
                     <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
                     Telegram
+                  </span>
+                )}
+                {imStatus.discord && (
+                  <span className="inline-flex items-center gap-0.5">
+                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                    Discord
                   </span>
                 )}
               </>
@@ -564,7 +570,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
       </div>
 
       {/* IM channel setup banner for home container without IM */}
-      {isOwnHome && imStatus && !imStatus.feishu && !imStatus.telegram && !imBannerDismissed && (
+      {isOwnHome && imStatus && !Object.values(imStatus).some(Boolean) && !imBannerDismissed && (
         <div className="flex items-center gap-2 px-4 py-2 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300 text-sm">
           <Link className="w-4 h-4 flex-shrink-0" />
           <span className="flex-1 min-w-0">未配置 IM 渠道，飞书 / Telegram 消息无法与主工作区互通</span>

--- a/web/src/components/chat/ImBindingDialog.tsx
+++ b/web/src/components/chat/ImBindingDialog.tsx
@@ -241,7 +241,7 @@ export function ImBindingDialog({ open, groupJid, agentId, agent, onClose }: ImB
 
           {!loading && imGroups.length === 0 && (
             <div className="text-center py-8 text-muted-foreground text-sm">
-              暂无群聊可绑定。请先在飞书/Telegram 群中向 Bot 发送消息，群聊会自动出现在此列表中。
+              暂无群聊可绑定。请先在飞书/Telegram/Discord 群中向 Bot 发送消息，群聊会自动出现在此列表中。
               <br />
               <span className="text-xs opacity-70">私聊不支持绑定到子对话。</span>
             </div>

--- a/web/src/components/settings/BindingsSection.tsx
+++ b/web/src/components/settings/BindingsSection.tsx
@@ -10,7 +10,7 @@ import { BindingTargetDialog } from './BindingTargetDialog';
 import type { AvailableImGroup } from '../../types';
 import type { BindingTarget } from './hooks/useImBindings';
 
-type ChannelFilter = 'all' | 'feishu' | 'telegram' | 'qq' | 'wechat';
+type ChannelFilter = 'all' | 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord';
 
 export function BindingsSection() {
   const { bindings, loading, targets, targetsLoading, reload, rebind, error: hookError, clearError: clearHookError } = useImBindings();
@@ -32,6 +32,8 @@ export function BindingsSection() {
     if (types.has('telegram')) all.push({ key: 'telegram', label: 'Telegram' });
     if (types.has('qq')) all.push({ key: 'qq', label: 'QQ' });
     if (types.has('wechat')) all.push({ key: 'wechat', label: '微信' });
+    if (types.has('dingtalk')) all.push({ key: 'dingtalk', label: '钉钉' });
+    if (types.has('discord')) all.push({ key: 'discord', label: 'Discord' });
     return all;
   }, [bindings]);
 
@@ -192,7 +194,7 @@ export function BindingsSection() {
             <CardContent className="text-center">
             <MessageSquare className="w-10 h-10 mx-auto text-muted-foreground mb-3" />
             <p className="text-sm text-muted-foreground">
-              暂无 IM 渠道。在飞书、Telegram、QQ 或微信中向 Bot 发送消息后，渠道会自动出现在这里。
+              暂无 IM 渠道。在飞书、Telegram、QQ、微信、钉钉或 Discord 中向 Bot 发送消息后，渠道会自动出现在这里。
             </p>
             </CardContent>
           </Card>

--- a/web/src/components/settings/DiscordChannelCard.tsx
+++ b/web/src/components/settings/DiscordChannelCard.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { api } from '../../api/client';
+import { getErrorMessage } from './types';
+
+interface UserDiscordConfig {
+  hasBotToken: boolean;
+  botTokenMasked: string | null;
+  enabled: boolean;
+  streamingMode: 'edit' | 'off';
+  connected: boolean;
+  updatedAt: string | null;
+}
+
+interface DiscordTestResult {
+  success: boolean;
+  bot_username?: string;
+  bot_name?: string;
+  error?: string;
+}
+
+export function DiscordChannelCard() {
+  const [config, setConfig] = useState<UserDiscordConfig | null>(null);
+  const [botToken, setBotToken] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [toggling, setToggling] = useState(false);
+
+  const enabled = config?.enabled ?? false;
+
+  const loadConfig = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.get<UserDiscordConfig>('/api/config/user-im/discord');
+      setConfig(data);
+      setBotToken('');
+    } catch {
+      setConfig(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  const handleToggle = async (newEnabled: boolean) => {
+    setToggling(true);
+    try {
+      const data = await api.put<UserDiscordConfig>('/api/config/user-im/discord', { enabled: newEnabled });
+      setConfig(data);
+      toast.success(`Discord 渠道已${newEnabled ? '启用' : '停用'}`);
+    } catch (err) {
+      toast.error(getErrorMessage(err, '切换 Discord 渠道状态失败'));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const token = botToken.trim();
+      if (!token && !config?.hasBotToken) {
+        toast.error('请输入 Discord Bot Token');
+        setSaving(false);
+        return;
+      }
+
+      const payload: Record<string, string | boolean> = { enabled: true };
+      if (token) payload.botToken = token;
+
+      const data = await api.put<UserDiscordConfig>('/api/config/user-im/discord', payload);
+      setConfig(data);
+      setBotToken('');
+      toast.success('Discord 配置已保存');
+    } catch (err) {
+      toast.error(getErrorMessage(err, '保存 Discord 配置失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    try {
+      const result = await api.post<DiscordTestResult>('/api/config/user-im/discord/test');
+      if (result.success) {
+        toast.success(`Discord 连接成功！Bot: ${result.bot_name} (@${result.bot_username})`);
+      } else {
+        toast.error(result.error || 'Discord 连接失败');
+      }
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Discord 连接测试失败'));
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-border bg-muted/50">
+        <div className="flex items-center gap-2">
+          <span className={`inline-block w-2 h-2 rounded-full ${config?.connected ? 'bg-success' : 'bg-muted-foreground/40'}`} />
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Discord</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">通过 Discord Bot 接收和回复消息</p>
+          </div>
+        </div>
+        <Switch checked={enabled} disabled={loading || toggling} onCheckedChange={handleToggle} />
+      </div>
+
+      <div className={`px-5 py-4 space-y-4 transition-opacity ${!enabled ? 'opacity-50 pointer-events-none' : ''}`}>
+        {loading ? (
+          <div className="text-sm text-muted-foreground">加载中...</div>
+        ) : (
+          <>
+            {config?.hasBotToken && (
+              <div className="text-xs text-muted-foreground">
+                当前 Token: {config.botTokenMasked || '已配置'}
+              </div>
+            )}
+            <div>
+              <Label className="text-xs text-muted-foreground mb-1">Bot Token</Label>
+              <Input
+                type="password"
+                value={botToken}
+                onChange={(e) => setBotToken(e.target.value)}
+                placeholder={config?.hasBotToken ? '留空不修改' : '输入 Discord Bot Token'}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button onClick={handleSave} disabled={saving}>
+                {saving && <Loader2 className="size-4 animate-spin" />}
+                保存 Discord 配置
+              </Button>
+              {config?.hasBotToken && (
+                <>
+                  <Button variant="outline" onClick={handleTest} disabled={testing}>
+                    {testing && <Loader2 className="size-4 animate-spin" />}
+                    测试连接
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="text-destructive hover:text-destructive"
+                    disabled={saving}
+                    onClick={async () => {
+                      try {
+                        setSaving(true);
+                        await api.put('/api/config/user-im/discord', { clearBotToken: true, enabled: false });
+                        setBotToken('');
+                        setConfig((prev) => prev ? { ...prev, hasBotToken: false, botTokenMasked: null, enabled: false, connected: false } : prev);
+                        toast.success('Bot Token 已清除');
+                      } catch { toast.error('清除失败'); }
+                      finally { setSaving(false); }
+                    }}
+                  >
+                    清除 Token
+                  </Button>
+                </>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between pt-2 border-t border-border">
+              <div>
+                <p className="text-xs font-medium text-foreground">流式编辑</p>
+                <p className="text-xs text-muted-foreground">回复时实时编辑消息（打字机效果），默认关闭</p>
+              </div>
+              <Switch
+                checked={config?.streamingMode === 'edit'}
+                disabled={loading || saving}
+                onCheckedChange={async (checked) => {
+                  try {
+                    await api.put('/api/config/user-im/discord', {
+                      streamingMode: checked ? 'edit' : 'off',
+                    });
+                    setConfig((prev) => prev ? { ...prev, streamingMode: checked ? 'edit' : 'off' } : prev);
+                    toast.success(checked ? '已开启流式编辑' : '已关闭流式编辑');
+                  } catch {
+                    toast.error('更新失败');
+                  }
+                }}
+              />
+            </div>
+
+            <div className="text-xs text-muted-foreground mt-2">
+              <p>获取 Bot Token：Discord Developer Portal → Applications → Bot → Token</p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/UserChannelsSection.tsx
+++ b/web/src/components/settings/UserChannelsSection.tsx
@@ -3,6 +3,7 @@ import { TelegramChannelCard } from './TelegramChannelCard';
 import { QQChannelCard } from './QQChannelCard';
 import { WeChatChannelCard } from './WeChatChannelCard';
 import { DingTalkChannelCard } from './DingTalkChannelCard';
+import { DiscordChannelCard } from './DiscordChannelCard';
 
 export function UserChannelsSection() {
   return (
@@ -15,6 +16,7 @@ export function UserChannelsSection() {
       <QQChannelCard />
       <WeChatChannelCard />
       <DingTalkChannelCard />
+      <DiscordChannelCard />
     </div>
   );
 }

--- a/web/src/components/settings/channel-meta.tsx
+++ b/web/src/components/settings/channel-meta.tsx
@@ -4,6 +4,7 @@ export const CHANNEL_LABEL: Record<string, string> = {
   qq: 'QQ',
   wechat: '微信',
   dingtalk: '钉钉',
+  discord: 'Discord',
 };
 
 export const CHANNEL_COLORS: Record<string, string> = {
@@ -12,6 +13,7 @@ export const CHANNEL_COLORS: Record<string, string> = {
   qq: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300',
   wechat: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300',
   dingtalk: 'bg-cyan-100 dark:bg-cyan-900/40 text-cyan-700 dark:text-cyan-300',
+  discord: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300',
 };
 
 const FeishuIcon = () => (
@@ -45,12 +47,19 @@ const DingTalkIcon = () => (
   </svg>
 );
 
+const DiscordIcon = () => (
+  <svg viewBox="0 0 24 24" className="w-3 h-3" fill="currentColor">
+    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+  </svg>
+);
+
 export const CHANNEL_ICON: Record<string, React.FC> = {
   feishu: FeishuIcon,
   telegram: TelegramIcon,
   qq: QQIcon,
   wechat: WeChatIcon,
   dingtalk: DingTalkIcon,
+  discord: DiscordIcon,
 };
 
 /** Render a channel badge with icon + label */

--- a/web/src/components/tasks/TaskDetail.tsx
+++ b/web/src/components/tasks/TaskDetail.tsx
@@ -13,6 +13,7 @@ const CHANNEL_LABELS: Record<string, string> = {
   qq: 'QQ',
   wechat: '微信',
   dingtalk: '钉钉',
+  discord: 'Discord',
 };
 
 interface TaskDetailProps {

--- a/web/src/pages/SetupChannelsPage.tsx
+++ b/web/src/pages/SetupChannelsPage.tsx
@@ -29,6 +29,9 @@ export function SetupChannelsPage() {
   const [qqAppId, setQqAppId] = useState('');
   const [qqAppSecret, setQqAppSecret] = useState('');
 
+  // Discord
+  const [discordBotToken, setDiscordBotToken] = useState('');
+
   // WeChat
   const [wechatQROpen, setWechatQROpen] = useState(false);
   const [wechatConnected, setWechatConnected] = useState(false);
@@ -49,8 +52,9 @@ export function SetupChannelsPage() {
     const hasFeishu = feishuAppId.trim() || feishuAppSecret.trim();
     const hasTelegram = telegramBotToken.trim();
     const hasQQ = qqAppId.trim() || qqAppSecret.trim();
+    const hasDiscord = discordBotToken.trim();
 
-    if (!hasFeishu && !hasTelegram && !hasQQ) {
+    if (!hasFeishu && !hasTelegram && !hasQQ && !hasDiscord) {
       navigate('/chat', { replace: true });
       return;
     }
@@ -92,6 +96,13 @@ export function SetupChannelsPage() {
         await api.put('/api/config/user-im/qq', {
           appId: qqAppId.trim(),
           appSecret: qqAppSecret.trim(),
+          enabled: true,
+        });
+      }
+
+      if (hasDiscord) {
+        await api.put('/api/config/user-im/discord', {
+          botToken: discordBotToken.trim(),
           enabled: true,
         });
       }
@@ -196,6 +207,25 @@ export function SetupChannelsPage() {
                   placeholder="输入 QQ Bot App Secret"
                 />
               </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Discord */}
+        <Card className="shadow-sm">
+          <CardContent>
+            <h2 className="text-base font-semibold text-foreground mb-3">Discord</h2>
+            <p className="text-xs text-muted-foreground mb-3">
+              填写 Discord Bot Token，绑定后即可在 Discord 中与 AI 对话。
+            </p>
+            <div>
+              <Label className="mb-1">Bot Token</Label>
+              <Input
+                type="password"
+                value={discordBotToken}
+                onChange={(e) => setDiscordBotToken(e.target.value)}
+                placeholder="输入 Discord Bot Token"
+              />
             </div>
           </CardContent>
         </Card>

--- a/web/src/utils/task-utils.ts
+++ b/web/src/utils/task-utils.ts
@@ -15,6 +15,7 @@ export const CHANNEL_OPTIONS = [
   { key: 'qq', label: 'QQ' },
   { key: 'wechat', label: '微信' },
   { key: 'dingtalk', label: '钉钉' },
+  { key: 'discord', label: 'Discord' },
 ] as const;
 
 /** Format interval milliseconds to human-readable string (e.g. "5 分钟"). */


### PR DESCRIPTION
## 问题描述

新增 Discord 作为第五个 IM 通道（飞书/Telegram/QQ/钉钉之后），参考 OpenClaw 的 Discord 实现，遵循 HappyClaw 现有的工厂模式架构。

## 实现方案

### 后端

#### 新增文件
- `src/discord.ts` — Discord 连接工厂（discord.js v14），实现 Gateway WebSocket 连接、消息收发、去重、附件处理等
- `src/discord-streaming-edit.ts` — 流式编辑控制器，通过编辑 Bot 消息实现打字机效果（可配置，默认关闭）

#### 修改文件
- `shared/channel-prefixes.ts` — 注册 `discord:` prefix
- `src/im-channel.ts` — 添加 Discord IMChannel 适配器和 StreamingSession 联合类型
- `src/im-manager.ts` — 添加 `connectUserDiscord` / `disconnectUserDiscord` / `isDiscordConnected`
- `src/runtime-config.ts` — 添加 `getUserDiscordConfig` / `saveUserDiscordConfig`（AES-256-GCM 加密）
- `src/schemas.ts` — 添加 `DiscordConfigSchema` + notify_channels 添加 discord
- `src/web-context.ts` — WebDeps 添加 discord
- `src/routes/config.ts` — 添加 `GET/PUT/POST /api/config/user-im/discord` 路由
- `src/index.ts` — 启动加载和热重载集成
- `src/im-downloader.ts` — channel union 添加 discord

### 前端

- `web/src/components/settings/DiscordChannelCard.tsx` — Bot Token 配置、测试连接、清除 Token、流式编辑开关
- `web/src/components/settings/channel-meta.tsx` — Discord 图标（Clyde）、标签、颜色（indigo）
- `web/src/components/settings/UserChannelsSection.tsx` — 注册 DiscordChannelCard
- `web/src/pages/SetupChannelsPage.tsx` — 新用户引导添加 Discord
- `web/src/components/chat/ChatView.tsx` — IM 状态指示器（通用化为 `Record<string, boolean>`）
- `web/src/utils/task-utils.ts`、`TaskDetail.tsx`、`BindingsSection.tsx`、`ImBindingDialog.tsx` — 联动更新

### 功能清单

| 功能 | 状态 |
|------|------|
| 文本收发（DM + Guild） | ✅ |
| 消息去重 | ✅ |
| 长消息分片（2000字符，代码围栏保留） | ✅ |
| @Bot mention 控制 | ✅ |
| 图片接收（base64 Vision） | ✅ |
| 图片/文件发送 | ✅ |
| 文件下载到工作区 | ✅ |
| Markdown 转换 | ✅ |
| Reaction 确认（👀） | ✅ |
| 斜杠命令（Discord Application Commands） | ✅ |
| 流式编辑消息（可配置，默认关闭） | ✅ |
| 连接测试 / 热重载 | ✅ |
| 清除 Token | ✅ |

### 注意事项

- 使用 discord.js 的 raw gateway event 处理消息（解决 DM partial channel 不触发 `MessageCreate` 的问题）
- `connect()` 等待 `ClientReady` 事件后返回，确保保存配置后状态灯立即亮起
- 群聊注册（`onNewChat`）提前到 mention gate 之前，解决首条消息因群组未注册而被丢弃的问题
- 消息分片预留 20 字符给 code fence 标记，避免超出 2000 字符限制

## Test plan

- [x] `make typecheck` — 后端、前端、agent-runner 全部通过
- [x] `make test` — 39 个现有测试通过
- [x] `make build` — 编译成功
- [x] 手动测试：DM 私聊收发
- [x] 手动测试：Guild 频道 @Bot 收发
- [x] 手动测试：图片接收（Vision）
- [x] 手动测试：/require_mention 切换
- [x] 手动测试：配置保存 / 测试连接 / 热重载