### PR TITLE
修复: 中断后 IPC 注入的消息不再丢失 (#421)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1025,8 +1025,13 @@ async function runQuery(
   disallowedTools?: string[],
   images?: Array<{ data: string; mimeType?: string }>,
   sourceKindOverride?: ContainerOutput['sourceKind'],
-): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean; contextOverflow?: boolean; unrecoverableTranscriptError?: boolean; interruptedDuringQuery: boolean; sessionResumeFailed?: boolean }> {
+): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean; contextOverflow?: boolean; unrecoverableTranscriptError?: boolean; interruptedDuringQuery: boolean; sessionResumeFailed?: boolean; pipedMessagesDuringQuery: Array<{ text: string; images?: Array<{ data: string; mimeType?: string }> }> }> {
   const stream = new MessageStream();
+  // Track messages piped into this query.  When the query is interrupted,
+  // these messages would otherwise be lost (consumed by the aborted query).
+  // The main loop uses them as the next prompt so the user's queued intent
+  // continues after the cancelled turn (#421, Claude Code-style queuing).
+  const pipedMessagesDuringQuery: Array<{ text: string; images?: Array<{ data: string; mimeType?: string }> }> = [];
   let newSessionId: string | undefined;
   let lastAssistantUuid: string | undefined;
   let canonicalAssistantText: string | undefined;
@@ -1144,6 +1149,7 @@ async function runQuery(
     const { messages } = drainIpcInput();
     for (const msg of messages) {
       log(`Piping IPC message into active query (${msg.text.length} chars, ${msg.images?.length || 0} images)`);
+      pipedMessagesDuringQuery.push(msg);
       const rejected = stream.push(msg.text, msg.images);
       for (const reason of rejected) {
         emit({ status: 'success', result: `\u26a0\ufe0f ${reason}`, newSessionId: undefined });
@@ -1216,7 +1222,7 @@ async function runQuery(
     suppressOutputAfterInterrupt = true;
     ipcPolling = false;
     stream.end();
-    return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery };
+    return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery, pipedMessagesDuringQuery };
   }
 
   // SystemSettings.autoCompactWindow（通过 AUTO_COMPACT_WINDOW 环境变量注入）
@@ -1420,7 +1426,7 @@ async function runQuery(
         // so the caller can retry with a fresh session instead of crashing.
         if (!newSessionId) {
           log(`Session resume failed (no init): ${resultSubtype}`);
-          return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery, sessionResumeFailed: true };
+          return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery, pipedMessagesDuringQuery, sessionResumeFailed: true };
         }
         const detail = textResult?.trim()
           ? textResult.trim()
@@ -1444,12 +1450,12 @@ async function runQuery(
           });
         }
         processor.resetFullTextAccumulator();
-        return { newSessionId, lastAssistantUuid, closedDuringQuery, contextOverflow: true, interruptedDuringQuery };
+        return { newSessionId, lastAssistantUuid, closedDuringQuery, contextOverflow: true, interruptedDuringQuery, pipedMessagesDuringQuery };
       }
       if (textResult && isUnrecoverableTranscriptError(textResult)) {
         log(`Unrecoverable transcript error in result: ${textResult.slice(0, 200)}`);
         processor.resetFullTextAccumulator();
-        return { newSessionId, lastAssistantUuid, closedDuringQuery, unrecoverableTranscriptError: true, interruptedDuringQuery };
+        return { newSessionId, lastAssistantUuid, closedDuringQuery, unrecoverableTranscriptError: true, interruptedDuringQuery, pipedMessagesDuringQuery };
       }
 
       const { effectiveResult } = processor.processResult(textResult);
