### PR TITLE
功能: QQ 配对聊天支持重命名

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -14,6 +14,7 @@ import {
   deleteChatHistory,
   getRegisteredGroup,
   setRegisteredGroup,
+  updateChatName,
   getAgent,
 } from '../db.js';
 import { authMiddleware, systemConfigMiddleware } from '../middleware/auth.js';
@@ -1864,6 +1865,37 @@ configRoutes.get('/user-im/qq/paired-chats', authMiddleware, (c) => {
     }
   }
   return c.json({ chats });
+});
+
+// Rename a QQ paired chat
+configRoutes.put('/user-im/qq/paired-chats/:jid', authMiddleware, async (c) => {
+  const user = c.get('user') as AuthUser;
+  const jid = decodeURIComponent(c.req.param('jid'));
+
+  if (!jid.startsWith('qq:')) {
+    return c.json({ error: 'Invalid QQ chat JID' }, 400);
+  }
+
+  const groups = deps?.getRegisteredGroups() ?? {};
+  const group = groups[jid];
+  if (!group) {
+    return c.json({ error: 'Chat not found' }, 404);
+  }
+  if (group.created_by !== user.id) {
+    return c.json({ error: 'Not authorized to rename this chat' }, 403);
+  }
+
+  const body = await c.req.json<{ name?: string }>();
+  const name = (body.name ?? '').trim();
+  if (!name) {
+    return c.json({ error: 'Name is required' }, 400);
+  }
+
+  group.name = name;
+  setRegisteredGroup(jid, group);
+  updateChatName(jid, name);
+  logger.info({ jid, name, userId: user.id }, 'QQ chat renamed');
+  return c.json({ success: true });
 });
 
 // Remove (unpair) a QQ chat

--- a/web/src/components/settings/PairingSection.tsx
+++ b/web/src/components/settings/PairingSection.tsx
@@ -1,4 +1,5 @@
-import { Loader2, Copy, Check, Link, X } from 'lucide-react';
+import { useState } from 'react';
+import { Loader2, Copy, Check, Link, X, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { PairedChat } from './hooks/usePairedChats';
 
@@ -16,8 +17,10 @@ interface PairingSectionProps {
     chats: PairedChat[];
     loading: boolean;
     removingJid: string | null;
+    renamingJid?: string | null;
     load: () => void;
     remove: (jid: string) => void;
+    rename?: (jid: string, name: string) => void;
   };
 }
 
