### PR TITLE
修复: compact 显示模式 AI 消息缺少分享图片入口

### DIFF
--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -305,6 +305,16 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
           >
             {copied ? <Check className="w-3 h-3 text-primary" /> : <Copy className="w-3 h-3" />}
           </button>
+          {isAI && (
+            <button
+              onClick={() => setShowShareDialog(true)}
+              className="w-5 h-5 rounded flex items-center justify-center text-muted-foreground/50 hover:text-foreground/70 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+              title="导出为长图"
+              aria-label="导出为长图"
+            >
+              <ImageDown className="w-3 h-3" />
+            </button>
+          )}
         </div>
 
         {/* Reasoning */}
@@ -345,7 +355,22 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
           <ImageLightbox images={lightboxState.images} initialIndex={lightboxState.index} onClose={() => setLightboxState(null)} />
         )}
         {contextMenu && (
-          <MessageContextMenu content={message.content} position={contextMenu} onClose={() => setContextMenu(null)} chatJid={message.chat_jid} messageId={message.id} />
+          <MessageContextMenu
+            content={message.content}
+            position={contextMenu}
+            onClose={() => setContextMenu(null)}
+            chatJid={message.chat_jid}
+            messageId={message.id}
+            onShareImage={isAI ? () => setShowShareDialog(true) : undefined}
+          />
+        )}
+        {showShareDialog && (
+          <Suspense>
+            <ShareImageDialog
+              onClose={() => setShowShareDialog(false)}
+              message={message}
+            />
+          </Suspense>
         )}
       </div>
     );


### PR DESCRIPTION
## 问题描述

在 compact 显示模式下，AI 消息的 sender line 只有复制按钮，**缺少「分享为图片」入口**。

任何使用 compact 模式的用户都无法通过 UI 触发 AI 消息的分享图片功能——这跟 bubble 模式下"气泡右上角 hover 显示分享按钮"的可用性明显不一致。

## 复现路径

1. 设置 → 显示模式切换为 **compact**
2. 打开任意会话，hover 到 AI 消息上
3. 预期：出现「复制」+「分享图片」按钮
4. 实际：只有「复制」按钮，无任何方式触发 ShareImageDialog

## 根因

`746fbad 功能: AI 消息生成分享图片（html-to-image + offscreen 渲染）` 在 `MessageBubble.tsx` 引入分享按钮时，只覆盖了 **bubble 模式**的气泡右上角工具栏（`absolute top-2 right-2`），**compact 模式分支被完整遗漏**：

- sender line（复制按钮所在容器）没有分享按钮
- 同 return block 里的 `MessageContextMenu` 未接 `onShareImage` prop
- return 末尾未 render `ShareImageDialog`

html-to-image 依赖和 `ShareImageDialog` / `ShareCardRenderer` 组件本身都正常工作，只是 compact 模式的入口被漏。

## 修复方案

对齐 bubble 模式的行为，给 compact 分支补齐 3 处：

### `web/src/components/chat/MessageBubble.tsx`

- 复制按钮右侧新增 `ImageDown` 分享按钮，`isAI` 条件下渲染
- `MessageContextMenu` 追加 `onShareImage` prop（右键菜单同步出现「生成分享图片」条目）
- return block 末尾 render lazy 加载的 `ShareImageDialog`（用 `Suspense` 包裹，沿用 bubble 模式同样的 lazy 策略）

仅 AI 消息显示分享按钮，用户消息保持不变。

## 测试计划

- [ ] Compact 模式下 AI 消息 hover 显示 ImageDown 图标（位于复制按钮右侧）
- [ ] 点击触发 ShareImageDialog 弹窗，渲染分享卡片
- [ ] 右键菜单/更多菜单有「生成分享图片」条目
- [ ] 用户消息不显示此按钮（原有行为）
- [ ] Bubble 模式行为不变