### PR TITLE
修复: 飞书视频/音频消息发送失败 (#400)

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -1824,8 +1824,12 @@ export function createFeishuConnection(
           throw new Error('文件上传失败：未返回 file_key');
         }
 
+        // Determine msg_type: Feishu requires upload file_type and send msg_type to match.
+        // mp4 → media (video message), opus → audio (audio message), others → file.
+        const msgType = fileType === 'mp4' ? 'media' : fileType === 'opus' ? 'audio' : 'file';
+
         // Send file message
-        await sendToFeishu(chatId, 'file', JSON.stringify({ file_key: fileKey }));
+        await sendToFeishu(chatId, msgType, JSON.stringify({ file_key: fileKey }));
 
         logger.info(
           { chatId, fileName, fileSize: buffer.length },


### PR DESCRIPTION
## 问题描述

关闭 #400。

飞书 `sendFile()` 上传文件时 `file_type` 正确区分了 `mp4`/`opus`/`stream` 等类型，但发送消息时 `msg_type` 固定为 `'file'`，导致飞书 API 返回 230055 错误，视频和音频文件无法发送。

## 修复方案

### `src/feishu.ts`

- 在 `sendToFeishu()` 调用前，根据 `fileType` 映射正确的 `msg_type`：
  - `mp4` → `media`（视频消息）
  - `opus` → `audio`（音频消息）
  - 其他 → `file`（文件消息，行为不变）
- 三种消息类型的 content 格式均为 `{"file_key": "xxx"}`，无需修改消息体

**次生影响**：无。仅影响 `sendFile()` 的 msg_type 参数，不改变上传逻辑、重试逻辑和其他消息类型的发送路径。


🤖 Generated with [Claude Code](https://claude.com/claude-code)