### PR TITLE
修复: /workspace/extra/ 容器重启后内容丢失 (#435)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ StreamEvent 类型以 `shared/stream-event.ts` 为单一真相源，构建时通
 | 项目级 Skills `container/skills/` | `/workspace/project-skills` | 只读 | 只读 |
 | 用户级 Skills `~/.claude/skills/` | `/workspace/user-skills` | 只读 | admin 创建的会话可读 |
 | 环境变量 `data/env/{folder}/env` | `/workspace/env-dir/env` | 只读 | 只读 |
+| 持久 extra 目录 `data/extra/{folder}/` | `/workspace/extra` | 读写 | 读写（仅自己） |
 | 额外挂载（白名单内） | `/workspace/extra/{name}` | 按白名单 | 按白名单（`nonMainReadOnly` 时强制只读） |
 
 ### 3.5 配置优先级
@@ -369,6 +370,7 @@ data/
   config/registration.json                 # 注册设置（开关、邀请码要求）
   config/session-secret.key                # 会话签名密钥（0600 权限）
   config/system-settings.json              # 系统运行参数（容器超时、并发限制等）
+  extra/{folder}/                            # 容器持久 extra 目录（bind-mount 到 /workspace/extra/）
   streaming-buffer/                         # 流式文本磁盘缓冲（崩溃恢复用，自动清理）
   skills/{userId}/                         # 用户级 Skills 数据
   mcp-servers/{userId}/servers.json        # 用户 MCP Servers 配置

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -602,6 +602,17 @@ function buildVolumeMounts(
     }
   }
 
+  // Per-group persistent extra directory: provides a durable /workspace/extra/ even when
+  // no additionalMounts are configured. User-configured additionalMounts from the allowlist
+  // are mounted as subdirectories (/workspace/extra/{name}) and overlay on top.
+  const extraDir = path.join(DATA_DIR, 'extra', group.folder);
+  mkdirForContainer(extraDir);
+  mounts.push({
+    hostPath: extraDir,
+    containerPath: '/workspace/extra',
+    readonly: false,
+  });
+
   // Additional mounts validated against external allowlist (tamper-proof from containers)
   if (group.containerConfig?.additionalMounts) {
     const validatedMounts = validateAdditionalMounts(


### PR DESCRIPTION
## 问题描述

关闭 #435。

`/workspace/extra/` 在容器内仅是 Dockerfile 创建的空目录，没有宿主机 bind-mount。容器 `--rm` 重启后内容全部丢失。而 `/workspace/group/`、`/workspace/global/`、`/workspace/memory/` 都有持久 bind-mount，行为不一致。

## 修复方案

### `src/container-runner.ts`

- 在 `buildVolumeMounts()` 的 `additionalMounts` 逻辑前，为每个群组自动创建 `data/extra/{folder}/` 目录并 bind-mount 到 `/workspace/extra/`
- 使用 `mkdirForContainer()` 确保权限正确（0o777，容器 node 用户可读写）
- 用户配置的 `additionalMounts` 仍作为子目录 `/workspace/extra/{name}` 叠加挂载，行为不变

### `CLAUDE.md`

- §3.4 挂载策略表新增持久 extra 目录行
- §6 目录约定新增 `data/extra/{folder}/` 条目