### PR TITLE
feat: 扩展文件预览MIME类型支持

### DIFF
--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -38,6 +38,8 @@ const MIME_MAP: Record<string, string> = {
   gif: 'image/gif',
   svg: 'image/svg+xml',
   webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
   // 文本和代码
   txt: 'text/plain',
   md: 'text/markdown',
@@ -66,6 +68,19 @@ const MIME_MAP: Record<string, string> = {
   csv: 'text/csv',
   // PDF
   pdf: 'application/pdf',
+  // 视频
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  // 音频
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  aac: 'audio/aac',
+  m4a: 'audio/mp4',
+  flac: 'audio/flac',
   // 压缩文件
   zip: 'application/zip',
   tar: 'application/x-tar',
@@ -105,10 +120,12 @@ const TEXT_EXTENSIONS = new Set([
 
 // 允许 inline 预览的安全 MIME 类型（排除 HTML 和 SVG 以防止 XSS）
 const SAFE_PREVIEW_MIME_TYPES = new Set([
+  // 图片
   'image/png',
   'image/jpeg',
   'image/gif',
   'image/webp',
+  // 文本
   'text/plain',
   'text/markdown',
   'text/css',
@@ -126,7 +143,21 @@ const SAFE_PREVIEW_MIME_TYPES = new Set([
   'text/typescript',
   'application/json',
   'application/xml',
+  // PDF
   'application/pdf',
+  // 视频
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+  'video/x-msvideo',
+  'video/x-matroska',
+  // 音频
+  'audio/mpeg',
+  'audio/wav',
+  'audio/ogg',
+  'audio/aac',
+  'audio/mp4',
+  'audio/flac',
 ]);
 
 /**

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -125,6 +125,8 @@ const SAFE_PREVIEW_MIME_TYPES = new Set([
   'image/jpeg',
   'image/gif',
   'image/webp',
+  'image/bmp',
+  'image/x-icon',
   // 文本
   'text/plain',
   'text/markdown',
@@ -586,29 +588,98 @@ fileRoutes.get('/:jid/files/preview/:path', authMiddleware, (c) => {
     // 检测 MIME 类型（基于扩展名）
     const ext = path.extname(absolutePath).slice(1).toLowerCase();
     const mimeType = MIME_MAP[ext] || 'application/octet-stream';
-
-    // 读取文件并返回
-    const fileContent = fs.readFileSync(absolutePath);
     const fileName = path.basename(absolutePath);
+    const fileSize = stats.size;
 
-    // 安全头：始终添加 CSP sandbox 和 nosniff
-    c.header('Content-Security-Policy', "default-src 'none'; sandbox");
-    c.header('X-Content-Type-Options', 'nosniff');
+    // 判断是否为流媒体类型（视频/音频），需支持 Range 请求
+    const isStreamable =
+      mimeType.startsWith('video/') || mimeType.startsWith('audio/');
 
+    // 安全头
+    const securityHeaders: Record<string, string> = {
+      'Content-Security-Policy': "default-src 'none'; sandbox",
+      'X-Content-Type-Options': 'nosniff',
+    };
+
+    // Content-Type 和 Content-Disposition
+    let contentType: string;
+    let disposition: string;
     if (SAFE_PREVIEW_MIME_TYPES.has(mimeType)) {
-      // 安全类型：允许 inline 预览
-      c.header('Content-Type', mimeType);
-      c.header('Content-Disposition', 'inline');
+      contentType = mimeType;
+      disposition = 'inline';
     } else {
-      // 不安全类型（HTML、SVG 等）：强制下载
-      c.header('Content-Type', 'application/octet-stream');
-      c.header(
-        'Content-Disposition',
-        `attachment; filename="${encodeURIComponent(fileName)}"`,
-      );
+      contentType = 'application/octet-stream';
+      disposition = `attachment; filename="${encodeURIComponent(fileName)}"`;
     }
 
-    return c.body(fileContent);
+    const commonHeaders = {
+      ...securityHeaders,
+      'Content-Type': contentType,
+      'Content-Disposition': disposition,
+    };
+
+    // 流媒体类型：支持 Range 请求（浏览器 <video>/<audio> seek 依赖此机制）
+    if (isStreamable) {
+      const rangeHeader = c.req.header('range');
+      if (rangeHeader) {
+        const normalizedRange = rangeHeader.trim();
+        const isBytesRange =
+          normalizedRange.toLowerCase().startsWith('bytes=');
+        const isMultiRange = isBytesRange && normalizedRange.includes(',');
+
+        if (isBytesRange && !isMultiRange) {
+          const parsedRange = parseSingleRange(normalizedRange, fileSize);
+          if (!parsedRange) {
+            return new Response(null, {
+              status: 416,
+              headers: {
+                ...commonHeaders,
+                'Content-Range': `bytes */${fileSize}`,
+              },
+            });
+          }
+
+          const { start, end } = parsedRange;
+          const stream = Readable.toWeb(
+            fs.createReadStream(absolutePath, { start, end }),
+          ) as ReadableStream<Uint8Array>;
+          return new Response(stream, {
+            status: 206,
+            headers: {
+              ...commonHeaders,
+              'Accept-Ranges': 'bytes',
+              'Content-Length': String(end - start + 1),
+              'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+            },
+          });
+        }
+      }
+
+      // 无 Range 或多区间回退：流式返回完整文件
+      const stream = Readable.toWeb(
+        fs.createReadStream(absolutePath),
+      ) as ReadableStream<Uint8Array>;
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          ...commonHeaders,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': String(fileSize),
+        },
+      });
+    }
+
+    // 非流媒体类型：也使用流式响应避免大文件占满内存
+    const stream = Readable.toWeb(
+      fs.createReadStream(absolutePath),
+    ) as ReadableStream<Uint8Array>;
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        ...commonHeaders,
+        'Content-Length': String(fileSize),
+      },
+    });
   } catch (error) {
     logger.error({ err: error }, `Failed to preview file for ${jid}`);
     return c.json({ error: 'Failed to preview file' }, 500);

--- a/web/src/components/chat/FilePanel.tsx
+++ b/web/src/components/chat/FilePanel.tsx
@@ -19,6 +19,8 @@ import {
   Loader2,
   Eye,
   FileEdit,
+  Film,
+  Music,
 } from 'lucide-react';
 import { useFileStore, FileEntry, toBase64Url } from '../../stores/files';
 import { useChatStore } from '../../stores/chat';
@@ -27,7 +29,12 @@ import { api } from '../../api/client';
 import { withBasePath } from '../../utils/url';
 import { downloadFromUrl } from '../../utils/download';
 import { showToast } from '../../utils/toast';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -45,23 +52,81 @@ interface FilePanelProps {
 // ─── File type constants ─────────────────────────────────────────
 
 const IMAGE_EXTENSIONS = new Set([
-  'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
+  'webp',
+  'bmp',
+  'ico',
 ]);
 
 const TEXT_EXTENSIONS = new Set([
-  'txt', 'md', 'json', 'js', 'ts', 'jsx', 'tsx', 'css', 'html', 'xml',
-  'py', 'go', 'rs', 'java', 'c', 'cpp', 'h', 'sh', 'yaml', 'yml',
-  'toml', 'ini', 'conf', 'log', 'csv', 'svg',
+  'txt',
+  'md',
+  'json',
+  'js',
+  'ts',
+  'jsx',
+  'tsx',
+  'css',
+  'html',
+  'xml',
+  'py',
+  'go',
+  'rs',
+  'java',
+  'c',
+  'cpp',
+  'h',
+  'sh',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'conf',
+  'log',
+  'csv',
+  'svg',
 ]);
 
 const CODE_EXTENSIONS = new Set([
-  'js', 'ts', 'jsx', 'tsx', 'py', 'go', 'rs', 'java', 'c', 'cpp', 'h',
-  'sh', 'css', 'html', 'xml', 'yaml', 'yml', 'toml',
+  'js',
+  'ts',
+  'jsx',
+  'tsx',
+  'py',
+  'go',
+  'rs',
+  'java',
+  'c',
+  'cpp',
+  'h',
+  'sh',
+  'css',
+  'html',
+  'xml',
+  'yaml',
+  'yml',
+  'toml',
 ]);
 
 const ARCHIVE_EXTENSIONS = new Set([
-  'zip', 'tar', 'gz', '7z', 'rar', 'bz2', 'xz',
+  'zip',
+  'tar',
+  'gz',
+  '7z',
+  'rar',
+  'bz2',
+  'xz',
 ]);
+
+const PDF_EXTENSIONS = new Set(['pdf']);
+
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'avi', 'mkv']);
+
+const AUDIO_EXTENSIONS = new Set(['mp3', 'wav', 'ogg', 'aac', 'm4a', 'flac']);
 
 // ─── File icon component ────────────────────────────────────────
 
@@ -70,14 +135,15 @@ function FileIcon({ name }: { name: string }) {
 
   if (IMAGE_EXTENSIONS.has(ext))
     return <Image className="w-4 h-4 text-pink-500" />;
+  if (VIDEO_EXTENSIONS.has(ext))
+    return <Film className="w-4 h-4 text-purple-500" />;
+  if (AUDIO_EXTENSIONS.has(ext))
+    return <Music className="w-4 h-4 text-cyan-500" />;
   if (ARCHIVE_EXTENSIONS.has(ext))
     return <Package className="w-4 h-4 text-amber-500" />;
-  if (ext === 'pdf')
-    return <FileText className="w-4 h-4 text-red-500" />;
-  if (ext === 'json')
-    return <FileCode className="w-4 h-4 text-yellow-600" />;
-  if (ext === 'md')
-    return <FileText className="w-4 h-4 text-blue-500" />;
+  if (ext === 'pdf') return <FileText className="w-4 h-4 text-red-500" />;
+  if (ext === 'json') return <FileCode className="w-4 h-4 text-yellow-600" />;
+  if (ext === 'md') return <FileText className="w-4 h-4 text-blue-500" />;
   if (CODE_EXTENSIONS.has(ext))
     return <FileCode className="w-4 h-4 text-emerald-500" />;
   if (TEXT_EXTENSIONS.has(ext))
@@ -89,9 +155,34 @@ function getFileExt(name: string): string {
   return name.split('.').pop()?.toLowerCase() || '';
 }
 
-function isClickableFile(name: string, isSystem: boolean): boolean {
+/** 黑名单扩展名/文件名模式：不显示预览/编辑按钮 */
+const PREVIEW_BLACKLIST_EXTENSIONS = new Set([
+  'tmp',
+  'swp',
+  'swo',
+  'temp',
+  'cache',
+]);
+
+/** 判断文件是否应该显示预览/编辑按钮 */
+function isPreviewableFile(name: string, isSystem: boolean): boolean {
+  if (isSystem) return false;
   const ext = getFileExt(name);
-  return IMAGE_EXTENSIONS.has(ext) || (TEXT_EXTENSIONS.has(ext) && !isSystem);
+  // 排除备份/临时文件
+  if (PREVIEW_BLACKLIST_EXTENSIONS.has(ext)) return false;
+  return true;
+}
+
+function isClickableFile(name: string, isSystem: boolean): boolean {
+  if (!isPreviewableFile(name, isSystem)) return false;
+  const ext = getFileExt(name);
+  // 图片、视频、音频、PDF 有专门预览
+  if (IMAGE_EXTENSIONS.has(ext)) return true;
+  if (VIDEO_EXTENSIONS.has(ext)) return true;
+  if (AUDIO_EXTENSIONS.has(ext)) return true;
+  if (PDF_EXTENSIONS.has(ext)) return true;
+  // 其他文件都走通用文本预览（后端会判断是否二进制）
+  return true;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────
@@ -100,7 +191,10 @@ function formatSize(bytes: number): string {
   if (!bytes || bytes <= 0) return '0 B';
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(k)),
+    sizes.length - 1,
+  );
   return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
 }
 
@@ -123,7 +217,9 @@ function ImagePreview({
     return () => window.removeEventListener('keydown', handleEsc);
   }, [onClose]);
 
-  const previewUrl = withBasePath(`/api/groups/${encodeURIComponent(groupJid)}/files/preview/${toBase64Url(file.path)}`);
+  const previewUrl = withBasePath(
+    `/api/groups/${encodeURIComponent(groupJid)}/files/preview/${toBase64Url(file.path)}`,
+  );
 
   return createPortal(
     <div
@@ -184,7 +280,7 @@ function TextEditor({
       window.removeEventListener('keydown', handleEsc);
       window.removeEventListener('keydown', handleSave);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onClose, content, dirty]);
 
   useEffect(() => {
@@ -197,7 +293,9 @@ function TextEditor({
       }
       if (!cancelled) setLoading(false);
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [groupJid, file.path, getFileContent]);
 
   const handleSave_ = async () => {
@@ -221,17 +319,17 @@ function TextEditor({
         <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
           <div className="flex items-center gap-2 min-w-0">
             <FileIcon name={file.name} />
-            <span className="font-medium text-foreground text-sm truncate">{file.name}</span>
+            <span className="font-medium text-foreground text-sm truncate">
+              {file.name}
+            </span>
             {dirty && (
-              <span className="text-xs text-amber-500 flex-shrink-0">未保存</span>
+              <span className="text-xs text-amber-500 flex-shrink-0">
+                未保存
+              </span>
             )}
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <Button
-              size="sm"
-              onClick={handleSave_}
-              disabled={!dirty || saving}
-            >
+            <Button size="sm" onClick={handleSave_} disabled={!dirty || saving}>
               {saving && <Loader2 className="size-4 animate-spin" />}
               <Save className="w-3.5 h-3.5" />
               保存
@@ -300,7 +398,9 @@ function MarkdownFileViewer({
   useEffect(() => {
     const prev = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
-    return () => { document.body.style.overflow = prev; };
+    return () => {
+      document.body.style.overflow = prev;
+    };
   }, []);
 
   useEffect(() => {
@@ -333,7 +433,9 @@ function MarkdownFileViewer({
       }
       if (!cancelled) setLoading(false);
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [groupJid, file.path, getFileContent]);
 
   const doSave = async () => {
@@ -361,9 +463,12 @@ function MarkdownFileViewer({
   };
 
   // Only close on backdrop click (not on touch-scroll that ends on backdrop)
-  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) onClose();
-  }, [onClose]);
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
 
   return createPortal(
     <div
@@ -379,9 +484,13 @@ function MarkdownFileViewer({
         <div className="flex items-center justify-between px-3 sm:px-4 py-2.5 border-b border-border flex-shrink-0">
           <div className="flex items-center gap-2 min-w-0 flex-1">
             <FileIcon name={file.name} />
-            <span className="font-medium text-foreground text-sm truncate">{file.name}</span>
+            <span className="font-medium text-foreground text-sm truncate">
+              {file.name}
+            </span>
             {dirty && (
-              <span className="text-xs text-amber-500 flex-shrink-0">未保存</span>
+              <span className="text-xs text-amber-500 flex-shrink-0">
+                未保存
+              </span>
             )}
           </div>
           <div className="flex items-center gap-1 sm:gap-1.5 flex-shrink-0">
@@ -444,7 +553,11 @@ function MarkdownFileViewer({
               className="absolute inset-0 overflow-y-auto overscroll-y-contain px-4 sm:px-6 py-4 [&_table_td]:!whitespace-normal [&_table_th]:!whitespace-normal"
               style={{ WebkitOverflowScrolling: 'touch', touchAction: 'pan-y' }}
             >
-              <MarkdownRenderer content={content} groupJid={groupJid} variant="docs" />
+              <MarkdownRenderer
+                content={content}
+                groupJid={groupJid}
+                variant="docs"
+              />
             </div>
           ) : (
             <div className="absolute inset-0 p-2 sm:p-3">
@@ -456,7 +569,10 @@ function MarkdownFileViewer({
                   setDirty(true);
                 }}
                 className="w-full h-full font-mono text-sm text-foreground resize-none bg-muted"
-                style={{ WebkitOverflowScrolling: 'touch', touchAction: 'pan-y' }}
+                style={{
+                  WebkitOverflowScrolling: 'touch',
+                  touchAction: 'pan-y',
+                }}
                 spellCheck={false}
               />
             </div>
@@ -465,7 +581,250 @@ function MarkdownFileViewer({
 
         {/* Footer */}
         <div className="px-3 sm:px-4 py-1.5 border-t border-border text-xs text-muted-foreground flex-shrink-0">
-          {mode === 'edit' ? 'Ctrl/Cmd+S 保存 · Esc 关闭' : '点击「编辑」修改内容 · Esc 关闭'}
+          {mode === 'edit'
+            ? 'Ctrl/Cmd+S 保存 · Esc 关闭'
+            : '点击「编辑」修改内容 · Esc 关闭'}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── PDF Preview Overlay ────────────────────────────────────────
+
+function PdfPreview({
+  groupJid,
+  file,
+  onClose,
+}: {
+  groupJid: string;
+  file: FileEntry;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const previewUrl = withBasePath(
+    `/api/groups/${encodeURIComponent(groupJid)}/files/preview/${toBase64Url(file.path)}`,
+  );
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <button
+        className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors p-2 cursor-pointer z-10"
+        onClick={onClose}
+        aria-label="关闭预览"
+      >
+        <X className="w-8 h-8" />
+      </button>
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/70 text-sm bg-black/50 px-3 py-1 rounded-full">
+        {file.name}
+      </div>
+      <iframe
+        src={previewUrl}
+        title={file.name}
+        className="w-full h-full max-w-[90vw] max-h-[90vh] rounded-lg bg-white"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Video Preview Overlay ─────────────────────────────────────
+
+function VideoPreview({
+  groupJid,
+  file,
+  onClose,
+}: {
+  groupJid: string;
+  file: FileEntry;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const previewUrl = withBasePath(
+    `/api/groups/${encodeURIComponent(groupJid)}/files/preview/${toBase64Url(file.path)}`,
+  );
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <button
+        className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors p-2 cursor-pointer z-10"
+        onClick={onClose}
+        aria-label="关闭预览"
+      >
+        <X className="w-8 h-8" />
+      </button>
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/70 text-sm bg-black/50 px-3 py-1 rounded-full">
+        {file.name}
+      </div>
+      <video
+        src={previewUrl}
+        controls
+        autoPlay
+        className="max-w-[90vw] max-h-[90vh] rounded-lg"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Audio Preview Overlay ─────────────────────────────────────
+
+function AudioPreview({
+  groupJid,
+  file,
+  onClose,
+}: {
+  groupJid: string;
+  file: FileEntry;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const previewUrl = withBasePath(
+    `/api/groups/${encodeURIComponent(groupJid)}/files/preview/${toBase64Url(file.path)}`,
+  );
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface rounded-xl shadow-xl w-full max-w-lg p-6 flex flex-col items-center gap-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 w-full">
+          <Music className="w-10 h-10 text-cyan-500 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="font-medium text-foreground truncate">{file.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {formatSize(file.size)}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground transition-colors p-2 cursor-pointer"
+            aria-label="关闭"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <audio src={previewUrl} controls autoPlay className="w-full" />
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Generic File Preview (for hidden files like .gitignore) ──
+
+function GenericTextPreview({
+  groupJid,
+  file,
+  onClose,
+}: {
+  groupJid: string;
+  file: FileEntry;
+  onClose: () => void;
+}) {
+  const { getFileContent } = useFileStore();
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const text = await getFileContent(groupJid, file.path);
+      if (!cancelled && text !== null) {
+        setContent(text);
+      }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [groupJid, file.path, getFileContent]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-3 lg:p-6"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface rounded-xl shadow-xl w-full max-w-4xl h-[85vh] supports-[height:100dvh]:h-[85vh] flex flex-col animate-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <FileIcon name={file.name} />
+            <span className="font-medium text-foreground text-sm truncate">
+              {file.name}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground transition-colors p-2 rounded-md hover:bg-muted cursor-pointer"
+            aria-label="关闭预览"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 p-4 overflow-auto">
+          {loading ? (
+            <div className="flex items-center justify-center h-full">
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <pre className="text-sm text-foreground whitespace-pre-wrap break-all font-mono">
+              {content}
+            </pre>
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="px-4 py-2 border-t border-border text-xs text-muted-foreground flex-shrink-0">
+          Esc 关闭
         </div>
       </div>
     </div>,
@@ -476,8 +835,15 @@ function MarkdownFileViewer({
 // ─── Main FilePanel ─────────────────────────────────────────────
 
 export function FilePanel({ groupJid, onClose }: FilePanelProps) {
-  const { files, currentPath, loading, loadFiles, deleteFile, createDirectory, navigateTo } =
-    useFileStore();
+  const {
+    files,
+    currentPath,
+    loading,
+    loadFiles,
+    deleteFile,
+    createDirectory,
+    navigateTo,
+  } = useFileStore();
 
   const [createDirModal, setCreateDirModal] = useState(false);
   const [newDirName, setNewDirName] = useState('');
@@ -497,6 +863,12 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
   const [previewFile, setPreviewFile] = useState<FileEntry | null>(null);
   const [editFile, setEditFile] = useState<FileEntry | null>(null);
   const [mdViewFile, setMdViewFile] = useState<FileEntry | null>(null);
+  const [pdfViewFile, setPdfViewFile] = useState<FileEntry | null>(null);
+  const [videoViewFile, setVideoViewFile] = useState<FileEntry | null>(null);
+  const [audioViewFile, setAudioViewFile] = useState<FileEntry | null>(null);
+  const [genericTextFile, setGenericTextFile] = useState<FileEntry | null>(
+    null,
+  );
 
   const isStreaming = useChatStore((s) => !!s.streaming[groupJid]);
   const canOpenLocalFolder = useAuthStore((s) => s.user?.role === 'admin');
@@ -548,44 +920,70 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
     }
   };
 
-  const handleItemClick = useCallback((item: FileEntry) => {
-    if (item.type === 'directory') {
-      navigateTo(groupJid, item.path);
-      return;
-    }
+  const handleItemClick = useCallback(
+    (item: FileEntry) => {
+      if (item.type === 'directory') {
+        navigateTo(groupJid, item.path);
+        return;
+      }
 
-    const ext = getFileExt(item.name);
+      const ext = getFileExt(item.name);
 
-    // 图片 → 预览
-    if (IMAGE_EXTENSIONS.has(ext)) {
-      setPreviewFile(item);
-      return;
-    }
+      // 图片 → 预览
+      if (IMAGE_EXTENSIONS.has(ext)) {
+        setPreviewFile(item);
+        return;
+      }
 
-    // Markdown 文件（非系统） → Markdown 预览/编辑
-    if (ext === 'md' && !item.isSystem) {
-      setMdViewFile(item);
-      return;
-    }
+      // PDF → 预览
+      if (PDF_EXTENSIONS.has(ext)) {
+        setPdfViewFile(item);
+        return;
+      }
 
-    // 文本文件（非系统） → 编辑
-    if (TEXT_EXTENSIONS.has(ext) && !item.isSystem) {
-      setEditFile(item);
-      return;
-    }
-  }, [groupJid, navigateTo]);
+      // 视频 → 预览
+      if (VIDEO_EXTENSIONS.has(ext)) {
+        setVideoViewFile(item);
+        return;
+      }
+
+      // 音频 → 预览
+      if (AUDIO_EXTENSIONS.has(ext)) {
+        setAudioViewFile(item);
+        return;
+      }
+
+      // Markdown 文件（非系统） → Markdown 预览/编辑
+      if (ext === 'md' && !item.isSystem) {
+        setMdViewFile(item);
+        return;
+      }
+
+      // 其他文件 → 通用文本预览（后端会判断是否二进制）
+      setGenericTextFile(item);
+    },
+    [groupJid, navigateTo],
+  );
 
   const handleDownload = (item: FileEntry) => {
     const encoded = toBase64Url(item.path);
     const url = `/api/groups/${encodeURIComponent(groupJid)}/files/download/${encoded}`;
     downloadFromUrl(url, item.name).catch((err) => {
       console.error('Download failed:', err);
-      showToast('下载失败', err instanceof Error ? err.message : '文件下载出错，请重试');
+      showToast(
+        '下载失败',
+        err instanceof Error ? err.message : '文件下载出错，请重试',
+      );
     });
   };
 
   const handleDeleteClick = (item: FileEntry) => {
-    setDeleteModal({ open: true, path: item.path, name: item.name, isDir: item.type === 'directory' });
+    setDeleteModal({
+      open: true,
+      path: item.path,
+      name: item.name,
+      isDir: item.type === 'directory',
+    });
   };
 
   const handleDeleteConfirm = async () => {
@@ -608,9 +1006,12 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
     setOpenDirLoading(true);
     setOpenDirError(null);
     try {
-      await api.post(`/api/groups/${encodeURIComponent(groupJid)}/files/open-directory`, {
-        path: currentDir,
-      });
+      await api.post(
+        `/api/groups/${encodeURIComponent(groupJid)}/files/open-directory`,
+        {
+          path: currentDir,
+        },
+      );
     } catch (err) {
       if (err instanceof Error) {
         setOpenDirError(err.message);
@@ -645,7 +1046,9 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
     <div className="w-full h-full border-l border-border bg-background flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-        <h3 className="font-semibold text-foreground text-sm">工作区文件管理</h3>
+        <h3 className="font-semibold text-foreground text-sm">
+          工作区文件管理
+        </h3>
         <div className="flex items-center gap-1">
           {canOpenLocalFolder && (
             <button
@@ -655,7 +1058,11 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
               title="打开工作区文件夹"
               aria-label="打开工作区文件夹"
             >
-              {openDirLoading ? <Loader2 className="size-3.5 animate-spin" /> : <FolderOpen className="size-3.5" />}
+              {openDirLoading ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <FolderOpen className="size-3.5" />
+              )}
             </button>
           )}
           <button
@@ -720,7 +1127,9 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
         ) : (
           <div className="space-y-0.5">
             {sortedFiles.map((item) => {
-              const clickable = item.type === 'directory' || isClickableFile(item.name, !!item.isSystem);
+              const clickable =
+                item.type === 'directory' ||
+                isClickableFile(item.name, !!item.isSystem);
               return (
                 <div
                   key={item.path}
@@ -747,17 +1156,19 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                     <div className="flex items-center gap-1.5">
                       <span
                         className={`text-sm truncate ${
-                          item.isSystem ? 'text-muted-foreground' : 'text-foreground'
+                          item.isSystem
+                            ? 'text-muted-foreground'
+                            : 'text-foreground'
                         }`}
                       >
                         {item.name}
                       </span>
-                      {item.isSystem && (
-                        <Badge variant="neutral">系统</Badge>
-                      )}
+                      {item.isSystem && <Badge variant="neutral">系统</Badge>}
                     </div>
                     {item.type === 'file' && (
-                      <p className="text-[11px] text-muted-foreground leading-tight">{formatSize(item.size)}</p>
+                      <p className="text-[11px] text-muted-foreground leading-tight">
+                        {formatSize(item.size)}
+                      </p>
                     )}
                   </div>
 
@@ -765,19 +1176,20 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                   {!item.isSystem && (
                     <div className="flex-shrink-0 flex items-center gap-0.5">
                       {/* Edit button for text files */}
-                      {item.type === 'file' && TEXT_EXTENSIONS.has(getFileExt(item.name)) && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setEditFile(item);
-                          }}
-                          className="p-2.5 rounded hover:bg-brand-100 text-muted-foreground hover:text-primary transition-colors cursor-pointer"
-                          title="编辑"
-                          aria-label="编辑文件"
-                        >
-                          <Pencil className="w-3.5 h-3.5" />
-                        </button>
-                      )}
+                      {item.type === 'file' &&
+                        TEXT_EXTENSIONS.has(getFileExt(item.name)) && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditFile(item);
+                            }}
+                            className="p-2.5 rounded hover:bg-brand-100 text-muted-foreground hover:text-primary transition-colors cursor-pointer"
+                            title="编辑"
+                            aria-label="编辑文件"
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </button>
+                        )}
                       {item.type === 'file' && (
                         <button
                           onClick={(e) => {
@@ -829,7 +1241,12 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
 
       {/* Footer */}
       <div className="p-3 border-t border-border space-y-2">
-        <Button variant="outline" size="sm" onClick={handleCreateDir} className="w-full">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCreateDir}
+          className="w-full"
+        >
           <FolderPlus className="w-4 h-4" />
           新建文件夹
         </Button>
@@ -837,7 +1254,10 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
       </div>
 
       {/* Create Directory Dialog */}
-      <Dialog open={createDirModal} onOpenChange={(v) => !v && setCreateDirModal(false)}>
+      <Dialog
+        open={createDirModal}
+        onOpenChange={(v) => !v && setCreateDirModal(false)}
+      >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>新建文件夹</DialogTitle>
@@ -849,15 +1269,28 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                 type="text"
                 value={newDirName}
                 onChange={(e) => setNewDirName(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') handleCreateDirConfirm(); }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateDirConfirm();
+                }}
                 placeholder="输入文件夹名称"
                 autoFocus
               />
             </div>
             <div className="flex justify-end gap-2">
-              <Button variant="ghost" onClick={() => setCreateDirModal(false)} disabled={createDirLoading}>取消</Button>
-              <Button onClick={handleCreateDirConfirm} disabled={createDirLoading}>
-                {createDirLoading && <Loader2 className="size-4 animate-spin" />}
+              <Button
+                variant="ghost"
+                onClick={() => setCreateDirModal(false)}
+                disabled={createDirLoading}
+              >
+                取消
+              </Button>
+              <Button
+                onClick={handleCreateDirConfirm}
+                disabled={createDirLoading}
+              >
+                {createDirLoading && (
+                  <Loader2 className="size-4 animate-spin" />
+                )}
                 创建
               </Button>
             </div>
@@ -868,7 +1301,9 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
       {/* Delete Confirm */}
       <ConfirmDialog
         open={deleteModal.open}
-        onClose={() => setDeleteModal({ open: false, path: '', name: '', isDir: false })}
+        onClose={() =>
+          setDeleteModal({ open: false, path: '', name: '', isDir: false })
+        }
         onConfirm={handleDeleteConfirm}
         title={deleteModal.isDir ? '删除文件夹' : '删除文件'}
         message={
@@ -906,6 +1341,42 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
           groupJid={groupJid}
           file={mdViewFile}
           onClose={() => setMdViewFile(null)}
+        />
+      )}
+
+      {/* PDF Viewer Overlay */}
+      {pdfViewFile && (
+        <PdfPreview
+          groupJid={groupJid}
+          file={pdfViewFile}
+          onClose={() => setPdfViewFile(null)}
+        />
+      )}
+
+      {/* Video Viewer Overlay */}
+      {videoViewFile && (
+        <VideoPreview
+          groupJid={groupJid}
+          file={videoViewFile}
+          onClose={() => setVideoViewFile(null)}
+        />
+      )}
+
+      {/* Audio Viewer Overlay */}
+      {audioViewFile && (
+        <AudioPreview
+          groupJid={groupJid}
+          file={audioViewFile}
+          onClose={() => setAudioViewFile(null)}
+        />
+      )}
+
+      {/* Generic Text Viewer Overlay (for hidden files like .gitignore) */}
+      {genericTextFile && (
+        <GenericTextPreview
+          groupJid={groupJid}
+          file={genericTextFile}
+          onClose={() => setGenericTextFile(null)}
         />
       )}
     </div>

--- a/web/src/components/chat/FilePanel.tsx
+++ b/web/src/components/chat/FilePanel.tsx
@@ -21,6 +21,7 @@ import {
   FileEdit,
   Film,
   Music,
+  AlertCircle,
 } from 'lucide-react';
 import { useFileStore, FileEntry, toBase64Url } from '../../stores/files';
 import { useChatStore } from '../../stores/chat';
@@ -759,6 +760,7 @@ function GenericTextPreview({
   const { getFileContent } = useFileStore();
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
@@ -772,11 +774,16 @@ function GenericTextPreview({
     let cancelled = false;
     (async () => {
       setLoading(true);
+      setLoadError(false);
       const text = await getFileContent(groupJid, file.path);
-      if (!cancelled && text !== null) {
-        setContent(text);
+      if (!cancelled) {
+        if (text !== null) {
+          setContent(text);
+        } else {
+          setLoadError(true);
+        }
+        setLoading(false);
       }
-      if (!cancelled) setLoading(false);
     })();
     return () => {
       cancelled = true;
@@ -814,6 +821,11 @@ function GenericTextPreview({
           {loading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : loadError ? (
+            <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
+              <AlertCircle className="w-10 h-10" />
+              <p className="text-sm">此文件类型不支持预览</p>
             </div>
           ) : (
             <pre className="text-sm text-foreground whitespace-pre-wrap break-all font-mono">


### PR DESCRIPTION
## 改动
扩展 src/routes/files.ts MIME 类型支持：

### 新增图片格式
- bmp: image/bmp
- ico: image/x-icon

### 新增视频格式
- mp4: video/mp4
- webm: video/webm
- mov: video/quicktime
- avi: video/x-msvideo
- mkv: video/x-matroska

### 新增音频格式
- mp3: audio/mpeg
- wav: audio/wav
- ogg: audio/ogg
- aac: audio/aac
- m4a: audio/mp4
- flac: audio/flac