### PR TITLE
构建: Docker 镜像动态跟踪 feishu-cli latest release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,7 +543,10 @@ WebSocket：`/ws`（协议详见 §3.6）。
 - **Issue / PR 规范**见下方 §10.1
 - 系统路径不可通过文件 API 操作：`logs/`、`CLAUDE.md`、`.claude/`、`conversations/`
 - StreamEvent 类型以 `shared/stream-event.ts` 为单一真相源，修改后运行 `make sync-types` 同步（`make build` 自动触发，`make typecheck` 校验一致性）
-- Claude SDK 和 CLI 始终使用最新版本（agent-runner `package.json` 中 `"*"`，通过 `make update-sdk` 更新）
+- Claude SDK / CLI 和容器内置的第三方工具始终使用最新版本：
+  - `@anthropic-ai/claude-agent-sdk` 在 `agent-runner/package.json` 用 `"*"` + 无 lock file + `CACHEBUST` 触发每次 `npm install` 重跑
+  - `feishu-cli` 在 `container/Dockerfile` 通过 `github.com/riba2534/feishu-cli/releases/latest` 的 **302 redirect Location header** 提取 tag 动态下载（不走 `api.github.com` 规避 rate limit），binary 和 skills 共享同一 `$VERSION` 确保一致
+  - 通过 `make update-sdk` 手动触发一次更新
 - 容器内以 `node` 非 root 用户运行，需注意文件权限
 - **关闭服务时禁止 `lsof -ti:PORT | xargs kill`**，该命令会杀掉所有连接到该端口的进程（包括 OrbStack/Docker 网络代理），导致 Docker daemon 崩溃。正确做法：`lsof -ti:PORT -sTCP:LISTEN | xargs kill`（仅杀监听进程）
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -109,26 +109,28 @@ ARG CACHEBUST=1
 RUN npm install -g agent-browser
 RUN npm install
 
-# Install feishu-cli (pre-compiled binary from GitHub Releases)
-# Non-fatal: GitHub API rate limits may cause transient failures
+# Install feishu-cli (binary + builtin skills), 始终跟踪 latest release。
+# 通过 302 redirect 从 github.com/releases/latest 的 Location header 提取 tag
+# （和 install.sh 作者自己用的技巧一致），不经 api.github.com 规避 rate limit。
+# CACHEBUST 已在此前触发，每次构建都会重新解析 latest。
 ARG TARGETARCH
-RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}"; \
-    VERSION=$(curl -fsSL https://api.github.com/repos/riba2534/feishu-cli/releases/latest 2>/dev/null | jq -r .tag_name 2>/dev/null); \
-    if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then \
-      curl -fsSL "https://github.com/riba2534/feishu-cli/releases/download/${VERSION}/feishu-cli_${VERSION}_linux-${ARCH}.tar.gz" \
-        | tar -xz --strip-components=1 -C /usr/local/bin && \
-      feishu-cli --version; \
-    else \
-      echo "WARNING: Failed to fetch feishu-cli version (GitHub API rate limit?), skipping installation"; \
-    fi
-
-# Install feishu-cli skills (builtin, lowest priority in discovery)
-# Non-fatal: GitHub API rate limits may cause transient failures
-RUN mkdir -p /opt/builtin-skills; \
-    curl -fsSL https://api.github.com/repos/riba2534/feishu-cli/tarball/main 2>/dev/null \
-      | tar -xz --strip-components=2 -C /opt/builtin-skills --wildcards '*/skills/*' 2>/dev/null \
-    && ls /opt/builtin-skills/ \
-    || echo "WARNING: Failed to fetch feishu-cli skills, skipping"
+RUN set -e && \
+    ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    VERSION=$(curl -sI "https://github.com/riba2534/feishu-cli/releases/latest" \
+      | grep -i '^location:' | head -1 \
+      | sed 's|.*/tag/\([^[:space:]]*\).*|\1|' | tr -d '\r\n') && \
+    if [ -z "$VERSION" ]; then echo "ERROR: 无法从 github.com 302 redirect 解析 feishu-cli 最新版本"; exit 1; fi && \
+    echo "Installing feishu-cli $VERSION for $ARCH" && \
+    curl -fsSL "https://github.com/riba2534/feishu-cli/releases/download/${VERSION}/feishu-cli_${VERSION}_linux-${ARCH}.tar.gz" \
+      | tar -xz --strip-components=1 -C /usr/local/bin && \
+    feishu-cli --version && \
+    mkdir -p /opt/builtin-skills && \
+    SKILLS_TMP=$(mktemp -d) && \
+    curl -fsSL "https://github.com/riba2534/feishu-cli/archive/refs/tags/${VERSION}.tar.gz" \
+      | tar -xz -C "$SKILLS_TMP" && \
+    cp -r "$SKILLS_TMP"/*/skills/. /opt/builtin-skills/ && \
+    rm -rf "$SKILLS_TMP" && \
+    ls /opt/builtin-skills/
 
 # Copy source code
 COPY agent-runner/ ./


### PR DESCRIPTION
## 问题描述

为 Agent 容器内置飞书开放平台 CLI（[riba2534/feishu-cli](https://github.com/riba2534/feishu-cli)）及其 14 个配套 skills，让 member 用户的 **container 执行模式**开箱即用，无需每个用户自行安装。

## 为什么动态跟踪 latest 而不是 pin 版本

遵循 CLAUDE.md §10 的既有约定："Claude SDK / CLI 和容器内置的第三方工具始终使用最新版本"。feishu-cli 加入这一条 policy。

## 为什么不走 `api.github.com`

- `api.github.com` 未认证配额 60 次/小时，共享同一出口 IP
- 多人共享网络 / CI / 多次构建场景下极易 403
- feishu-cli 作者的 `install.sh` 自己也是先走 302 redirect trick，API 仅作 fallback（见 `install.sh get_latest_version` 函数）

## 实现

**`container/Dockerfile`**:

- 用 `curl -sI github.com/riba2534/feishu-cli/releases/latest` 的 `Location` header 提取 tag 作为 `$VERSION`
- 从 `github.com/.../releases/download/${VERSION}/...` 直链下载 binary
- 从 `github.com/.../archive/refs/tags/${VERSION}.tar.gz` 解压源码 tarball 的 `skills/` 到 `/opt/builtin-skills/`
  - `entrypoint.sh` line 32 的 skill 发现顺序：`/opt/builtin-skills → /workspace/external-skills → /workspace/project-skills → /workspace/user-skills`（后覆盖前）
  - builtin 优先级最低，用户挂载的 user skills 可以覆盖
- binary 和 skills 共享同一 `$VERSION` 变量，确保同一 release 一致
- 302 解析失败直接 `exit 1`，不再像之前那样非致命 fallback 到 warning
- CACHEBUST 机制已经让此 RUN 层每次 build 都重跑，不依赖额外机制

## 尊重宿主机环境（重要）

**host 执行模式（admin 主容器）不代为安装 feishu-cli skills 或 binary**。HappyClaw 作为开源项目，host 模式应完全尊重宿主机现有环境；第三方 CLI 依赖只在 Docker 镜像层做。如果 admin 想在 host 模式用到这些能力，由用户自行 `npx skills add` + `curl install.sh | bash`。

## CLAUDE.md §10 文档同步

扩展原"Claude SDK 和 CLI 始终使用最新版本"为三条子弹：
1. `@anthropic-ai/claude-agent-sdk` 用 `"*"` + 无 lock file + CACHEBUST
2. `feishu-cli` 走 github.com 302 redirect 动态解析 latest tag
3. `make update-sdk` 手动触发一次更新

## Test plan

- [x] `./container/build.sh` 构建成功，无 error 无 warning
- [x] `docker run --rm --entrypoint sh happyclaw-agent:latest -c 'feishu-cli --version'` → `feishu-cli version v1.18.0 (built 2026-04-10_19:47:35)`
- [x] `docker run --rm --entrypoint sh happyclaw-agent:latest -c 'ls /opt/builtin-skills/'` → 14 个 feishu-cli-* 目录全部存在（auth / bitable / board / chat / doc-guide / export / import / msg / perm / read / search / toolkit / vc / write）
- [x] 每个 skill 目录下 `SKILL.md` 可读（采样 `feishu-cli-import/SKILL.md` 前 5 行验证）
- [ ] **合入前建议跑一次 `./container/build.sh`** 验证当天 302 解析到的 latest 版本仍能正常下载（GitHub 偶发短暂不可用）
- [ ] **member 用户的 container 模式**发消息触发 Agent 调用 `feishu-cli-import` 之类 skill，确认 `/opt/builtin-skills/` 被 entrypoint.sh 正确 symlink 到 `/home/node/.claude/skills/` 且 SDK 能发现