### PR TITLE
修复: listUsers 默认过滤已删除用户

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -3212,6 +3212,8 @@ export function listUsers(options: ListUsersOptions = {}): ListUsersResult {
   if (status) {
     whereParts.push('u.status = ?');
     params.push(status);
+  } else {
+    whereParts.push("u.status != 'deleted'");
   }
   if (query) {
     whereParts.push(


### PR DESCRIPTION
## 问题描述

`listUsers` 在未指定 `status` 过滤参数时，会返回所有用户，**包括 `status='deleted'` 的软删除用户**。

这导致用户管理页的默认视图里会混入已软删除的用户，行为与仓库内其他类似查询不一致。

## 根因

仓库内其他涉及用户的查询都默认排除 deleted 用户：

- `src/db.ts:1014` — `SELECT id FROM users WHERE status != 'deleted'`
- `src/db.ts:1086` — `SELECT id, role FROM users WHERE status != 'deleted' AND role != 'admin'`
- `src/db.ts:5188` — `WHERE u.status != 'deleted'`
- `src/db.ts:5418` — `SELECT COUNT(*) as cnt FROM users WHERE status != 'deleted'`
- `src/db.ts:5434` — `WHERE u.status != 'deleted'`

唯独 `listUsers`（`src/db.ts:3194`）在构造 where 子句时，`status` 为 null 就不追加任何过滤条件 —— 明显是疏漏。

## 修复方案

在 `listUsers` 的 where 分支里增加 `else`：当未显式传 `status` 时，默认追加 `u.status != 'deleted'`。

显式传 `status='deleted'`（软删除用户恢复场景）仍可正常查询到这些用户，**行为兼容**。

### `src/db.ts`

- 在 status 判断分支里增加 else：默认过滤 deleted

## 测试计划

- [ ] 用户管理页默认视图不再出现已软删除的用户
- [ ] 软删除用户恢复流程（显式传 `status='deleted'`）仍能查到用户
- [ ] 显式传其他 status（`active`、`disabled`）过滤行为不变