### PR TITLE
功能: 会话自动命名，跳过命名弹窗

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4181,7 +4181,11 @@ function mapAgentRow(row: Record<string, unknown>): SubAgent {
       typeof row.root_message_id === 'string' ? row.root_message_id : null,
     title_source:
       typeof row.title_source === 'string'
-        ? (row.title_source as 'manual' | 'feishu_root')
+        ? (row.title_source as
+            | 'manual'
+            | 'feishu_root'
+            | 'auto'
+            | 'auto_pending')
         : null,
     last_active_at:
       typeof row.last_active_at === 'string' ? row.last_active_at : null,

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -22,6 +22,7 @@ import {
   getJidsByFolder,
   updateAgentLastImJid,
   updateAgentInfo,
+  updateAgentContextInfo,
   updateChatName,
   getMessagesPageMulti,
   deleteImContextBindingsByWorkspace,
@@ -167,10 +168,12 @@ router.post('/:jid/agents', authMiddleware, async (c) => {
   }
 
   const body = await c.req.json().catch(() => ({}));
-  const name = typeof body.name === 'string' ? body.name.trim() : '';
-  if (!name || name.length > 40) {
-    return c.json({ error: 'Name is required (max 40 chars)' }, 400);
+  let name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (name.length > 40) {
+    return c.json({ error: 'Name too long (max 40 chars)' }, 400);
   }
+  const isAutoTitle = !name;
+  if (!name) name = '新对话';
   const description =
     typeof body.description === 'string' ? body.description.trim() : '';
 
@@ -191,6 +194,7 @@ router.post('/:jid/agents', authMiddleware, async (c) => {
     result_summary: null,
     last_im_jid: null,
     spawned_from_jid: null,
+    title_source: isAutoTitle ? 'auto_pending' : 'manual',
   };
 
   createAgent(agent);
@@ -262,6 +266,7 @@ router.patch('/:jid/agents/:agentId', authMiddleware, async (c) => {
 
   // Update agent name in DB
   updateAgentInfo(agentId, name, agent.prompt);
+  updateAgentContextInfo(agentId, { title_source: 'manual' });
 
   // Update virtual chat name
   const virtualChatJid = `${jid}#agent:${agentId}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,7 +322,7 @@ export interface SubAgent {
   source_kind?: 'manual' | 'feishu_thread' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
-  title_source?: 'manual' | 'feishu_root' | null;
+  title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;
   last_active_at?: string | null;
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -72,6 +72,7 @@ import {
   isGroupShared,
   getUserById,
   updateAgentContextInfo,
+  updateChatName,
 } from './db.js';
 import { isSessionExpired, verifySessionToken } from './auth.js';
 import type {
@@ -375,6 +376,33 @@ async function handleWebUserMessage(
   return { ok: true, messageId, timestamp };
 }
 
+// --- Auto-title for conversations ---
+
+/** Extract a short title from the first user message content. */
+function generateAutoTitle(content: string): string | null {
+  let text = content.trim();
+  if (!text || text.startsWith('/')) return null;
+
+  // Strip markdown formatting
+  text = text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]+`/g, (m) => m.slice(1, -1))
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#*_~>|]/g, '')
+    .replace(/\n+/g, ' ')
+    .trim();
+
+  if (!text) return null;
+
+  // Take first line
+  const firstLine = text.split('\n')[0].trim();
+  if (!firstLine) return null;
+
+  if (firstLine.length <= 20) return firstLine;
+  return firstLine.slice(0, 20) + '…';
+}
+
 // --- Agent Conversation Message Handler ---
 
 async function handleAgentConversationMessage(
@@ -426,6 +454,16 @@ async function handleAgentConversationMessage(
     { attachments: attachmentsStr },
   );
   updateAgentContextInfo(agentId, { last_active_at: timestamp });
+
+  // Auto-title: generate title from first user message
+  if (agent.title_source === 'auto_pending') {
+    const autoTitle = generateAutoTitle(content);
+    if (autoTitle) {
+      updateAgentContextInfo(agentId, { name: autoTitle, title_source: 'auto' });
+      updateChatName(virtualChatJid, autoTitle);
+      broadcastAgentStatus(chatJid, agentId, agent.status as import('./types.js').AgentStatus, autoTitle, agent.prompt);
+    }
+  }
 
   // Broadcast new_message with agentId so frontend routes to agent tab
   broadcastNewMessage(

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -70,7 +70,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const [mobileActionsOpen, setMobileActionsOpen] = useState(false);
   // null = dialog closed; MAIN_BINDING = main conversation; other = agent id
   const [bindingAgentId, setBindingAgentId] = useState<string | null>(null);
-  const [showNewConversation, setShowNewConversation] = useState(false);
   const [renameTarget, setRenameTarget] = useState<{ agentId: string; name: string } | null>(null);
   const [topicFilter, setTopicFilter] = useState('');
   const [isDesktop, setIsDesktop] = useState(() =>
@@ -600,7 +599,11 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
             deleteAgentAction(groupJid, id);
           }}
           onRenameAgent={(id, currentName) => setRenameTarget({ agentId: id, name: currentName })}
-          onCreateConversation={() => setShowNewConversation(true)}
+          onCreateConversation={() => {
+            createConversation(groupJid, '').then((agent) => {
+              if (agent) setActiveAgentTab(groupJid, agent.id);
+            });
+          }}
           onBindIm={setBindingAgentId}
           onBindMainIm={!isHome ? () => setBindingAgentId(MAIN_BINDING) : undefined}
           onReorder={(orderedIds) => reorderConversations(groupJid, orderedIds)}
@@ -979,19 +982,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
           onClose={() => setBindingAgentId(null)}
         />
       )}
-
-      <PromptDialog
-        open={showNewConversation}
-        title="新建对话"
-        label="对话名称"
-        placeholder="输入对话名称"
-        onConfirm={(name) => {
-          createConversation(groupJid, name).then((agent) => {
-            if (agent) setActiveAgentTab(groupJid, agent.id);
-          });
-        }}
-        onClose={() => setShowNewConversation(false)}
-      />
 
       <PromptDialog
         open={renameTarget !== null}

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -209,7 +209,7 @@ interface ChatState {
   setActiveAgentTab: (jid: string, agentId: string | null) => void;
   // Conversation agent actions
   reorderConversations: (jid: string, orderedIds: string[]) => void;
-  createConversation: (jid: string, name: string, description?: string) => Promise<AgentInfo | null>;
+  createConversation: (jid: string, name?: string, description?: string) => Promise<AgentInfo | null>;
   renameConversation: (jid: string, agentId: string, name: string) => Promise<boolean>;
   loadAgentMessages: (jid: string, agentId: string, loadMore?: boolean) => Promise<void>;
   sendAgentMessage: (jid: string, agentId: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => void;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -34,7 +34,7 @@ export interface AgentInfo {
   source_kind?: 'manual' | 'feishu_thread' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
-  title_source?: 'manual' | 'feishu_root' | null;
+  title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;
   last_active_at?: string | null;
   latest_message?: { content: string; timestamp: string } | null;
 }


### PR DESCRIPTION
## 问题描述

新建会话时必须先通过弹窗输入名称才能开始对话，不符合业界主流交互（ChatGPT / Claude.ai 均为直接开始，自动生成标题）。

## 实现方案

### 核心机制：title_source 状态机

```
创建时无名称 → title_source='auto_pending', name='新对话'
首条用户消息 → title_source='auto', name=消息摘要（前20字符）
用户手动重命名 → title_source='manual', name=用户指定
```

### 后端

- **src/routes/agents.ts POST**：name 从必填改为可选，空则默认"新对话"+auto_pending
- **src/routes/agents.ts PATCH**：手动重命名设置 title_source=manual
- **src/web.ts**：generateAutoTitle() 纯函数 + handleAgentConversationMessage 中检测 auto_pending 触发自动命名，复用已有 broadcastAgentStatus WS 事件
- **src/types.ts**：title_source 扩展 auto / auto_pending

### 前端

- **ChatView.tsx**：删除新建会话 PromptDialog，"+" 按钮直接创建并切换
- **chat.ts store**：createConversation name 参数改为可选

## 测试记录

### API e2e（16/16 通过）

```
Test 1: Create conversation without name
  ✓ Name: "新对话"
  ✓ title_source: auto_pending

Test 2: Create conversation with explicit name
  ✓ Name: "测试对话"
  ✓ title_source: manual

Test 3: Send message → auto-rename
  ✓ Auto-rename: "帮我写一个 Python 爬虫脚本，要求…"
  ✓ Title length 21 <= 21

Test 4: Verify via API
  ✓ title_source: auto

Test 5: Manual rename
  ✓ title_source: manual

=== 16 passed, 0 failed ===
```

### UI 自动化（browser-use 无头浏览器）

| 步骤 | 验证项 | 结果 |
|------|--------|------|
| 点击 "+" 按钮 | 不弹出命名对话框，直接创建 | ✓ |
| 检查标签栏 | 新标签显示 "新对话" | ✓ |
| 发送消息 | 标签自动更新为消息摘要 | ✓ |

### 静态检查

- make typecheck ✓
- make test ✓（53 tests）
- make build ✓
