### PR TITLE
修复: ensure-latest-sdk 中 sed 找不到 package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ensure-latest-sdk: ## 启动前自动检测并更新 SDK（有新版才更新）
 	LATEST=$$(npm view @anthropic-ai/claude-agent-sdk version --fetch-timeout=5000 2>/dev/null || echo "$$LOCAL"); \
 	if [ "$$LOCAL" != "$$LATEST" ]; then \
 		echo "🔄 Claude Agent SDK 有新版本: $$LOCAL → $$LATEST，正在更新..."; \
-		cd container/agent-runner && $(PKG) update @anthropic-ai/claude-agent-sdk && $(PKG) run build; \
+		(cd container/agent-runner && $(PKG) update @anthropic-ai/claude-agent-sdk && $(PKG) run build); \
 		sed -i '' 's/"@anthropic-ai\/claude-agent-sdk": "[^"]*"/"@anthropic-ai\/claude-agent-sdk": "*"/' container/agent-runner/package.json; \
 		echo "✅ SDK 更新完成（内置 Claude Code 版本随之更新）"; \
 	else \


### PR DESCRIPTION
## 问题描述

`make start` 触发 `ensure-latest-sdk`，当本地 SDK 版本落后于 npm registry 最新版时会报：

```
sed: container/agent-runner/package.json: No such file or directory
```

## 根因

`ensure-latest-sdk` 的 recipe 用 \`\\\` 续行连成一整条命令，Make 在**同一个 shell 进程**里执行：

\`\`\`makefile
ensure-latest-sdk:
	@LOCAL=...; \\
	if [ ... ]; then \\
		cd container/agent-runner && \$(PKG) update ... ; \\
		sed -i '' '...' container/agent-runner/package.json; \\   # ← cwd 已是 container/agent-runner
	fi
\`\`\`

\`cd\` 的副作用延续到 \`sed\`，cwd 变成 \`container/agent-runner\`，再拼相对路径 \`container/agent-runner/package.json\` 实际解析成 \`container/agent-runner/container/agent-runner/package.json\`，文件不存在。

对比同文件的 \`update-sdk\` target，它用两条独立的 recipe 行写，Make 每行新开 shell，不会有这个问题。

## 复现路径

1. 手动回写一个旧版本: \`sed -i '' 's/"@anthropic-ai\\/claude-agent-sdk": "\\*"/"@anthropic-ai\\/claude-agent-sdk": "0.2.80"/' container/agent-runner/package.json\`
2. \`cd container/agent-runner && npm install\` 让 node_modules 里版本也回退
3. \`make start\`
4. 期望: \`sed\` 回写 \`"*"\` 成功；实际: \`sed: container/agent-runner/package.json: No such file or directory\`

由于 sed 失败，\`package.json\` 会保留 npm update 后的具体版本号（如 \`"0.2.89"\`），后续构建失去\"始终拉最新\"的语义。

## 影响

- 触发条件（SDK 有新版且用户依赖 \`make start\` 自动更新）下，\`package.json\` 里的 \`"*"\` 会被悄悄替换成具体版本号
- 终端刷一行 sed 错误但进程继续，容易被忽略

## 修复方案

用子 shell \`(...)\` 隔离 \`cd\` 的作用域：

\`\`\`diff
- cd container/agent-runner && \$(PKG) update @anthropic-ai/claude-agent-sdk && \$(PKG) run build; \\
+ (cd container/agent-runner && \$(PKG) update @anthropic-ai/claude-agent-sdk && \$(PKG) run build); \\
\`\`\`

子 shell 退出后父 shell 的 cwd 恢复到原目录，后续 \`sed\` 用原相对路径命中文件。

## 测试

\`\`\`bash
$ (cd container/agent-runner && pwd) ; pwd
/tmp/.../container/agent-runner
/tmp/...                                 # ← 回到原目录
$ sed -i '' 's/.../.../' container/agent-runner/package.json   # ✓ 成功
\`\`\`