### PR TITLE
修复: QQ 渠道图片发送 localImagePaths 参数未透传

### DIFF
--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -450,7 +450,11 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       }
     },
 
-    async sendMessage(chatId: string, text: string): Promise<void> {
+    async sendMessage(
+      chatId: string,
+      text: string,
+      localImagePaths?: string[],
+    ): Promise<void> {
       if (!inner) {
         logger.warn(
           { chatId },
@@ -458,7 +462,7 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
         );
         return;
       }
-      await inner.sendMessage(chatId, text);
+      await inner.sendMessage(chatId, text, localImagePaths);
     },
 
     async sendImage(

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -10,6 +10,7 @@
  * Reference: https://github.com/sliverp/qqbot (QQ Bot API v2)
  */
 import crypto from 'crypto';
+import fs from 'node:fs';
 import http from 'node:http';
 import https from 'node:https';
 import WebSocket from 'ws';
@@ -1091,7 +1092,11 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       logger.info('QQ bot disconnected');
     },
 
-    async sendMessage(chatId: string, text: string): Promise<void> {
+    async sendMessage(
+      chatId: string,
+      text: string,
+      localImagePaths?: string[],
+    ): Promise<void> {
       const parsed = parseQQChatId(chatId);
       if (!parsed) {
         logger.error({ chatId }, 'Invalid QQ chat ID format');
@@ -1104,6 +1109,20 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
         for (const chunk of chunks) {
           await sendQQMessage(parsed.type, parsed.openid, chunk);
+        }
+
+        // Send local images after text (same pattern as Feishu)
+        for (const imgPath of localImagePaths || []) {
+          try {
+            const buf = fs.readFileSync(imgPath);
+            await sendQQImageMessage(parsed.type, parsed.openid, buf);
+            logger.info({ chatId, imgPath }, 'QQ local image sent');
+          } catch (imgErr) {
+            logger.warn(
+              { err: imgErr, chatId, imgPath },
+              'Failed to send local image via QQ',
+            );
+          }
         }
 
         logger.info({ chatId }, 'QQ message sent');


### PR DESCRIPTION
## 问题描述

QQ 渠道的 Agent 输出中包含本地图片路径（如 `![](image.png)`），上层 `extractLocalImImagePaths()` 解析后通过 `localImagePaths` 参数传递给 `sendMessage`，但 QQ 适配器层未接收该参数，导致图片始终无法发送。

## 修复方案

### `src/im-channel.ts`
- `createQQChannel` 的 `sendMessage` 方法增加 `localImagePaths?: string[]` 可选参数
- 将该参数透传给内层 `inner.sendMessage()`

### `src/qq.ts`
- `sendMessage` 增加 `localImagePaths?: string[]` 可选参数
- 发完文本分片后，遍历图片路径，逐张 `fs.readFileSync` → `sendQQImageMessage` 上传发送
- 单张图片发送失败仅 warn，不中断后续图片和消息流程
- 与飞书渠道的图片发送模式保持一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)