### PR TITLE
修复: Discord 通道 follow-up (#386)

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -732,40 +732,18 @@ export function createDiscordConnection(
           }
         });
 
-        // Message create event — use raw event as primary to ensure DM delivery,
-        // then resolve the Message object from cache or API
-        discordClient.on('raw', async (packet: { t: string; d: any }) => {
-          if (packet.t !== 'MESSAGE_CREATE') return;
+        // Message create event — use Events.MessageCreate which delivers a fully
+        // resolved Message object directly. With Partials.Channel + Partials.Message
+        // configured (line 658), DMs are also delivered without needing raw fallback.
+        // This avoids the 2x REST fetch (channels.fetch + messages.fetch) per message
+        // that the previous raw-event handler incurred.
+        discordClient.on(Events.MessageCreate, async (msg) => {
           if (stopping) return;
+          if (msg.author?.bot) return;
           try {
-            const data = packet.d;
-            // Skip bot messages early (before resolving full Message)
-            if (data.author?.bot) return;
-
-            // Try to get the Message from the discord.js cache
-            const channelId = data.channel_id;
-            let channel = discordClient!.channels.cache.get(channelId) ?? undefined;
-            if (!channel) {
-              try {
-                channel = (await discordClient!.channels.fetch(channelId)) ?? undefined;
-              } catch {
-                logger.warn({ channelId }, 'Discord: could not fetch channel for raw MESSAGE_CREATE');
-                return;
-              }
-            }
-            if (!channel || !channel.isTextBased()) return;
-
-            let msg: Message;
-            try {
-              msg = await (channel as TextBasedChannel).messages.fetch(data.id);
-            } catch {
-              logger.warn({ msgId: data.id }, 'Discord: could not fetch message from raw event');
-              return;
-            }
-
             await handleMessage(msg, opts);
           } catch (err) {
-            logger.error({ err }, 'Error in Discord raw message handler');
+            logger.error({ err }, 'Error in Discord message handler');
           }
         });
 

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -63,8 +63,14 @@ export interface IMChannelConnectOpts {
     chatName: string,
     code: string,
   ) => Promise<boolean>;
-  /** Slash command callback (e.g. /clear). Returns reply text or null. */
-  onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+  /** Slash command callback (e.g. /clear). Returns reply text or null.
+   *  senderImId is the channel-specific user ID (e.g. Discord user.id, Telegram from.id);
+   *  channels that don't have a stable per-user ID may pass undefined. */
+  onCommand?: (
+    chatJid: string,
+    command: string,
+    senderImId?: string,
+  ) => Promise<string | null>;
   /** 根据 jid 解析群组 folder，用于下载文件/图片到工作区 */
   resolveGroupFolder?: (jid: string) => string | undefined;
   /** 将 IM chatJid 解析为绑定目标 JID（conversation agent 或工作区主对话） */

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -2163,6 +2163,7 @@ configRoutes.post('/user-im/discord/test', authMiddleware, async (c) => {
     return c.json({ error: 'Discord Bot Token not configured' }, 400);
   }
 
+  let timeoutId: NodeJS.Timeout | undefined;
   try {
     // Test by creating a temporary Client and logging in
     const { Client, GatewayIntentBits } = await import('discord.js');
@@ -2187,12 +2188,12 @@ configRoutes.post('/user-im/discord/test', authMiddleware, async (c) => {
           });
         },
       ),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => {
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
           testClient.destroy();
           reject(new Error('Connection test timed out (10s)'));
-        }, 10000),
-      ),
+        }, 10000);
+      }),
     ]);
 
     return c.json(result);
