### PR TITLE
修复: 主容器 send_file/send_image 路由 bug + 新增微信 sendFile 实现

### DIFF
--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -553,6 +553,21 @@ export function createWeChatChannel(config: WeChatConnectionConfig): IMChannel {
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
 
+    async sendFile(
+      chatId: string,
+      filePath: string,
+      fileName: string,
+    ): Promise<void> {
+      if (!inner) {
+        logger.warn(
+          { chatId },
+          'WeChat channel not connected, skip sending file',
+        );
+        return;
+      }
+      await inner.sendFile(chatId, filePath, fileName);
+    },
+
     async setTyping(chatId: string, isTyping: boolean): Promise<void> {
       if (!inner) return;
       await inner.sendTyping(chatId, isTyping);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4207,15 +4207,26 @@ function startIpcWatcher(): void {
 
                   // For conversation agents, use activeImReplyRoutes (the IM
                   // channel this conversation agent is bound to — e.g. DingTalk JID).
+                  // For home containers, always prefer activeImReplyRoutes because
+                  // the agent's ctx.chatJid is frozen to whichever IM channel
+                  // started the session, while home containers serve messages
+                  // from multiple IM channels concurrently — the route map is
+                  // the source of truth, updated via activeRouteUpdaters on each
+                  // IPC injection.
                   const imgImRoute = ipcAgentId
                     ? (activeImReplyRoutes.get(
                         `${data.chatJid}#agent:${ipcAgentId}`,
                       ) ??
                       activeImReplyRoutes.get(sourceGroup) ??
                       null)
-                    : getChannelType(data.chatJid) !== null
-                      ? data.chatJid
-                      : (activeImReplyRoutes.get(sourceGroup) ?? null);
+                    : isHome
+                      ? (activeImReplyRoutes.get(sourceGroup) ??
+                        (getChannelType(data.chatJid) !== null
+                          ? data.chatJid
+                          : null))
+                      : getChannelType(data.chatJid) !== null
+                        ? data.chatJid
+                        : (activeImReplyRoutes.get(sourceGroup) ?? null);
                   if (imgImRoute) {
                     const sent = await retryImOperation(
                       'send_image',
@@ -5062,13 +5073,20 @@ async function processTaskIpc(
 
           // Route to IM: for conversation agents, use activeImReplyRoutes (the IM
           // channel this conversation agent is bound to — e.g. DingTalk group JID).
+          // Home containers also prefer the route map because their ctx.chatJid
+          // is frozen to the session's first IM source, see send_image above.
           const fileImRoute = ipcAgentId
             ? (activeImReplyRoutes.get(`${data.chatJid}#agent:${ipcAgentId}`) ??
               activeImReplyRoutes.get(sourceGroup) ??
               null)
-            : getChannelType(data.chatJid) !== null
-              ? data.chatJid
-              : (activeImReplyRoutes.get(sourceGroup) ?? null);
+            : isHome
+              ? (activeImReplyRoutes.get(sourceGroup) ??
+                (getChannelType(data.chatJid) !== null
+                  ? data.chatJid
+                  : null))
+              : getChannelType(data.chatJid) !== null
+                ? data.chatJid
+                : (activeImReplyRoutes.get(sourceGroup) ?? null);
           if (fileImRoute) {
             const imFileName = data.fileName || path.basename(resolvedPath);
             const sent = await retryImOperation('send_file', fileImRoute, () =>

--- a/src/wechat-crypto.ts
+++ b/src/wechat-crypto.ts
@@ -7,6 +7,14 @@ import { logger } from './logger.js';
 // CDN Base URL
 const DEFAULT_CDN_BASE = 'https://novac2c.cdn.weixin.qq.com/c2c';
 
+// iLink-App identity headers (mirrors openclaw-weixin 2.1.1 upstream).
+// Server-side file upload (media_type=3) validates these headers; without them
+// getuploadurl returns {"ret":-1}. Image uploads (media_type=1) don't require
+// them, but it's harmless to send for all calls.
+const ILINK_APP_ID = 'bot';
+// uint32 encoded as 0x00MMNNPP — "2.1.1" → (2<<16)|(1<<8)|1 = 131329
+const ILINK_APP_CLIENT_VERSION = '131329';
+
 /** AES-128-ECB 加密（PKCS7 padding） */
 export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
   const cipher = crypto.createCipheriv('aes-128-ecb', key, null);
@@ -180,6 +188,8 @@ export async function getUploadUrl(params: {
       Authorization: `Bearer ${params.token}`,
       AuthorizationType: 'ilink_bot_token',
       'X-WECHAT-UIN': xWechatUin,
+      'iLink-App-Id': ILINK_APP_ID,
+      'iLink-App-ClientVersion': ILINK_APP_CLIENT_VERSION,
     },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(15_000),
@@ -229,7 +239,9 @@ export async function uploadMediaBuffer(params: {
   const aeskeyBuf = crypto.randomBytes(16);
   const aeskeyHex = aeskeyBuf.toString('hex');
   const filesize = aesEcbPaddedSize(rawsize);
-  const filekey = `${Date.now()}_${params.fileName}`;
+  // filekey is a 32-char hex string — the server rejects non-ASCII chars
+  // (e.g. Chinese filenames) with {"ret":-1}. Mirrors openclaw-weixin upstream.
+  const filekey = crypto.randomBytes(16).toString('hex');
 
   const { uploadParam } = await getUploadUrl({
     baseUrl: params.baseUrl,

--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -12,6 +12,7 @@
  * CDN URL:  https://novac2c.cdn.weixin.qq.com/c2c
  */
 import crypto from 'crypto';
+import fs from 'fs';
 import {
   storeChatMetadata,
   storeMessageDirect,
@@ -22,7 +23,11 @@ import { broadcastNewMessage } from './web.js';
 import { logger } from './logger.js';
 import { saveDownloadedFile, MAX_FILE_SIZE } from './im-downloader.js';
 import { detectImageMimeType } from './image-detector.js';
-import { downloadAndDecryptMedia, uploadMediaBuffer } from './wechat-crypto.js';
+import {
+  downloadAndDecryptMedia,
+  uploadMediaBuffer,
+  uploadMediaFile,
+} from './wechat-crypto.js';
 import { markdownToPlainText, splitTextChunks } from './im-utils.js';
 
 // ─── Constants ──────────────────────────────────────────────────
@@ -99,6 +104,11 @@ export interface WeChatConnection {
     mimeType: string,
     caption?: string,
     fileName?: string,
+  ): Promise<void>;
+  sendFile(
+    chatId: string,
+    filePath: string,
+    fileName: string,
   ): Promise<void>;
   sendTyping(chatId: string, isTyping: boolean): Promise<void>;
   isConnected(): boolean;
@@ -944,6 +954,88 @@ export function createWeChatConnection(
         );
       } catch (err) {
         logger.error({ err, chatId }, 'Failed to send WeChat image');
+        throw err;
+      }
+    },
+
+    async sendFile(
+      chatId: string,
+      filePath: string,
+      fileName: string,
+    ): Promise<void> {
+      const userId = chatId;
+
+      const contextToken = contextTokenCache.get(userId);
+      if (!contextToken) {
+        logger.warn(
+          { chatId },
+          'No context_token for WeChat user, cannot send file',
+        );
+        return;
+      }
+
+      const stat = await fs.promises.stat(filePath);
+      if (stat.size > MAX_FILE_SIZE) {
+        throw new Error(
+          `WeChat file size ${stat.size} exceeds max ${MAX_FILE_SIZE}`,
+        );
+      }
+
+      try {
+        // Upload raw bytes to WeChat CDN as FILE attachment (mediaType=3).
+        const upload = await uploadMediaFile({
+          filePath,
+          toUserId: userId,
+          baseUrl,
+          token: config.botToken,
+          cdnBaseUrl,
+          mediaType: 3, // MEDIA_FILE
+        });
+
+        const clientId = String(crypto.randomBytes(4).readUInt32BE(0));
+        const resp = await apiPost<{
+          ret?: number;
+          errcode?: number;
+          errmsg?: string;
+        }>('ilink/bot/sendmessage', {
+          msg: {
+            to_user_id: userId,
+            context_token: contextToken,
+            item_list: [
+              {
+                type: MESSAGE_ITEM_TYPE_FILE,
+                file_item: {
+                  media: {
+                    encrypt_query_param: upload.downloadEncryptedQueryParam,
+                    aes_key: upload.aeskey,
+                    encrypt_type: 1,
+                  },
+                  file_name: fileName,
+                  // 'len' is the raw (plaintext) file size as a string — per
+                  // nightsailer/wechat-clawbot reference.
+                  len: String(upload.fileSize),
+                },
+              },
+            ],
+            message_type: MESSAGE_TYPE_BOT,
+            message_state: MESSAGE_STATE_FINISH,
+            client_id: clientId,
+          },
+          base_info: baseInfo(),
+        });
+
+        if (resp.ret !== undefined && resp.ret !== 0) {
+          throw new Error(
+            `sendFile failed: ret=${resp.ret} errcode=${resp.errcode} errmsg=${resp.errmsg ?? ''}`,
+          );
+        }
+
+        logger.info(
+          { chatId, size: stat.size, fileName },
+          'WeChat file sent',
+        );
+      } catch (err) {
+        logger.error({ err, chatId, fileName }, 'Failed to send WeChat file');
         throw err;
       }
     },


### PR DESCRIPTION
本 PR 包含两个改动,均围绕 `send_file` 路径,合并处理便于一次性验证。

---

## 改动 1:修复主容器 send_file/send_image 路由到陈旧 IM 渠道的 bug

### 用户现象

主容器(`is_home=true`,如 admin 的 `main` 或 member 的 `home-{userId}`)接入多个 IM 渠道(飞书/Telegram/微信/QQ/钉钉)时,agent 调用 `mcp__happyclaw__send_file` 或 `send_image`,文件/图片**总是发到这个 agent session 启动时的第一个 IM 渠道**,而不是当前对话所在的渠道。

**复现路径**:
1. 用户从 Telegram 私聊 bot "你好"(启动 main agent session)
2. 同一 session 内,用户再从 WeChat 发消息 "发个文件给我"
3. Agent 调 `send_file` 发送 `report.pdf`
4. **实际**:文件被投递到 Telegram(启动时的第一个渠道)
5. **期望**:文件被投递到 WeChat(当前消息所在的渠道)

### 根因

`agent-runner` 启动时 `ctx.chatJid` 被设为**第一条** `ContainerInput` 里的 `chatJid`,之后通过 IPC 注入的后续消息并不更新 `ctx.chatJid`。主进程 IPC 处理器对非 conversation-agent 分支写了短路逻辑:只要 `data.chatJid` 长得像 IM jid,就直接拿来做 `imRoute`,完全绕过了 `activeRouteUpdaters` 已经刷新到 `activeImReplyRoutes` 的新路由。

非 home 容器(纯 IM 群组)不踩这个坑 —— 它们的 `ctx.chatJid` 天然等于该群组的 jid,不跨渠道。

### 修复

对 home 容器(`isHome=true`,非 conversation-agent 分支)改为**优先读取** `activeImReplyRoutes.get(sourceGroup)`,仅在路由表为空时 fallback 到 `data.chatJid` 兜底:

```ts
ipcAgentId
  ? ...(existing, unchanged)
  : isHome
    ? (activeImReplyRoutes.get(sourceGroup) ??
      (getChannelType(data.chatJid) !== null ? data.chatJid : null))
    : getChannelType(data.chatJid) !== null
      ? data.chatJid
      : (activeImReplyRoutes.get(sourceGroup) ?? null);
```

#### `src/index.ts`
- `startIpcWatcher()` 内 `send_image` IPC 处理:加 `isHome` 分支,优先路由表
- `processTaskIpc()` 内 `send_file` IPC 处理:加 `isHome` 分支,优先路由表

### 不影响的情况
- 非 home 容器(纯 IM 群组):分支未变
- conversation sub-agent(`ipcAgentId` 非空):分支未变
- `send_message` 文本路径:走 `replySourceImJid` 闭包变量,本来就正确

---

## 改动 2:新增微信通道 `sendFile` 实现

### 背景

之前微信通道只实现了 `sendImage`,没有 `sendFile`。主容器对接微信后 agent 调用 `send_file` 会直接报 "channel does not support file sending"。本次补齐实现,真实微信收发已验证通过(PDF 成功送达)。

### 实现要点

#### `src/wechat.ts`
- `WeChatConnection` 接口新增 `sendFile(chatId, filePath, fileName)`
- 实现:`uploadMediaFile(mediaType=3)` → `ilink/bot/sendmessage`,`item_list` 用 `MESSAGE_ITEM_TYPE_FILE=4`,`file_item.media` 带加密参数
- `file_item.len` 填**明文字节数字符串**(不是密文 size),参考 [nightsailer/wechat-clawbot](https://github.com/nightsailer/wechat-clawbot) 的 Python 实现
- 调用前用 `fs.promises.stat` 做 `MAX_FILE_SIZE` 预检

#### `src/wechat-crypto.ts`(两个坑,单独拎出来说明)

**坑 1:缺 `iLink-App-*` header → 服务端返回 `ret=-1`**

图片上传(`media_type=1`)不校验这两个 header,文件上传(`media_type=3`)却会校验。没有这两个 header,`getuploadurl` 直接返回 `{"ret":-1}`,没有任何错误信息。

修复:在 `getUploadUrl` 的 fetch headers 里加上(所有 media type 共用,无副作用):

```ts
'iLink-App-Id': 'bot',
'iLink-App-ClientVersion': '131329',  // uint32 编码的 "2.1.1" = (2<<16)|(1<<8)|1
```

值参考 openclaw-weixin 2.1.1 upstream,`ClientVersion` 是三段版本号按 `0x00MMNNPP` 打包成 uint32 后的十进制字符串。

**坑 2:`filekey` 含中文 → 服务端返回 `ret=-1`**

原实现:
```ts
const filekey = `${Date.now()}_${params.fileName}`;
```

遇到中文文件名(如 `dji-mic-mini-录歌手册.pdf`)时,`filekey` 含非 ASCII 字符,服务端直接拒绝。该字段只是服务端用来去重/标记的不透明 ID,不需要包含文件名。

修复:改用 16 字节随机 hex(32 字符):
```ts
const filekey = crypto.randomBytes(16).toString('hex');
```

参考 openclaw-weixin upstream,图片路径此前没暴露这个 bug 是因为测试都用英文文件名。

#### `src/im-channel.ts`
- `createWeChatChannel` 增加 `sendFile` 转发到 inner connection

---

## 测试计划

- [x] Telegram → 启动 main agent session → 再从 WeChat 触发 `send_file`,文件落到 WeChat(依赖改动 1)
- [x] 微信发送中文文件名 PDF(`dji-mic-mini-录歌手册.pdf`),真实账号收到(依赖改动 2)
- [ ] 反向验证 Telegram → WeChat → Telegram 三跳,每次都应落到**最近**一次消息所在的渠道
- [ ] 飞书群聊独立 session 内调用 `send_file`,保持发到飞书群(非 home 分支,行为不变)
- [ ] conversation sub-agent 调用 `send_file`,保持发到绑定渠道(`ipcAgentId` 分支,行为不变)
- [ ] `make typecheck` 通过
- [ ] `make test` 通过

## 依赖

与 #408(清理 ad37134 误提交的 skills 目录)互不依赖。