### PR TITLE
功能: admin 宿主机支持原生 Claude Code 模式

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -981,8 +981,19 @@ function buildMemoryRecallPrompt(isHome: boolean, isAdminHome: boolean, disableM
   ].join('\n');
 }
 
-/** 从 settings.json 读取用户配置的 MCP servers（stdio/http/sse 类型） */
+/** 读取用户配置的 MCP servers（stdio/http/sse 类型） */
 function loadUserMcpServers(): Record<string, unknown> {
+  // 禁用记忆层模式下 CLAUDE_CONFIG_DIR 指向 ~/.claude/，HappyClaw 管理的 per-user MCP
+  // 不在那份 settings.json 里，container-runner 通过 env 透传。优先读 env。
+  const envJson = process.env.HAPPYCLAW_USER_MCP_SERVERS_JSON;
+  if (envJson) {
+    try {
+      const parsed = JSON.parse(envJson);
+      if (parsed && typeof parsed === 'object') {
+        return parsed as Record<string, unknown>;
+      }
+    } catch { /* fall through to settings.json */ }
+  }
   const configDir = process.env.CLAUDE_CONFIG_DIR
     || path.join(process.env.HOME || '/home/node', '.claude');
   const settingsFile = path.join(configDir, 'settings.json');

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -564,6 +564,7 @@ function trimSessionJsonl(jsonlPath: string): void {
 function createPreCompactHook(
   isHome: boolean,
   _isAdminHome: boolean,
+  nativeClaudeMode: boolean,
   deps: { emit: (output: ContainerOutput) => void; getFullText: () => string; resetFullText: () => void },
 ): HookCallback {
   return async (input, _toolUseId, _context) => {
@@ -634,7 +635,8 @@ function createPreCompactHook(
     hadCompaction = true;
 
     // Flag memory flush for home containers (full memory write access)
-    if (isHome) {
+    // Skip in native Claude mode — user's ~/.claude/ Playbook handles memory persistence
+    if (isHome && !nativeClaudeMode) {
       needsMemoryFlush = true;
       log('PreCompact: flagged memory flush for home container');
     }
@@ -908,7 +910,11 @@ function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: str
   });
 }
 
-function buildMemoryRecallPrompt(isHome: boolean, isAdminHome: boolean): string {
+function buildMemoryRecallPrompt(isHome: boolean, isAdminHome: boolean, nativeClaudeMode: boolean): string {
+  // 原生 Claude Code 模式：完全跳过 HappyClaw 的记忆系统提示，让用户本机 ~/.claude/ Playbook 接管
+  if (nativeClaudeMode) {
+    return '';
+  }
   if (isHome) {
     // Home container (admin or member): full memory system with read/write access to user's global CLAUDE.md
     return [
@@ -1162,6 +1168,7 @@ async function runQuery(
   const processor = new StreamEventProcessor(emit, log);
 
   const { isHome, isAdminHome } = normalizeHomeFlags(containerInput);
+  const nativeClaudeMode = process.env.HAPPYCLAW_NATIVE_CLAUDE_MODE === 'true';
 
   // Resumed sessions carry prior history — skip re-injecting HEARTBEAT.md to save cache tokens.
   let heartbeatContent = '';
@@ -1251,7 +1258,7 @@ async function runQuery(
         happyclaw: mcpServerConfig,  // 内置 SDK MCP 放最后，确保不被同名覆盖
       },
       hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook(isHome, isAdminHome, {
+        PreCompact: [{ hooks: [createPreCompactHook(isHome, isAdminHome, nativeClaudeMode, {
           emit,
           getFullText: () => processor.getFullText(),
           resetFullText: () => processor.resetFullTextAccumulator(),
@@ -1624,6 +1631,9 @@ async function main(): Promise<void> {
   latestSessionId = sessionId;
   const { isHome, isAdminHome } = normalizeHomeFlags(containerInput);
 
+  // 原生 Claude Code 模式：关闭 HappyClaw 自带的 memory MCP 工具，让 Agent 按用户本机 Playbook 行事
+  const nativeClaudeMode = process.env.HAPPYCLAW_NATIVE_CLAUDE_MODE === 'true';
+
   // Create in-process SDK MCP server (replaces the stdio subprocess)
   const mcpToolsConfig = {
     chatJid: containerInput.chatJid,
@@ -1635,6 +1645,7 @@ async function main(): Promise<void> {
     workspaceGroup: WORKSPACE_GROUP,
     workspaceGlobal: WORKSPACE_GLOBAL,
     workspaceMemory: WORKSPACE_MEMORY,
+    nativeClaudeMode,
   };
   const buildMcpServerConfig = () => createSdkMcpServer({
     name: 'happyclaw',
@@ -1642,7 +1653,7 @@ async function main(): Promise<void> {
     tools: createMcpTools(mcpToolsConfig),
   });
   let mcpServerConfig = buildMcpServerConfig();
-  const memoryRecallPrompt = buildMemoryRecallPrompt(isHome, isAdminHome);
+  const memoryRecallPrompt = buildMemoryRecallPrompt(isHome, isAdminHome, nativeClaudeMode);
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
   // Clean up stale sentinels from previous container runs.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -564,7 +564,7 @@ function trimSessionJsonl(jsonlPath: string): void {
 function createPreCompactHook(
   isHome: boolean,
   _isAdminHome: boolean,
-  nativeClaudeMode: boolean,
+  disableMemoryLayer: boolean,
   deps: { emit: (output: ContainerOutput) => void; getFullText: () => string; resetFullText: () => void },
 ): HookCallback {
   return async (input, _toolUseId, _context) => {
@@ -636,7 +636,7 @@ function createPreCompactHook(
 
     // Flag memory flush for home containers (full memory write access)
     // Skip in native Claude mode — user's ~/.claude/ Playbook handles memory persistence
-    if (isHome && !nativeClaudeMode) {
+    if (isHome && !disableMemoryLayer) {
       needsMemoryFlush = true;
       log('PreCompact: flagged memory flush for home container');
     }
@@ -910,9 +910,9 @@ function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: str
   });
 }
 
-function buildMemoryRecallPrompt(isHome: boolean, isAdminHome: boolean, nativeClaudeMode: boolean): string {
-  // 原生 Claude Code 模式：完全跳过 HappyClaw 的记忆系统提示，让用户本机 ~/.claude/ Playbook 接管
-  if (nativeClaudeMode) {
+function buildMemoryRecallPrompt(isHome: boolean, isAdminHome: boolean, disableMemoryLayer: boolean): string {
+  // 禁用记忆层：完全跳过 HappyClaw 的记忆系统提示，让用户本机 ~/.claude/ Playbook 接管
+  if (disableMemoryLayer) {
     return '';
   }
   if (isHome) {
@@ -1168,11 +1168,12 @@ async function runQuery(
   const processor = new StreamEventProcessor(emit, log);
 
   const { isHome, isAdminHome } = normalizeHomeFlags(containerInput);
-  const nativeClaudeMode = process.env.HAPPYCLAW_NATIVE_CLAUDE_MODE === 'true';
+  const disableMemoryLayer = process.env.HAPPYCLAW_DISABLE_MEMORY_LAYER === 'true';
 
   // Resumed sessions carry prior history — skip re-injecting HEARTBEAT.md to save cache tokens.
+  // HEARTBEAT.md 住在 HappyClaw 记忆层（WORKSPACE_GLOBAL），禁用该层时不读取。
   let heartbeatContent = '';
-  if (isHome && !sessionId) {
+  if (isHome && !sessionId && !disableMemoryLayer) {
     const heartbeatPath = path.join(WORKSPACE_GLOBAL, 'HEARTBEAT.md');
     if (fs.existsSync(heartbeatPath)) {
       try {
@@ -1203,7 +1204,7 @@ async function runQuery(
     `<behavior>\n${INTERACTION_GUIDELINES}\n</behavior>`,
     `<skill-routing>\n${SKILL_ROUTING_GUIDELINES}\n</skill-routing>`,
     `<security>\n${SECURITY_RULES}\n</security>`,
-    `<memory-system>\n${memoryRecall}\n</memory-system>`,
+    memoryRecall && `<memory-system>\n${memoryRecall}\n</memory-system>`,
     heartbeatContent && `<recent-work>\n${heartbeatContent}\n</recent-work>`,
     GUIDELINES_BLOCK,
     channelGuidelines && `<channel-format>\n${channelGuidelines}\n</channel-format>`,
@@ -1213,9 +1214,13 @@ async function runQuery(
   // Home containers (admin & member) can access global and memory directories.
   // Non-home containers only access memory directory; global CLAUDE.md is NOT
   // injected into systemPrompt but remains accessible via filesystem (readonly mount).
-  const extraDirs = isHome
-    ? [WORKSPACE_GLOBAL, WORKSPACE_MEMORY]
-    : [WORKSPACE_MEMORY];
+  // 禁用记忆层时 WORKSPACE_GLOBAL/MEMORY 环境变量未设置，fallback 到 /workspace/xxx
+  // 容器路径在宿主机不存在，会让 SDK 报警告；此时直接给空数组。
+  const extraDirs = disableMemoryLayer
+    ? []
+    : isHome
+      ? [WORKSPACE_GLOBAL, WORKSPACE_MEMORY]
+      : [WORKSPACE_MEMORY];
 
   if (shouldInterrupt()) {
     log('Interrupt sentinel detected before query start, skipping query');
@@ -1258,7 +1263,7 @@ async function runQuery(
         happyclaw: mcpServerConfig,  // 内置 SDK MCP 放最后，确保不被同名覆盖
       },
       hooks: {
-        PreCompact: [{ hooks: [createPreCompactHook(isHome, isAdminHome, nativeClaudeMode, {
+        PreCompact: [{ hooks: [createPreCompactHook(isHome, isAdminHome, disableMemoryLayer, {
           emit,
           getFullText: () => processor.getFullText(),
           resetFullText: () => processor.resetFullTextAccumulator(),
@@ -1631,8 +1636,8 @@ async function main(): Promise<void> {
   latestSessionId = sessionId;
   const { isHome, isAdminHome } = normalizeHomeFlags(containerInput);
 
-  // 原生 Claude Code 模式：关闭 HappyClaw 自带的 memory MCP 工具，让 Agent 按用户本机 Playbook 行事
-  const nativeClaudeMode = process.env.HAPPYCLAW_NATIVE_CLAUDE_MODE === 'true';
+  // 禁用 HappyClaw 记忆层：不注册 memory MCP 工具，让 Agent 按用户本机 Playbook 行事
+  const disableMemoryLayer = process.env.HAPPYCLAW_DISABLE_MEMORY_LAYER === 'true';
 
   // Create in-process SDK MCP server (replaces the stdio subprocess)
   const mcpToolsConfig = {
@@ -1645,7 +1650,7 @@ async function main(): Promise<void> {
     workspaceGroup: WORKSPACE_GROUP,
     workspaceGlobal: WORKSPACE_GLOBAL,
     workspaceMemory: WORKSPACE_MEMORY,
-    nativeClaudeMode,
+    disableMemoryLayer,
   };
   const buildMcpServerConfig = () => createSdkMcpServer({
     name: 'happyclaw',
@@ -1653,7 +1658,7 @@ async function main(): Promise<void> {
     tools: createMcpTools(mcpToolsConfig),
   });
   let mcpServerConfig = buildMcpServerConfig();
-  const memoryRecallPrompt = buildMemoryRecallPrompt(isHome, isAdminHome, nativeClaudeMode);
+  const memoryRecallPrompt = buildMemoryRecallPrompt(isHome, isAdminHome, disableMemoryLayer);
   fs.mkdirSync(IPC_INPUT_DIR, { recursive: true });
 
   // Clean up stale sentinels from previous container runs.

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -26,6 +26,9 @@ export interface McpContext {
   workspaceGroup: string;
   workspaceGlobal: string;
   workspaceMemory: string;
+  // 原生 Claude Code 模式：禁用 HappyClaw 的 memory MCP 工具（memory_append/search/get），
+  // 让 Agent 完全按用户本机 ~/.claude/ 下的 Playbook 约定管理记忆
+  nativeClaudeMode?: boolean;
 }
 
 function writeIpcFile(dir: string, data: object): string {
@@ -953,8 +956,8 @@ Use the skills panel in the UI to find the skill ID (directory name, e.g. "memor
     );
   }
 
-  // --- memory_append --- (only available for home containers)
-  if (ctx.isHome) {
+  // --- memory_append --- (only available for home containers, skipped in native Claude mode)
+  if (ctx.isHome && !ctx.nativeClaudeMode) {
     tools.push(
       tool(
         'memory_append',
@@ -1074,8 +1077,9 @@ Use the skills panel in the UI to find the skill ID (directory name, e.g. "memor
     );
   }
 
-  // --- memory_search --- (available for all containers)
-  tools.push(
+  // --- memory_search + memory_get --- (skipped in native Claude mode)
+  if (!ctx.nativeClaudeMode) {
+    tools.push(
     tool(
       'memory_search',
       `\u5728\u5de5\u4f5c\u533a\u7684\u8bb0\u5fc6\u6587\u4ef6\u4e2d\u641c\u7d22\uff08CLAUDE.md\u3001memory/\u3001conversations/ \u53ca\u5176\u4ed6 .md/.txt \u6587\u4ef6\uff09\u3002
@@ -1282,6 +1286,7 @@ Use the skills panel in the UI to find the skill ID (directory name, e.g. "memor
       },
     ),
   );
+  }
 
   return tools;
 }

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -26,9 +26,9 @@ export interface McpContext {
   workspaceGroup: string;
   workspaceGlobal: string;
   workspaceMemory: string;
-  // 原生 Claude Code 模式：禁用 HappyClaw 的 memory MCP 工具（memory_append/search/get），
+  // 禁用 HappyClaw 的 memory MCP 工具（memory_append/search/get），
   // 让 Agent 完全按用户本机 ~/.claude/ 下的 Playbook 约定管理记忆
-  nativeClaudeMode?: boolean;
+  disableMemoryLayer?: boolean;
 }
 
 function writeIpcFile(dir: string, data: object): string {
@@ -957,7 +957,7 @@ Use the skills panel in the UI to find the skill ID (directory name, e.g. "memor
   }
 
   // --- memory_append --- (only available for home containers, skipped in native Claude mode)
-  if (ctx.isHome && !ctx.nativeClaudeMode) {
+  if (ctx.isHome && !ctx.disableMemoryLayer) {
     tools.push(
       tool(
         'memory_append',
@@ -1078,7 +1078,7 @@ Use the skills panel in the UI to find the skill ID (directory name, e.g. "memor
   }
 
   // --- memory_search + memory_get --- (skipped in native Claude mode)
-  if (!ctx.nativeClaudeMode) {
+  if (!ctx.disableMemoryLayer) {
     tools.push(
     tool(
       'memory_search',

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1278,6 +1278,18 @@ export async function runHostAgent(
 
     if (disableMemoryLayer) {
       hostEnv['HAPPYCLAW_DISABLE_MEMORY_LAYER'] = 'true';
+      // SDK 读的是 $CLAUDE_CONFIG_DIR/settings.json（此时指向 ~/.claude/），
+      // HappyClaw 写在 groupSessionsDir/settings.json 的 REQUIRED_SETTINGS_ENV 会丢。
+      // 直接注入到进程 env，SDK 按 process.env 读，绕开 settings.json 路径。
+      for (const [key, value] of Object.entries(REQUIRED_SETTINGS_ENV)) {
+        hostEnv[key] = value;
+      }
+      // 同样，per-user MCP servers 在 ~/.claude/settings.json 里没有，
+      // 通过 env 透传，agent-runner 合并进 SDK mcpServers 参数。
+      if (hostMcpServers && Object.keys(hostMcpServers).length > 0) {
+        hostEnv['HAPPYCLAW_USER_MCP_SERVERS_JSON'] =
+          JSON.stringify(hostMcpServers);
+      }
     }
     // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败
     hostEnv['DEBUG_CLAUDE_AGENT_SDK'] = '1';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1234,29 +1234,47 @@ export async function runHostAgent(
       hostEnv['AUTO_COMPACT_WINDOW'] = String(hostAutoCompact);
     }
 
+    // admin host 模式 + 系统设置 disableMemoryLayerForAdminHost 时启用原生 Claude Code 模式：
+    // 不注入 HappyClaw 的 memory 抽象，Agent 完全按用户本机 ~/.claude/ 的 Playbook 工作
+    const isCreatorAdmin = ownerHomeFolder === 'main';
+    const nativeClaudeMode =
+      isCreatorAdmin && getSystemSettings().disableMemoryLayerForAdminHost;
+
     // 路径映射
     hostEnv['HAPPYCLAW_WORKSPACE_GROUP'] = groupDir;
-    // Per-user global memory
-    const ownerId = group.created_by;
-    if (ownerId) {
-      const userGlobalDir = path.join(GROUPS_DIR, 'user-global', ownerId);
-      fs.mkdirSync(userGlobalDir, { recursive: true });
-      hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = userGlobalDir;
-    } else {
-      const legacyGlobalDir = path.join(GROUPS_DIR, 'global');
-      fs.mkdirSync(legacyGlobalDir, { recursive: true });
-      hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = legacyGlobalDir;
-    }
-    const memoryFolder = group.is_home
-      ? group.folder
-      : ownerHomeFolder || group.folder;
-    hostEnv['HAPPYCLAW_WORKSPACE_MEMORY'] = path.join(
-      DATA_DIR,
-      'memory',
-      memoryFolder,
-    );
     hostEnv['HAPPYCLAW_WORKSPACE_IPC'] = groupIpcDir;
-    hostEnv['CLAUDE_CONFIG_DIR'] = groupSessionsDir;
+
+    if (!nativeClaudeMode) {
+      // Per-user global memory（HappyClaw 自带 memory 层）
+      const ownerId = group.created_by;
+      if (ownerId) {
+        const userGlobalDir = path.join(GROUPS_DIR, 'user-global', ownerId);
+        fs.mkdirSync(userGlobalDir, { recursive: true });
+        hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = userGlobalDir;
+      } else {
+        const legacyGlobalDir = path.join(GROUPS_DIR, 'global');
+        fs.mkdirSync(legacyGlobalDir, { recursive: true });
+        hostEnv['HAPPYCLAW_WORKSPACE_GLOBAL'] = legacyGlobalDir;
+      }
+      const memoryFolder = group.is_home
+        ? group.folder
+        : ownerHomeFolder || group.folder;
+      hostEnv['HAPPYCLAW_WORKSPACE_MEMORY'] = path.join(
+        DATA_DIR,
+        'memory',
+        memoryFolder,
+      );
+    }
+
+    // 原生模式且配置了 customCwd 时不覆盖 CLAUDE_CONFIG_DIR，让 SDK 使用用户真实 $HOME/.claude/
+    // 未配 customCwd 时保留 override，避免 HappyClaw 的 cwd 污染 ~/.claude/projects/
+    if (!nativeClaudeMode || !group.customCwd) {
+      hostEnv['CLAUDE_CONFIG_DIR'] = groupSessionsDir;
+    }
+
+    if (nativeClaudeMode) {
+      hostEnv['HAPPYCLAW_NATIVE_CLAUDE_MODE'] = 'true';
+    }
     // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败
     hostEnv['DEBUG_CLAUDE_AGENT_SDK'] = '1';
     // CLI 禁止 root 用户使用 --dangerously-skip-permissions，

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1234,17 +1234,21 @@ export async function runHostAgent(
       hostEnv['AUTO_COMPACT_WINDOW'] = String(hostAutoCompact);
     }
 
-    // admin host 模式 + 系统设置 disableMemoryLayerForAdminHost 时启用原生 Claude Code 模式：
-    // 不注入 HappyClaw 的 memory 抽象，Agent 完全按用户本机 ~/.claude/ 的 Playbook 工作
+    // admin 主容器 + 系统设置 disableMemoryLayerForAdminHost 时禁用 HappyClaw 记忆层：
+    // 不注入 memory MCP 工具 / WORKSPACE_GLOBAL/MEMORY env / 记忆提示，
+    // 让 Agent 完全按用户本机 ~/.claude/ 的 Playbook 工作。
+    // 仅作用于 admin 主容器（is_home=1, folder=main），不影响 admin 创建的其他子群组。
     const isCreatorAdmin = ownerHomeFolder === 'main';
-    const nativeClaudeMode =
-      isCreatorAdmin && getSystemSettings().disableMemoryLayerForAdminHost;
+    const disableMemoryLayer =
+      isCreatorAdmin &&
+      !!group.is_home &&
+      getSystemSettings().disableMemoryLayerForAdminHost;
 
     // 路径映射
     hostEnv['HAPPYCLAW_WORKSPACE_GROUP'] = groupDir;
     hostEnv['HAPPYCLAW_WORKSPACE_IPC'] = groupIpcDir;
 
-    if (!nativeClaudeMode) {
+    if (!disableMemoryLayer) {
       // Per-user global memory（HappyClaw 自带 memory 层）
       const ownerId = group.created_by;
       if (ownerId) {
@@ -1266,14 +1270,14 @@ export async function runHostAgent(
       );
     }
 
-    // 原生模式且配置了 customCwd 时不覆盖 CLAUDE_CONFIG_DIR，让 SDK 使用用户真实 $HOME/.claude/
+    // 禁用记忆层且配置了 customCwd 时不覆盖 CLAUDE_CONFIG_DIR，让 SDK 使用用户真实 $HOME/.claude/
     // 未配 customCwd 时保留 override，避免 HappyClaw 的 cwd 污染 ~/.claude/projects/
-    if (!nativeClaudeMode || !group.customCwd) {
+    if (!disableMemoryLayer || !group.customCwd) {
       hostEnv['CLAUDE_CONFIG_DIR'] = groupSessionsDir;
     }
 
-    if (nativeClaudeMode) {
-      hostEnv['HAPPYCLAW_NATIVE_CLAUDE_MODE'] = 'true';
+    if (disableMemoryLayer) {
+      hostEnv['HAPPYCLAW_DISABLE_MEMORY_LAYER'] = 'true';
     }
     // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败
     hostEnv['DEBUG_CLAUDE_AGENT_SDK'] = '1';

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1210,6 +1210,22 @@ configRoutes.put(
       );
     }
 
+    // 启用「禁用 HappyClaw 记忆层」开关前必须给 admin 主容器配 customCwd，
+    // 否则 CLAUDE_CONFIG_DIR 仍指向 data/sessions/main/.claude，SDK 读不到 ~/.claude/
+    // 又没有 HappyClaw 记忆层注入，agent 会变成空白沙箱。
+    if (validation.data.disableMemoryLayerForAdminHost === true) {
+      const adminMain = getRegisteredGroup('web:main');
+      if (!adminMain || !adminMain.customCwd) {
+        return c.json(
+          {
+            error:
+              '启用前请先给 admin 主容器（web:main）配置 customCwd，否则 SDK 既读不到 HappyClaw 记忆层也读不到 ~/.claude/，会是空白沙箱。',
+          },
+          400,
+        );
+      }
+    }
+
     try {
       const saved = saveSystemSettings(validation.data);
       clearBillingEnabledCache();

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3484,6 +3484,9 @@ export interface SystemSettings {
   externalClaudeDir: string;
   // Claude Agent SDK 自动对话压缩触发点（tokens）。0 = 保留 SDK 默认（约 1M）
   autoCompactWindow: number;
+  // 关闭 admin host 模式下 HappyClaw 自带的 memory 注入层（MCP 工具、模板 CLAUDE.md、WORKSPACE_GLOBAL/MEMORY env）
+  // 启用后 admin 可以在 host 模式下完全按原生 Claude Code 的 Playbook 使用 ~/.claude/ 下的 memory/skills/rules
+  disableMemoryLayerForAdminHost: boolean;
 }
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -3503,6 +3506,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   billingCurrencyRate: 1,
   externalClaudeDir: '',
   autoCompactWindow: 0,
+  disableMemoryLayerForAdminHost: false,
 };
 
 function parseIntEnv(envVar: string | undefined, fallback: number): number {
@@ -3593,6 +3597,10 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       typeof raw.autoCompactWindow === 'number' && raw.autoCompactWindow >= 0
         ? raw.autoCompactWindow
         : DEFAULT_SYSTEM_SETTINGS.autoCompactWindow,
+    disableMemoryLayerForAdminHost:
+      typeof raw.disableMemoryLayerForAdminHost === 'boolean'
+        ? raw.disableMemoryLayerForAdminHost
+        : DEFAULT_SYSTEM_SETTINGS.disableMemoryLayerForAdminHost,
   };
 }
 
@@ -3654,6 +3662,9 @@ function buildEnvFallbackSettings(): SystemSettings {
       process.env.AUTO_COMPACT_WINDOW,
       DEFAULT_SYSTEM_SETTINGS.autoCompactWindow,
     ),
+    disableMemoryLayerForAdminHost:
+      process.env.DISABLE_MEMORY_LAYER_FOR_ADMIN_HOST === 'true' ||
+      DEFAULT_SYSTEM_SETTINGS.disableMemoryLayerForAdminHost,
   };
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -244,6 +244,7 @@ export const SystemSettingsSchema = z.object({
       'autoCompactWindow must be 0 (disabled) or between 10000 and 2000000',
     )
     .optional(),
+  disableMemoryLayerForAdminHost: z.boolean().optional(),
 });
 
 export const AppearanceConfigSchema = z.object({

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -451,6 +451,12 @@ export function SystemSettingsSection() {
               下的模板 CLAUDE.md 和 data/memory/ 下 memory_append 累积的日记。
               若有有价值的内容，建议迁移到 ~/.claude/memory/ 下再启用。
             </p>
+            <p className="text-xs text-muted-foreground mt-2">
+              <strong>Auto-memory 共享</strong>：启用后 SDK auto-memory 会写入
+              ~/.claude/projects/{'{cwd-slug}'}/memory/，与本机原生 Claude Code 共享。
+              如果 HappyClaw Agent 和你本人的风格/语言偏好不同，两边会互相污染 —
+              介意就不要开这个开关。
+            </p>
           </div>
           <Switch
             checked={disableMemoryLayerForAdminHost}

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -435,8 +435,12 @@ export function SystemSettingsSection() {
               不注入 WORKSPACE_GLOBAL/MEMORY 环境变量、不注入 HappyClaw 记忆系统提示、
               PreCompact 钩子不触发 memory flush，让 Agent 完全按本机
               ~/.claude/ 下的 Playbook（CLAUDE.md + rules/ + memory/）行事。
-              建议配合主容器的 customCwd 使用，让 Agent cwd 指向真实项目目录，
-              使 SDK auto-memory 与原生 Claude Code 共用 ~/.claude/projects/。
+            </p>
+            <p className="text-xs text-destructive mt-2">
+              <strong>前置要求</strong>：必须先在 admin 主容器配置 customCwd
+              指向真实项目目录。未配置时 CLAUDE_CONFIG_DIR 仍会指向 data/sessions/main/.claude，
+              SDK 既读不到 HappyClaw 记忆层也读不到 ~/.claude/，Agent 会变成空白沙箱。
+              后端会在保存时校验，未配置则拒绝启用。
             </p>
             <p className="text-xs text-muted-foreground mt-2">
               <strong>仅作用范围</strong>：admin 的主容器（is_home=1，folder=main）。admin

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -152,6 +152,7 @@ export function SystemSettingsSection() {
   const [billingCurrency, setBillingCurrency] = useState('USD');
   const [billingCurrencyRate, setBillingCurrencyRate] = useState(1);
   const [externalClaudeDir, setExternalClaudeDir] = useState('');
+  const [disableMemoryLayerForAdminHost, setDisableMemoryLayerForAdminHost] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -177,6 +178,7 @@ export function SystemSettingsSection() {
         setBillingCurrency(data.billingCurrency ?? 'USD');
         setBillingCurrencyRate(data.billingCurrencyRate ?? 1);
         setExternalClaudeDir(data.externalClaudeDir ?? '');
+        setDisableMemoryLayerForAdminHost(data.disableMemoryLayerForAdminHost ?? false);
       } catch (err) {
         toast.error(getErrorMessage(err, '加载系统参数失败'));
       } finally {
@@ -222,6 +224,7 @@ export function SystemSettingsSection() {
         billingCurrency,
         billingCurrencyRate,
         externalClaudeDir,
+        disableMemoryLayerForAdminHost,
       };
       for (const f of fields) {
         const val = displayValues[f.key];
@@ -241,6 +244,7 @@ export function SystemSettingsSection() {
       setBillingCurrency(data.billingCurrency ?? 'USD');
       setBillingCurrencyRate(data.billingCurrencyRate ?? 1);
       setExternalClaudeDir(data.externalClaudeDir ?? '');
+      setDisableMemoryLayerForAdminHost(data.disableMemoryLayerForAdminHost ?? false);
       // 刷新计费状态，更新导航栏可见性
       loadBillingStatus();
       toast.success('系统参数已保存，新参数将对后续启动的容器/进程生效');
@@ -417,6 +421,29 @@ export function SystemSettingsSection() {
             </div>
           </>
         )}
+      </div>
+
+      {/* 原生 Claude Code 模式（admin 宿主机专用） */}
+      <div className="border-t border-border pt-6 space-y-5">
+        <h3 className="text-sm font-semibold text-foreground">原生 Claude Code 模式</h3>
+
+        <div className="flex items-center justify-between">
+          <div className="flex-1 pr-4">
+            <Label>admin 宿主机关闭 HappyClaw 记忆层</Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              启用后 admin 的 host 模式容器不再注入 memory_append/search/get MCP 工具、
+              不注入 WORKSPACE_GLOBAL/MEMORY 环境变量、不强制注入记忆系统提示，
+              让 Agent 完全按本机 ~/.claude/ 下的 Playbook（CLAUDE.md + rules/ + memory/）行事。
+              建议配合群组的 customCwd 使用，让 Agent cwd 指向真实项目目录。
+              仅影响 admin 的 host 模式；member 容器和非 admin 场景不受影响。
+            </p>
+          </div>
+          <Switch
+            checked={disableMemoryLayerForAdminHost}
+            onCheckedChange={setDisableMemoryLayerForAdminHost}
+            aria-label="admin 宿主机关闭 HappyClaw 记忆层"
+          />
+        </div>
       </div>
 
       <div>

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -423,25 +423,35 @@ export function SystemSettingsSection() {
         )}
       </div>
 
-      {/* 原生 Claude Code 模式（admin 宿主机专用） */}
+      {/* 禁用 HappyClaw 记忆层（admin 主容器专用） */}
       <div className="border-t border-border pt-6 space-y-5">
-        <h3 className="text-sm font-semibold text-foreground">原生 Claude Code 模式</h3>
+        <h3 className="text-sm font-semibold text-foreground">禁用 HappyClaw 记忆层（admin 主容器）</h3>
 
         <div className="flex items-center justify-between">
           <div className="flex-1 pr-4">
-            <Label>admin 宿主机关闭 HappyClaw 记忆层</Label>
+            <Label>禁用后按本机 ~/.claude/ Playbook 运行</Label>
             <p className="text-xs text-muted-foreground mt-0.5">
-              启用后 admin 的 host 模式容器不再注入 memory_append/search/get MCP 工具、
-              不注入 WORKSPACE_GLOBAL/MEMORY 环境变量、不强制注入记忆系统提示，
-              让 Agent 完全按本机 ~/.claude/ 下的 Playbook（CLAUDE.md + rules/ + memory/）行事。
-              建议配合群组的 customCwd 使用，让 Agent cwd 指向真实项目目录。
-              仅影响 admin 的 host 模式；member 容器和非 admin 场景不受影响。
+              启用后 admin 主容器（folder=main）不再注入 memory_append/search/get MCP 工具、
+              不注入 WORKSPACE_GLOBAL/MEMORY 环境变量、不注入 HappyClaw 记忆系统提示、
+              PreCompact 钩子不触发 memory flush，让 Agent 完全按本机
+              ~/.claude/ 下的 Playbook（CLAUDE.md + rules/ + memory/）行事。
+              建议配合主容器的 customCwd 使用，让 Agent cwd 指向真实项目目录，
+              使 SDK auto-memory 与原生 Claude Code 共用 ~/.claude/projects/。
+            </p>
+            <p className="text-xs text-muted-foreground mt-2">
+              <strong>仅作用范围</strong>：admin 的主容器（is_home=1，folder=main）。admin
+              创建的其他 host 子群组、member 容器、Docker 容器模式均不受影响。
+            </p>
+            <p className="text-xs text-muted-foreground mt-2">
+              <strong>数据迁移提示</strong>：启用后 Agent 不再读取 data/groups/user-global/
+              下的模板 CLAUDE.md 和 data/memory/ 下 memory_append 累积的日记。
+              若有有价值的内容，建议迁移到 ~/.claude/memory/ 下再启用。
             </p>
           </div>
           <Switch
             checked={disableMemoryLayerForAdminHost}
             onCheckedChange={setDisableMemoryLayerForAdminHost}
-            aria-label="admin 宿主机关闭 HappyClaw 记忆层"
+            aria-label="禁用 HappyClaw 记忆层"
           />
         </div>
       </div>

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -104,6 +104,7 @@ export interface SystemSettings {
   billingCurrencyRate: number;
   externalClaudeDir: string;
   autoCompactWindow: number;
+  disableMemoryLayerForAdminHost: boolean;
 }
 
 // ─── OAuth Usage ────────────────────────────────────────────


### PR DESCRIPTION
## 问题描述

HappyClaw 给 admin 的 host 模式容器强制注入了一套自己的记忆抽象
（`memory_append`/`memory_search`/`memory_get` MCP 工具 +
`HAPPYCLAW_WORKSPACE_GLOBAL`/`WORKSPACE_MEMORY` 环境变量 +
记忆系统提示词），和用户本机 `~/.claude/` 下累积的 Playbook
（`CLAUDE.md` + `rules/` + `memory/`）是两套平行世界。

对已经在原生 Claude Code 里建立成熟 Playbook 的 admin 用户，这会造成：

1. 两套记忆规则互相冲突——本机 `rules/memory-policy.md` 要求写
   `~/.claude/memory/xxx.md`，HappyClaw 模板让用 `memory_append`
2. 用户在原生 CC 累积的 `~/.claude/memory/MEMORY.md`、feedback、wiki_registry
   等在 HappyClaw 里看不到，SDK auto-memory 也因 `CLAUDE_CONFIG_DIR` 被
   重写而隔离
3. Agent 行为漂移——有时写到本机 `~/.claude/`，有时写到 HappyClaw 沙箱

## 修复方案

在系统设置新增 `disableMemoryLayerForAdminHost` 开关（默认关，保留现状）。
仅 admin 主容器（`is_home=1` + `folder=main`）生效。

### `src/runtime-config.ts` / `src/schemas.ts`

`SystemSettings` 添加 `disableMemoryLayerForAdminHost: boolean`，支持从文件
加载、env 变量 fallback（`DISABLE_MEMORY_LAYER_FOR_ADMIN_HOST`），zod 校验。

### `src/container-runner.ts`

`runHostAgent()` 开头计算 `disableMemoryLayer = isCreatorAdmin && !!group.is_home && setting`。
条件化 env 注入：

- `HAPPYCLAW_WORKSPACE_GLOBAL` / `WORKSPACE_MEMORY`：开关开启时不注入
- `CLAUDE_CONFIG_DIR`：开关开启 + `customCwd` 存在时不注入，让 SDK
  使用 `\$HOME/.claude/`；未配 `customCwd` 时保留 override 避免污染
  `~/.claude/projects/`
- 新增 `HAPPYCLAW_DISABLE_MEMORY_LAYER=true` 透传给 agent-runner
- **关键 env 直接透传（绕过 settings.json）**：禁用记忆层时 SDK 读
  `~/.claude/settings.json`，HappyClaw 写在 `data/sessions/main/.claude/settings.json`
  的 `REQUIRED_SETTINGS_ENV`（`CLAUDE_CODE_DISABLE_ATTACHMENTS` 等 4 个
  prompt-cache/auto-memory 关键 flag）会丢。改为直接注入到进程 env。
- **Per-user MCP servers 通过 env 透传**：同理 `hostMcpServers` 通过
  `HAPPYCLAW_USER_MCP_SERVERS_JSON` env 传给 agent-runner，由 SDK `mcpServers`
  参数注入，不依赖 settings.json 路径。

### `container/agent-runner/src/index.ts` / `mcp-tools.ts`

- `McpContext` 添加 `disableMemoryLayer?: boolean`
- `createMcpTools` 在禁用记忆层时跳过 `memory_append`/`memory_search`/`memory_get`
  注册（保留 `send_message`/`schedule_task` 等）
- `buildMemoryRecallPrompt` 返回空字符串；`<memory-system>` 块从 systemPromptAppend 过滤
- `createPreCompactHook` 不触发 `needsMemoryFlush`
- `extraDirs` 给空数组，避免 `/workspace/global` 容器路径在宿主机泄漏
- `loadUserMcpServers()` 优先读 `HAPPYCLAW_USER_MCP_SERVERS_JSON` env，
  找不到再回落到 `CLAUDE_CONFIG_DIR/settings.json`

### `src/routes/config.ts`

`PUT /api/config/system` 在启用开关时强制校验 admin 主容器（`web:main`）
必须已配置 `customCwd`；否则返回 400 拒绝保存。避免「开关开 + customCwd 空」
导致 agent 变成空白沙箱（`CLAUDE_CONFIG_DIR` 仍被 override，既读不到
HappyClaw 记忆层也读不到 `~/.claude/`）。

### `web/src/components/settings/SystemSettingsSection.tsx`

设置页新增「禁用 HappyClaw 记忆层（admin 主容器）」卡片，开关 + 说明文案，
包含前置要求（customCwd 必须先配）和数据迁移提示。

## 测试计划

- [x] `make typecheck` 通过（后端 + 前端 + agent-runner）
- [x] `make test` 通过（58/58 约束测试）
- [x] 本地 dev 模式验证：开启开关后 `ps eww <agent-runner-pid>` 确认
      `HAPPYCLAW_DISABLE_MEMORY_LAYER=true`、4 个 `CLAUDE_CODE_*` flag 存在、
      `WORKSPACE_GLOBAL`/`WORKSPACE_MEMORY` 不存在、`CLAUDE_CONFIG_DIR` 按条件保留
- [x] 日志确认 `Skills: 60/60 loaded`——skills/rules 链路未受影响
- [x] 未配 customCwd 时保存系统设置收到 400 报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)