### PR TITLE
修复: scanSkillDirectory 跳过 symlink 形式的 skill 目录

### DIFF
--- a/src/skill-utils.ts
+++ b/src/skill-utils.ts
@@ -101,17 +101,30 @@ export function listFiles(
 ): Array<{ name: string; type: 'file' | 'directory'; size: number }> {
   try {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
-    return entries
-      .filter((entry) => !entry.name.startsWith('.'))
-      .map((entry) => {
-        const fullPath = path.join(dir, entry.name);
+    const result: Array<{
+      name: string;
+      type: 'file' | 'directory';
+      size: number;
+    }> = [];
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      const fullPath = path.join(dir, entry.name);
+      try {
+        // Use statSync (follows symlinks) so that symlinks pointing to
+        // directories are correctly classified as 'directory' instead of
+        // 'file'. Dangling or circular symlinks throw and are skipped.
         const stats = fs.statSync(fullPath);
-        return {
+        const isDirectory = stats.isDirectory();
+        result.push({
           name: entry.name,
-          type: entry.isDirectory() ? 'directory' : 'file',
-          size: entry.isDirectory() ? 0 : stats.size,
-        };
-      });
+          type: isDirectory ? 'directory' : 'file',
+          size: isDirectory ? 0 : stats.size,
+        });
+      } catch {
+        // Skip dangling symlinks or unreadable entries
+      }
+    }
+    return result;
   } catch {
     return [];
   }

--- a/src/skill-utils.ts
+++ b/src/skill-utils.ts
@@ -127,9 +127,17 @@ export function scanSkillDirectory(
   try {
     const entries = fs.readdirSync(rootDir, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
 
       const skillDir = path.join(rootDir, entry.name);
+      // Symlink must resolve to a directory
+      if (entry.isSymbolicLink()) {
+        try {
+          if (!fs.statSync(skillDir).isDirectory()) continue;
+        } catch {
+          continue; // dangling symlink
+        }
+      }
       const skillMdPath = path.join(skillDir, 'SKILL.md');
       const skillMdDisabledPath = path.join(skillDir, 'SKILL.md.disabled');
 


### PR DESCRIPTION
## 问题描述

`scanSkillDirectory()` 使用 `entry.isDirectory()` 过滤 skill 目录，但 Node.js 的 `Dirent.isDirectory()` 对符号链接返回 `false`（符号链接只有 `isSymbolicLink()` 返回 `true`）。

这导致 `~/.claude/skills/` 中以 symlink 形式安装的 skill 在扫描时被全部跳过，前端 Skills 列表无法显示这些 skill。

注意：`container-runner.ts` 的 `linkSkillEntries` 已经正确处理了 symlink（同时检查 `isDirectory()` 和 `isSymbolicLink()`），所以 skill 的实际加载不受影响，只是扫描/展示缺失。

## 修复方案

### `src/skill-utils.ts`

- 同时检查 `entry.isDirectory()` 和 `entry.isSymbolicLink()`
- 对 symlink 使用 `fs.statSync()` 跟随链接判断目标是否为目录
- 悬空 symlink（目标不存在）静默跳过，不报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)