@@ -85,27 +88,92 @@ export function PairingSection({ channelName, pairing, paired }: PairingSectionP
         ) : (
           <div className="space-y-1.5">
             {paired.chats.map((chat) => (
-              <div key={chat.jid} className="flex items-center justify-between px-3 py-2 rounded-lg bg-muted group">
-                <div className="min-w-0">
-                  <div className="text-sm text-foreground truncate">{chat.name}</div>
-                  <div className="text-xs text-muted-foreground">{new Date(chat.addedAt).toLocaleString('zh-CN')}</div>
-                </div>
-                <button
-                  onClick={() => paired.remove(chat.jid)}
-                  disabled={paired.removingJid === chat.jid}
-                  className="ml-2 p-1 rounded text-muted-foreground hover:text-error hover:bg-error-bg opacity-0 group-hover:opacity-100 transition-all disabled:opacity-50"
-                  title="移除配对"
-                >
-                  {paired.removingJid === chat.jid ? (
-                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  ) : (
-                    <X className="w-3.5 h-3.5" />
-                  )}
-                </button>
-              </div>
+              <PairedChatRow
+                key={chat.jid}
+                chat={chat}
+                paired={paired}
+              />
             ))}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function PairedChatRow({
+  chat,
+  paired,
+}: {
+  chat: PairedChat;
+  paired: PairingSectionProps['paired'];
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(chat.name);
+
+  const handleSave = async () => {
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === chat.name) {
+      setEditing(false);
+      setDraft(chat.name);
+      return;
+    }
+    await paired.rename?.(chat.jid, trimmed);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleSave();
+    if (e.key === 'Escape') {
+      setEditing(false);
+      setDraft(chat.name);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between px-3 py-2 rounded-lg bg-muted group">
+      <div className="min-w-0 flex-1">
+        {editing ? (
+          <input
+            className="text-sm text-foreground bg-background border border-border rounded px-2 py-0.5 w-full outline-none focus:ring-1 focus:ring-primary"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={handleSave}
+            onKeyDown={handleKeyDown}
+            autoFocus
+          />
+        ) : (
+          <div className="text-sm text-foreground truncate">{chat.name}</div>
+        )}
+        <div className="text-xs text-muted-foreground">{new Date(chat.addedAt).toLocaleString('zh-CN')}</div>
+      </div>
+      <div className="flex items-center ml-2 gap-0.5">
+        {paired.rename && !editing && (
+          <button
+            onClick={() => { setDraft(chat.name); setEditing(true); }}
+            disabled={paired.renamingJid === chat.jid}
+            className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted-foreground/10 opacity-0 group-hover:opacity-100 transition-all disabled:opacity-50"
+            title="重命名"
+          >
+            {paired.renamingJid === chat.jid ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Pencil className="w-3.5 h-3.5" />
+            )}
+          </button>
+        )}
+        <button
+          onClick={() => paired.remove(chat.jid)}
+          disabled={paired.removingJid === chat.jid}
+          className="p-1 rounded text-muted-foreground hover:text-error hover:bg-error-bg opacity-0 group-hover:opacity-100 transition-all disabled:opacity-50"
+          title="移除配对"
+        >
+          {paired.removingJid === chat.jid ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <X className="w-3.5 h-3.5" />
+          )}
+        </button>
       </div>
     </div>
   );

--- a/web/src/components/settings/hooks/usePairedChats.ts
+++ b/web/src/components/settings/hooks/usePairedChats.ts
@@ -18,6 +18,7 @@ export function usePairedChats({ endpoint }: UsePairedChatsOptions) {
   const [chats, setChats] = useState<PairedChat[]>([]);
   const [loading, setLoading] = useState(false);
   const [removingJid, setRemovingJid] = useState<string | null>(null);
+  const [renamingJid, setRenamingJid] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -47,5 +48,23 @@ export function usePairedChats({ endpoint }: UsePairedChatsOptions) {
     [endpoint],
   );
 
-  return { chats, loading, removingJid, load, remove };
+  const rename = useCallback(
+    async (jid: string, name: string) => {
+      setRenamingJid(jid);
+      try {
+        await api.put(`${endpoint}/${encodeURIComponent(jid)}`, { name });
+        setChats((prev) =>
+          prev.map((c) => (c.jid === jid ? { ...c, name } : c)),
+        );
+        toast.success('已重命名');
+      } catch (err) {
+        toast.error(getErrorMessage(err, '重命名失败'));
+      } finally {
+        setRenamingJid(null);
+      }
+    },
+    [endpoint],
+  );
+
+  return { chats, loading, removingJid, renamingJid, load, remove, rename };
 }


### PR DESCRIPTION
## 问题描述

QQ Bot API v2 的 WebSocket 消息中，`data.author.username` 字段经常为 `undefined`，代码直接 fallback 到了硬编码的 `"QQ用户"`：

```typescript
const senderName = data.author?.username || `QQ用户`;
```

配对时这个默认名称被写入数据库，导致管理台「设置 → 消息通道 → QQ → 聊天配对」列表中所有 QQ 用户都显示为"QQ用户"，无法区分。

**对比其他渠道：**
- 飞书：有 API 查询用户名 + 缓存
- Telegram：消息自带 `first_name` / `last_name`
- 钉钉：消息自带 `senderNick`
- QQ：`author.username` 经常为空，且无公开 API 查询昵称

## 修复方案

支持在管理台对已配对的 QQ 聊天进行重命名，最小侵入式改动，不影响其他渠道。

### `src/routes/config.ts`
- 新增 `PUT /user-im/qq/paired-chats/:jid` 接口
- 接受 `{ name: string }`，同步更新 `registered_groups` 和 `chats` 两张表
- 权限校验：只允许重命名自己创建的配对

### `web/src/components/settings/hooks/usePairedChats.ts`
- 新增 `rename(jid, name)` 方法和 `renamingJid` loading 状态
- `rename` 和 `renamingJid` 为可选字段，未传入的渠道（如 Telegram）不受影响

### `web/src/components/settings/PairingSection.tsx`
- 提取 `PairedChatRow` 组件，hover 显示铅笔图标
- 点击进入内联编辑模式：Enter 保存、Escape 取消、失焦自动保存
- 仅当 `rename` prop 存在时显示编辑按钮，其他渠道无侵入

🤖 Generated with [Claude Code](https://claude.com/claude-code)