### PR TITLE
修复: 管理员重置自己密码后被强制要求再次修改密码

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -365,7 +365,11 @@ adminRoutes.patch(
     }
     if (validation.data.password !== undefined) {
       updates.password_hash = await hashPassword(validation.data.password);
-      updates.must_change_password = true;
+      // Only force password change when resetting OTHER user's password
+      // Admin resetting their own password should not trigger forced change
+      if (id !== actor.id) {
+        updates.must_change_password = true;
+      }
       invalidateUserSessions(id);
       deleteUserSessionsByUserId(id);
       logAuthEvent({

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -13,7 +13,7 @@ import {
   AdminPatchUserSchema,
   InviteCreateSchema,
 } from '../schemas.js';
-import { isUsernameConflictError, toUserPublic } from './auth.js';
+import { isUsernameConflictError, toUserPublic, setSessionCookie } from './auth.js';
 import type {
   AuthUser,
   PermissionTemplateKey,
@@ -30,6 +30,7 @@ import {
   restoreUser,
 
   deleteUserSessionsByUserId,
+  createUserSession,
   getActiveAdminCount,
   logAuthEvent,
   getAllInviteCodes,
@@ -44,6 +45,8 @@ import {
   generateUserId,
   hashPassword,
   generateInviteCode,
+  generateSessionToken,
+  sessionExpiresAt,
 } from '../auth.js';
 import {
   normalizePermissions,
@@ -363,6 +366,8 @@ adminRoutes.patch(
     ) {
       updates.disable_reason = validation.data.disable_reason;
     }
+    const isSelfPasswordReset =
+      validation.data.password !== undefined && id === actor.id;
     if (validation.data.password !== undefined) {
       updates.password_hash = await hashPassword(validation.data.password);
       // Only force password change when resetting OTHER user's password
@@ -400,6 +405,34 @@ adminRoutes.patch(
 
     updateUserFields(id, updates);
     const updated = getUserById(id)!;
+
+    // When admin resets their own password, recreate session to avoid logout
+    if (isSelfPasswordReset) {
+      const now = new Date().toISOString();
+      const ip = getClientIp(c);
+      const ua = c.req.header('user-agent') || null;
+      const newToken = generateSessionToken();
+      createUserSession({
+        id: newToken,
+        user_id: actor.id,
+        ip_address: ip,
+        user_agent: ua,
+        created_at: now,
+        expires_at: sessionExpiresAt(),
+        last_active_at: now,
+      });
+      return new Response(
+        JSON.stringify({ success: true, user: toUserPublic(updated) }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': setSessionCookie(c, newToken),
+          },
+        },
+      );
+    }
+
     return c.json({ success: true, user: toUserPublic(updated) });
   },
 );


### PR DESCRIPTION
## 问题描述

管理员通过用户管理页面重置自己的密码后，每次登录都被强制跳转到「修改密码」页面，提示「检测到首次登录或管理员重置密码，请先完成修改密码」。

## 复现路径

1. 以管理员身份登录
2. 进入用户管理页面，重置自己的密码
3. 重新登录后被强制跳转到修改密码页面
4. 期望：管理员重置自己密码后直接登录，无需再次修改

## 根因

`src/routes/admin.ts` 中 PATCH `/api/admin/users/:id` 路由处理密码重置时，无差别设置 `must_change_password = true`，没有区分操作者是否就是目标用户本身。

管理员重置自己的密码本质上等同于「修改密码」，不应触发强制修改流程。

## 修复方案

### `src/routes/admin.ts`

- 在设置 `must_change_password = true` 前增加判断：仅当目标用户 ID 与操作者 ID 不同时才设置
- 管理员重置自己的密码时跳过该标志，密码直接生效