### PR TITLE
修复: 宿主机模式与容器模式 Agent 能力不一致 (#416)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev dev-backend dev-web build build-backend build-web start \
        typecheck typecheck-backend typecheck-web typecheck-agent-runner \
-       format format-check install clean reset-init update-sdk ensure-latest-sdk sync-types \
+       format format-check install install-host-tools clean reset-init update-sdk ensure-latest-sdk sync-types \
        backup restore help _ensure-docker-image
 
 # ─── Runtime Detection ──────────────────────────────────────
@@ -193,6 +193,9 @@ ensure-latest-sdk: ## 启动前自动检测并更新 SDK（有新版才更新）
 	fi
 
 # ─── Setup ───────────────────────────────────────────────────
+
+install-host-tools: ## 安装宿主机模式所需的外部工具（feishu-cli、agent-browser、uv）+ 刷新 builtin-skills 缓存
+	@./scripts/install-host-tools.sh
 
 install: ## 安装全部依赖并编译 agent-runner
 	$(PKG) install

--- a/scripts/install-host-tools.sh
+++ b/scripts/install-host-tools.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# install-host-tools.sh — Install external tools required by host-mode agents.
+#
+# This script brings the host environment closer to what the Docker container
+# provides (feishu-cli, agent-browser, uv).  It is safe to re-run — it skips
+# tools that are already installed and updates the builtin-skills cache.
+#
+# Usage:
+#   ./scripts/install-host-tools.sh          # install everything
+#   ./scripts/install-host-tools.sh skills   # only refresh builtin-skills cache
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATA_DIR="$PROJECT_ROOT/data"
+BUILTIN_SKILLS_DIR="$DATA_DIR/builtin-skills"
+
+# ── Helpers ──────────────────────────────────────────────────
+
+info()  { echo "  [INFO]  $*"; }
+ok()    { echo "  [OK]    $*"; }
+skip()  { echo "  [SKIP]  $*"; }
+warn()  { echo "  [WARN]  $*" >&2; }
+
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+# Detect platform
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  ARCH_GO="amd64" ;;
+  aarch64|arm64) ARCH_GO="arm64" ;;
+  *) warn "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+case "$OS" in
+  Darwin) OS_GO="Darwin" ;;
+  Linux)  OS_GO="linux" ;;
+  *) warn "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# ── feishu-cli ───────────────────────────────────────────────
+
+install_feishu_cli() {
+  if has_cmd feishu-cli; then
+    skip "feishu-cli already installed ($(feishu-cli --version 2>/dev/null || echo 'unknown version'))"
+  else
+    info "Installing feishu-cli..."
+    VERSION=$(curl -sI "https://github.com/riba2534/feishu-cli/releases/latest" \
+      | grep -i '^location:' | head -1 \
+      | sed 's|.*/tag/\([^[:space:]]*\).*|\1|' | tr -d '\r\n')
+    if [ -z "$VERSION" ]; then
+      warn "Failed to detect feishu-cli latest version"
+      return 1
+    fi
+    curl -fsSL "https://github.com/riba2534/feishu-cli/releases/download/${VERSION}/feishu-cli_${VERSION}_${OS_GO}-${ARCH_GO}.tar.gz" \
+      | tar -xz --strip-components=1 -C /usr/local/bin 2>/dev/null \
+      || tar -xzf <(curl -fsSL "https://github.com/riba2534/feishu-cli/releases/download/${VERSION}/feishu-cli_${VERSION}_${OS_GO}-${ARCH_GO}.tar.gz") -C /usr/local/bin
+    ok "feishu-cli $VERSION installed"
+  fi
+}
+
+# ── feishu-cli builtin skills cache ──────────────────────────
+
+refresh_builtin_skills() {
+  info "Refreshing builtin-skills cache in $BUILTIN_SKILLS_DIR ..."
+  VERSION=$(curl -sI "https://github.com/riba2534/feishu-cli/releases/latest" \
+    | grep -i '^location:' | head -1 \
+    | sed 's|.*/tag/\([^[:space:]]*\).*|\1|' | tr -d '\r\n')
+  if [ -z "$VERSION" ]; then
+    warn "Failed to detect feishu-cli latest version — cannot refresh builtin-skills"
+    return 1
+  fi
+
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"' RETURN
+  curl -fsSL "https://github.com/riba2534/feishu-cli/archive/refs/tags/${VERSION}.tar.gz" \
+    | tar -xz -C "$TMP"
+
+  # Clear old cache and copy fresh skills
+  rm -rf "$BUILTIN_SKILLS_DIR"
+  mkdir -p "$BUILTIN_SKILLS_DIR"
+  cp -r "$TMP"/*/skills/. "$BUILTIN_SKILLS_DIR"/
+  ok "Cached $(ls -d "$BUILTIN_SKILLS_DIR"/*/ 2>/dev/null | wc -l | tr -d ' ') builtin skills (feishu-cli $VERSION)"
+}
+
+# ── agent-browser ────────────────────────────────────────────
+
+install_agent_browser() {
+  if has_cmd agent-browser; then
+    skip "agent-browser already installed"
+  else
+    info "Installing agent-browser..."
+    npm install -g agent-browser
+    ok "agent-browser installed"
+  fi
+}
+
+# ── uv ───────────────────────────────────────────────────────
+
+install_uv() {
+  if has_cmd uv; then
+    skip "uv already installed ($(uv --version 2>/dev/null || echo 'unknown'))"
+  else
+    info "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    ok "uv installed"
+  fi
+}
+
+# ── Main ─────────────────────────────────────────────────────
+
+echo "=== HappyClaw Host Tools Installer ==="
+echo "    OS=$OS  ARCH=$ARCH"
+echo ""
+
+if [ "${1:-}" = "skills" ]; then
+  refresh_builtin_skills
+  exit 0
+fi
+
+install_feishu_cli
+refresh_builtin_skills
+install_agent_browser
+install_uv
+
+echo ""
+echo "=== Done ==="
+echo "Restart HappyClaw to pick up the new tools."

