### PR TITLE
修复: 宿主机模式 customCwd 下日志不应写入用户项目目录

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -956,7 +956,9 @@ export async function runHostAgent(
     }
   }
 
-  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+  // Always store logs in data/groups/{folder}/logs/, not in customCwd
+  const logsBaseDir = path.join(defaultGroupDir, 'logs');
+  fs.mkdirSync(logsBaseDir, { recursive: true });
   fs.mkdirSync(path.join(DATA_DIR, 'memory', group.folder), {
     recursive: true,
   });
@@ -1203,7 +1205,7 @@ export async function runHostAgent(
       'Spawning host agent',
     );
 
-    const logsDir = path.join(groupDir, 'logs');
+    const logsDir = logsBaseDir;
 
     const hostResult = await new Promise<ContainerOutput>((resolve) => {
       let settled = false;


### PR DESCRIPTION
## 问题描述

宿主机模式使用 `customCwd` 指向用户的项目目录时（如 `~/.openclaw/workspace-invest`），happyclaw 会在该目录下创建 `logs/` 子目录存放运行日志，污染用户的项目目录。

## 设计理念

`customCwd` 的语义是「让 Agent 在用户指定的项目目录中工作」，该目录属于用户的项目，happyclaw 不应在其中写入平台级运行时产物。

happyclaw 的运行时数据有清晰的分层：

| 数据类型 | 存放位置 | 归属 |
|---------|---------|------|
| CLAUDE.md | `customCwd/` | 项目（合理，与 Claude Code 原生行为一致） |
| 记忆 | `data/memory/{folder}/` | 平台 |
| 会话 | `data/sessions/{folder}/` | 平台 |
| **日志** | ~~`customCwd/logs/`~~ → `data/groups/{folder}/logs/` | **应归平台** |

日志与记忆、会话同属平台运行时数据，应统一存放在 `data/` 下。

## 修复方案

### `src/container-runner.ts`

- `logs/` 目录始终创建在 `data/groups/{folder}/logs/`（即 `defaultGroupDir`），不再跟随 `groupDir`（`customCwd`）
- 后续日志写入路径引用同一变量，保持一致