### PR TITLE
测试: 补 session resume 恢复测试 + 修复主进程 escape 不一致 (#387)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -32,6 +32,10 @@ import type {
 export type { StreamEventType, StreamEvent } from './types.js';
 
 import { sanitizeFilename, generateFallbackName } from './utils.js';
+import {
+  extractSessionHistory as extractSessionHistoryImpl,
+  parseTranscript,
+} from './session-history.js';
 import { StreamEventProcessor } from './stream-processor.js';
 import { PREDEFINED_AGENTS } from './agent-definitions.js';
 import { createMcpTools } from './mcp-tools.js';
@@ -565,75 +569,23 @@ function createPreCompactHook(
 }
 
 /**
- * Extract recent conversation history from a session's JSONL transcript.
- * Used when session resume fails to inject context into the fresh session's prompt.
+ * Wrapper around the pure extractSessionHistory implementation in
+ * session-history.ts. Resolves the SDK transcript directory using the
+ * runtime CLAUDE_CONFIG_DIR + WORKSPACE_GROUP layout, then delegates.
  */
 function extractSessionHistory(oldSessionId: string): string | null {
-  try {
-    const configDir = process.env.CLAUDE_CONFIG_DIR
-      || path.join(process.env.HOME || '/home/node', '.claude');
-    // SDK stores transcripts at: <configDir>/projects/<encoded-cwd>/<sessionId>.jsonl
-    // where encoded-cwd replaces '/' with '-'
-    const encodedCwd = WORKSPACE_GROUP.replace(/\//g, '-');
-    const transcriptPath = path.join(configDir, 'projects', encodedCwd, `${oldSessionId}.jsonl`);
-
-    if (!fs.existsSync(transcriptPath)) {
-      log(`Session transcript not found at ${transcriptPath}`);
-      return null;
-    }
-
-    const content = fs.readFileSync(transcriptPath, 'utf-8');
-    const messages = parseTranscript(content);
-    if (messages.length === 0) return null;
-
-    // Take the last N messages for context (aligned with RECOVERY_HISTORY_LIMIT in src/index.ts)
-    const RECOVERY_HISTORY_LIMIT = 20;
-    const recentMessages = messages.slice(-RECOVERY_HISTORY_LIMIT);
-
-    const historyLines = recentMessages.map((m) => {
-      const role = m.role === 'user' ? 'User' : 'HappyClaw';
-      const truncated = m.content.length > 500 ? m.content.slice(0, 500) + '…' : m.content;
-      // Strip lone surrogates (unpaired) to avoid API JSON errors, preserving valid surrogate pairs (emoji etc.)
-      const cleaned = truncated.replace(/(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g, '');
-      return `[${role}] ${cleaned}`;
-    });
-
-    log(`Extracted ${recentMessages.length} messages from old session ${oldSessionId} for context injection`);
-
-    return '<system_context>\n' +
-      '会话恢复失败，当前为新会话。以下是之前的对话记录，供你了解上下文（请基于这些上下文继续对话）：\n\n' +
-      historyLines.join('\n') +
-      '\n</system_context>\n\n';
-  } catch (err) {
-    log(`Failed to extract session history: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
-  }
-}
-
-function parseTranscript(content: string): ParsedMessage[] {
-  const messages: ParsedMessage[] = [];
-
-  for (const line of content.split('\n')) {
-    if (!line.trim()) continue;
-    try {
-      const entry = JSON.parse(line);
-      if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string'
-          ? entry.message.content
-          : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
-        if (text) messages.push({ role: 'user', content: text });
-      } else if (entry.type === 'assistant' && entry.message?.content) {
-        const textParts = entry.message.content
-          .filter((c: { type: string }) => c.type === 'text')
-          .map((c: { text: string }) => c.text);
-        const text = textParts.join('');
-        if (text) messages.push({ role: 'assistant', content: text });
-      }
-    } catch {
-    }
-  }
-
-  return messages;
+  const configDir =
+    process.env.CLAUDE_CONFIG_DIR ||
+    path.join(process.env.HOME || '/home/node', '.claude');
+  // SDK stores transcripts at: <configDir>/projects/<encoded-cwd>/<sessionId>.jsonl
+  // where encoded-cwd replaces '/' with '-'
+  const encodedCwd = WORKSPACE_GROUP.replace(/\//g, '-');
+  const transcriptDir = path.join(configDir, 'projects', encodedCwd);
+  return extractSessionHistoryImpl({
+    transcriptDir,
+    sessionId: oldSessionId,
+    log,
+  });
 }
 
 function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null): string {

--- a/container/agent-runner/src/session-history.ts
+++ b/container/agent-runner/src/session-history.ts
@@ -1,0 +1,123 @@
+// Pure session-history utilities — extracted from index.ts to enable
+// unit testing without pulling in the full agent-runner module graph.
+
+import fs from 'fs';
+import path from 'path';
+
+import type { ParsedMessage } from './types.js';
+
+const RECOVERY_HISTORY_LIMIT = 20;
+const RECOVERY_MESSAGE_TRUNCATE = 500;
+
+// Strip lone (unpaired) surrogates while preserving valid surrogate pairs
+// such as emoji. Must stay byte-for-byte aligned with the matching regex
+// in src/index.ts (recoveryGroups path) — both sides feed the same Anthropic
+// API and must produce identical strings to keep behavior consistent across
+// the agent-runner-side and main-process-side recovery codepaths.
+const LONE_SURROGATE_RE =
+  /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g;
+
+export function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content
+                .map((c: { text?: string }) => c.text || '')
+                .join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+      // Tolerate malformed JSONL lines silently — partial recovery is better
+      // than failing the whole resume path on a single corrupt entry.
+    }
+  }
+
+  return messages;
+}
+
+export interface ExtractSessionHistoryOptions {
+  /** Directory containing the SDK transcript files (e.g. ~/.claude/projects/<encoded-cwd>) */
+  transcriptDir: string;
+  /** Session ID to extract history for. The function reads `${transcriptDir}/${sessionId}.jsonl`. */
+  sessionId: string;
+  /** Optional logger for debug breadcrumbs. Defaults to no-op. */
+  log?: (msg: string) => void;
+}
+
+/**
+ * Extract recent conversation history from a session's JSONL transcript and
+ * format it as a `<system_context>` block suitable for prompt injection.
+ *
+ * Returns null when:
+ * - the transcript file does not exist
+ * - the transcript contains zero recoverable messages
+ * - any I/O error occurs
+ *
+ * Behavior is intentionally tolerant — recovery is best-effort.
+ */
+export function extractSessionHistory(
+  opts: ExtractSessionHistoryOptions,
+): string | null {
+  const { transcriptDir, sessionId, log = () => {} } = opts;
+
+  try {
+    const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+
+    if (!fs.existsSync(transcriptPath)) {
+      log(`Session transcript not found at ${transcriptPath}`);
+      return null;
+    }
+
+    const content = fs.readFileSync(transcriptPath, 'utf-8');
+    const messages = parseTranscript(content);
+    if (messages.length === 0) return null;
+
+    const recentMessages = messages.slice(-RECOVERY_HISTORY_LIMIT);
+
+    const historyLines = recentMessages.map((m) => {
+      const role = m.role === 'user' ? 'User' : 'HappyClaw';
+      const truncated =
+        m.content.length > RECOVERY_MESSAGE_TRUNCATE
+          ? m.content.slice(0, RECOVERY_MESSAGE_TRUNCATE) + '…'
+          : m.content;
+      const cleaned = truncated.replace(LONE_SURROGATE_RE, '');
+      return `[${role}] ${cleaned}`;
+    });
+
+    log(
+      `Extracted ${recentMessages.length} messages from old session ${sessionId} for context injection`,
+    );
+
+    return (
+      '<system_context>\n' +
+      '会话恢复失败，当前为新会话。以下是之前的对话记录，供你了解上下文（请基于这些上下文继续对话）：\n\n' +
+      historyLines.join('\n') +
+      '\n</system_context>\n\n'
+    );
+  } catch (err) {
+    opts.log?.(
+      `Failed to extract session history: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
+// Test-only re-exports for assertions on internal constants.
+export const __test__ = {
+  RECOVERY_HISTORY_LIMIT,
+  RECOVERY_MESSAGE_TRUNCATE,
+  LONE_SURROGATE_RE,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2317,8 +2317,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         const role = m.is_from_me ? 'assistant' : m.sender_name;
         const truncated =
           m.content.length > 500 ? m.content.slice(0, 500) + '…' : m.content;
-        // Strip lone surrogates to avoid API JSON errors
-        const cleaned = truncated.replace(/[\uD800-\uDFFF]/g, '');
+        // Strip lone (unpaired) surrogates while preserving valid surrogate pairs
+        // such as emoji. Must stay byte-for-byte aligned with the matching regex
+        // in container/agent-runner/src/index.ts:extractSessionHistory — both
+        // sides feed the same Anthropic API and must produce identical strings.
+        const cleaned = truncated.replace(
+          /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g,
+          '',
+        );
         return `[${role}] ${cleaned}`;
       });
       prompt =

--- a/tests/session-history.test.ts
+++ b/tests/session-history.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  __test__,
+  extractSessionHistory,
+  parseTranscript,
+} from '../container/agent-runner/src/session-history';
+
+const { RECOVERY_HISTORY_LIMIT, RECOVERY_MESSAGE_TRUNCATE, LONE_SURROGATE_RE } =
+  __test__;
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-history-test-'));
+});
+
+afterEach(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function writeTranscript(sessionId: string, lines: object[]): void {
+  const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+  fs.writeFileSync(
+    transcriptPath,
+    lines.map((l) => JSON.stringify(l)).join('\n'),
+  );
+}
+
+describe('parseTranscript', () => {
+  test('extracts user and assistant text content', () => {
+    const content = [
+      JSON.stringify({
+        type: 'user',
+        message: { content: 'hello' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'hi back' }],
+        },
+      }),
+    ].join('\n');
+
+    const messages = parseTranscript(content);
+    expect(messages).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi back' },
+    ]);
+  });
+
+  test('tolerates malformed JSONL lines', () => {
+    const content = [
+      JSON.stringify({ type: 'user', message: { content: 'first' } }),
+      'this is not valid json',
+      '{not even close',
+      JSON.stringify({ type: 'user', message: { content: 'last' } }),
+    ].join('\n');
+
+    const messages = parseTranscript(content);
+    expect(messages).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'user', content: 'last' },
+    ]);
+  });
+
+  test('skips messages without text content', () => {
+    const content = [
+      JSON.stringify({ type: 'user', message: { content: '' } }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id: 'x' }] },
+      }),
+    ].join('\n');
+
+    expect(parseTranscript(content)).toEqual([]);
+  });
+});
+
+describe('extractSessionHistory', () => {
+  test('returns null when transcript file missing', () => {
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 'nonexistent',
+    });
+    expect(result).toBeNull();
+  });
+
+  test('honors RECOVERY_HISTORY_LIMIT (only last N messages)', () => {
+    // Write 25 messages, expect only the last 20 to appear
+    const messages = Array.from({ length: 25 }, (_, i) => ({
+      type: 'user',
+      message: { content: `msg-${i}` },
+    }));
+    writeTranscript('s1', messages);
+
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 's1',
+    });
+    expect(result).not.toBeNull();
+    // First 5 messages should be dropped, msg-5..msg-24 should remain
+    expect(result).not.toContain('msg-4');
+    expect(result).toContain('msg-5');
+    expect(result).toContain('msg-24');
+    // Quick sanity check: should have exactly RECOVERY_HISTORY_LIMIT entries
+    const lineCount = (result!.match(/\[User\]/g) || []).length;
+    expect(lineCount).toBe(RECOVERY_HISTORY_LIMIT);
+  });
+
+  test('truncates messages longer than RECOVERY_MESSAGE_TRUNCATE characters', () => {
+    const longText = 'x'.repeat(RECOVERY_MESSAGE_TRUNCATE + 100);
+    writeTranscript('s2', [
+      { type: 'user', message: { content: longText } },
+    ]);
+
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 's2',
+    });
+    expect(result).not.toBeNull();
+    // Should have exactly RECOVERY_MESSAGE_TRUNCATE 'x' characters followed by '…'
+    const xRun = 'x'.repeat(RECOVERY_MESSAGE_TRUNCATE);
+    expect(result).toContain(xRun + '…');
+    // Should NOT contain the truncated tail (one extra x)
+    expect(result).not.toContain(xRun + 'x');
+  });
+
+  test('strips lone surrogates while preserving valid emoji surrogate pairs', () => {
+    // Build a string with: valid emoji 😀 (U+1F600 = D83D DE00),
+    // lone high surrogate D800, lone low surrogate DC00, plain ASCII
+    const validEmoji = '\uD83D\uDE00'; // 😀
+    const loneHigh = '\uD800';
+    const loneLow = '\uDC00';
+    const input = `hi ${validEmoji} ${loneHigh} ${loneLow} bye`;
+
+    writeTranscript('s3', [
+      { type: 'user', message: { content: input } },
+    ]);
+
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 's3',
+    });
+    expect(result).not.toBeNull();
+    // Valid emoji should be preserved
+    expect(result).toContain(validEmoji);
+    // Lone surrogates should be stripped
+    expect(result).not.toContain(loneHigh);
+    expect(result).not.toContain(loneLow);
+  });
+
+  test('returns null when transcript has zero recoverable messages', () => {
+    writeTranscript('s4', [
+      { type: 'system', message: { content: 'meta only' } },
+    ]);
+
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 's4',
+    });
+    expect(result).toBeNull();
+  });
+
+  test('returns null and does not throw on malformed transcript', () => {
+    const transcriptPath = path.join(tmpDir, 'sbad.jsonl');
+    fs.writeFileSync(transcriptPath, 'completely invalid jsonl\n!@#$%');
+
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 'sbad',
+    });
+    // parseTranscript tolerates malformed lines and returns []. Then
+    // extractSessionHistory returns null because messages.length === 0.
+    expect(result).toBeNull();
+  });
+
+  test('wraps history in <system_context> block with restart prelude', () => {
+    writeTranscript('s5', [
+      { type: 'user', message: { content: 'hello' } },
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hi' }] },
+      },
+    ]);
+
+    const result = extractSessionHistory({
+      transcriptDir: tmpDir,
+      sessionId: 's5',
+    });
+    expect(result).toContain('<system_context>');
+    expect(result).toContain('</system_context>');
+    expect(result).toContain('[User] hello');
+    expect(result).toContain('[HappyClaw] hi');
+  });
+});
+
+describe('LONE_SURROGATE_RE invariant', () => {
+  // This regex MUST stay byte-for-byte aligned with the inline copy in
+  // src/index.ts (recoveryGroups path). If you edit this test, also audit
+  // src/index.ts to keep both code paths producing identical strings.
+  test('matches lone high surrogate', () => {
+    expect('\uD800'.replace(LONE_SURROGATE_RE, '')).toBe('');
+  });
+
+  test('matches lone low surrogate', () => {
+    expect('\uDC00'.replace(LONE_SURROGATE_RE, '')).toBe('');
+  });
+
+  test('preserves valid surrogate pair', () => {
+    const pair = '\uD83D\uDE00'; // 😀
+    expect(pair.replace(LONE_SURROGATE_RE, '')).toBe(pair);
+  });
+
+  test('preserves ASCII text', () => {
+    expect('hello world'.replace(LONE_SURROGATE_RE, '')).toBe('hello world');
+  });
+});


