### PR TITLE
性能: 接入 SDK autoCompactWindow 作为系统设置 (#389 #390)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,7 @@ scripts/                      # 构建辅助脚本
 | `MAX_CONCURRENT_HOST_PROCESSES` | `5` | 宿主机模式并发上限（可通过设置页覆盖） |
 | `MAX_LOGIN_ATTEMPTS` | `5` | 登录失败锁定阈值（可通过设置页覆盖） |
 | `LOGIN_LOCKOUT_MINUTES` | `15` | 锁定持续时间（分钟）（可通过设置页覆盖） |
+| `AUTO_COMPACT_WINDOW` | `0`（禁用，使用 SDK 默认 ~1M） | Claude Agent SDK 自动对话压缩触发点（tokens），0 = 关闭，>0 范围 [10000, 2000000]（可通过设置页覆盖） |
 | `TRUST_PROXY` | `false` | 信任反向代理的 `X-Forwarded-For` 头（启用后从代理头获取客户端 IP） |
 | `TZ` | 系统时区 | 定时任务时区 |
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1281,6 +1281,14 @@ async function runQuery(
     return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery };
   }
 
+  // SystemSettings.autoCompactWindow（通过 AUTO_COMPACT_WINDOW 环境变量注入）
+  // 0 = SDK 默认（约 1M）；>0 = 通过 settings flag-layer 提前触发对话压缩
+  const autoCompactWindow = parseInt(process.env.AUTO_COMPACT_WINDOW ?? '0', 10);
+  const flagSettings: Record<string, unknown> = {};
+  if (Number.isFinite(autoCompactWindow) && autoCompactWindow > 0) {
+    flagSettings.autoCompactWindow = autoCompactWindow;
+  }
+
   try {
     const q = query({
     prompt: stream,
@@ -1299,6 +1307,7 @@ async function runQuery(
       agentProgressSummaries: true,
       settingSources: ['project', 'user'],
       includePartialMessages: true,
+      ...(Object.keys(flagSettings).length > 0 ? { settings: flagSettings as any } : {}),
       mcpServers: {
         ...loadUserMcpServers(),     // 用户配置的 MCP（stdio/http/sse），SDK 原生支持
         happyclaw: mcpServerConfig,  // 内置 SDK MCP 放最后，确保不被同名覆盖

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -183,7 +183,7 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
     // --- send_image ---
     tool(
       'send_image',
-      "Send an image file from the workspace to the user or group via IM (Feishu/Telegram/DingTalk). The file must be an image (PNG, JPEG, GIF, WebP, etc.) and must exist in the workspace. Use this when you've generated or downloaded an image and want to share it with the user. Optionally include a caption.",
+      'Send an image file from the workspace to the user via IM. Supports PNG/JPEG/GIF/WebP. Optional caption.',
       {
         file_path: z
           .string()

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -487,6 +487,11 @@ function buildVolumeMounts(
     containerOverride,
     resolvedProvider?.customEnv,
   );
+  // SystemSettings.autoCompactWindow > 0 时注入到容器，让 agent-runner 通过 query() settings 传给 SDK
+  const sysAutoCompact = getSystemSettings().autoCompactWindow;
+  if (sysAutoCompact > 0) {
+    envLines.push(`AUTO_COMPACT_WINDOW=${sysAutoCompact}`);
+  }
   if (envLines.length > 0) {
     const envFilePath = path.join(envDir, 'env');
     const quotedLines = shellQuoteEnvLines(envLines);
@@ -1219,6 +1224,12 @@ export async function runHostAgent(
           'Failed to write .credentials.json for host agent',
         );
       }
+    }
+
+    // SystemSettings.autoCompactWindow > 0 时注入到 host 进程，agent-runner 通过 query() settings 传给 SDK
+    const hostAutoCompact = getSystemSettings().autoCompactWindow;
+    if (hostAutoCompact > 0) {
+      hostEnv['AUTO_COMPACT_WINDOW'] = String(hostAutoCompact);
     }
 
     // 路径映射

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3482,6 +3482,8 @@ export interface SystemSettings {
   billingCurrencyRate: number;
   // External Claude directory (admin only)
   externalClaudeDir: string;
+  // Claude Agent SDK 自动对话压缩触发点（tokens）。0 = 保留 SDK 默认（约 1M）
+  autoCompactWindow: number;
 }
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -3500,6 +3502,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   billingCurrency: 'USD',
   billingCurrencyRate: 1,
   externalClaudeDir: '',
+  autoCompactWindow: 0,
 };
 
 function parseIntEnv(envVar: string | undefined, fallback: number): number {
@@ -3586,6 +3589,10 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       typeof raw.externalClaudeDir === 'string'
         ? raw.externalClaudeDir.trim()
         : DEFAULT_SYSTEM_SETTINGS.externalClaudeDir,
+    autoCompactWindow:
+      typeof raw.autoCompactWindow === 'number' && raw.autoCompactWindow >= 0
+        ? raw.autoCompactWindow
+        : DEFAULT_SYSTEM_SETTINGS.autoCompactWindow,
   };
 }
 
@@ -3643,6 +3650,10 @@ function buildEnvFallbackSettings(): SystemSettings {
     ),
     externalClaudeDir:
       process.env.EXTERNAL_CLAUDE_DIR || DEFAULT_SYSTEM_SETTINGS.externalClaudeDir,
+    autoCompactWindow: parseIntEnv(
+      process.env.AUTO_COMPACT_WINDOW,
+      DEFAULT_SYSTEM_SETTINGS.autoCompactWindow,
+    ),
   };
 }
 
@@ -3727,6 +3738,17 @@ export function saveSystemSettings(
       DEFAULT_SYSTEM_SETTINGS.billingMinStartBalanceUsd;
   if (merged.billingMinStartBalanceUsd > 1000000)
     merged.billingMinStartBalanceUsd = 1000000;
+
+  // autoCompactWindow: 0 表示禁用（使用 SDK 默认），>0 必须在 [10000, 2000000] 范围
+  if (
+    merged.autoCompactWindow < 0 ||
+    !Number.isFinite(merged.autoCompactWindow)
+  ) {
+    merged.autoCompactWindow = 0;
+  } else if (merged.autoCompactWindow > 0) {
+    if (merged.autoCompactWindow < 10000) merged.autoCompactWindow = 10000;
+    if (merged.autoCompactWindow > 2000000) merged.autoCompactWindow = 2000000;
+  }
 
   // Validate externalClaudeDir: must be empty or an absolute directory path
   if (merged.externalClaudeDir) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -236,6 +236,14 @@ export const SystemSettingsSchema = z.object({
   billingCurrency: z.string().min(1).max(10).optional(),
   billingCurrencyRate: z.number().min(0.0001).max(1000000).optional(),
   externalClaudeDir: z.string().max(512).optional(),
+  autoCompactWindow: z
+    .number()
+    .int()
+    .refine(
+      (v) => v === 0 || (v >= 10000 && v <= 2000000),
+      'autoCompactWindow must be 0 (disabled) or between 10000 and 2000000',
+    )
+    .optional(),
 });
 
 export const AppearanceConfigSchema = z.object({

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -126,6 +126,20 @@ const fields: FieldConfig[] = [
     max: 600,
     step: 5,
   },
+  {
+    key: 'autoCompactWindow',
+    label: '对话自动压缩阈值',
+    description:
+      '达到该 token 数时主动触发 SDK 对话压缩。0 = 保留 SDK 默认（约 1M）。'
+      + '经验值：Opus 1M 建议 300-500，Sonnet/Haiku 200K 建议 80-120。'
+      + '压缩前会通过 PreCompact hook 归档对话',
+    unit: 'K tokens',
+    toDisplay: (v) => Math.round(v / 1000),
+    toStored: (v) => v * 1000,
+    min: 0,
+    max: 2000,
+    step: 10,
+  },
 ];
 
 export function SystemSettingsSection() {

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -103,6 +103,7 @@ export interface SystemSettings {
   billingCurrency: string;
   billingCurrencyRate: number;
   externalClaudeDir: string;
+  autoCompactWindow: number;
 }
 
 // ─── OAuth Usage ────────────────────────────────────────────


### PR DESCRIPTION
## 问题描述

关闭 #389，推进 #390。

#377 报告的单日 \$290 成本 spike 主因经定位是 agent-runner 完全没有设置 SDK 的 \`autoCompactWindow\`，对话历史需要堆积到接近 1M tokens 才会触发 PreCompact，长会话场景下 \`cache_read\` 中位数高达 ~850K tokens。

\`#389\` 原计划精简 MCP 工具 description，但实际核查发现 13 个工具里只有 \`send_image\`(199 字符) 接近上限，收益很小，因此搭车到本 PR 一并处理。

## 实现方案

\`autoCompactWindow\` **不硬编码**而是接入现有 \`SystemSettings\` 机制作为 Web 可配置项。理由：不同 Claude 模型的上下文窗口差异巨大（Opus 1M / Sonnet 200K / Haiku 200K），同一个阈值不可能同时合适。

### \`src/runtime-config.ts\`
\`SystemSettings\` 接口新增 \`autoCompactWindow\` 字段，默认 \`0\`（保留 SDK 默认行为，约 1M）。\`readSystemSettingsFromFile\` / \`buildEnvFallbackSettings\` / \`saveSystemSettings\` 三处对应增加读取 / env fallback / 范围校验（允许 0 或 [10000, 2000000]）。

### \`src/schemas.ts\`
\`SystemSettingsSchema\` 增加 zod 校验。

### \`src/container-runner.ts\`
Docker 模式（写入 env file）和 Host 模式（hostEnv 对象）两个分支都从 \`getSystemSettings()\` 读取 \`autoCompactWindow\`，>0 时通过 \`AUTO_COMPACT_WINDOW\` 环境变量注入容器/进程；=0 时不注入，保持 SDK 默认。

### \`container/agent-runner/src/index.ts\`
\`runQuery()\` 读取 \`process.env.AUTO_COMPACT_WINDOW\`，>0 时通过 \`settings\` flag-layer 字段（最高优先级）传给 SDK。

**重要细节**：在 SDK 0.2.101 中 \`autoCompactWindow\` 从 \`Options\` 移到了 \`Settings\` interface（line 4114），不能直接作为 query() options 顶层字段传入，必须通过 \`settings: { autoCompactWindow }\` 包装。这是 SDK 升级时容易踩的坑。

### \`web/src/components/settings/SystemSettingsSection.tsx\`
表单字段，K tokens 单位显示，min: 0 / max: 2000 / step: 10，描述包含 per-model 经验值建议（Opus 300-500K / Sonnet/Haiku 80-120K）。

### \`container/agent-runner/src/mcp-tools.ts\`
\`send_image\` description 从 199 字符精简到 100 字符（搭车 #389）。

### \`CLAUDE.md\` §9
追加 \`AUTO_COMPACT_WINDOW\` 环境变量行。

## 上线策略

**默认值 0 保持现有行为完全不变**。合并后管理员需要在 Web 设置页手动按模型开启：

| 模型 | 建议阈值 |
|------|---------|
| Opus 1M / claude-opus-4-6[1m] | 300000 |
| Sonnet 200K / claude-sonnet-4-6 | 100000 |
| Haiku 200K | 80000 |

观察 \`usage_daily_summary\` 1 周后，如果效果好可以考虑后续把默认值改成 300000。

## Test plan

- [x] \`make typecheck\` 三处全通过（根 / web / agent-runner）
- [x] \`make test\` 47 个测试全通过
- [ ] 部署到本地：Web UI 进入系统设置页确认看到"对话自动压缩阈值"输入框，默认显示 0
- [ ] 设置为 300（即 300K tokens），保存后启动新容器，\`docker exec\` 进入容器 \`echo \$AUTO_COMPACT_WINDOW\` 应返回 \`300000\`
- [ ] 长对话测试（30+ 轮）观察 \`usage_daily_summary.cache_read_tokens\` 中位数变化
- [ ] 验证 PreCompact hook 归档逻辑仍然正常（\`data/groups/{folder}/conversations/\` 有新增文件）