@@ -1526,7 +1532,7 @@ async function runQuery(
   ipcPolling = false;
   ipcQueryWatcher.close();
   log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}, interruptedDuringQuery: ${interruptedDuringQuery}`);
-  return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery };
+  return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery, pipedMessagesDuringQuery };
   } catch (err) {
     ipcPolling = false;
     ipcQueryWatcher.close();
@@ -1547,19 +1553,19 @@ async function runQuery(
           finalizationReason: 'error',
         });
       }
-      return { newSessionId, lastAssistantUuid, closedDuringQuery, contextOverflow: true, interruptedDuringQuery };
+      return { newSessionId, lastAssistantUuid, closedDuringQuery, contextOverflow: true, interruptedDuringQuery, pipedMessagesDuringQuery };
     }
 
     // 检测不可恢复的转录错误
     if (isUnrecoverableTranscriptError(errorMessage)) {
       log(`Unrecoverable transcript error: ${errorMessage}`);
-      return { newSessionId, lastAssistantUuid, closedDuringQuery, unrecoverableTranscriptError: true, interruptedDuringQuery };
+      return { newSessionId, lastAssistantUuid, closedDuringQuery, unrecoverableTranscriptError: true, interruptedDuringQuery, pipedMessagesDuringQuery };
     }
 
     // 中断导致的 SDK 错误（error_during_execution 等）：正常返回，不抛出
     if (interruptedDuringQuery) {
       log(`runQuery error during interrupt (non-fatal): ${errorMessage}`);
-      return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery };
+      return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery, pipedMessagesDuringQuery };
     }
 
     // SDK 在 yield result 后可能再抛异常（如检测到 result text 含错误内容），
@@ -1571,7 +1577,7 @@ async function runQuery(
       if (err instanceof Error && err.stack) {
         log(`runQuery post-result error stack:\n${err.stack}`);
       }
-      return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery };
+      return { newSessionId, lastAssistantUuid, closedDuringQuery, interruptedDuringQuery, pipedMessagesDuringQuery };
     }
 
     // 其他错误：记录完整堆栈后继续抛出
@@ -1806,9 +1812,8 @@ async function main(): Promise<void> {
         break;
       }
 
-      // 中断后：跳过 memory flush 和 session update，等待下一条消息
+      // 中断后：跳过 memory flush 和 session update
       if (queryResult.interruptedDuringQuery) {
-        log('Query interrupted by user, waiting for next message');
         // 中断后清除 resumeAt：被中断的 assistant 消息可能未完整提交到 session 历史。
         // 使用 undefined 让 SDK 自行选择恢复点，避免因指向不完整消息的 UUID 导致 resume 失败。
         resumeAt = undefined;
@@ -1818,9 +1823,33 @@ async function main(): Promise<void> {
           streamEvent: { eventType: 'status', statusText: 'interrupted' },
           newSessionId: sessionId,  // 确保主进程持久化 session ID
         });
-        // 清理可能残留的 _interrupt 文件
+        // 清理可能残留的 _interrupt / _drain 文件
         try { fs.unlinkSync(IPC_INPUT_INTERRUPT_SENTINEL); } catch { /* ignore */ }
-        // 不 break，等待下一条消息
+        try { fs.unlinkSync(IPC_INPUT_DRAIN_SENTINEL); } catch { /* ignore */ }
+        clearInterruptRequested();
+        consecutiveCompactions = 0;
+
+        // Claude Code-style 排队行为：被中断的 query 已经消费了 pipe 进来的消息，
+        // 但这些消息尚未得到回复。将它们写回 IPC 目录作为新文件，通过 waitForIpcMessage
+        // 正常路径走下一个 query，避免 MCP server "Already connected" 问题 (#421)。
+        if (queryResult.pipedMessagesDuringQuery.length > 0) {
+          const piped = queryResult.pipedMessagesDuringQuery;
+          log(`Query interrupted; re-enqueueing ${piped.length} queued message(s) to IPC`);
+          for (const msg of piped) {
+            const filename = `${Date.now()}-requeue-${Math.random().toString(36).slice(2, 8)}.json`;
+            const filepath = path.join(IPC_INPUT_DIR, filename);
+            const tempPath = `${filepath}.tmp`;
+            try {
+              fs.writeFileSync(tempPath, JSON.stringify({ type: 'message', text: msg.text, images: msg.images }));
+              fs.renameSync(tempPath, filepath);
+            } catch (err) {
+              log(`Failed to re-enqueue piped message: ${err}`);
+            }
+          }
+        }
+
+        // 等待下一条消息（包括刚重新入队的 piped 消息）
+        log('Query interrupted by user, waiting for next message');
         const nextMessage = await waitForIpcMessage();
         if (nextMessage === null) {
           log('Close sentinel received after interrupt, exiting');
@@ -1828,11 +1857,12 @@ async function main(): Promise<void> {
           writeOutput({ status: 'success', result: null, newSessionId: sessionId });
           break;
         }
-        clearInterruptRequested();
-        consecutiveCompactions = 0;
         prompt = nextMessage.text;
         promptImages = nextMessage.images;
         containerInput.turnId = generateTurnId();
+        // Rebuild MCP server to avoid "Already connected to a transport" error
+        // when the previous query was aborted mid-stream (#421).
+        mcpServerConfig = buildMcpServerConfig();
         continue;
       }
 

--- a/tests/e2e/interrupt-ipc-message-loss.mjs
+++ b/tests/e2e/interrupt-ipc-message-loss.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// E2E test for #421: Interrupt should not cause loss of IPC-injected message
+//
+// Scenario (Claude Code-style queuing):
+//   1. Send message A (triggers long-running operation)
+//   2. While agent is processing, send message B
+//   3. Click interrupt (Esc)
+//   4. Verify message B still gets replied to
+//
+// Usage:
+//   node tests/e2e/interrupt-ipc-message-loss.mjs <username> <password>
+
+import WebSocket from 'ws';
+
+const BASE = process.env.HAPPYCLAW_URL || 'http://localhost:3000';
+const WS_URL = BASE.replace(/^http/, 'ws') + '/ws';
+const USERNAME = process.argv[2];
+const PASSWORD = process.argv[3];
+const JID = process.env.JID || 'web:main';
+const TIMEOUT_MS = parseInt(process.env.TIMEOUT_MS || '120000', 10);
+
+if (!USERNAME || !PASSWORD) {
+  console.error('Usage: node interrupt-ipc-message-loss.mjs <username> <password>');
+  process.exit(1);
+}
+
+async function login() {
+  const res = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: USERNAME, password: PASSWORD }),
+  });
+  if (!res.ok) throw new Error(`Login failed: ${res.status}`);
+  const setCookie = res.headers.get('set-cookie');
+  if (!setCookie) throw new Error('No Set-Cookie header');
+  return setCookie.split(';')[0];
+}
+
+async function api(cookie, method, path, body) {
+  const opts = { method, headers: { Cookie: cookie, 'Content-Type': 'application/json' } };
+  if (body) opts.body = JSON.stringify(body);
+  return (await fetch(`${BASE}${path}`, opts)).json();
+}
+
+function connectWs(cookie) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(WS_URL, { headers: { Cookie: cookie } });
+    ws.on('open', () => resolve(ws));
+    ws.on('error', reject);
+  });
+}
+
+function sendMessage(ws, content) {
+  ws.send(JSON.stringify({ type: 'send_message', chatJid: JID, content }));
+}
+
+function waitForStreamStart(ws, timeoutMs = 30000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { ws.off('message', handler); reject(new Error('Timeout stream start')); }, timeoutMs);
+    const handler = (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === 'stream_event' && msg.chatJid === JID) {
+          clearTimeout(timer); ws.off('message', handler); resolve();
+        }
+      } catch {}
+    };
+    ws.on('message', handler);
+  });
+}
+
+function waitForReplyContaining(ws, keyword, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { ws.off('message', handler); reject(new Error(`Timeout waiting for "${keyword}"`)); }, timeoutMs);
+    const handler = (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        // DEBUG: log all incoming events
+        if (msg.type === 'new_message' || msg.type === 'agent_reply') {
+          console.log(`      [ws] type=${msg.type} chatJid=${msg.chatJid} is_from_me=${msg.is_from_me} sender=${msg.message?.sender} content="${(msg.message?.content || msg.text || '').substring(0, 60)}"`);
+        }
+        if (msg.type === 'new_message' && msg.chatJid === JID && msg.is_from_me) {
+          if (msg.message?.sender === '__system__') return;
+          const text = msg.message?.content || '';
+          if (text.includes(keyword)) { clearTimeout(timer); ws.off('message', handler); resolve(text); }
+        }
+        if (msg.type === 'agent_reply' && msg.chatJid === JID) {
+          const text = msg.text || '';
+          if (text.includes(keyword)) { clearTimeout(timer); ws.off('message', handler); resolve(text); }
+        }
+      } catch {}
+    };
+    ws.on('message', handler);
+  });
+}
+
+async function main() {
+  console.log('=== E2E Test: Interrupt + IPC Injection (Issue #421) ===\n');
+  console.log('[1/7] Login...');
+  const cookie = await login();
+  console.log('      OK');
+
+  console.log('[2/7] Connect WS...');
+  const ws = await connectWs(cookie);
+  console.log('      OK\n');
+
+  const kA = `MARKER_${Date.now()}_A`;
+  const kB = `MARKER_${Date.now()}_B`;
+
+  const msgA = `请执行 sleep 8 然后回复 ${kA}`;
+  console.log(`[3/7] Send A: "${msgA}"`);
+  sendMessage(ws, msgA);
+
+  console.log('[4/7] Waiting for agent start...');
+  await waitForStreamStart(ws);
+  console.log('      Started');
+
+  await new Promise(r => setTimeout(r, 3000));
+  const msgB = `忽略上一条，直接回复 ${kB}`;
+  console.log(`[5/7] Send B: "${msgB}"`);
+  sendMessage(ws, msgB);
+
+  await new Promise(r => setTimeout(r, 3000));
+  console.log('[6/7] Interrupt...');
+  const result = await api(cookie, 'POST', `/api/groups/${encodeURIComponent(JID)}/interrupt`);
+  console.log(`      ${JSON.stringify(result)}\n`);
+
+  console.log(`[7/7] Waiting for reply with "${kB}" (up to ${TIMEOUT_MS / 1000}s)...`);
+  try {
+    const text = await waitForReplyContaining(ws, kB, TIMEOUT_MS);
+    console.log(`      Reply: "${text.substring(0, 120)}"`);
+    console.log('\n✅ PASS');
+    ws.close();
+    process.exit(0);
+  } catch (err) {
+    console.log(`\n❌ FAIL: ${err.message}`);
+    ws.close();
+    process.exit(1);
+  }
+}
+
+main().catch(err => { console.error('Error:', err.message); process.exit(2); });


### PR DESCRIPTION
## 问题描述

关闭 #421。

消息 A 处理中时发送消息 B，B 被 IPC 注入到当前 query 作为 follow-up 消息。用户点击中断后，当前 query 被取消，但消息 B 随 query 一起被吞掉，用户需要重新发送。

## 实现方案

采用 Claude Code 风格的排队行为：

- 消息 1 处理中 → 发消息 2 → 点击中断 → 取消消息 1，继续处理消息 2
- 再次点击中断 → 取消消息 2

## 与 #423 的区别

#423 通过 host 侧 `preIpcCursor` 回滚游标 + `enqueueMessageCheck` 触发 drain 来修复，但会导致消息 A 被重新执行（因为游标回滚到 A 之前）。

本 PR 改在 agent-runner 内部解决：中断后把被 query 吞掉的 IPC 消息重新入队 IPC 文件夹，下一轮 `waitForIpcMessage()` 会取出并启动新 query 只处理这些排队消息。消息 A 不会被重跑。

## 改动

### `container/agent-runner/src/index.ts`

- **`runQuery` 跟踪 piped messages**：查询执行期间，IPC 轮询 pipe 进来的消息同时被记录到 `pipedMessagesDuringQuery` 返回给调用方
- **中断处理重新入队**：被中断后将这些消息作为新 IPC 文件写回 `data/ipc/{folder}/input/` 目录，让 `waitForIpcMessage()` 在下一轮正常取出
- **rebuild MCP server**：中断后 `continue` 前调用 `mcpServerConfig = buildMcpServerConfig()`，避免 "Already connected to a transport" 错误（SDK MCP Protocol 实例已被第一个 query 占用）

### `tests/e2e/interrupt-ipc-message-loss.mjs`

E2E 测试脚本，验证中断后消息不丢失：

```
USERNAME=xxx PASSWORD=xxx node tests/e2e/interrupt-ipc-message-loss.mjs <user> <pass>
```

流程：登录 → 发消息 A（`sleep 8 + MARKER_A`）→ 等 agent 开始 → 发消息 B（`回复 MARKER_B`）→ 调用 interrupt API → 验证 120s 内收到包含 MARKER_B 的 WebSocket 回复。

## 验证

本地测试通过：

```
[6/7] Interrupt... {"success":true,"interrupted":true}
[7/7] Waiting for reply with "MARKER_B" (up to 120s)...
      Reply: "MARKER_B"
✅ PASS
```

手动测试：Web UI 打开新对话 → 发"随便说 30 秒" → 等 agent 开始输出 → 发"hi" → 点中断 → 第一条显示"已中断"，第二条获得正常回复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)