@@ -2201,6 +2202,10 @@ configRoutes.post('/user-im/discord/test', authMiddleware, async (c) => {
       err instanceof Error ? err.message : 'Connection test failed';
     logger.warn({ err }, 'Discord connection test failed');
     return c.json({ error: message }, 400);
+  } finally {
+    // Defense-in-depth: clear the race timer in both success and failure paths
+    // so the process doesn't keep an active handle for up to 10s after the test.
+    if (timeoutId) clearTimeout(timeoutId);
   }
 });
 

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -28,6 +28,17 @@ import { showToast } from '../../utils/toast';
 /** Sentinel value for binding the main conversation (vs. a specific agent) */
 const MAIN_BINDING = '__main__' as const;
 
+// IM channel display labels — used by the data-driven ChannelBadge renderer in the
+// chat header. Add new channels here when extending IM connection support.
+const IM_CHANNEL_LABELS: Record<string, string> = {
+  feishu: '飞书',
+  telegram: 'Telegram',
+  discord: 'Discord',
+  qq: 'QQ',
+  wechat: '微信',
+  dingtalk: '钉钉',
+};
+
 const SIDEBAR_TABS = [
   { id: 'files' as const, icon: FolderOpen, label: '文件管理' },
   { id: 'env' as const, icon: Variable, label: '环境变量' },
@@ -507,24 +518,14 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
             {isOwnHome && imStatus && Object.entries(imStatus).some(([, v]) => v) && (
               <>
                 <span className="text-muted-foreground/40">·</span>
-                {imStatus.feishu && (
-                  <span className="inline-flex items-center gap-0.5">
-                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-                    飞书
-                  </span>
-                )}
-                {imStatus.telegram && (
-                  <span className="inline-flex items-center gap-0.5">
-                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-                    Telegram
-                  </span>
-                )}
-                {imStatus.discord && (
-                  <span className="inline-flex items-center gap-0.5">
-                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-                    Discord
-                  </span>
-                )}
+                {Object.entries(imStatus)
+                  .filter(([, connected]) => connected)
+                  .map(([channel]) => (
+                    <span key={channel} className="inline-flex items-center gap-0.5">
+                      <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                      {IM_CHANNEL_LABELS[channel] ?? channel}
+                    </span>
+                  ))}
               </>
             )}
           </div>
@@ -573,7 +574,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
       {isOwnHome && imStatus && !Object.values(imStatus).some(Boolean) && !imBannerDismissed && (
         <div className="flex items-center gap-2 px-4 py-2 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300 text-sm">
           <Link className="w-4 h-4 flex-shrink-0" />
-          <span className="flex-1 min-w-0">未配置 IM 渠道，飞书 / Telegram 消息无法与主工作区互通</span>
+          <span className="flex-1 min-w-0">未配置 IM 渠道（飞书 / Telegram / Discord / QQ / 微信 / 钉钉），消息无法与主工作区互通</span>
           <button
             onClick={() => navigate('/setup/channels')}
             className="flex-shrink-0 px-3 py-1 text-xs font-medium rounded-md bg-amber-600 text-white hover:bg-amber-700 transition-colors cursor-pointer"

--- a/web/src/components/settings/DiscordChannelCard.tsx
+++ b/web/src/components/settings/DiscordChannelCard.tsx
@@ -191,8 +191,13 @@ export function DiscordChannelCard() {
               />
             </div>
 
-            <div className="text-xs text-muted-foreground mt-2">
+            <div className="text-xs text-muted-foreground mt-2 space-y-1">
               <p>获取 Bot Token：Discord Developer Portal → Applications → Bot → Token</p>
+              <p>
+                斜杠命令首次注册后通过 Discord Global Commands 通道分发，
+                Discord 官方说明可能需要 5-60 分钟才在所有服务器生效。期间可以用纯文本命令兜底，
+                例如直接发送 <code>/clear</code>、<code>/list</code>、<code>/status</code>。
+              </p>
             </div>
           </>
         )}


### PR DESCRIPTION
## 问题描述

关闭 #386。本 PR 一并处理 Discord 通道上线后审查反馈中可分阶段解决的小问题（除代码去重外）。

## 修复方案 / 实现方案

### \`src/discord.ts\` — raw 事件 → \`Events.MessageCreate\`（性能真 bug）

原 handler 监听 \`client.on('raw')\` + \`MESSAGE_CREATE\` packet，每条消息都要：
1. \`channels.fetch(channelId)\` — 1 次 REST
2. \`channels.messages.fetch(data.id)\` — 1 次 REST

即使 \`Partials.Channel + Partials.Message\` 已经配置（line 658）也照样 fetch。大群高频场景会显著放大 Discord API 速率限制压力。

修复后 \`Events.MessageCreate\` 直接传入完整 \`Message\` 对象，去重逻辑保持不变（LRU 1000 条 / 30min TTL）。

### \`src/im-channel.ts\` — onCommand 签名对齐

\`IMChannelConnectOpts.onCommand\` 从 \`(chatJid, command) => Promise<string | null>\` 扩展为：

\`\`\`ts
onCommand?: (
  chatJid: string,
  command: string,
  senderImId?: string,
) => Promise<string | null>;
\`\`\`

\`senderImId\` 保持可选。Discord 侧 (\`src/discord.ts:719\`) 已经在传 \`interaction.user.id\`，类型层面终于对齐。其他渠道（feishu / telegram / qq / wechat / dingtalk）无需立即提供该参数。

### \`src/routes/config.ts\` — Discord 测试 setTimeout 资源泄漏

\`Promise.race\` 中的 10s timeout 没 \`clearTimeout\`。修复：保存 timer 句柄到外层变量，在 \`finally\` 里 \`clearTimeout\`。成功和失败路径都会清理。

### \`web/src/components/chat/ChatView.tsx\` — ChannelBadge 数据驱动 + banner 文案

**当前**：硬编码渲染 \`imStatus.feishu / .telegram / .discord\`，qq / wechat / dingtalk 连接时 header 没有徽章（存量问题）。

**修复**：
- 新增模块顶部常量 \`IM_CHANNEL_LABELS\`（feishu / telegram / discord / qq / wechat / dingtalk → 中文标签）
- 遍历 \`imStatus\` 中所有 \`connected=true\` 的 key，按 map 渲染 ChannelBadge
- 缺失的 channel 自动降级为 raw key 显示

**Banner 文案**：从"未配置 IM 渠道，飞书 / Telegram 消息无法与主工作区互通"改为"未配置 IM 渠道（飞书 / Telegram / Discord / QQ / 微信 / 钉钉），消息无法与主工作区互通"。

### \`web/src/components/settings/DiscordChannelCard.tsx\` — Global Commands 延迟提示

在已有的"获取 Bot Token"提示下方追加一段文案，告知用户：

> 斜杠命令首次注册后通过 Discord Global Commands 通道分发，Discord 官方说明可能需要 5-60 分钟才在所有服务器生效。期间可以用纯文本命令兜底，例如直接发送 \`/clear\`、\`/list\`、\`/status\`。

避免"配置完连不上斜杠命令"的疑惑。

## 不在本 PR 范围

\`splitDiscordChunks\` (\`src/discord.ts:140\`) 和 \`splitWithCodeFences\` (\`src/discord-streaming-edit.ts:599\`) 的代码去重 (#386 子项 6)。两者实现深度差异大（19 行 wrapper vs 50+ 行独立实现），合并需要先补单测再做，留待独立 chore PR。

## Test plan

- [x] \`make typecheck\` 三处全通过
- [x] \`make test\` 47 个测试全通过
- [ ] 部署后用一个测试 Discord bot 发多条消息：
  - 普通文字消息正常处理 + 去重
  - DM 消息正常 deliver
  - 斜杠命令仍然工作
  - bot 日志确认无 \`channels.fetch()\` / \`messages.fetch()\` 高频调用
- [ ] 前端：连接 feishu + telegram + discord + qq 三种组合，确认 ChannelBadge 正确渲染
- [ ] \`POST /api/config/user-im/discord/test\` 触发一次，确认成功后进程内无悬挂 timer