### PR DESCRIPTION
## 问题描述

跟进 #387 的两项审查遗留：

1. **测试覆盖缺失**：\`extractSessionHistory\` 是 #382 加入的恢复机制，没有任何测试。审查时已经标注需要补 5 个 case。
2. **审查时漏掉的 escape bug**：\`src/index.ts:2321\`（recoveryGroups 路径）的 surrogate 正则用 \`/[\uD800-\uDFFF]/g\`，会把**有效 emoji 一起删掉**。而 \`container/agent-runner/src/index.ts\` 的 \`extractSessionHistory\` 用了 \"剔除孤立代理对、保留有效 emoji\" 的更精确版本。两处行为不一致。

## 修复方案

### 抽离纯函数模块 \`container/agent-runner/src/session-history.ts\`

把 \`extractSessionHistory\` + \`parseTranscript\` 从 \`index.ts\` 抽离为独立模块：
- 接收 \`{ transcriptDir, sessionId, log? }\` 三个参数（去掉对 \`WORKSPACE_GROUP\` / \`log\` 全局的隐式依赖）
- \`RECOVERY_HISTORY_LIMIT\`、\`RECOVERY_MESSAGE_TRUNCATE\`、\`LONE_SURROGATE_RE\` 提取为命名常量
- \`__test__\` re-export 暴露常量给单测断言

### \`container/agent-runner/src/index.ts\`

保留同名 \`extractSessionHistory(oldSessionId)\` wrapper（维持原有调用方签名 1791/1991 行不变），删除内联实现，改为 import session-history 模块。

### \`src/index.ts\` — 修复 escape 正则

把 \`/[\uD800-\uDFFF]/g\` 改为：

\`\`\`typescript
/(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g
\`\`\`

两处现在产生 byte-for-byte 一致的字符串，供同一个 Anthropic API。注释提示后续编辑必须同步审计另一侧。

### \`tests/session-history.test.ts\` — 14 个 case

\`parseTranscript\`：
- 提取 user / assistant 文本
- 容忍 malformed JSONL 行
- 跳过没有文本内容的消息

\`extractSessionHistory\`：
- 缺失 transcript 文件 → graceful return null
- 25 条消息只取最后 \`RECOVERY_HISTORY_LIMIT (20)\` 条
- 长消息截断到 \`RECOVERY_MESSAGE_TRUNCATE (500)\` 字符
- **有效 emoji 保留 + 孤立 surrogate 清理**（核心 bug 防回归）
- 零消息 / 全 invalid → null
- \`<system_context>\` 包装文案

\`LONE_SURROGATE_RE\` invariant：
- 高/低 lone surrogate 清理
- 有效 pair 保留
- ASCII 透传

## 不在本 PR 范围（#387 后续）

- **\`<system_context>\` sentinel 强化**：500 字符截断已大幅缓解 \`</system_context>\` 字面量歧义，作为低优先级 follow-up 留在 #387
- **\`pollIpcDuringQuery\` 守护代码清理**：现有注释已经充分说明 invariant + defense-in-depth 用意（line 1090-1098 + 245-251），不动

## Test plan

- [x] \`make typecheck\` 三处全通过
- [x] \`make test\` 61 个测试全通过（新增 14 个）
- [x] 抽离后 \`extractSessionHistory\` wrapper 保持原签名 \`(oldSessionId: string) => string | null\`，调用点 1791 / 1991 无需修改
- [ ] 部署后手动触发 session resume 失败场景：删除一个 \`~/.claude/projects/{folder}/{sessionId}.jsonl\` 文件后重启 agent，确认两侧恢复逻辑都正确处理含 emoji 的用户消息