--- a/src/agent-capabilities.ts
+++ b/src/agent-capabilities.ts
@@ -1,0 +1,112 @@
+/**
+ * Agent Capability Preflight — shared capability declarations for host mode.
+ *
+ * Container mode gets these tools via Dockerfile; host mode relies on the
+ * host OS having them installed.  This module detects what's available and
+ * returns environment variables + log messages so `runHostAgent()` can act
+ * on the results.
+ */
+
+import { execFileSync } from 'child_process';
+import os from 'os';
+import { logger } from './logger.js';
+
+export interface AgentCapability {
+  /** Human-readable name */
+  name: string;
+  /** Binary to look up in $PATH */
+  binary: string;
+  /** Extra env vars to inject when the tool is present */
+  envVars?: Record<string, string>;
+  /** Platform-specific overrides for envVars (merged on top) */
+  platformEnvVars?: Partial<Record<NodeJS.Platform, Record<string, string>>>;
+  /** If true the preflight logs an error; otherwise a warning */
+  required: boolean;
+  /** One-liner install command shown in the log */
+  installHint: string;
+}
+
+export const AGENT_CAPABILITIES: AgentCapability[] = [
+  {
+    name: 'feishu-cli',
+    binary: 'feishu-cli',
+    required: false,
+    installHint:
+      'See scripts/install-host-tools.sh or: curl -fsSL https://github.com/riba2534/feishu-cli/releases/latest/download/install.sh | sh',
+  },
+  {
+    name: 'agent-browser',
+    binary: 'agent-browser',
+    platformEnvVars: {
+      darwin: {
+        AGENT_BROWSER_EXECUTABLE_PATH:
+          '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      },
+      linux: {
+        AGENT_BROWSER_EXECUTABLE_PATH: '/usr/bin/chromium',
+      },
+    },
+    required: false,
+    installHint: 'npm install -g agent-browser',
+  },
+  {
+    name: 'uv',
+    binary: 'uv',
+    required: false,
+    installHint: 'curl -LsSf https://astral.sh/uv/install.sh | sh',
+  },
+];
+
+function isBinaryAvailable(binary: string): boolean {
+  try {
+    execFileSync('which', [binary], { stdio: 'pipe', timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CapabilityCheckResult {
+  available: AgentCapability[];
+  missing: AgentCapability[];
+  /** Env vars to inject into the host process (only for available tools) */
+  envVars: Record<string, string>;
+}
+
+/** Detect which agent capabilities are present on the host. */
+export function checkHostCapabilities(): CapabilityCheckResult {
+  const available: AgentCapability[] = [];
+  const missing: AgentCapability[] = [];
+  const envVars: Record<string, string> = {};
+
+  for (const cap of AGENT_CAPABILITIES) {
+    if (isBinaryAvailable(cap.binary)) {
+      available.push(cap);
+      if (cap.envVars) Object.assign(envVars, cap.envVars);
+      const platformVars = cap.platformEnvVars?.[os.platform()];
+      if (platformVars) Object.assign(envVars, platformVars);
+    } else {
+      missing.push(cap);
+    }
+  }
+
+  return { available, missing, envVars };
+}
+
+/** Log preflight results — warnings for missing, nothing for available. */
+export function logCapabilityPreflight(
+  groupName: string,
+  result: CapabilityCheckResult,
+): void {
+  if (result.missing.length === 0) return;
+
+  for (const cap of result.missing) {
+    const logFn = cap.required
+      ? logger.error.bind(logger)
+      : logger.warn.bind(logger);
+    logFn(
+      { group: groupName, tool: cap.name },
+      `Host preflight: ${cap.name} not found — some agent capabilities will be unavailable. Install: ${cap.installHint}`,
+    );
+  }
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -36,6 +36,10 @@ import { providerPool } from './provider-pool.js';
 import { isApiError } from './agent-output-parser.js';
 import type { ClaudeProviderConfig } from './runtime-config.js';
 import { loadUserMcpServers } from './mcp-utils.js';
+import {
+  checkHostCapabilities,
+  logCapabilityPreflight,
+} from './agent-capabilities.js';
 import { MessageSourceKind, RegisteredGroup, StreamEvent } from './types.js';
 import {
   attachStderrHandler,
@@ -1128,6 +1132,9 @@ export async function runHostAgent(
 
     // 外部 skills（最低优先级）
     // 宿主机 skills（最低优先级）
+    // Builtin skills (lowest priority, e.g. feishu-cli builtin — mirrors /opt/builtin-skills in container)
+    const builtinSkillsDir = path.join(DATA_DIR, 'builtin-skills');
+    linkSkillEntries(builtinSkillsDir);
     linkSkillEntries(path.join(effectiveExtDir, 'skills'));
     // 项目级 skills
     const projectRoot = process.cwd();
@@ -1263,6 +1270,13 @@ export async function runHostAgent(
     // 通过 IS_SANDBOX 标记告知 CLI 当前运行在受控环境中以绕过此限制
     if (typeof process.getuid === 'function' && process.getuid() === 0) {
       hostEnv['IS_SANDBOX'] = '1';
+    }
+
+    // 5b. Host capability preflight — detect external tools & inject env vars
+    const capResult = checkHostCapabilities();
+    logCapabilityPreflight(group.name, capResult);
+    for (const [key, value] of Object.entries(capResult.envVars)) {
+      if (!hostEnv[key]) hostEnv[key] = value;
     }
 
     // 6. 编译检查


### PR DESCRIPTION
## 问题描述

关闭 #416。

宿主机模式（host mode）的 Agent 缺少容器模式通过 Dockerfile 安装的外部工具（feishu-cli、agent-browser、uv）和 builtin skills，导致飞书文档操作和浏览器自动化功能不可用。

## 修复方案

引入共享的 Agent 能力声明模块，让两种执行模式的能力对齐有机制保障。

### `src/agent-capabilities.ts`（新增）
- 定义 `AgentCapability` 接口和 `AGENT_CAPABILITIES` 注册表（feishu-cli、agent-browser、uv）
- `checkHostCapabilities()` 通过 `which` 检测宿主机已安装的工具
- `logCapabilityPreflight()` 在启动时记录缺失工具的警告日志和安装指引
- 支持平台适配环境变量（macOS 的 Chrome 路径 vs Linux 的 Chromium 路径）

### `src/container-runner.ts`
- **Skills 链接补齐**：在 `runHostAgent()` 的 skills 链接逻辑中，新增 `data/builtin-skills/` 作为最低优先级来源，对应容器 `entrypoint.sh` 中的 `/opt/builtin-skills`
- **Preflight 检查**：启动前调用 `checkHostCapabilities()` 检测外部工具，缺失时 warn 级别日志（不阻断启动）
- **环境变量注入**：将可用工具的平台适配环境变量（如 `AGENT_BROWSER_EXECUTABLE_PATH`）注入宿主机进程

### `scripts/install-host-tools.sh`（新增）
- 一键安装宿主机所需外部工具（feishu-cli、agent-browser、uv）
- 下载 feishu-cli builtin skills 到 `data/builtin-skills/` 缓存
- 支持 `skills` 子命令仅刷新 builtin-skills 缓存
- 自动检测平台和架构（macOS/Linux, amd64/arm64）

### `Makefile`
- 新增 `make install-host-tools` 目标

## 新增后的 Skills 链接优先级

| 优先级 | 来源 | 说明 |
|--------|------|------|
| 1（最低） | `data/builtin-skills/` | feishu-cli 内置 skills（**本次新增**） |
| 2 | `~/.claude/skills/` | 宿主机用户级 skills |
| 3 | `container/skills/` | 项目级 skills |
| 4（最高） | `data/skills/{userId}` | 用户级 skills |