### PR TITLE
修复: 中断后 IPC 注入的消息被吞掉不会被处理 (#421)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1820,6 +1820,10 @@ async function main(): Promise<void> {
         });
         // 清理可能残留的 _interrupt 文件
         try { fs.unlinkSync(IPC_INPUT_INTERRUPT_SENTINEL); } catch { /* ignore */ }
+        // 清理可能残留的 _drain 文件：中断后应继续处理排队的 IPC 消息，
+        // 而非因 _drain 导致 waitForIpcMessage() 立即返回 null 而退出。
+        // _drain 是消息到达时 enqueueMessageCheck() 写入的，此时已过时。
+        try { fs.unlinkSync(IPC_INPUT_DRAIN_SENTINEL); } catch { /* ignore */ }
         // 不 break，等待下一条消息
         const nextMessage = await waitForIpcMessage();
         if (nextMessage === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,11 +299,17 @@ let lastAgentTimestamp: Record<string, MessageCursor> = {};
 // Recovery-safe cursor: only advances when an agent actually finishes processing.
 // recoverPendingMessages() uses this to detect IPC-injected but unprocessed messages.
 let lastCommittedCursor: Record<string, MessageCursor> = {};
+// Tracks cursor position before IPC injection, for rollback on interrupt.
+// When messages are IPC-injected into an active query and the query is interrupted,
+// the injected messages are lost.  Rolling back lastAgentTimestamp allows the
+// message loop to re-discover them on the next poll.
+let preIpcCursor: Record<string, MessageCursor> = {};
 
 /** Set both cursors directly (no max-merge) and persist. */
 function setCursors(jid: string, cursor: MessageCursor): void {
   lastAgentTimestamp[jid] = cursor;
   lastCommittedCursor[jid] = cursor;
+  delete preIpcCursor[jid];
   saveState();
 }
 
@@ -314,6 +320,19 @@ function advanceCursors(jid: string, candidate: MessageCursor): void {
     current && current.timestamp > candidate.timestamp ? current : candidate;
   lastAgentTimestamp[jid] = target;
   lastCommittedCursor[jid] = target;
+  saveState();
+}
+
+/**
+ * Roll back lastAgentTimestamp to the position before IPC-injected messages.
+ * Called on interrupt so the message loop re-discovers messages that were
+ * consumed by the aborted query.
+ */
+function rollbackIpcCursors(jid: string): void {
+  const saved = preIpcCursor[jid];
+  if (!saved) return;
+  lastAgentTimestamp[jid] = saved;
+  delete preIpcCursor[jid];
   saveState();
 }
 let messageLoopRunning = false;
@@ -2512,6 +2531,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       id: lastProcessed.id,
     });
     cursorCommitted = true;
+    // Cursor committed — IPC-injected messages are considered processed.
+    delete preIpcCursor[chatJid];
   };
 
   if (effectiveGroup.created_by) {
@@ -2643,6 +2664,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                   clearStreamingSnapshot(chatJid);
                   streamingAccumulatedText = '';
                   streamingAccumulatedThinking = '';
+                  // Roll back cursor before commit so IPC-injected messages
+                  // are re-discovered by the next message loop poll (#421).
+                  rollbackIpcCursors(chatJid);
                   commitCursor();
                 } catch (err) {
                   logger.warn(
@@ -3153,6 +3177,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           },
         });
         sentReply = true;
+        rollbackIpcCursors(chatJid);
         commitCursor();
       } catch (err) {
         logger.warn({ err, chatJid }, 'Failed to save interrupted text');
@@ -6114,6 +6139,12 @@ async function startMessageLoop(): Promise<void> {
               'Piped messages to active container',
             );
             const lastProcessed = messagesToSend[messagesToSend.length - 1];
+            // Save pre-injection cursor for rollback on interrupt (#421).
+            // Only the first injection per agent run needs saving — subsequent
+            // injections extend the same rollback window.
+            if (!preIpcCursor[chatJid] && lastAgentTimestamp[chatJid]) {
+              preIpcCursor[chatJid] = { ...lastAgentTimestamp[chatJid] };
+            }
             lastAgentTimestamp[chatJid] = {
               timestamp: lastProcessed.timestamp,
               id: lastProcessed.id,


### PR DESCRIPTION
## 问题描述

关闭 #421。

消息 B 通过 IPC 注入到正在运行的 query 中，query 被中断后，消息 B 随 query 一起丢失。原因是 IPC 注入时 `lastAgentTimestamp` 已推进到消息 B 的位置，中断时 `commitCursor()` 通过 `advanceCursors()` 将 `lastCommittedCursor` 也同步到该位置，导致消息 B 永远不会被重新发现。

## 修复方案

### `src/index.ts` — Host 侧游标回滚

- 新增 `preIpcCursor` 记录 IPC 注入前的游标位置
- `startMessageLoop()` 中 IPC 注入成功时保存回滚点（仅首次注入）
- 新增 `rollbackIpcCursors()` 函数：将 `lastAgentTimestamp` 回滚到注入前位置
- 两处中断路径（inline status event + finally block）在 `commitCursor()` 前调用 `rollbackIpcCursors()`
- `commitCursor()` 成功提交后清理 `preIpcCursor`（确认消息已处理）
- `setCursors()` 也清理 `preIpcCursor`（强制重置场景）

### `container/agent-runner/src/index.ts` — Agent 侧 `_drain` 清理

- 中断后 `waitForIpcMessage()` 前清理残留的 `_drain` sentinel
- 防止 `enqueueMessageCheck()` 写入的 `_drain` 导致 agent 提前退出