### PR TITLE
修复: iOS 端输入框不支持换行

### DIFF
--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -15,6 +15,7 @@ import {
 import { useFileStore } from '../../stores/files';
 import { useChatStore } from '../../stores/chat';
 import { useDisplayMode } from '../../hooks/useDisplayMode';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 interface PendingFile {
   /** Display name: relative path for folder uploads, file name otherwise */
@@ -63,6 +64,7 @@ export function MessageInput({
   const { drafts, saveDraft, clearDraft } = useChatStore();
   const { mode: displayMode } = useDisplayMode();
   const isCompact = displayMode === 'compact';
+  const isMobile = useMediaQuery('(max-width: 1023px)');
 
   // iOS keyboard adaptation
   useKeyboardHeight();
@@ -141,7 +143,7 @@ export function MessageInput({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (composingRef.current || e.nativeEvent.isComposing) return;
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
       if (Date.now() - compositionEndTimeRef.current < 100) return;
       e.preventDefault();
       handleSend();


### PR DESCRIPTION
## 问题描述

iOS 软键盘没有 Shift 键，用户无法通过 Shift+Enter 在输入框中插入换行。当前 Enter 键直接发送消息，移动端无法输入多行文本。

## 修复方案

对齐 Telegram 的交互设计：

| 平台 | Enter 键 | 发送方式 |
|------|---------|---------|
| 桌面端（>1023px） | 发送消息 | Enter 或点击发送按钮 |
| 移动端（≤1023px） | 插入换行 | 点击发送按钮 |

### `web/src/components/chat/MessageInput.tsx`

- 引入 `useMediaQuery` 检测移动端
- `handleKeyDown` 中增加 `!isMobile` 条件，移动端 Enter 不再触发发送
- 移动端通过 textarea 默认行为插入换行，已有的发送按钮用于发送消息

🤖 Generated with [Claude Code](https://claude.com/claude-code)