### PR TITLE
功能: QQ 渠道支持 Markdown 消息发送

### DIFF
--- a/src/qq.ts
+++ b/src/qq.ts
@@ -345,8 +345,8 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         : `/v2/groups/${openid}/messages`;
 
     await apiRequest('POST', endpoint, {
-      content,
-      msg_type: 0, // text
+      markdown: { content },
+      msg_type: 2, // markdown
       msg_seq: msgSeq,
     });
   }
@@ -1099,8 +1099,7 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       }
 
       try {
-        const plainText = markdownToPlainText(text);
-        const chunks = splitTextChunks(plainText, MSG_SPLIT_LIMIT);
+        const chunks = splitTextChunks(text, MSG_SPLIT_LIMIT);
 
         for (const chunk of chunks) {
           await sendQQMessage(parsed.type, parsed.openid, chunk);


### PR DESCRIPTION
## 问题描述

QQ 渠道发送消息时，先将 Markdown 转为纯文本再发送（`markdownToPlainText`），导致用户收到的消息丢失所有格式（标题、加粗、列表、代码块等）。

## 实现方案

### `src/qq.ts`
- `sendQQMessage` 的请求体从 `{ content, msg_type: 0 }`（纯文本）改为 `{ markdown: { content }, msg_type: 2 }`（Markdown）
- `sendMessage` 移除 `markdownToPlainText()` 转换，直接将原始 Markdown 文本分片发送

QQ Bot API v2 原生支持 `msg_type: 2` Markdown 消息，无需额外处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)