### PR TITLE
修复: 飞书 sendFile 视频/音频消息发送失败 (#400)

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -1824,8 +1824,14 @@ export function createFeishuConnection(
           throw new Error('文件上传失败：未返回 file_key');
         }
 
-        // Send file message
-        await sendToFeishu(chatId, 'file', JSON.stringify({ file_key: fileKey }));
+        // Send file message — msg_type must match upload file_type
+        const msgType =
+          fileType === 'mp4' ? 'media' : fileType === 'opus' ? 'audio' : 'file';
+        await sendToFeishu(
+          chatId,
+          msgType,
+          JSON.stringify({ file_key: fileKey }),
+        );
 
         logger.info(
           { chatId, fileName, fileSize: buffer.length },


### PR DESCRIPTION
## 问题描述

关闭 #400。

`sendFile()` 中 `msg_type` 硬编码为 `'file'`，导致上传 mp4/opus 文件后发送消息时 `file_type` 与 `msg_type` 不匹配，飞书 API 返回 230055 错误。视频和音频文件始终无法通过飞书渠道发送。

## 修复方案

### `src/feishu.ts`

- 在 `sendToFeishu()` 调用前，根据上传的 `fileType` 映射正确的 `msg_type`：
  - `mp4` → `media`（视频消息）
  - `opus` → `audio`（音频消息）
  - 其他（pdf/doc/xls/ppt/stream） → `file`（文件消息）
- 三种消息类型的 content 格式均为 `{"file_key": "xxx"}`，无需额外修改