### PR TITLE
修复: 历史图片 base64 累积导致请求撞 20MB API 上限

### DIFF
--- a/container/agent-runner/src/history-image-prune.ts
+++ b/container/agent-runner/src/history-image-prune.ts
@@ -1,0 +1,411 @@
+import fs from 'fs';
+import path from 'path';
+
+export const PRUNED_HISTORY_IMAGE_MARKER =
+  '[image data removed - already processed by model]';
+
+const IMAGE_REFERENCE_PATTERN = /\[图片:[^\]]+\]/;
+const HISTORY_ARCHIVE_PATTERN = /\[历史图片已归档 [^\]]+\]/;
+
+type ImageDimensions = { width: number; height: number } | null;
+
+interface TranscriptLine {
+  index: number;
+  parsed: Record<string, unknown> | null;
+}
+
+interface PruneResult {
+  value: unknown;
+  didMutate: boolean;
+  prunedImages: number;
+}
+
+export interface TranscriptContentPruneResult {
+  content: string;
+  didMutate: boolean;
+  prunedImages: number;
+}
+
+export interface SessionTranscriptPruneResult {
+  didMutate: boolean;
+  prunedImages: number;
+  transcriptPath?: string;
+}
+
+export interface TranscriptPruneOptions {
+  getImageDimensions?: (base64Data: string) => ImageDimensions;
+}
+
+function findLastAssistantIndex(lines: TranscriptLine[]): number {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].parsed?.type === 'assistant') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function collectTextFragments(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectTextFragments(item));
+  }
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  const record = value as Record<string, unknown>;
+  const fragments: string[] = [];
+  if (typeof record.text === 'string') {
+    fragments.push(record.text);
+  }
+  if ('content' in record) {
+    fragments.push(...collectTextFragments(record.content));
+  }
+  return fragments;
+}
+
+function findImageReference(...values: unknown[]): string | null {
+  for (const value of values) {
+    for (const text of collectTextFragments(value)) {
+      const match = text.match(IMAGE_REFERENCE_PATTERN);
+      if (match) {
+        return match[0];
+      }
+    }
+  }
+  return null;
+}
+
+function hasHistoryArchiveMarker(value: unknown): boolean {
+  return collectTextFragments(value).some((text) => HISTORY_ARCHIVE_PATTERN.test(text));
+}
+
+function formatHistoryArchiveMarker(timestamp: unknown): string | null {
+  if (typeof timestamp === 'string') {
+    const isoMatch = timestamp.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})/);
+    if (isoMatch) {
+      return `[历史图片已归档 ${isoMatch[1]} ${isoMatch[2]}]`;
+    }
+  }
+
+  const date = new Date(timestamp as string | number | Date);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return `[历史图片已归档 ${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}]`;
+}
+
+function getImageMediaType(block: Record<string, unknown>): string | null {
+  const source = block.source;
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+  const mediaType = (source as Record<string, unknown>).media_type;
+  return typeof mediaType === 'string' ? mediaType : null;
+}
+
+function getImageBase64(block: Record<string, unknown>): string | null {
+  const source = block.source;
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+  const data = (source as Record<string, unknown>).data;
+  return typeof data === 'string' ? data : null;
+}
+
+function buildPlaceholderText(
+  block: Record<string, unknown>,
+  imageReference: string | null,
+  getImageDimensions?: (base64Data: string) => ImageDimensions,
+): string {
+  if (imageReference) {
+    return `${PRUNED_HISTORY_IMAGE_MARKER} ${imageReference}`;
+  }
+
+  const base64Data = getImageBase64(block);
+  const mediaType = getImageMediaType(block);
+  const dimensions = base64Data && getImageDimensions ? getImageDimensions(base64Data) : null;
+  if (dimensions && mediaType) {
+    return `${PRUNED_HISTORY_IMAGE_MARKER.slice(0, -1)} (原 ${dimensions.width}×${dimensions.height} ${mediaType})]`;
+  }
+
+  return PRUNED_HISTORY_IMAGE_MARKER;
+}
+
+function pruneImageBlocksInValue(
+  value: unknown,
+  imageReference: string | null,
+  getImageDimensions?: (base64Data: string) => ImageDimensions,
+): PruneResult {
+  if (Array.isArray(value)) {
+    let didMutate = false;
+    let prunedImages = 0;
+    const next = value.map((item) => {
+      if (!item || typeof item !== 'object') {
+        return item;
+      }
+
+      const block = item as Record<string, unknown>;
+      if (block.type === 'image') {
+        didMutate = true;
+        prunedImages += 1;
+        return {
+          type: 'text',
+          text: buildPlaceholderText(block, imageReference, getImageDimensions),
+        };
+      }
+
+      if ('content' in block) {
+        const nested = pruneImageBlocksInValue(
+          block.content,
+          imageReference,
+          getImageDimensions,
+        );
+        if (nested.didMutate) {
+          didMutate = true;
+          prunedImages += nested.prunedImages;
+          return {
+            ...block,
+            content: nested.value,
+          };
+        }
+      }
+
+      return item;
+    });
+
+    return {
+      value: didMutate ? next : value,
+      didMutate,
+      prunedImages,
+    };
+  }
+
+  if (value && typeof value === 'object' && 'content' in (value as Record<string, unknown>)) {
+    const record = value as Record<string, unknown>;
+    const nested = pruneImageBlocksInValue(record.content, imageReference, getImageDimensions);
+    if (nested.didMutate) {
+      return {
+        value: { ...record, content: nested.value },
+        didMutate: true,
+        prunedImages: nested.prunedImages,
+      };
+    }
+  }
+
+  return {
+    value,
+    didMutate: false,
+    prunedImages: 0,
+  };
+}
+
+function appendHistoryArchiveMarker(
+  messageContent: unknown,
+  archiveMarker: string | null,
+): { value: unknown; didMutate: boolean } {
+  if (!archiveMarker) {
+    return { value: messageContent, didMutate: false };
+  }
+
+  if (typeof messageContent === 'string') {
+    return {
+      value: messageContent
+        ? `${messageContent}\n${archiveMarker}`
+        : archiveMarker,
+      didMutate: true,
+    };
+  }
+
+  if (Array.isArray(messageContent)) {
+    return {
+      value: [...messageContent, { type: 'text', text: archiveMarker }],
+      didMutate: true,
+    };
+  }
+
+  return { value: messageContent, didMutate: false };
+}
+
+export function pruneProcessedHistoryImagesInTranscriptContent(
+  content: string,
+  options: TranscriptPruneOptions = {},
+): TranscriptContentPruneResult {
+  const lines = content.split('\n');
+  const parsedLines: TranscriptLine[] = lines.map((line, index) => {
+    if (!line.trim()) {
+      return { index, parsed: null };
+    }
+
+    try {
+      return {
+        index,
+        parsed: JSON.parse(line) as Record<string, unknown>,
+      };
+    } catch {
+      return { index, parsed: null };
+    }
+  });
+
+  const lastAssistantIndex = findLastAssistantIndex(parsedLines);
+  if (lastAssistantIndex < 0) {
+    return { content, didMutate: false, prunedImages: 0 };
+  }
+
+  let didMutate = false;
+  let prunedImages = 0;
+
+  for (let i = 0; i < lastAssistantIndex; i++) {
+    const entry = parsedLines[i].parsed;
+    if (!entry || entry.type !== 'user') {
+      continue;
+    }
+
+    const message = entry.message;
+    const messageRecord =
+      message && typeof message === 'object'
+        ? (message as Record<string, unknown>)
+        : null;
+
+    const imageReference = findImageReference(
+      messageRecord?.content,
+      entry.toolUseResult,
+    );
+
+    let entryChanged = false;
+    let entryPrunedImages = 0;
+
+    if (messageRecord && 'content' in messageRecord) {
+      const prunedMessage = pruneImageBlocksInValue(
+        messageRecord.content,
+        imageReference,
+        options.getImageDimensions,
+      );
+      if (prunedMessage.didMutate) {
+        entry.message = {
+          ...messageRecord,
+          content: prunedMessage.value,
+        };
+        entryChanged = true;
+        entryPrunedImages += prunedMessage.prunedImages;
+      }
+    }
+
+    if ('toolUseResult' in entry) {
+      const prunedToolResult = pruneImageBlocksInValue(
+        entry.toolUseResult,
+        imageReference,
+        options.getImageDimensions,
+      );
+      if (prunedToolResult.didMutate) {
+        entry.toolUseResult = prunedToolResult.value;
+        entryChanged = true;
+        entryPrunedImages += prunedToolResult.prunedImages;
+      }
+    }
+
+    if (
+      entryPrunedImages > 0 &&
+      messageRecord &&
+      'content' in messageRecord &&
+      !imageReference &&
+      !hasHistoryArchiveMarker(messageRecord.content)
+    ) {
+      const archiveMarker = formatHistoryArchiveMarker(entry.timestamp);
+      const appended = appendHistoryArchiveMarker(
+        (entry.message as Record<string, unknown>).content,
+        archiveMarker,
+      );
+      if (appended.didMutate) {
+        entry.message = {
+          ...(entry.message as Record<string, unknown>),
+          content: appended.value,
+        };
+        entryChanged = true;
+      }
+    }
+
+    if (entryChanged) {
+      didMutate = true;
+      prunedImages += entryPrunedImages;
+      lines[parsedLines[i].index] = JSON.stringify(entry);
+    }
+  }
+
+  return {
+    content: didMutate ? lines.join('\n') : content,
+    didMutate,
+    prunedImages,
+  };
+}
+
+export function pruneProcessedHistoryImagesInTranscript(params: {
+  claudeConfigDir: string;
+  sessionId?: string;
+  getImageDimensions?: (base64Data: string) => ImageDimensions;
+}): SessionTranscriptPruneResult {
+  if (!params.sessionId) {
+    return { didMutate: false, prunedImages: 0 };
+  }
+
+  const projectsDir = path.join(params.claudeConfigDir, 'projects');
+  if (!fs.existsSync(projectsDir)) {
+    return { didMutate: false, prunedImages: 0 };
+  }
+
+  let transcriptPath: string | undefined;
+  try {
+    const projectEntries = fs.readdirSync(projectsDir, { withFileTypes: true });
+    for (const projectEntry of projectEntries) {
+      if (!projectEntry.isDirectory()) {
+        continue;
+      }
+
+      const candidate = path.join(
+        projectsDir,
+        projectEntry.name,
+        `${params.sessionId}.jsonl`,
+      );
+      if (fs.existsSync(candidate)) {
+        transcriptPath = candidate;
+        break;
+      }
+    }
+  } catch {
+    return { didMutate: false, prunedImages: 0 };
+  }
+
+  if (!transcriptPath) {
+    return { didMutate: false, prunedImages: 0 };
+  }
+
+  try {
+    const original = fs.readFileSync(transcriptPath, 'utf-8');
+    const result = pruneProcessedHistoryImagesInTranscriptContent(original, {
+      getImageDimensions: params.getImageDimensions,
+    });
+    if (!result.didMutate) {
+      return { didMutate: false, prunedImages: 0, transcriptPath };
+    }
+
+    const originalSize = Buffer.byteLength(original, 'utf-8');
+    const nextSize = Buffer.byteLength(result.content, 'utf-8');
+    if (originalSize === nextSize) {
+      return { didMutate: false, prunedImages: 0, transcriptPath };
+    }
+
+    const tempPath = `${transcriptPath}.tmp`;
+    fs.writeFileSync(tempPath, result.content);
+    fs.renameSync(tempPath, transcriptPath);
+
+    return {
+      didMutate: true,
+      prunedImages: result.prunedImages,
+      transcriptPath,
+    };
+  } catch {
+    return { didMutate: false, prunedImages: 0, transcriptPath };
+  }
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { query, HookCallback, PreCompactHookInput, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { detectImageMimeTypeFromBase64Strict } from './image-detector.js';
+import { pruneProcessedHistoryImagesInTranscript as pruneProcessedHistoryImagesInTranscriptFile } from './history-image-prune.js';
 import { getChannelFromJid } from './channel-prefixes.js';
 
 import type {
@@ -990,6 +991,22 @@ function loadUserMcpServers(): Record<string, unknown> {
   return {};
 }
 
+function pruneProcessedHistoryImagesInTranscript(sessionId: string | undefined): void {
+  const configDir = process.env.CLAUDE_CONFIG_DIR
+    || path.join(process.env.HOME || '/home/node', '.claude');
+  const result = pruneProcessedHistoryImagesInTranscriptFile({
+    claudeConfigDir: configDir,
+    sessionId,
+    getImageDimensions,
+  });
+  if (result.didMutate) {
+    log(
+      `History image prune: removed ${result.prunedImages} image block(s)` +
+      `${result.transcriptPath ? ` from ${result.transcriptPath}` : ''}`,
+    );
+  }
+}
+
 /**
  * Run a single query and stream results via writeOutput.
  * Uses MessageStream (AsyncIterable) to keep isSingleUserTurn=false,
@@ -1673,6 +1690,8 @@ async function main(): Promise<void> {
   let pendingHistoryContext: string | null = null;
   try {
     while (true) {
+      pruneProcessedHistoryImagesInTranscript(sessionId);
+
       // 清理残留的 _interrupt sentinel（空闲期间写入的中断信号不应影响下一次 query）。
       // 注意：_drain 不在此处清理 — 如果 _drain 存在，说明有待处理的消息，
       // pollIpcDuringQuery 会在查询结果后检测到并正确退出容器。
@@ -1732,6 +1751,8 @@ async function main(): Promise<void> {
         mcpServerConfig = buildMcpServerConfig();
         continue;
       }
+
+      pruneProcessedHistoryImagesInTranscript(sessionId);
 
       // 不可恢复的转录错误（如超大图片或 MIME 错配被固化在会话历史中）
       if (queryResult.unrecoverableTranscriptError) {

--- a/tests/history-image-prune.test.ts
+++ b/tests/history-image-prune.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  PRUNED_HISTORY_IMAGE_MARKER,
+  pruneProcessedHistoryImagesInTranscriptContent,
+} from '../container/agent-runner/src/history-image-prune.js';
+
+const makeImageBlock = (data = 'image-data', mediaType = 'image/png') => ({
+  type: 'image',
+  source: { type: 'base64', media_type: mediaType, data },
+});
+
+describe('pruneProcessedHistoryImagesInTranscriptContent', () => {
+  test('保留最后一条 assistant 之后的图片，裁剪之前的历史图片', () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-04-14T02:03:04.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '历史图片' },
+            { type: 'text', text: '[图片: downloads/old.png]' },
+            makeImageBlock('old-base64'),
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: '已处理' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-04-14T03:03:04.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '最新图片' },
+            makeImageBlock('latest-base64'),
+          ],
+        },
+      }),
+    ].join('\n');
+
+    const result = pruneProcessedHistoryImagesInTranscriptContent(transcript);
+    const entries = result.content.split('\n').map((line) => JSON.parse(line));
+
+    expect(result.didMutate).toBe(true);
+    expect(result.prunedImages).toBe(1);
+    expect(entries[0].message.content).toEqual([
+      { type: 'text', text: '历史图片' },
+      { type: 'text', text: '[图片: downloads/old.png]' },
+      {
+        type: 'text',
+        text: `${PRUNED_HISTORY_IMAGE_MARKER} [图片: downloads/old.png]`,
+      },
+    ]);
+    expect(entries[2].message.content[1]).toEqual(makeImageBlock('latest-base64'));
+  });
+
+  test('幂等，第二次执行不再修改 transcript', () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-04-14T02:03:04.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '历史图片' },
+            { type: 'text', text: '[历史图片已归档 2026-04-14 02:03]' },
+            { type: 'text', text: '[image data removed - already processed by model (640×480 image/png)]' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: '已处理' }],
+        },
+      }),
+    ].join('\n');
+
+    const firstRun = pruneProcessedHistoryImagesInTranscriptContent(transcript, {
+      getImageDimensions: () => ({ width: 640, height: 480 }),
+    });
+    const secondRun = pruneProcessedHistoryImagesInTranscriptContent(firstRun.content, {
+      getImageDimensions: () => ({ width: 640, height: 480 }),
+    });
+
+    expect(firstRun.didMutate).toBe(false);
+    expect(secondRun.didMutate).toBe(false);
+    expect(secondRun.prunedImages).toBe(0);
+    expect(secondRun.content).toBe(transcript);
+  });
+
+  test('被裁消息保留图片线索，没有 [图片:] 时补 [历史图片已归档 ...] 和尺寸信息', () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-04-14T12:34:56.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '帮我看看这张图' },
+            makeImageBlock('needs-dims', 'image/jpeg'),
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: '已处理' }],
+        },
+      }),
+    ].join('\n');
+
+    const result = pruneProcessedHistoryImagesInTranscriptContent(transcript, {
+      getImageDimensions: (data) =>
+        data === 'needs-dims' ? { width: 1024, height: 768 } : null,
+    });
+    const [entry] = result.content.split('\n').map((line) => JSON.parse(line));
+
+    expect(result.didMutate).toBe(true);
+    expect(entry.message.content).toEqual([
+      { type: 'text', text: '帮我看看这张图' },
+      {
+        type: 'text',
+        text: '[image data removed - already processed by model (原 1024×768 image/jpeg)]',
+      },
+      { type: 'text', text: '[历史图片已归档 2026-04-14 12:34]' },
+    ]);
+  });
+
+  test('tool_result 中的图片也会被处理', () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-04-14T12:34:56.000Z',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-1',
+              content: [
+                { type: 'text', text: '截图结果' },
+                makeImageBlock('tool-result', 'image/webp'),
+              ],
+            },
+          ],
+        },
+        toolUseResult: [
+          { type: 'text', text: '截图结果' },
+          makeImageBlock('tool-result', 'image/webp'),
+        ],
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: '已处理' }],
+        },
+      }),
+    ].join('\n');
+
+    const result = pruneProcessedHistoryImagesInTranscriptContent(transcript, {
+      getImageDimensions: () => ({ width: 300, height: 200 }),
+    });
+    const [entry] = result.content.split('\n').map((line) => JSON.parse(line));
+
+    expect(result.prunedImages).toBe(2);
+    expect(entry.message.content).toEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-1',
+        content: [
+          { type: 'text', text: '截图结果' },
+          {
+            type: 'text',
+            text: '[image data removed - already processed by model (原 300×200 image/webp)]',
+          },
+        ],
+      },
+      { type: 'text', text: '[历史图片已归档 2026-04-14 12:34]' },
+    ]);
+    expect(entry.toolUseResult).toEqual([
+      { type: 'text', text: '截图结果' },
+      {
+        type: 'text',
+        text: '[image data removed - already processed by model (原 300×200 image/webp)]',
+      },
+    ]);
+  });
+
+  test('assistant 自身的 image block 不被触碰', () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          stop_reason: 'end_turn',
+          content: [
+            { type: 'text', text: '这是结果图' },
+            makeImageBlock('assistant-image'),
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-04-14T12:34:56.000Z',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '下一轮输入' },
+            makeImageBlock('latest-user-image'),
+          ],
+        },
+      }),
+    ].join('\n');
+
+    const result = pruneProcessedHistoryImagesInTranscriptContent(transcript);
+    const entries = result.content.split('\n').map((line) => JSON.parse(line));
+
+    expect(result.didMutate).toBe(false);
+    expect(entries[0].message.content[1]).toEqual(makeImageBlock('assistant-image'));
+    expect(entries[1].message.content[1]).toEqual(makeImageBlock('latest-user-image'));
+  });
+});


### PR DESCRIPTION
## 问题描述

长期会话（尤其是 IM 多轮发图场景）中，用户消息里附带的图片以 base64 内联形式持久化进 `.claude/projects/<...>/<sessionId>.jsonl`。每次 query 重发整段历史时，base64 数据被重复携带 → 单次请求体积线性增长 → 最终撞上 Anthropic API 的 **20MB 单请求上限**：

```
Request too large (max 20MB). Try with a smaller file.
```

实测一个长跑 7 天的会话，58 张图片让 jsonl 长到 53 MB，session 直接卡死，无法继续对话。SDK 自己的 auto-compaction 触发点是 token 数，跟字节数不等价，所以等 compact 介入时早就超 20 MB 了，太晚。

## 修复方案

参考 OpenClaw 的 [`context-pruning`](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-extensions/context-pruning/pruner.ts) 思路：**把图片从"会话历史的一部分"降级成"当前轮输入的一部分"**。

核心规则：
- **保护边界**：找到 transcript 中最后一条 assistant 消息的位置。该位置**之后**（即"当前未被回答的 user turn"）的 image block 一律保留原样。
- 最后一条 assistant **之前**的 user / tool_result 中所有 `type:"image"` block，替换成 `type:"text"` 占位符 `[image data removed - already processed by model]`。
- **保留可重读线索**：如果同一条消息里已有 `[图片: downloads/.../xxx.png]` 这类路径引用，placeholder 自动复用；如果没有，从 base64 提维度 + media_type 补成 `(原 W×H mime)`，并追加 `[历史图片已归档 YYYY-MM-DD HH:MM]`，让 Agent 必要时可以 `Read` 工具按需重新读图。
- **幂等**：重跑不会二次破坏 placeholder。
- **原子写入**：`.tmp + rename`，大小无变化不写盘。

接入点：`agent-runner` 的 query 主循环里，每轮 `query()` 之前 + 每轮 assistant 完成之后各调用一次。

### 端到端验证

在真实 53 MB session 上手动跑 pruner：58 image block 全部裁掉，文件 **53 MB → 225 KB**，文字对话 100% 保留。之后让用户用自然语言提问"还记得周日那几张泡泡玛特的图吗"，Agent 通过 HERMES-MEMORY.md 推断出日期 → `Read` 工具自主读了 8 张 png → 给出基于 vision 的新分析。完整工具链路通畅。

## 改动清单

### `container/agent-runner/src/history-image-prune.ts`（新增）
- 纯函数 `pruneProcessedHistoryImagesInTranscriptContent(content, options)`：可单测，输入字符串，输出裁剪后字符串。
- 高层 `pruneProcessedHistoryImagesInTranscript({ claudeConfigDir, sessionId, getImageDimensions })`：负责定位 jsonl + 原子写盘。
- 占位符常量 `PRUNED_HISTORY_IMAGE_MARKER`、文本线索正则 `IMAGE_REFERENCE_PATTERN` / `HISTORY_ARCHIVE_PATTERN`。

### `container/agent-runner/src/index.ts`
- 新增本地 wrapper `pruneProcessedHistoryImagesInTranscript(sessionId)`，内部读 `CLAUDE_CONFIG_DIR` env 并复用现有 `getImageDimensions()`。
- 在 query 主循环 `while (true)` 入口处调用一次（line 1669）。
- 在每轮 assistant 完成之后再调用一次（line 1711），让同进程下一轮也轻装上阵。

### `tests/history-image-prune.test.ts`（新增，5 个用例）
1. 最后 assistant 之后的 image 保留、之前的被裁
2. 幂等性：连续运行两次第二次不修改
3. 被裁消息保留 `[图片: ...]` 或 `[历史图片已归档 ...]` 线索
4. `tool_result` 中的 image 也会被处理
5. assistant 自身带 image 不被触碰（防御性）

## 不在本 PR 范围

- 不动 `src/` 下 IM 入口侧 base64 处理 / DB attachments 存储 / Web UI
- 不做 tool_result 的 soft-trim / hard-clear（OpenClaw pruner 第二层，可作为 Phase 2）
- 不做 Files API 迁移（依赖代理服务器对 beta endpoints 的支持，需要单独评估）

## 测试

- `make typecheck` ✅
- `make test` ✅ 44 pass / 0 fail
- 真实生产 session 端到端验证 ✅（见上"端到端验证"段）