### PR TITLE
文档: 把 CLAUDE.md §7 Web API 拆出到 docs/API.md (#379 PR-A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,81 +390,26 @@ scripts/                      # 构建辅助脚本
 
 ## 7. Web API
 
-### 认证
-- `GET /api/auth/status` — 系统初始化状态（`initialized`、是否有用户）
-- `POST /api/auth/setup` — 创建首个管理员（仅用户表为空时可用）
-- `POST /api/auth/login` · `POST /api/auth/logout` · `GET /api/auth/me`（含 `setupStatus`）
-- `POST /api/auth/register` · `PUT /api/auth/profile` · `PUT /api/auth/change-password`
+> **完整 API 端点列表见 [`docs/API.md`](docs/API.md)**。新增或修改 Web 路由前请先阅读该文档。
+> 拆分原因：原 §7 整段约 3.5 KB / ~900 tokens 是只在新增/修改 API 时才需要的参考清单，
+> 强制每请求加载到 cache_read 不划算。详细清单按需 Read，下表保留路由文件入口作为快速锚点。
 
-### 群组
-- `GET /api/groups` · `POST /api/groups`（创建 Web 会话）
-- `PATCH /api/groups/:jid`（重命名） · `DELETE /api/groups/:jid`
-- `POST /api/groups/:jid/reset-session`（重建工作区）
-- `GET /api/groups/:jid/messages`（分页 + 轮询，支持多 JID 查询）
-- `GET|PUT /api/groups/:jid/env`（群组级容器环境变量）
+| 模块 | 入口文件 |
+|------|---------|
+| 认证 | `src/routes/auth.ts` |
+| 群组 | `src/routes/groups.ts` |
+| 文件 | `src/routes/files.ts` |
+| 记忆 | `src/routes/memory.ts` |
+| 配置（Claude / IM / 系统设置） | `src/routes/config.ts` |
+| 任务 | `src/routes/tasks.ts` |
+| 管理（用户 / 邀请码 / 审计） | `src/routes/admin.ts` |
+| Sub-Agent | `src/routes/agents.ts` |
+| 目录浏览 | `src/routes/browse.ts` |
+| MCP Servers | `src/routes/mcp-servers.ts` |
+| 用量统计 | `src/routes/usage.ts` |
+| 监控 / 健康检查 | `src/routes/monitor.ts`（`GET /api/health` 无需认证） |
 
-### 文件
-- `GET /api/groups/:jid/files` · `POST /api/groups/:jid/files`（上传，50MB 限制）
-- `GET /api/groups/:jid/files/download/:path` · `DELETE /api/groups/:jid/files/:path`
-- `POST /api/groups/:jid/directories`
-
-### 记忆
-- `GET /api/memory/sources` · `GET /api/memory/search`（全文检索）
-- `GET|PUT /api/memory/file`
-
-### 配置
-- `GET|PUT /api/config/claude` · `PUT /api/config/claude/secrets`
-- `GET|PUT /api/config/claude/custom-env`
-- `POST /api/config/claude/test`（连通性测试） · `POST /api/config/claude/apply`（应用到所有容器）
-- `GET|PUT /api/config/feishu`（**deprecated**，使用 `/api/config/user-im/feishu` 代替）
-- `GET|PUT /api/config/telegram` · `POST /api/config/telegram/test`（**deprecated**，使用 `/api/config/user-im/telegram` 代替）
-- `GET|PUT /api/config/appearance` · `GET /api/config/appearance/public`（外观配置，public 端点无需认证）
-- `GET|PUT /api/config/system` — 系统运行参数（容器超时、并发限制等），需要 `manage_system_config` 权限
-- `GET /api/config/user-im/status`（所有渠道连接状态，含 QQ）
-- `GET|PUT /api/config/user-im/feishu`（用户级飞书 IM 配置，GET 返回 `connected` 字段）
-- `GET|PUT /api/config/user-im/telegram`（用户级 Telegram IM 配置，GET 返回 `connected`、`effectiveProxyUrl`、`proxySource`，PUT 支持 `proxyUrl`/`clearProxyUrl`）
-- `POST /api/config/user-im/telegram/test`（Telegram Bot Token 连通性测试，使用 per-user proxyUrl）
-- `GET|PUT /api/config/user-im/qq`（用户级 QQ IM 配置，GET 返回 `connected` 字段）
-- `POST /api/config/user-im/qq/test`（QQ 凭据连通性测试）
-- `POST /api/config/user-im/qq/pairing-code`（生成 QQ 配对码）
-- `GET /api/config/user-im/qq/paired-chats`（已配对的 QQ 聊天列表）
-- `DELETE /api/config/user-im/qq/paired-chats/:jid`（移除 QQ 配对）
-- `GET|PUT /api/config/user-im/dingtalk`（用户级钉钉 IM 配置，GET 返回 `connected` 字段）
-
-### 任务
-- `GET /api/tasks` · `POST /api/tasks` · `PATCH /api/tasks/:id` · `DELETE /api/tasks/:id`
-- `GET /api/tasks/:id/logs`
-
-### 管理
-- `GET /api/admin/users` · `POST /api/admin/users` · `PATCH /api/admin/users/:id`
-- `DELETE /api/admin/users/:id` · `POST /api/admin/users/:id/restore`
-- `POST /api/admin/invites` · `GET /api/admin/invites` · `DELETE /api/admin/invites/:code`
-- `GET /api/admin/audit-log`
-- `GET|PUT /api/admin/settings/registration`
-
-### Sub-Agent
-- `GET /api/groups/:jid/agents` · `POST /api/groups/:jid/agents`（创建 Sub-Agent）
-- `DELETE /api/groups/:jid/agents/:agentId`
-
-### 目录浏览
-- `GET /api/browse/directories`（列出可选目录，受挂载白名单约束）
-- `POST /api/browse/directories`（创建自定义工作目录）
-
-### MCP Servers
-- `GET /api/mcp-servers` · `POST /api/mcp-servers`（CRUD，per-user）
-- `PATCH /api/mcp-servers/:id` · `DELETE /api/mcp-servers/:id`
-- `POST /api/mcp-servers/sync-host`（从宿主机同步 MCP Server 配置）
-
-### 用量统计
-- `GET /api/usage/stats?days=7&userId=&model=`（从 `usage_daily_summary` 查询，支持用户/模型筛选）
-- `GET /api/usage/models`（去重模型列表）
-- `GET /api/usage/users`（有用量数据的用户列表，admin 可见全部）
-
-### 监控
-- `GET /api/status` · `GET /api/health`（无需认证）
-
-### WebSocket
-- `/ws`（详见 §3.6 WebSocket 协议）
+WebSocket：`/ws`（协议详见 §3.6）。
 
 ## 8. 关键行为
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,95 @@
+# HappyClaw Web API 参考
+
+> 本文档从 `CLAUDE.md` §7 拆分而来。修改 / 新增 API 端点时请同步更新。
+>
+> 顶层 `CLAUDE.md` 只保留路由文件入口索引作为 Agent 快速导航锚点；
+> 详细端点清单按需 Read 本文档（每请求约节省 ~1K cache_read tokens）。
+
+## 认证
+
+- `GET /api/auth/status` — 系统初始化状态（`initialized`、是否有用户）
+- `POST /api/auth/setup` — 创建首个管理员（仅用户表为空时可用）
+- `POST /api/auth/login` · `POST /api/auth/logout` · `GET /api/auth/me`（含 `setupStatus`）
+- `POST /api/auth/register` · `PUT /api/auth/profile` · `PUT /api/auth/change-password`
+
+## 群组
+
+- `GET /api/groups` · `POST /api/groups`（创建 Web 会话）
+- `PATCH /api/groups/:jid`（重命名） · `DELETE /api/groups/:jid`
+- `POST /api/groups/:jid/reset-session`（重建工作区）
+- `GET /api/groups/:jid/messages`（分页 + 轮询，支持多 JID 查询）
+- `GET|PUT /api/groups/:jid/env`（群组级容器环境变量）
+
+## 文件
+
+- `GET /api/groups/:jid/files` · `POST /api/groups/:jid/files`（上传，50MB 限制）
+- `GET /api/groups/:jid/files/download/:path` · `DELETE /api/groups/:jid/files/:path`
+- `POST /api/groups/:jid/directories`
+
+## 记忆
+
+- `GET /api/memory/sources` · `GET /api/memory/search`（全文检索）
+- `GET|PUT /api/memory/file`
+
+## 配置
+
+- `GET|PUT /api/config/claude` · `PUT /api/config/claude/secrets`
+- `GET|PUT /api/config/claude/custom-env`
+- `POST /api/config/claude/test`（连通性测试） · `POST /api/config/claude/apply`（应用到所有容器）
+- `GET|PUT /api/config/feishu`（**deprecated**，使用 `/api/config/user-im/feishu` 代替）
+- `GET|PUT /api/config/telegram` · `POST /api/config/telegram/test`（**deprecated**，使用 `/api/config/user-im/telegram` 代替）
+- `GET|PUT /api/config/appearance` · `GET /api/config/appearance/public`（外观配置，public 端点无需认证）
+- `GET|PUT /api/config/system` — 系统运行参数（容器超时、并发限制、`autoCompactWindow` 等），需要 `manage_system_config` 权限
+- `GET /api/config/user-im/status`（所有渠道连接状态，含 QQ）
+- `GET|PUT /api/config/user-im/feishu`（用户级飞书 IM 配置，GET 返回 `connected` 字段）
+- `GET|PUT /api/config/user-im/telegram`（用户级 Telegram IM 配置，GET 返回 `connected`、`effectiveProxyUrl`、`proxySource`，PUT 支持 `proxyUrl`/`clearProxyUrl`）
+- `POST /api/config/user-im/telegram/test`（Telegram Bot Token 连通性测试，使用 per-user proxyUrl）
+- `GET|PUT /api/config/user-im/qq`（用户级 QQ IM 配置，GET 返回 `connected` 字段）
+- `POST /api/config/user-im/qq/test`（QQ 凭据连通性测试）
+- `POST /api/config/user-im/qq/pairing-code`（生成 QQ 配对码）
+- `GET /api/config/user-im/qq/paired-chats`（已配对的 QQ 聊天列表）
+- `DELETE /api/config/user-im/qq/paired-chats/:jid`（移除 QQ 配对）
+- `GET|PUT /api/config/user-im/dingtalk`（用户级钉钉 IM 配置，GET 返回 `connected` 字段）
+
+## 任务
+
+- `GET /api/tasks` · `POST /api/tasks` · `PATCH /api/tasks/:id` · `DELETE /api/tasks/:id`
+- `GET /api/tasks/:id/logs`
+
+## 管理
+
+- `GET /api/admin/users` · `POST /api/admin/users` · `PATCH /api/admin/users/:id`
+- `DELETE /api/admin/users/:id` · `POST /api/admin/users/:id/restore`
+- `POST /api/admin/invites` · `GET /api/admin/invites` · `DELETE /api/admin/invites/:code`
+- `GET /api/admin/audit-log`
+- `GET|PUT /api/admin/settings/registration`
+
+## Sub-Agent
+
+- `GET /api/groups/:jid/agents` · `POST /api/groups/:jid/agents`（创建 Sub-Agent）
+- `DELETE /api/groups/:jid/agents/:agentId`
+
+## 目录浏览
+
+- `GET /api/browse/directories`（列出可选目录，受挂载白名单约束）
+- `POST /api/browse/directories`（创建自定义工作目录）
+
+## MCP Servers
+
+- `GET /api/mcp-servers` · `POST /api/mcp-servers`（CRUD，per-user）
+- `PATCH /api/mcp-servers/:id` · `DELETE /api/mcp-servers/:id`
+- `POST /api/mcp-servers/sync-host`（从宿主机同步 MCP Server 配置）
+
+## 用量统计
+
+- `GET /api/usage/stats?days=7&userId=&model=`（从 `usage_daily_summary` 查询，支持用户/模型筛选）
+- `GET /api/usage/models`（去重模型列表）
+- `GET /api/usage/users`（有用量数据的用户列表，admin 可见全部）
+
+## 监控
+
+- `GET /api/status` · `GET /api/health`（无需认证）
+
+## WebSocket
+
+- `/ws`（详见 `CLAUDE.md` §3.6 WebSocket 协议）


### PR DESCRIPTION
## 问题描述

\`#379\` 拆分计划的第一步（PR-A），最安全的章节先做以验证 pointer 机制。

\`CLAUDE.md\` §7 Web API 整段约 78 行 / 3.5 KB / ~900 tokens，是 SDK \`settingSources: ['project']\` 强制每次请求加载的 baseline context 中**只在新增/修改 API 端点时才需要的参考清单**。强制每请求 cache_read 这部分内容不划算。

## 实现方案

### \`docs/API.md\` 新增

原 §7 整段内容原样迁移，按"认证 / 群组 / 文件 / 记忆 / 配置 / 任务 / 管理 / Sub-Agent / 目录浏览 / MCP Servers / 用量统计 / 监控 / WebSocket"组织。

### \`CLAUDE.md\` §7 替换

从 78 行端点清单替换为 23 行的路由文件入口表 + pointer：

\`\`\`markdown
## 7. Web API

> 完整 API 端点列表见 docs/API.md。新增或修改 Web 路由前请先阅读该文档。

| 模块 | 入口文件 |
|------|---------|
| 认证 | src/routes/auth.ts |
| 群组 | src/routes/groups.ts |
| ...（共 12 行）|
\`\`\`

Agent 仍然能从入口表快速定位代码（这是最常用的导航场景），需要详细 API 清单时按需 \`Read docs/API.md\`。

## 效果

\`CLAUDE.md\`：

| 指标 | 之前 | 之后 | 变化 |
|------|------|------|------|
| 行数 | 779 | 724 | -55 行 |
| 字节 | 46,861 | 43,741 | -3,120 字节 |
| 估算 tokens | ~12,000 | ~11,200 | ~-800 tokens |

每请求节省约 800 cache_read tokens（cache hit 状态下 \$0.0012 / 请求，低估值；cache miss 状态下 \$0.012 / 请求）。

## 后续

\`#379\` PR-B/C/D/E/F（认证 / 数据库 / 架构 / 行为 / 开发流程拆分）**不在本 PR 范围**：

- 等本 PR 落地观察 1-2 天，验证 \"路由入口表 + 按需 Read\" 的 pointer 机制是否可靠（Agent 在新增 API 任务中能否主动 Read \`docs/API.md\`）
- 等 #390 \`autoCompactWindow\` 的效果出来后再决定剩余章节拆分的优先级（如果长会话 cache_read 已经压到 200K 以下，固定开销优化的相对收益会大幅下降）

## Test plan

- [x] \`make typecheck\` 三处全通过（无代码改动，纯 markdown）
- [x] CLAUDE.md 行数 / 字节数确认下降
- [ ] 部署后 fresh session 测试：在新建群组里发"请帮我新增一个 \`/api/test/hello\` GET 路由"，观察 Agent 是否会主动 \`Read docs/API.md\`
- [ ] 部署后观察 \`usage_daily_summary\` 的 cache_read 中位数 1-2 天，确认下降趋势