### PR TITLE
修复: 弱网/断网下 Web 输入框内容发送失败后凭空消失 (#427)

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -341,8 +341,10 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const [scrollTrigger, setScrollTrigger] = useState(0);
 
   const handleSend = async (content: string, attachments?: Array<{ data: string; mimeType: string }>) => {
-    await sendMessage(groupJid, content, attachments);
-    setScrollTrigger(n => n + 1);
+    const ok = await sendMessage(groupJid, content, attachments);
+    // 只有发送成功时才触发滚动；失败时保留当前视图位置，避免用户上下文切换。
+    if (ok) setScrollTrigger(n => n + 1);
+    return ok;
   };
 
   const handleLoadMore = () => {
@@ -662,9 +664,10 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                       agentId={activeAgentTab}
                     />
                     <MessageInput
-                      onSend={async (content, attachments) => {
-                        sendAgentMessage(groupJid, activeAgentTab, content, attachments);
-                        setScrollTrigger(n => n + 1);
+                      onSend={(content, attachments) => {
+                        const ok = sendAgentMessage(groupJid, activeAgentTab, content, attachments);
+                        if (ok) setScrollTrigger(n => n + 1);
+                        return ok;
                       }}
                       groupJid={groupJid}
                       onResetSession={() => { setResetAgentId(activeAgentTab); setShowResetConfirm(true); }}
@@ -697,9 +700,10 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                 agentId={activeAgentTab}
               />
               <MessageInput
-                onSend={async (content, attachments) => {
-                  sendAgentMessage(groupJid, activeAgentTab, content, attachments);
-                  setScrollTrigger(n => n + 1);
+                onSend={(content, attachments) => {
+                  const ok = sendAgentMessage(groupJid, activeAgentTab, content, attachments);
+                  if (ok) setScrollTrigger(n => n + 1);
+                  return ok;
                 }}
                 groupJid={groupJid}
                 onResetSession={() => { setResetAgentId(activeAgentTab); setShowResetConfirm(true); }}

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -33,7 +33,17 @@ interface PendingImage {
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 
 interface MessageInputProps {
-  onSend: (content: string, attachments?: Array<{ data: string; mimeType: string }>) => void;
+  /**
+   * 发送回调。必须返回 boolean（或 Promise<boolean>）表示发送是否成功：
+   * - true：MessageInput 清空输入框和附件
+   * - false：保留输入框内容和附件，用户可重试（弱网/断网场景）
+   *
+   * 允许返回 void 以兼容仍未改造的调用方，此时按 true 处理。
+   */
+  onSend: (
+    content: string,
+    attachments?: Array<{ data: string; mimeType: string }>,
+  ) => Promise<boolean | void> | boolean | void;
   groupJid?: string;
   disabled?: boolean;
   onResetSession?: () => void;
@@ -161,21 +171,28 @@ export function MessageInput({
     setSending(true);
     setSendError(null);
 
+    // 先组装 message 但不立刻清空 pendingFiles/pendingImages，
+    // 让 onSend 失败时用户的附件也能保留、可以重试。
+    let message = trimmed;
+    if (hasPending) {
+      const list = pendingFiles.map((f) => `- ${f.label}`).join('\n');
+      const prefix = `[我上传了以下文件到工作区，请查看并使用]\n${list}`;
+      message = message ? `${prefix}\n\n${message}` : prefix;
+    }
+    const attachments = hasImages
+      ? pendingImages.map((img) => ({ data: img.data, mimeType: img.mimeType }))
+      : undefined;
+
+    let ok = false;
     try {
-      let message = trimmed;
+      const result = await onSend(message, attachments);
+      // onSend 返回 void 视为成功（兼容尚未改造的调用方）；显式 false 视为失败。
+      ok = result !== false;
+    } catch {
+      ok = false;
+    }
 
-      if (hasPending) {
-        const list = pendingFiles.map((f) => `- ${f.label}`).join('\n');
-        const prefix = `[我上传了以下文件到工作区，请查看并使用]\n${list}`;
-        message = message ? `${prefix}\n\n${message}` : prefix;
-        setPendingFiles([]);
-      }
-
-      const attachments = hasImages
-        ? pendingImages.map((img) => ({ data: img.data, mimeType: img.mimeType }))
-        : undefined;
-
-      onSend(message, attachments);
+    if (ok) {
       successTap();
       setContent('');
       if (groupJid) clearDraft(groupJid);
@@ -183,18 +200,18 @@ export function MessageInput({
         clearTimeout(draftTimerRef.current);
         draftTimerRef.current = undefined;
       }
-
-      // Clean up image previews
+      if (hasPending) setPendingFiles([]);
       if (hasImages) {
         pendingImages.forEach((img) => URL.revokeObjectURL(img.preview));
         setPendingImages([]);
       }
-    } catch {
-      setSendError('发送失败，请重试');
-      setTimeout(() => setSendError(null), 3000);
-    } finally {
-      setSending(false);
+    } else {
+      // 失败：保留输入、保留附件；同步保存草稿，刷新/崩溃也能恢复。
+      if (groupJid && trimmed) saveDraft(groupJid, trimmed);
+      setSendError('发送失败，输入已保留，请重试');
+      setTimeout(() => setSendError(null), 4000);
     }
+    setSending(false);
   };
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -184,7 +184,7 @@ interface ChatState {
   selectGroup: (jid: string) => void;
   loadMessages: (jid: string, loadMore?: boolean) => Promise<void>;
   refreshMessages: (jid: string) => Promise<void>;
-  sendMessage: (jid: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => Promise<void>;
+  sendMessage: (jid: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => Promise<boolean>;
   stopGroup: (jid: string) => Promise<boolean>;
   interruptQuery: (jid: string) => Promise<boolean>;
   resetSession: (jid: string, agentId?: string) => Promise<boolean>;
@@ -212,7 +212,7 @@ interface ChatState {
   createConversation: (jid: string, name?: string, description?: string) => Promise<AgentInfo | null>;
   renameConversation: (jid: string, agentId: string, name: string) => Promise<boolean>;
   loadAgentMessages: (jid: string, agentId: string, loadMore?: boolean) => Promise<void>;
-  sendAgentMessage: (jid: string, agentId: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => void;
+  sendAgentMessage: (jid: string, agentId: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => boolean;
   refreshAgentMessages: (jid: string, agentId: string) => Promise<void>;
   // Runner state sync
   handleRunnerState: (chatJid: string, state: string) => void;
@@ -960,46 +960,57 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
 
       const data = await api.post<{ success: boolean; messageId: string; timestamp: string }>('/api/messages', body);
-      if (data.success) {
-        // Add user message to local state immediately
-        const authState = useAuthStore.getState();
-        const sender = authState.user?.id || 'web-user';
-        const senderName = authState.user?.display_name || authState.user?.username || 'Web';
-        const msg: Message = {
-          id: data.messageId,
-          chat_jid: jid,
-          sender,
-          sender_name: senderName,
-          content,
-          // Use server timestamp so incremental polling cursor stays monotonic with backend data.
-          timestamp: data.timestamp,
-          // is_from_me is from the bot's perspective: true = bot sent it, false = human sent it
-          is_from_me: false,
-          attachments: body.attachments ? JSON.stringify(body.attachments) : undefined,
-        };
-        set((s) => {
-          const existing = s.messages[jid] || [];
-          if (!s.messages[jid]) {
-            console.warn('[sendMessage] messages[jid] is undefined at send time', { jid, storeKeys: Object.keys(s.messages) });
-          }
-          const merged = mergeMessagesChronologically(existing, [msg]);
-          const latest = merged.length > 0 ? merged[merged.length - 1] : null;
-          const shouldWait =
-            !!latest &&
-            latest.is_from_me === false &&
-            !isTerminalSystemMessage(latest);
-          return {
-            messages: {
-              ...s.messages,
-              [jid]: merged,
-            },
-            waiting: { ...s.waiting, [jid]: shouldWait },
-            error: null,
-          };
-        });
+      if (!data.success) {
+        // Server returned non-success payload — surface as a send failure so caller can retain input.
+        const msg = '服务器返回失败，请重试';
+        set({ error: msg });
+        showToast('发送失败', msg);
+        return false;
       }
+      // Add user message to local state immediately
+      const authState = useAuthStore.getState();
+      const sender = authState.user?.id || 'web-user';
+      const senderName = authState.user?.display_name || authState.user?.username || 'Web';
+      const msg: Message = {
+        id: data.messageId,
+        chat_jid: jid,
+        sender,
+        sender_name: senderName,
+        content,
+        // Use server timestamp so incremental polling cursor stays monotonic with backend data.
+        timestamp: data.timestamp,
+        // is_from_me is from the bot's perspective: true = bot sent it, false = human sent it
+        is_from_me: false,
+        attachments: body.attachments ? JSON.stringify(body.attachments) : undefined,
+      };
+      set((s) => {
+        const existing = s.messages[jid] || [];
+        if (!s.messages[jid]) {
+          console.warn('[sendMessage] messages[jid] is undefined at send time', { jid, storeKeys: Object.keys(s.messages) });
+        }
+        const merged = mergeMessagesChronologically(existing, [msg]);
+        const latest = merged.length > 0 ? merged[merged.length - 1] : null;
+        const shouldWait =
+          !!latest &&
+          latest.is_from_me === false &&
+          !isTerminalSystemMessage(latest);
+        return {
+          messages: {
+            ...s.messages,
+            [jid]: merged,
+          },
+          waiting: { ...s.waiting, [jid]: shouldWait },
+          error: null,
+        };
+      });
+      return true;
     } catch (err) {
-      set({ error: err instanceof Error ? err.message : String(err) });
+      // 弱网/断网/后端 500 等场景：记录错误并给用户可见的 toast，
+      // 返回 false 让调用方（MessageInput）保留输入不清空。
+      const message = err instanceof Error ? err.message : String(err);
+      set({ error: message });
+      showToast('发送失败', '消息未发送，输入已保留，请检查网络后重试');
+      return false;
     }
   },
 
@@ -2089,24 +2100,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   sendAgentMessage: (jid, agentId, content, attachments?) => {
-    // Clear agent streaming state before sending
-    set((s) => {
-      const next = { ...s.agentStreaming };
-      delete next[agentId];
-      return { agentStreaming: next };
-    });
-    // Send via WebSocket with agentId
+    // Send via WebSocket with agentId.
+    // NOTE: 先尝试 ws.send，成功后再清 agentStreaming / 置 agentWaiting，
+    // 避免失败时 UI 进入"等待中但消息没发出"的不一致状态。
     const normalizedAttachments = attachments && attachments.length > 0
       ? attachments.map(att => ({ type: 'image' as const, ...att }))
       : undefined;
     const sent = wsManager.send({ type: 'send_message', chatJid: jid, content, agentId, attachments: normalizedAttachments });
     if (!sent) {
-      showToast('发送失败', 'WebSocket 未连接，请稍后重试');
-      return;
+      showToast('发送失败', 'WebSocket 未连接，输入已保留，请稍后重试');
+      return false;
     }
-    set((s) => ({
-      agentWaiting: { ...s.agentWaiting, [agentId]: true },
-    }));
+    set((s) => {
+      const nextAgentStreaming = { ...s.agentStreaming };
+      delete nextAgentStreaming[agentId];
+      return {
+        agentStreaming: nextAgentStreaming,
+        agentWaiting: { ...s.agentWaiting, [agentId]: true },
+      };
+    });
+    return true;
   },
 
   refreshAgentMessages: async (jid, agentId) => {


### PR DESCRIPTION
## 问题描述

关闭 #427。

Web 端输入框在弱网/断网下点发送，会出现：

- 输入框瞬间清空，文字凭空消失
- 消息列表里没有出现这条消息
- 没有明显错误提示，没有重试入口
- 用户辛苦敲的长 prompt 只能凭记忆重写

根因是 `MessageInput.onSend` 声明为返回 `void`，`handleSend` 把它当同步调用用，`setContent('')` 无条件执行；即便 `store.sendMessage` 把异常塞进了 `error` 字段，调用方也拿不到失败信号，更没法把输入还给用户。

## 修复方案

采用 issue 中推荐的 **Layer 1（最小修复）**：把失败信号从 store 一路传回 `MessageInput`，失败时保留输入、保留附件、同步写入草稿。

### `web/src/stores/chat.ts`

- `sendMessage` 类型从 `Promise<void>` 改为 `Promise<boolean>`；HTTP 异常、`data.success=false` 都返回 `false` 并 `showToast('发送失败', ...)`，不再静默吞
- `sendAgentMessage` 类型从 `void` 改为 `boolean`；WebSocket 未连接时仍 toast，但返回 `false`
- `sendAgentMessage` 把 `agentStreaming` 清理 / `agentWaiting=true` 的副作用挪到发送成功之后，避免失败时 UI 卡在「等待中但消息没发出」的不一致状态

### `web/src/components/chat/MessageInput.tsx`

- `onSend` prop 类型改为 `Promise<boolean | void> | boolean | void`（允许返回 `void` 以兼容尚未改造的调用方，按成功处理）
- `handleSend` `await onSend(...)`：仅在结果不为 `false` 时清空输入、清空 `pendingFiles/pendingImages`、清 draft；失败时保留全部，banner 显示「发送失败，输入已保留，请重试」，4s 后淡出
- 失败分支调 `saveDraft(groupJid, trimmed)` 同步落盘，配合已有的 draft 恢复机制，刷新/误关标签后也能找回内容

### `web/src/components/chat/ChatView.tsx`

- `handleSend` `await sendMessage(...)` 拿到 `ok`，仅在成功时 `setScrollTrigger`
- 两处 `sendAgentMessage` 的 `onSend` 回调也透传 `ok` 给 `MessageInput`

## 取舍

Issue 建议 Layer 1 + Layer 2（乐观渲染 + 失败消息气泡 + 重试按钮）。本 PR 只做 Layer 1，原因：
- Layer 1 已经能消除「文字凭空消失」这个最核心的用户痛点（输入被保留、有可见提示、附件也不丢）
- Layer 2 涉及 `pending` 态消息模型、重试逻辑、气泡样式，改动面大，放独立 PR 更易 review
- Layer 3（sessionStorage）现有 `saveDraft`/`drafts` zustand 已覆盖「同一 session 内保留」的 90% 场景

## Test plan

- [x] `make typecheck` 全量通过
- [x] `make build`（前后端 + agent-runner）通过
- [x] `make test`（58 tests）通过
- [ ] 手动：打开 Web 端 → 输入长文本 → `make stop` 杀后端 → 点发送 → 输入框应保留内容，顶部出现红色 banner「发送失败，输入已保留，请重试」
- [ ] 手动：同样路径但在 Sub-Agent tab 下 → 应弹 toast「WebSocket 未连接，输入已保留，请稍后重试」且输入保留
- [ ] 手动：恢复网络后原输入直接再点发送可成功