### PR TITLE
修复: 定时任务消息路由到绑定 IM 群 + 创建表单补齐消息目标/上下文模式

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -774,7 +774,7 @@ function shouldDrain(): boolean {
  * Returns messages found (with optional images), or empty array.
  */
 interface IpcDrainResult {
-  messages: Array<{ text: string; images?: Array<{ data: string; mimeType?: string }> }>;
+  messages: Array<{ text: string; images?: Array<{ data: string; mimeType?: string }>; taskId?: string }>;
 }
 
 function drainIpcInput(): IpcDrainResult {
@@ -793,6 +793,7 @@ function drainIpcInput(): IpcDrainResult {
           result.messages.push({
             text: data.text,
             images: data.images,
+            taskId: typeof data.taskId === 'string' ? data.taskId : undefined,
           });
         }
       } catch (err) {
@@ -864,7 +865,7 @@ function createIpcWatcher(onFileDetected: () => void): { close: () => void } {
  * Wait for a new IPC message or _close sentinel.
  * Returns the messages (with optional images), or null if _close.
  */
-function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: string; mimeType?: string }> } | null> {
+function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: string; mimeType?: string }>; taskId?: string } | null> {
   return new Promise((resolve) => {
     let resolved = false;
     const tryDrain = () => {
@@ -895,9 +896,19 @@ function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: str
       if (messages.length > 0) {
         const combinedText = messages.map((m) => m.text).join('\n');
         const allImages = messages.flatMap((m) => m.images || []);
+        // If any drained message carries a taskId, attribute the combined turn
+        // to it (take the last one — later messages supersede earlier in a batch).
+        let combinedTaskId: string | undefined;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].taskId) { combinedTaskId = messages[i].taskId; break; }
+        }
         resolved = true;
         ipcWatcher?.close();
-        resolve({ text: combinedText, images: allImages.length > 0 ? allImages : undefined });
+        resolve({
+          text: combinedText,
+          images: allImages.length > 0 ? allImages : undefined,
+          taskId: combinedTaskId,
+        });
         return;
       }
     };
@@ -1631,12 +1642,16 @@ async function main(): Promise<void> {
   const { isHome, isAdminHome } = normalizeHomeFlags(containerInput);
 
   // Create in-process SDK MCP server (replaces the stdio subprocess)
+  // NOTE: currentTaskId is mutated in-place by the main loop below so that
+  // createMcpTools() closures observe updates via ctx reference. See the
+  // clear-before-next-turn logic at the bottom of the query loop.
   const mcpToolsConfig = {
     chatJid: containerInput.chatJid,
     groupFolder: containerInput.groupFolder,
     isHome,
     isAdminHome,
     isScheduledTask: containerInput.isScheduledTask || false,
+    currentTaskId: containerInput.messageTaskId ?? null,
     workspaceIpc: WORKSPACE_IPC,
     workspaceGroup: WORKSPACE_GROUP,
     workspaceGlobal: WORKSPACE_GLOBAL,
@@ -1860,6 +1875,8 @@ async function main(): Promise<void> {
         prompt = nextMessage.text;
         promptImages = nextMessage.images;
         containerInput.turnId = generateTurnId();
+        // See main-loop comment: reset task attribution for this new turn.
+        mcpToolsConfig.currentTaskId = nextMessage.taskId ?? null;
         // Rebuild MCP server to avoid "Already connected to a transport" error
         // when the previous query was aborted mid-stream (#421).
         mcpServerConfig = buildMcpServerConfig();
@@ -2015,6 +2032,12 @@ async function main(): Promise<void> {
       prompt = nextMessage.text;
       promptImages = nextMessage.images;
       containerInput.turnId = generateTurnId();
+      // Clear per-turn task attribution: the previous query may have been a
+      // scheduled-task turn, but this new IPC message is a regular follow-up
+      // unless it explicitly carried a taskId (see nextMessage.taskId below).
+      // Forgetting to clear would cause regular user replies to be broadcast
+      // to the task's notify channels, hijacking later conversation.
+      mcpToolsConfig.currentTaskId = nextMessage.taskId ?? null;
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -22,6 +22,10 @@ export interface McpContext {
   isHome: boolean;
   isAdminHome: boolean;
   isScheduledTask?: boolean;
+  /** Mutable: set when the current IPC turn was triggered by a task prompt.
+   * Cleared between turns by the agent-runner main loop so that regular
+   * follow-up messages aren't misattributed to the prior task. */
+  currentTaskId?: string | null;
   workspaceIpc: string;
   workspaceGroup: string;
   workspaceGlobal: string;
@@ -150,6 +154,37 @@ function parseMemoryFileReference(fileRef: string): {
 }
 
 /**
+ * Build the IPC payload shared by send_message / send_image MCP tools.
+ *
+ * Always stamps `chatJid`, `groupFolder`, `timestamp`. Conditionally stamps
+ * `isScheduledTask` (when ctx.isScheduledTask is truthy) and `taskId` (when
+ * ctx.currentTaskId is non-empty). The conditional stamping matters for host-
+ * side routing: a missing `taskId` key means "regular user-turn reply", while
+ * a present `taskId` key triggers the task-broadcast branch in the IPC
+ * consumer. `extras` carries per-tool fields (`type`, `text`, `imageBase64`, …).
+ *
+ * Pure function; exported for unit testing.
+ */
+export function buildSendMessageData(
+  ctx: McpContext,
+  extras: Record<string, unknown>,
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    chatJid: ctx.chatJid,
+    groupFolder: ctx.groupFolder,
+    timestamp: new Date().toISOString(),
+    ...extras,
+  };
+  if (ctx.isScheduledTask) {
+    data.isScheduledTask = true;
+  }
+  if (ctx.currentTaskId) {
+    data.taskId = ctx.currentTaskId;
+  }
+  return data;
+}
+
+/**
  * Create all HappyClaw MCP tool definitions for in-process SDK MCP server.
  */
 export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
@@ -165,16 +200,10 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
       "Send a message to the user or group immediately while you're still running. Use this for progress updates or to send multiple messages. You can call this multiple times. Note: when running as a scheduled task, your final output is NOT sent to the user — use this tool if you need to communicate with the user or group.",
       { text: z.string().describe('The message text to send') },
       async (args) => {
-        const data: Record<string, unknown> = {
+        const data = buildSendMessageData(ctx, {
           type: 'message',
-          chatJid: ctx.chatJid,
           text: args.text,
-          groupFolder: ctx.groupFolder,
-          timestamp: new Date().toISOString(),
-        };
-        if (ctx.isScheduledTask) {
-          data.isScheduledTask = true;
-        }
+        });
         writeIpcFile(MESSAGES_DIR, data);
         return { content: [{ type: 'text' as const, text: 'Message sent.' }] };
       },
@@ -278,19 +307,13 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
           };
         }
 
-        const data: Record<string, unknown> = {
+        const data = buildSendMessageData(ctx, {
           type: 'image',
-          chatJid: ctx.chatJid,
           imageBase64: base64,
           mimeType,
           caption: args.caption || undefined,
           fileName: path.basename(resolved),
-          groupFolder: ctx.groupFolder,
-          timestamp: new Date().toISOString(),
-        };
-        if (ctx.isScheduledTask) {
-          data.isScheduledTask = true;
-        }
+        });
         writeIpcFile(MESSAGES_DIR, data);
         return {
           content: [

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -21,6 +21,10 @@ export interface ContainerInput {
   /** Whether this is the admin's home container (full privileges). */
   isAdminHome?: boolean;
   isScheduledTask?: boolean;
+  /** If the last unprocessed message was emitted by a scheduled task prompt,
+   * this is that task's ID; used to tag MCP send_message outputs so the host
+   * routes results to the task's configured chat_jid / notify channels. */
+  messageTaskId?: string;
   images?: Array<{ data: string; mimeType?: string }>;
   agentId?: string;
   agentName?: string;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -188,6 +188,10 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   /** Isolated task run ID — determines IPC namespace (tasks-run/{taskRunId}/) */
   taskRunId?: string;
+  /** If the last unprocessed message was emitted by a scheduled task prompt,
+   * this is that task's ID; propagated into agent-runner so MCP send_message
+   * outputs can be attributed back to the task record. */
+  messageTaskId?: string;
   images?: Array<{ data: string; mimeType?: string }>;
   agentId?: string;
   agentName?: string;

--- a/src/db.ts
+++ b/src/db.ts
@@ -2919,6 +2919,8 @@ export function getGroupsByOwner(
     created_by: string | null;
     is_home: number;
     selected_skills: string | null;
+    target_main_jid: string | null;
+    target_agent_id: string | null;
   }>;
 
   return rows.map((row) => ({
@@ -2935,6 +2937,8 @@ export function getGroupsByOwner(
     initGitUrl: row.init_git_url ?? undefined,
     created_by: row.created_by ?? undefined,
     is_home: row.is_home === 1,
+    target_main_jid: row.target_main_jid ?? undefined,
+    target_agent_id: row.target_agent_id ?? undefined,
   }));
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -77,8 +77,8 @@ function stmts() {
       storeMessageInsert: db.prepare(
         `INSERT OR REPLACE INTO messages (
           id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me,
-          attachments, token_usage, turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          attachments, token_usage, turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason, task_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ),
       insertUsageInsert: db.prepare(
         `INSERT INTO usage_records (id, user_id, group_folder, agent_id, message_id, model,
@@ -124,7 +124,7 @@ function stmts() {
          )`,
       ),
       getMessagesSince: db.prepare(
-        `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments
+        `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, task_id
          FROM messages
          WHERE chat_jid = ? AND (timestamp > ? OR (timestamp = ? AND id > ?)) AND is_from_me = 0
          ORDER BY timestamp ASC, id ASC`,
@@ -142,7 +142,7 @@ function getNewMessagesStmt(jidCount: number): any {
   if (!s) {
     const placeholders = Array(jidCount).fill('?').join(',');
     s = db.prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments
+      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, task_id
        FROM messages
        WHERE (timestamp > ? OR (timestamp = ? AND id > ?))
          AND chat_jid IN (${placeholders})
@@ -161,6 +161,7 @@ interface StoredMessageMeta {
   sdkMessageUuid?: string | null;
   sourceKind?: MessageSourceKind | null;
   finalizationReason?: MessageFinalizationReason | null;
+  taskId?: string | null;
 }
 
 function hasColumn(tableName: string, columnName: string): boolean {
@@ -700,6 +701,7 @@ export function initDatabase(): void {
   ensureColumn('messages', 'sdk_message_uuid', 'TEXT');
   ensureColumn('messages', 'source_kind', 'TEXT');
   ensureColumn('messages', 'finalization_reason', 'TEXT');
+  ensureColumn('messages', 'task_id', 'TEXT');
   ensureColumn('agents', 'source_kind', 'TEXT');
   ensureColumn('agents', 'thread_id', 'TEXT');
   ensureColumn('agents', 'root_message_id', 'TEXT');
@@ -1233,7 +1235,7 @@ export function initDatabase(): void {
     db.exec('ALTER TABLE agents ADD COLUMN spawned_from_jid TEXT');
   }
 
-  const SCHEMA_VERSION = '34';
+  const SCHEMA_VERSION = '35';
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', SCHEMA_VERSION);
@@ -1376,6 +1378,7 @@ export function storeMessageDirect(
     meta?.sdkMessageUuid ?? null,
     meta?.sourceKind ?? null,
     meta?.finalizationReason ?? null,
+    meta?.taskId ?? null,
   );
   return effectiveMsgId;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4033,11 +4033,16 @@ function broadcastToOwnerIMChannels(
       getGroupsByOwner,
       getChannelType,
       resolveJidFolder: (jid: string) => {
-        // Follow ImBindingDialog's target_main_jid binding: look up the
-        // referenced workspace and return its folder. Cache-first
-        // (registeredGroups) then DB fallback — mirrors the lookup pattern
-        // used by resolveOwnerHomeFolder at src/index.ts:593-598.
-        const target = registeredGroups[jid] ?? getRegisteredGroup(jid);
+        // Follow ImBindingDialog's target_main_jid binding to the bound
+        // workspace's folder. Delegated to resolveWorkspaceJid so we inherit
+        // its legacy-format compatibility: historical DBs may store
+        // target_main_jid as `web:{folder}` instead of `web:{uuid}`,
+        // and resolveWorkspaceJid folds both shapes to the canonical
+        // registered jid.
+        const effectiveJid = resolveWorkspaceJid(jid);
+        if (!effectiveJid) return null;
+        const target =
+          registeredGroups[effectiveJid] ?? getRegisteredGroup(effectiveJid);
         return target?.folder ?? null;
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4032,6 +4032,14 @@ function broadcastToOwnerIMChannels(
       getConnectedChannelTypes: imManager.getConnectedChannelTypes.bind(imManager),
       getGroupsByOwner,
       getChannelType,
+      resolveJidFolder: (jid: string) => {
+        // Follow ImBindingDialog's target_main_jid binding: look up the
+        // referenced workspace and return its folder. Cache-first
+        // (registeredGroups) then DB fallback — mirrors the lookup pattern
+        // used by resolveOwnerHomeFolder at src/index.ts:593-598.
+        const target = registeredGroups[jid] ?? getRegisteredGroup(jid);
+        return target?.folder ?? null;
+      },
     },
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,12 @@ import {
   resolveLocationInfo,
   type WorkspaceInfo,
 } from './im-command-utils.js';
+import {
+  extractLastTaskId,
+  broadcastToOwnerIMChannels as broadcastToOwnerIMChannelsPure,
+  resolveBroadcastFolder,
+  resolveTaskRoutingDecision,
+} from './task-routing.js';
 import { invalidateSessionCache, getWebDeps } from './web-context.js';
 import {
   getFeishuProviderConfigWithSource,
@@ -2377,6 +2383,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const images = collectMessageImages(chatJid, missedMessages);
   const imagesForAgent = images.length > 0 ? images : undefined;
 
+  // Extract task_id from the most recent task-prompt message (if any).
+  // See extractLastTaskId() for semantics; see §C of the routing fix plan for
+  // why getMessagesSince (not getNewMessages) surfaces task-prompt rows here.
+  const messageTaskId = extractLastTaskId(missedMessages);
+
   logger.info(
     {
       group: group.name,
@@ -2385,6 +2396,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       imageCount: images.length,
       shared,
       isRecovery,
+      messageTaskId,
     },
     'Processing messages',
   );
@@ -3100,6 +3112,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         }
       },
       imagesForAgent,
+      messageTaskId,
     );
   } finally {
     await setTyping(chatJid, false);
@@ -3530,6 +3543,7 @@ async function runAgent(
   turnId?: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   images?: Array<{ data: string; mimeType?: string }>,
+  messageTaskId?: string,
 ): Promise<{ status: 'success' | 'error' | 'closed'; error?: string }> {
   const isHome = !!group.is_home;
   // For the agent-runner: isMain means this is an admin home container (full privileges)
@@ -3619,6 +3633,7 @@ async function runAgent(
           isHome,
           isAdminHome,
           images,
+          messageTaskId,
         },
         onProcessCb,
         wrappedOnOutput,
@@ -3637,6 +3652,7 @@ async function runAgent(
           isHome,
           isAdminHome,
           images,
+          messageTaskId,
         },
         onProcessCb,
         wrappedOnOutput,
@@ -3994,10 +4010,11 @@ export function canSendCrossGroupMessage(
   return false;
 }
 
-/**
- * Broadcast a message to all connected IM channels of a user that haven't
- * already received it. Used by scheduled tasks to fan out to all IM channels.
- */
+// Thin production wrapper around the pure helper in ./task-routing.ts so the
+// internal call sites keep their short signature (deps inferred from the
+// runtime IM manager + DB). Tests should import `broadcastToOwnerIMChannels`
+// from ./task-routing.js directly and pass their own deps — that file has no
+// side effects, unlike this one (which runs main() at module load).
 function broadcastToOwnerIMChannels(
   userId: string,
   sourceFolder: string,
@@ -4005,24 +4022,18 @@ function broadcastToOwnerIMChannels(
   sendFn: (jid: string) => void,
   notifyChannels?: string[] | null,
 ): void {
-  const sentChannelTypes = new Set<string>();
-  for (const jid of alreadySentJids) {
-    const ct = getChannelType(jid);
-    if (ct) sentChannelTypes.add(ct);
-  }
-  const connectedTypes = imManager.getConnectedChannelTypes(userId);
-  const ownerGroups = getGroupsByOwner(userId);
-  for (const channelType of connectedTypes) {
-    if (sentChannelTypes.has(channelType)) continue;
-    if (notifyChannels && !notifyChannels.includes(channelType)) continue;
-    const target = ownerGroups.find(
-      (g) => getChannelType(g.jid) === channelType && g.folder === sourceFolder,
-    );
-    if (target) {
-      sendFn(target.jid);
-      sentChannelTypes.add(channelType);
-    }
-  }
+  broadcastToOwnerIMChannelsPure(
+    userId,
+    sourceFolder,
+    alreadySentJids,
+    sendFn,
+    notifyChannels,
+    {
+      getConnectedChannelTypes: imManager.getConnectedChannelTypes.bind(imManager),
+      getGroupsByOwner,
+      getChannelType,
+    },
+  );
 }
 
 function startIpcWatcher(): void {
@@ -4091,10 +4102,22 @@ function startIpcWatcher(): void {
       /* tasks-run dir may not exist */
     }
 
-    // Pre-resolve owner's home folder once per group (avoid repeated DB queries in the message loop)
-    const ownerHomeFolderForIm = sourceGroupEntry?.created_by
-      ? getUserHomeGroup(sourceGroupEntry.created_by)?.folder || sourceGroup
-      : sourceGroup;
+    // Broadcast folder: the workspace folder whose IPC message we are
+    // processing. Fix F: use sourceGroup (the emitting workspace's folder),
+    // NOT the owner's home folder — non-home workspaces bind to their own
+    // IM groups and must route replies to those bindings.
+    //
+    // Go through resolveBroadcastFolder so the choice between sourceGroup
+    // and ownerHome is locked by a unit test. Reverting this line to
+    // `ownerHome?.folder || sourceGroup` (the pre-fix F behavior) must
+    // break the helper's test, not silently pass CI.
+    const ownerHomeFolderCandidate = sourceGroupEntry?.created_by
+      ? getUserHomeGroup(sourceGroupEntry.created_by)?.folder
+      : null;
+    const broadcastFolder = resolveBroadcastFolder(
+      sourceGroup,
+      ownerHomeFolderCandidate,
+    );
 
     for (const {
       path: ipcRoot,
@@ -4155,29 +4178,32 @@ function startIpcWatcher(): void {
                     sendImWithFailTracking(ipcImRoute, data.text, localImages);
                   }
 
-                  // Scheduled task: route to the task's configured chat_jid,
-                  // or broadcast to all connected IM channels of the owner
-                  if (data.isScheduledTask && sourceGroupEntry?.created_by) {
+                  // Scheduled-task output routing. Decision logic is in
+                  // resolveTaskRoutingDecision() (src/task-routing.ts) so it
+                  // can be unit-tested without booting this module.
+                  const routingDecision = resolveTaskRoutingDecision(
+                    data,
+                    ipcTaskId,
+                    !!sourceGroupEntry?.created_by,
+                    { getTaskById, getChannelType },
+                  );
+                  if (
+                    routingDecision.mode !== 'none' &&
+                    sourceGroupEntry?.created_by
+                  ) {
                     const taskLocalImages = extractLocalImImagePaths(
                       data.text,
                       sourceGroup,
                     );
-                    let taskNotifyChannels: string[] | null | undefined;
-                    let taskChatJid: string | undefined;
-                    if (ipcTaskId) {
-                      const taskRecord = getTaskById(ipcTaskId);
-                      taskNotifyChannels = taskRecord?.notify_channels;
-                      taskChatJid = taskRecord?.chat_jid;
-                    }
-                    // If the task targets a specific IM group, send directly to it
-                    // (skip if already sent via data.chatJid or ipcImRoute above)
-                    if (taskChatJid && getChannelType(taskChatJid)) {
+                    if (routingDecision.mode === 'direct') {
+                      // Task targets a specific IM group; send there unless
+                      // the prior branches already delivered to the same jid.
                       if (
-                        taskChatJid !== data.chatJid &&
-                        taskChatJid !== ipcImRoute
+                        routingDecision.taskChatJid !== data.chatJid &&
+                        routingDecision.taskChatJid !== ipcImRoute
                       ) {
                         sendImWithFailTracking(
-                          taskChatJid,
+                          routingDecision.taskChatJid,
                           data.text,
                           taskLocalImages,
                         );
@@ -4189,7 +4215,7 @@ function startIpcWatcher(): void {
                       );
                       broadcastToOwnerIMChannels(
                         sourceGroupEntry.created_by,
-                        ownerHomeFolderForIm,
+                        broadcastFolder,
                         alreadySent,
                         (jid) =>
                           sendImWithFailTracking(
@@ -4197,7 +4223,7 @@ function startIpcWatcher(): void {
                             data.text,
                             taskLocalImages,
                           ),
-                        taskNotifyChannels,
+                        routingDecision.notifyChannels,
                       );
                     }
                   }
@@ -4311,24 +4337,28 @@ function startIpcWatcher(): void {
                   });
                   broadcastToWebClients(imgChatJid, displayText);
 
-                  // Scheduled task: broadcast image to all connected IM channels
-                  // (not applicable for agent IPC)
+                  // Scheduled-task image routing. Same decision function as the
+                  // message branch; image IPC has no direct-to-chat_jid mode
+                  // (images only ever fan out), so we ignore 'direct' and
+                  // broadcast on either 'direct' or 'broadcast'.
+                  const imgRoutingDecision = ipcAgentId
+                    ? { mode: 'none' as const }
+                    : resolveTaskRoutingDecision(
+                        data,
+                        ipcTaskId,
+                        !!sourceGroupEntry?.created_by,
+                        { getTaskById, getChannelType },
+                      );
                   if (
-                    !ipcAgentId &&
-                    data.isScheduledTask &&
+                    imgRoutingDecision.mode !== 'none' &&
                     sourceGroupEntry?.created_by
                   ) {
                     const alreadySent = new Set<string>(
                       [data.chatJid, imgImRoute].filter(Boolean) as string[],
                     );
-                    let imgTaskNotifyChannels: string[] | null | undefined;
-                    if (ipcTaskId) {
-                      const imgTaskRecord = getTaskById(ipcTaskId);
-                      imgTaskNotifyChannels = imgTaskRecord?.notify_channels;
-                    }
                     broadcastToOwnerIMChannels(
                       sourceGroupEntry.created_by,
-                      ownerHomeFolderForIm,
+                      broadcastFolder,
                       alreadySent,
                       (jid) =>
                         imManager
@@ -4345,7 +4375,7 @@ function startIpcWatcher(): void {
                               'Failed to broadcast task image to IM',
                             ),
                           ),
-                      imgTaskNotifyChannels,
+                      imgRoutingDecision.notifyChannels,
                     );
                   }
 
@@ -4662,12 +4692,30 @@ async function processTaskIpc(
           data.context_mode === 'group' || data.context_mode === 'isolated'
             ? data.context_mode
             : 'isolated';
-        const executionMode =
-          data.execution_mode === 'host' && isAdminHome
-            ? 'host'
-            : data.execution_mode === 'container'
-              ? 'container'
-              : null;
+        // Inherit execution_mode from the source workspace.
+        // - Source is host: default host, allow explicit container downgrade.
+        // - Source is container: default container, REJECT explicit host
+        //   (prevents container-bound agents from escaping isolation; security).
+        // This matches the user-facing semantics: "a task created from a
+        // docker workspace runs in docker; a task created from a host workspace
+        // runs on host unless explicitly overridden to docker."
+        const sourceIsHost = sourceGroupEntry?.executionMode === 'host';
+        let executionMode: 'host' | 'container';
+        if (data.execution_mode === 'host') {
+          if (!sourceIsHost) {
+            logger.warn(
+              { sourceGroup, targetJid },
+              'schedule_task: host mode requested from container source — forcing container',
+            );
+            executionMode = 'container';
+          } else {
+            executionMode = 'host';
+          }
+        } else if (data.execution_mode === 'container') {
+          executionMode = 'container';
+        } else {
+          executionMode = sourceIsHost ? 'host' : 'container';
+        }
         const taskCreatedBy = resolveTaskOwner(
           {},
           sourceGroupEntry,
@@ -7985,7 +8033,7 @@ async function main(): Promise<void> {
     sendMessage,
     broadcastStreamEvent,
     onWorkspaceCreated: broadcastGroupCreated,
-    storePromptMessage: (chatJid, senderId, senderName, text) => {
+    storePromptMessage: (chatJid, senderId, senderName, text, taskId) => {
       const msgId = crypto.randomUUID();
       const now = new Date().toISOString();
       ensureChatExists(chatJid);
@@ -7998,7 +8046,7 @@ async function main(): Promise<void> {
         now,
         false,
         {
-          meta: { sourceKind: 'scheduled_task_prompt' },
+          meta: { sourceKind: 'scheduled_task_prompt', taskId },
         },
       );
       broadcastNewMessage(chatJid, {
@@ -8024,11 +8072,12 @@ async function main(): Promise<void> {
 
       if (options.ownerId) {
         const ownerHome = getUserHomeGroup(options.ownerId);
-        if (ownerHome?.folder) {
-          const localImages = extractLocalImImagePaths(text, ownerHome.folder);
+        const broadcastFolder = options.workspaceFolder ?? ownerHome?.folder;
+        if (broadcastFolder) {
+          const localImages = extractLocalImImagePaths(text, broadcastFolder);
           broadcastToOwnerIMChannels(
             options.ownerId,
-            ownerHome.folder,
+            broadcastFolder,
             new Set<string>(),
             (jid) => sendImWithFailTracking(jid, text, localImages),
             options.notifyChannels,

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -59,12 +59,17 @@ tasksRoutes.get('/', authMiddleware, async (c) => {
   const visibleTaskIds = new Set(tasks.map((t) => t.id));
   const filteredRunningIds = getRunningTaskIds().filter((id) => visibleTaskIds.has(id));
 
-  // Build jid → name mapping for all registered groups (including IM channels)
+  // Build jid → name mapping for all registered groups (including IM channels).
+  // Mirror the visibility rule used by GET /api/groups (src/routes/groups.ts:190-192):
+  // non-admins must not see host workspaces in the task-target dropdown, even
+  // though POST /api/tasks would reject them with 403 — rendering them here
+  // would be a misleading UI affordance. Authorization is still enforced on
+  // write; this filter is purely for surface consistency.
   const groupNames: Record<string, string> = {};
   for (const [jid, group] of Object.entries(allGroups)) {
-    if (canAccessGroup({ id: authUser.id, role: authUser.role }, { ...group, jid })) {
-      groupNames[jid] = group.name || jid;
-    }
+    if (!canAccessGroup({ id: authUser.id, role: authUser.role }, { ...group, jid })) continue;
+    if (isHostExecutionGroup(group) && !hasHostExecutionPermission(authUser)) continue;
+    groupNames[jid] = group.name || jid;
   }
 
   // Enrich Feishu group names with real chat names from API.
@@ -149,15 +154,26 @@ tasksRoutes.post('/', authMiddleware, async (c) => {
     return c.json({ error: '只有管理员可以创建脚本类型任务' }, 403);
   }
 
-  // Determine execution_mode
+  // Determine execution_mode by inheriting from the source workspace.
+  // - Source is host: default host (admin-only via hasHostExecutionPermission
+  //   check above), allow explicit container downgrade.
+  // - Source is container: default container; explicit host request rejected
+  //   even for admins, to keep task execution consistent with its workspace.
+  const sourceIsHost = isHostExecutionGroup(group);
   let taskExecutionMode: 'host' | 'container';
-  if (authUser.role === 'admin') {
-    taskExecutionMode = validation.data.execution_mode || 'host';
-  } else {
-    if (validation.data.execution_mode === 'host') {
-      return c.json({ error: '只有管理员可以创建宿主机任务' }, 403);
+  if (validation.data.execution_mode === 'host') {
+    if (!sourceIsHost) {
+      return c.json(
+        { error: '当前工作区运行在容器模式，任务不能使用宿主机执行模式' },
+        400,
+      );
     }
+    // Non-admin already blocked above by isHostExecutionGroup + hasHostExecutionPermission check
+    taskExecutionMode = 'host';
+  } else if (validation.data.execution_mode === 'container') {
     taskExecutionMode = 'container';
+  } else {
+    taskExecutionMode = sourceIsHost ? 'host' : 'container';
   }
 
   const taskId = crypto.randomUUID();
@@ -250,6 +266,7 @@ tasksRoutes.patch('/:id', authMiddleware, async (c) => {
 
   // Validate chat_jid if being changed
   const patchData = { ...validation.data } as typeof validation.data & { group_folder?: string };
+  let effectiveTargetGroup: ReturnType<typeof getRegisteredGroup> = group;
   if (validation.data.chat_jid !== undefined) {
     const targetGroup = getRegisteredGroup(validation.data.chat_jid);
     if (!targetGroup) {
@@ -260,6 +277,27 @@ tasksRoutes.patch('/:id', authMiddleware, async (c) => {
     }
     // Keep group_folder in sync with chat_jid
     patchData.group_folder = targetGroup.folder;
+    effectiveTargetGroup = targetGroup;
+  }
+
+  // Final-state consistency: after the patch, if the task runs as 'host', the
+  // target workspace must itself be a host workspace. Container workspaces
+  // reject host execution for ALL roles (including admin) — execution mode
+  // must match the source workspace's capabilities.
+  const finalExecutionMode =
+    patchData.execution_mode ?? existing.execution_mode;
+  if (
+    finalExecutionMode === 'host' &&
+    effectiveTargetGroup &&
+    !isHostExecutionGroup(effectiveTargetGroup)
+  ) {
+    return c.json(
+      {
+        error:
+          '目标工作区运行在容器模式，任务不能使用宿主机执行模式。请同时把执行模式改为 container。',
+      },
+      400,
+    );
   }
 
   // Auto-recalculate next_run when schedule changes (avoid pulling cron-parser into frontend)
@@ -485,25 +523,65 @@ tasksRoutes.post('/ai', authMiddleware, async (c) => {
   }
   const notifyChannels: string[] | null = body.notify_channels ?? null;
 
-  // Resolve home group
-  const homeGroup = getUserHomeGroup(authUser.id);
-  if (!homeGroup) return c.json({ error: 'Home group not found' }, 400);
+  // Optional user-supplied target workspace. If absent, fall back to the
+  // user's home group for backward compatibility.
+  const requestedChatJid =
+    typeof body.chat_jid === 'string' && body.chat_jid ? body.chat_jid : null;
+  const requestedContextMode =
+    body.context_mode === 'group' || body.context_mode === 'isolated'
+      ? (body.context_mode as 'group' | 'isolated')
+      : null;
+
+  let groupFolder: string;
+  let chatJid: string;
+  let sourceIsHost: boolean;
+
+  if (requestedChatJid) {
+    // User-selected workspace: run the same validation chain as POST /api/tasks
+    // so the AI path cannot be used to bypass group-access / host-exec checks.
+    const group = getRegisteredGroup(requestedChatJid);
+    if (!group) return c.json({ error: 'Group not found' }, 404);
+    if (!canAccessGroup({ id: authUser.id, role: authUser.role }, group)) {
+      return c.json({ error: 'Group not found' }, 404);
+    }
+    if (isHostExecutionGroup(group) && !hasHostExecutionPermission(authUser)) {
+      return c.json(
+        { error: 'Insufficient permissions for host execution mode' },
+        403,
+      );
+    }
+    groupFolder = group.folder;
+    chatJid = requestedChatJid;
+    sourceIsHost = isHostExecutionGroup(group);
+  } else {
+    const homeGroup = getUserHomeGroup(authUser.id);
+    if (!homeGroup) return c.json({ error: 'Home group not found' }, 400);
+    groupFolder = homeGroup.folder;
+    chatJid = homeGroup.jid;
+    const registered = getRegisteredGroup(homeGroup.jid);
+    sourceIsHost = registered ? isHostExecutionGroup(registered) : false;
+  }
 
   const taskId = crypto.randomUUID();
   const now = new Date().toISOString();
 
-  // Determine execution_mode
-  const taskExecutionMode = authUser.role === 'admin' ? 'host' : 'container';
+  // Inherit execution_mode from the resolved source workspace (same rule as
+  // POST /api/tasks). Previously hard-coded to admin=host / member=container,
+  // which would misattribute tasks whose target workspace is container-mode
+  // even for admin, or vice-versa.
+  const taskExecutionMode: 'host' | 'container' = sourceIsHost
+    ? 'host'
+    : 'container';
 
   // Create task immediately with 'parsing' status and description as prompt
   createTask({
     id: taskId,
-    group_folder: homeGroup.folder,
-    chat_jid: homeGroup.jid,
+    group_folder: groupFolder,
+    chat_jid: chatJid,
     prompt: description,
     schedule_type: 'cron',
     schedule_value: '0 0 * * *', // placeholder, will be updated after parsing
-    context_mode: 'group',
+    context_mode: requestedContextMode ?? 'group',
     execution_type: 'agent',
     execution_mode: taskExecutionMode,
     script_command: null,

--- a/src/task-routing.ts
+++ b/src/task-routing.ts
@@ -140,8 +140,57 @@ export function resolveTaskRoutingDecision(
 
 export interface BroadcastToOwnerIMChannelsDeps {
   getConnectedChannelTypes: (userId: string) => string[];
-  getGroupsByOwner: (userId: string) => Array<{ jid: string; folder: string }>;
+  getGroupsByOwner: (
+    userId: string,
+  ) => Array<{
+    jid: string;
+    folder: string;
+    /**
+     * Set by ImBindingDialog when an IM group is explicitly bound to a
+     * non-home workspace. Overrides the group's own `folder` for routing
+     * purposes — see resolveImGroupEffectiveFolder.
+     */
+    target_main_jid?: string | null;
+  }>;
   getChannelType: (jid: string) => string | null;
+  /**
+   * Resolve a `web:xxx` JID to the workspace folder it points to. Used to
+   * follow `target_main_jid` bindings when matching broadcast targets.
+   * Return null for unknown / unresolvable JIDs so the caller can fall
+   * back to the IM group's own folder.
+   */
+  resolveJidFolder: (jid: string) => string | null;
+}
+
+/**
+ * Compute the workspace folder an IM group should be considered to "belong"
+ * to when the scheduled-task broadcaster is looking for recipients.
+ *
+ * There are TWO ways a user can bind an IM group to a workspace:
+ *
+ * 1. **Shared folder** — the IM group's own `folder` matches the workspace's
+ *    folder. Used for home workspaces (auto-registered via onNewChat) and
+ *    some migration flows.
+ * 2. **target_main_jid** — the IM group keeps its own `folder` (usually the
+ *    home folder) but stores a pointer to the intended workspace via
+ *    `target_main_jid`. Used by the ImBindingDialog UI.
+ *
+ * Both must be respected by the broadcast matcher; otherwise scheduled
+ * tasks created in non-home workspaces will silently fail to reach
+ * their bound IM groups when the binding is the (2) kind.
+ *
+ * Precedence: `target_main_jid` wins when present and resolvable, matching
+ * the semantics used by `resolveOwnerHomeFolder` in src/index.ts.
+ */
+export function resolveImGroupEffectiveFolder(
+  group: { folder: string; target_main_jid?: string | null },
+  resolveJidFolder: (jid: string) => string | null,
+): string {
+  if (group.target_main_jid) {
+    const resolved = resolveJidFolder(group.target_main_jid);
+    if (resolved) return resolved;
+  }
+  return group.folder;
 }
 
 /**
@@ -197,9 +246,16 @@ export function broadcastToOwnerIMChannels(
   for (const channelType of connectedTypes) {
     if (sentChannelTypes.has(channelType)) continue;
     if (notifyChannels && !notifyChannels.includes(channelType)) continue;
-    const target = ownerGroups.find(
-      (g) => deps.getChannelType(g.jid) === channelType && g.folder === sourceFolder,
-    );
+    const target = ownerGroups.find((g) => {
+      if (deps.getChannelType(g.jid) !== channelType) return false;
+      // Match on the group's *effective* routing folder so both "shared
+      // folder" and "target_main_jid" bindings reach this broadcaster.
+      // Without this, ImBindingDialog-bound IM groups (whose own folder
+      // stays at 'main') silently miss scheduled-task broadcasts from
+      // non-home workspaces.
+      const effectiveFolder = resolveImGroupEffectiveFolder(g, deps.resolveJidFolder);
+      return effectiveFolder === sourceFolder;
+    });
     if (target) {
       sendFn(target.jid);
       sentChannelTypes.add(channelType);

--- a/src/task-routing.ts
+++ b/src/task-routing.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure helpers used by the scheduled-task IM routing pipeline.
+ *
+ * Extracted from src/index.ts so unit tests can import them without booting
+ * the main service (src/index.ts runs main() at module load). All external
+ * lookups are injected via `deps`; this file has no side effects.
+ */
+
+/**
+ * Scan a message list backwards and return the most recent non-empty `task_id`,
+ * or undefined if none. Used to propagate the triggering task's id from
+ * getMessagesSince() output into agent-runner via ContainerInput.messageTaskId.
+ *
+ * Mixed-batch semantics ("later wins"): when a batch contains both normal user
+ * messages and task-prompt rows, the whole batch is attributed to the most
+ * recent task_id in the batch. The batch is collapsed into a single agent
+ * turn and cannot be split back apart; we accept a slightly conservative
+ * misattribution (a user-initiated send may be routed through the task's
+ * IM broadcast path) over losing task attribution entirely (which would cause
+ * the task's configured notify_channels / chat_jid to be silently ignored).
+ * See tests/container-input-taskid.test.ts for the locked-in cases.
+ */
+export function extractLastTaskId(
+  messages: ReadonlyArray<{ task_id?: string | null }>,
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const candidate = messages[i]?.task_id;
+    if (candidate) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Inputs observable on an IPC message from agent-runner. Mirrors the fields
+ * the real IPC consumer in src/index.ts inspects; keep this in sync if new
+ * fields become load-bearing for routing.
+ */
+export interface IpcMessageInputs {
+  /** Legacy isolated-run flag (tasks-run/{runId}/ IPC namespace). */
+  isScheduledTask?: boolean;
+  /** Per-message task attribution, emitted by group-mode task turns. */
+  taskId?: string | null;
+}
+
+/** Task record fields consumed by the IPC router. */
+export interface TaskRecordForRouting {
+  notify_channels?: string[] | null;
+  chat_jid?: string | null;
+}
+
+/**
+ * Output of resolveTaskRoutingDecision. Describes how the IPC consumer should
+ * route a scheduled-task output to IM channels.
+ *
+ * - `mode: 'none'`: not a task message; caller falls through to regular routing.
+ * - `mode: 'direct'`: task has a configured chat_jid; caller sends to it
+ *   directly (unless it was already sent via data.chatJid / ipcImRoute).
+ * - `mode: 'broadcast'`: no direct chat_jid; caller fans out to the owner's
+ *   connected IM channels, filtered by `notifyChannels` if present.
+ */
+export type TaskRoutingDecision =
+  | { mode: 'none' }
+  | {
+      mode: 'direct';
+      /** The IM JID the task is configured to reply into. */
+      taskChatJid: string;
+      /** notify_channels from the task record, forwarded for parity with broadcast branch. */
+      notifyChannels: string[] | null | undefined;
+      /** Echoed for logging / debugging. */
+      effectiveTaskId: string;
+    }
+  | {
+      mode: 'broadcast';
+      notifyChannels: string[] | null | undefined;
+      /** undefined when neither data.taskId nor ipcTaskId was available. */
+      effectiveTaskId: string | undefined;
+    };
+
+export interface ResolveTaskRoutingDeps {
+  getTaskById: (taskId: string) => TaskRecordForRouting | null | undefined;
+  /** Should mirror src/im-channel.ts#getChannelType: non-null iff the jid belongs to an IM channel. */
+  getChannelType: (jid: string) => string | null;
+}
+
+/**
+ * Pure decision function capturing the "scheduled task output" branch of the
+ * IPC consumer in src/index.ts (message + image variants). Separated out so
+ * unit tests can exercise each codepath (`mode: 'none' | 'direct' | 'broadcast'`)
+ * without booting the main service.
+ *
+ * Contract (locked by tests/task-routing-decision.test.ts):
+ * - `hasCreatedBy` must be true for any non-none result (owner attribution is
+ *   required to look up notify channels).
+ * - A message is a task message iff `data.isScheduledTask || data.taskId`.
+ * - `effectiveTaskId` prefers per-message `data.taskId` over the legacy
+ *   `ipcTaskId` (the directory-derived id used by isolated-run tasks).
+ * - Direct-mode requires the task record's `chat_jid` to be a valid IM JID
+ *   (getChannelType non-null). A null/web/unknown chat_jid falls back to
+ *   broadcast so tasks without a configured IM target still fan out.
+ */
+export function resolveTaskRoutingDecision(
+  data: IpcMessageInputs,
+  ipcTaskId: string | null | undefined,
+  hasCreatedBy: boolean,
+  deps: ResolveTaskRoutingDeps,
+): TaskRoutingDecision {
+  const isTaskMessage = !!(data.isScheduledTask || data.taskId);
+  if (!isTaskMessage || !hasCreatedBy) {
+    return { mode: 'none' };
+  }
+
+  const effectiveTaskId =
+    typeof data.taskId === 'string' && data.taskId
+      ? data.taskId
+      : (ipcTaskId ?? undefined);
+
+  let notifyChannels: string[] | null | undefined;
+  let taskChatJid: string | null | undefined;
+  if (effectiveTaskId) {
+    const taskRecord = deps.getTaskById(effectiveTaskId);
+    notifyChannels = taskRecord?.notify_channels;
+    taskChatJid = taskRecord?.chat_jid;
+  }
+
+  if (taskChatJid && deps.getChannelType(taskChatJid)) {
+    return {
+      mode: 'direct',
+      taskChatJid,
+      notifyChannels,
+      effectiveTaskId: effectiveTaskId as string, // non-empty per the branch above
+    };
+  }
+
+  return {
+    mode: 'broadcast',
+    notifyChannels,
+    effectiveTaskId,
+  };
+}
+
+export interface BroadcastToOwnerIMChannelsDeps {
+  getConnectedChannelTypes: (userId: string) => string[];
+  getGroupsByOwner: (userId: string) => Array<{ jid: string; folder: string }>;
+  getChannelType: (jid: string) => string | null;
+}
+
+/**
+ * Pick the folder used to fan out a scheduled-task message to the owner's IM
+ * channels. This is a *deliberate decision* between two candidates — the
+ * emitting workspace's own folder (`sourceFolder`), or the owner's home
+ * workspace folder (`ownerHomeFolder`) — and the answer is always
+ * `sourceFolder`.
+ *
+ * This encodes fix F: pre-fix code returned `ownerHomeFolder`, which broke
+ * non-home workspaces bound to their own IM groups (replies were routed to
+ * the home workspace's IM bindings instead of the emitting workspace's).
+ *
+ * Both candidates are accepted as parameters so the caller can't silently
+ * revert to ownerHome by choosing a different expression — any regression
+ * shows up as a functional change to this helper (locked by tests), not an
+ * innocent-looking one-line edit at the call site.
+ *
+ * The `ownerHomeFolder` parameter is intentionally unused in the return
+ * value; it exists purely as a "witness" that the caller considered both
+ * options and chose sourceFolder. See tests/task-routing-decision.test.ts
+ * for the locked contract.
+ */
+export function resolveBroadcastFolder(
+  sourceFolder: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _ownerHomeFolder: string | null | undefined,
+): string {
+  return sourceFolder;
+}
+
+/**
+ * Broadcast a message to all connected IM channels of a user that haven't
+ * already received it. Used by scheduled tasks to fan out to all IM channels.
+ * `sourceFolder` filters to groups whose folder matches the emitting workspace,
+ * so IM bindings on unrelated workspaces are ignored.
+ */
+export function broadcastToOwnerIMChannels(
+  userId: string,
+  sourceFolder: string,
+  alreadySentJids: Set<string>,
+  sendFn: (jid: string) => void,
+  notifyChannels: string[] | null | undefined,
+  deps: BroadcastToOwnerIMChannelsDeps,
+): void {
+  const sentChannelTypes = new Set<string>();
+  for (const jid of alreadySentJids) {
+    const ct = deps.getChannelType(jid);
+    if (ct) sentChannelTypes.add(ct);
+  }
+  const connectedTypes = deps.getConnectedChannelTypes(userId);
+  const ownerGroups = deps.getGroupsByOwner(userId);
+  for (const channelType of connectedTypes) {
+    if (sentChannelTypes.has(channelType)) continue;
+    if (notifyChannels && !notifyChannels.includes(channelType)) continue;
+    const target = ownerGroups.find(
+      (g) => deps.getChannelType(g.jid) === channelType && g.folder === sourceFolder,
+    );
+    if (target) {
+      sendFn(target.jid);
+      sentChannelTypes.add(channelType);
+    }
+  }
+}

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -180,7 +180,7 @@ export interface SchedulerDependencies {
   broadcastStreamEvent?: (chatJid: string, event: StreamEvent) => void;
   onWorkspaceCreated?: (jid: string, folder: string, name: string, userId?: string) => void;
   /** Store task prompt as a user-visible message in the workspace chat */
-  storePromptMessage?: (chatJid: string, senderId: string, senderName: string, text: string) => void;
+  storePromptMessage?: (chatJid: string, senderId: string, senderName: string, text: string, taskId?: string) => void;
   /** Store task result in workspace chat and push to owner's IM channels */
   storeResultAndNotify?: (
     chatJid: string,
@@ -190,6 +190,7 @@ export interface SchedulerDependencies {
       notifyChannels?: string[] | null;
       sourceKind?: ContainerOutput['sourceKind'];
       skipStore?: boolean;
+      workspaceFolder?: string;
     },
   ) => Promise<void>;
   assistantName: string;
@@ -348,7 +349,7 @@ async function runTask(
   if (deps.storePromptMessage) {
     const owner = workspaceGroup.created_by ? getUserById(workspaceGroup.created_by) : null;
     const senderName = owner?.display_name || owner?.username || '定时任务';
-    deps.storePromptMessage(workspace.jid, owner?.id || 'system', senderName, task.prompt);
+    deps.storePromptMessage(workspace.jid, owner?.id || 'system', senderName, task.prompt, task.id);
   }
 
   let result: string | null = null;
@@ -520,6 +521,7 @@ async function runTask(
           ownerId: workspaceGroup.created_by || undefined,
           notifyChannels: task.notify_channels,
           sourceKind: 'sdk_final',
+          workspaceFolder: workspace.folder,
         });
       } catch (err) {
         logger.error(
@@ -659,6 +661,7 @@ async function runScriptTask(
               ownerId: group.created_by,
               notifyChannels: task.notify_channels,
               skipStore: true,
+              workspaceFolder: task.group_folder,
             });
           } catch (notifyErr) {
             logger.error(
@@ -735,6 +738,7 @@ async function runGroupModeTask(
       owner?.id || 'system',
       senderName,
       task.prompt,
+      task.id,
     );
 
     // Trigger normal message processing for the source workspace

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,7 @@ export interface NewMessage {
   sdk_message_uuid?: string | null;
   source_kind?: MessageSourceKind | null;
   finalization_reason?: MessageFinalizationReason | null;
+  task_id?: string | null;
 }
 
 export type MessageSourceKind =

--- a/tests/container-input-taskid.test.ts
+++ b/tests/container-input-taskid.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+
+import { extractLastTaskId } from '../src/task-routing.js';
+
+// Minimal shape that matches the ReadonlyArray<{ task_id?: string | null }>
+// signature exported from src/index.ts. The production caller passes full
+// NewMessage rows, but the helper only reads `task_id`.
+type Row = { task_id?: string | null };
+
+describe('extractLastTaskId', () => {
+  test('returns undefined for empty array', () => {
+    expect(extractLastTaskId([])).toBeUndefined();
+  });
+
+  test('returns undefined when no row carries task_id', () => {
+    const rows: Row[] = [
+      { task_id: null },
+      { task_id: undefined },
+      {},
+    ];
+    expect(extractLastTaskId(rows)).toBeUndefined();
+  });
+
+  test('returns the last non-null task_id (reverse scan semantics)', () => {
+    // Mirrors the description's canonical fixture:
+    // [{task_id: null}, {task_id: 't2'}, {task_id: null}] → 't2'
+    const rows: Row[] = [
+      { task_id: null },
+      { task_id: 't2' },
+      { task_id: null },
+    ];
+    expect(extractLastTaskId(rows)).toBe('t2');
+  });
+
+  test('later task prompt wins when multiple are present', () => {
+    // If an agent turn contains multiple task prompts, the most recent one
+    // determines attribution.
+    const rows: Row[] = [
+      { task_id: 't-early' },
+      { task_id: null },
+      { task_id: 't-late' },
+      { task_id: null },
+    ];
+    expect(extractLastTaskId(rows)).toBe('t-late');
+  });
+
+  test('single row with task_id returns that id', () => {
+    expect(extractLastTaskId([{ task_id: 'only-one' }])).toBe('only-one');
+  });
+
+  test('empty-string task_id is treated as absent (falsy)', () => {
+    // The impl uses truthy check (`if (candidate)`), so '' should not match.
+    const rows: Row[] = [{ task_id: '' }, { task_id: null }];
+    expect(extractLastTaskId(rows)).toBeUndefined();
+  });
+
+  test('mixed-batch "later wins": user msg + trailing task prompt → task id', () => {
+    // Load-bearing contract (locked per Codex remediation C2):
+    // when getMessagesSince returns a batch that mixes regular user messages
+    // and a scheduled_task_prompt row, the entire batch is collapsed into
+    // one agent turn and attributed to the most recent task_id in the batch.
+    // We accept the conservative misattribution (user's send may route
+    // through the task's IM broadcast path) to preserve task attribution,
+    // which is otherwise unrecoverable once the prompts are merged.
+    const rows: Row[] = [
+      { task_id: null }, // normal user message
+      { task_id: 't_later' }, // task prompt arriving in the same batch
+    ];
+    expect(extractLastTaskId(rows)).toBe('t_later');
+  });
+
+  test('mixed-batch "later wins": task prompt followed by user msg → still the task id', () => {
+    // Complements the previous case: when the task prompt comes first and is
+    // followed by user messages, the scan still returns the most recent
+    // non-null task_id because user rows have task_id=null. Collapsed batch
+    // is still attributed to the task. Same rationale: we cannot split the
+    // batch back apart once agent-runner receives it as a single prompt.
+    const rows: Row[] = [
+      { task_id: 't_early' },
+      { task_id: null },
+      { task_id: null },
+    ];
+    expect(extractLastTaskId(rows)).toBe('t_early');
+  });
+});

--- a/tests/im-broadcast-folder.test.ts
+++ b/tests/im-broadcast-folder.test.ts
@@ -33,6 +33,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'tg:T1', folder: 'home-u' },
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -59,6 +60,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'tg:T1', folder: 'home-u' },
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -83,6 +85,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'tg:T1', folder: 'home-u' },
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -108,6 +111,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'tg:T1', folder: 'ws-x' }, // also bound to ws-x for this case
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -134,6 +138,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'tg:T1', folder: 'ws-x' },
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -158,6 +163,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'tg:T1', folder: 'ws-x' },
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -186,6 +192,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
         { jid: 'feishu:F-wsx', folder: 'ws-x' },
       ],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -210,6 +217,7 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
       getConnectedChannelTypes: () => ['feishu'],
       getGroupsByOwner: () => [{ jid: 'tg:T1', folder: 'ws-x' }],
       getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
     };
 
     broadcastToOwnerIMChannels(
@@ -222,5 +230,143 @@ describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regressio
     );
 
     expect(sendFn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression suite for a bug discovered after fix F shipped: the
+ * ImBindingDialog UI binds an IM group to a non-home workspace via
+ * `target_main_jid` WITHOUT changing the group's own `folder`. The
+ * initial fix F only matched on folder equality, so scheduled tasks in
+ * non-home workspaces silently failed to reach their bound IM groups
+ * when the binding was of the target_main_jid kind.
+ *
+ * These tests lock in that `resolveImGroupEffectiveFolder` (via
+ * resolveJidFolder) is consulted during matching, so both binding
+ * mechanisms work:
+ *   - shared folder (handled by the suite above)
+ *   - target_main_jid redirection (this suite)
+ */
+describe('broadcastToOwnerIMChannels — target_main_jid binding (ImBindingDialog)', () => {
+  test('IM group with target_main_jid matches via resolved target folder, not own folder', () => {
+    // Feishu group's own folder is 'home-u' (registered there on first contact),
+    // but the user bound it to workspace 'ws-x' via ImBindingDialog. The binding
+    // is stored as target_main_jid='web:ws-x-jid'. A scheduled task running in
+    // ws-x (sourceFolder='ws-x') must still fan out to this Feishu group.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu'],
+      getGroupsByOwner: () => [
+        {
+          jid: 'feishu:F-bound',
+          folder: 'home-u',
+          target_main_jid: 'web:ws-x-jid',
+        },
+      ],
+      getChannelType: fakeGetChannelType,
+      resolveJidFolder: (jid) => (jid === 'web:ws-x-jid' ? 'ws-x' : null),
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F-bound');
+  });
+
+  test('target_main_jid takes precedence over own folder when both could match different sourceFolders', () => {
+    // IM group's own folder is 'home-u', target_main_jid points to 'ws-x'.
+    // When sourceFolder='home-u', it MUST NOT match — the binding redirects
+    // this group to ws-x only. (Prevents double-delivery when home and ws-x
+    // both host scheduled tasks.)
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu'],
+      getGroupsByOwner: () => [
+        {
+          jid: 'feishu:F-bound',
+          folder: 'home-u',
+          target_main_jid: 'web:ws-x-jid',
+        },
+      ],
+      getChannelType: fakeGetChannelType,
+      resolveJidFolder: (jid) => (jid === 'web:ws-x-jid' ? 'ws-x' : null),
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'home-u',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).not.toHaveBeenCalled();
+  });
+
+  test('target_main_jid that cannot be resolved falls back to own folder', () => {
+    // target_main_jid points to a workspace that was deleted (resolveJidFolder
+    // returns null). The group should gracefully fall back to matching on its
+    // own folder so at least the pre-fix F behavior is preserved.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu'],
+      getGroupsByOwner: () => [
+        {
+          jid: 'feishu:F-orphan',
+          folder: 'home-u',
+          target_main_jid: 'web:deleted-ws',
+        },
+      ],
+      getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null, // deleted target
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'home-u',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F-orphan');
+  });
+
+  test('group with target_main_jid=null / undefined behaves like legacy folder-only match', () => {
+    // Regression guard: ensure adding the target_main_jid code path didn't
+    // break the existing folder-equality behavior for groups without binding.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x', target_main_jid: null },
+        { jid: 'tg:T1', folder: 'ws-x' }, // no target_main_jid field at all
+      ],
+      getChannelType: fakeGetChannelType,
+      resolveJidFolder: () => null,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(2);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F1');
+    expect(sendFn).toHaveBeenCalledWith('tg:T1');
   });
 });

--- a/tests/im-broadcast-folder.test.ts
+++ b/tests/im-broadcast-folder.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  broadcastToOwnerIMChannels,
+  type BroadcastToOwnerIMChannelsDeps,
+} from '../src/task-routing.js';
+
+// Mirror of src/channel-prefixes.ts prefix → type mapping, inlined for test
+// independence. If CHANNEL_PREFIXES ever changes, update this alongside.
+const PREFIX_TO_TYPE: Record<string, string> = {
+  feishu: 'feishu',
+  tg: 'telegram',
+  qq: 'qq',
+  ding: 'dingtalk',
+  discord: 'discord',
+  web: 'web',
+};
+
+function fakeGetChannelType(jid: string): string | null {
+  const prefix = jid.split(':')[0];
+  return PREFIX_TO_TYPE[prefix] ?? null;
+}
+
+describe('broadcastToOwnerIMChannels — folder-precise routing (fix F regression guard)', () => {
+  test('routes only to groups whose folder matches sourceFolder', () => {
+    // Owner has two IM bindings: feishu bound to ws-x, telegram bound to home-u.
+    // Task runs in workspace ws-x → feishu fires, telegram does NOT.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x' },
+        { jid: 'tg:T1', folder: 'home-u' },
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F1');
+    expect(sendFn).not.toHaveBeenCalledWith('tg:T1');
+  });
+
+  test('sourceFolder=home-u routes only to telegram binding', () => {
+    // Symmetric case: same bindings, different sourceFolder → telegram only.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x' },
+        { jid: 'tg:T1', folder: 'home-u' },
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'home-u',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('tg:T1');
+  });
+
+  test('no group matches sourceFolder → no sendFn calls', () => {
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x' },
+        { jid: 'tg:T1', folder: 'home-u' },
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'some-other-folder',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).not.toHaveBeenCalled();
+  });
+
+  test('channel type already sent (in alreadySentJids) is skipped', () => {
+    // alreadySentJids says feishu was already covered; broadcast should skip
+    // the feishu binding even though it matches the folder.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x' },
+        { jid: 'tg:T1', folder: 'ws-x' }, // also bound to ws-x for this case
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set(['feishu:F1']),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('tg:T1');
+  });
+
+  test('notifyChannels filter restricts output to allowed channel types', () => {
+    // Both feishu and telegram bind to ws-x, but notifyChannels=['telegram']
+    // means only telegram should receive.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x' },
+        { jid: 'tg:T1', folder: 'ws-x' },
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      ['telegram'],
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('tg:T1');
+  });
+
+  test('notifyChannels=null means no filter (fan out to all matching)', () => {
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu', 'telegram'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F1', folder: 'ws-x' },
+        { jid: 'tg:T1', folder: 'ws-x' },
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      null,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(2);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F1');
+    expect(sendFn).toHaveBeenCalledWith('tg:T1');
+  });
+
+  test('one channel type, multiple candidate bindings: only the folder-matching one wins', () => {
+    // Owner has feishu bound to two different workspaces. Only the one whose
+    // folder === sourceFolder should fire. This is the core "folder precision"
+    // property that fix F is defending.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu'],
+      getGroupsByOwner: () => [
+        { jid: 'feishu:F-home', folder: 'home-u' },
+        { jid: 'feishu:F-wsx', folder: 'ws-x' },
+      ],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F-wsx');
+    expect(sendFn).not.toHaveBeenCalledWith('feishu:F-home');
+  });
+
+  test('connected channel type with no binding at sourceFolder is silently skipped', () => {
+    // Owner has feishu connected, but no feishu binding exists for this folder.
+    // Should not throw, should not send.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu'],
+      getGroupsByOwner: () => [{ jid: 'tg:T1', folder: 'ws-x' }],
+      getChannelType: fakeGetChannelType,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'ws-x',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/im-broadcast-folder.test.ts
+++ b/tests/im-broadcast-folder.test.ts
@@ -342,6 +342,45 @@ describe('broadcastToOwnerIMChannels — target_main_jid binding (ImBindingDialo
     expect(sendFn).toHaveBeenCalledWith('feishu:F-orphan');
   });
 
+  test('legacy target_main_jid format `web:{folder}` still resolves (DB-migration compat)', () => {
+    // Historical data shape: some old DBs stored target_main_jid as
+    // `web:{folder}` (using the folder name as a pseudo-jid) instead of the
+    // canonical `web:{uuid}` the current writer uses. The production
+    // resolveJidFolder delegates to resolveWorkspaceJid which folds this shape
+    // back to the real registered jid. This test exercises the shape
+    // contract: a resolveJidFolder impl that interprets the legacy shape
+    // correctly (returns a folder) must still hit the broadcast path.
+    const sendFn = vi.fn<(jid: string) => void>();
+    const deps: BroadcastToOwnerIMChannelsDeps = {
+      getConnectedChannelTypes: () => ['feishu'],
+      getGroupsByOwner: () => [
+        {
+          jid: 'feishu:F-legacy',
+          folder: 'home-u',
+          // Legacy shape: `web:{folder-name}`, not `web:{uuid}`.
+          target_main_jid: 'web:flow-legacy-42',
+        },
+      ],
+      getChannelType: fakeGetChannelType,
+      // Simulate resolveWorkspaceJid's legacy fallback: legacy shape inputs
+      // are translated to the canonical folder rather than returning null.
+      resolveJidFolder: (jid) =>
+        jid === 'web:flow-legacy-42' ? 'flow-legacy-42' : null,
+    };
+
+    broadcastToOwnerIMChannels(
+      'user-1',
+      'flow-legacy-42',
+      new Set<string>(),
+      sendFn,
+      undefined,
+      deps,
+    );
+
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith('feishu:F-legacy');
+  });
+
   test('group with target_main_jid=null / undefined behaves like legacy folder-only match', () => {
     // Regression guard: ensure adding the target_main_jid code path didn't
     // break the existing folder-equality behavior for groups without binding.

--- a/tests/mcp-send-message-taskid.test.ts
+++ b/tests/mcp-send-message-taskid.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildSendMessageData,
+  type McpContext,
+} from '../container/agent-runner/src/mcp-tools.js';
+
+function baseCtx(overrides: Partial<McpContext> = {}): McpContext {
+  return {
+    chatJid: 'web:ws-x',
+    groupFolder: 'ws-x',
+    isHome: false,
+    isAdminHome: false,
+    isScheduledTask: false,
+    currentTaskId: null,
+    workspaceIpc: '/tmp/ipc',
+    workspaceGroup: '/tmp/group',
+    workspaceGlobal: '/tmp/global',
+    ...overrides,
+  } as McpContext;
+}
+
+describe('buildSendMessageData — task attribution stamping', () => {
+  test('currentTaskId set → data includes taskId', () => {
+    const ctx = baseCtx({ currentTaskId: 'task-42' });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'hi' });
+    expect(data.taskId).toBe('task-42');
+    // Caller-provided fields flow through
+    expect(data.type).toBe('message');
+    expect(data.text).toBe('hi');
+    // chatJid + groupFolder stamped
+    expect(data.chatJid).toBe('web:ws-x');
+    expect(data.groupFolder).toBe('ws-x');
+  });
+
+  test('currentTaskId null → data has NO taskId key (not undefined value)', () => {
+    const ctx = baseCtx({ currentTaskId: null });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'hi' });
+    // Critical: must be absent, not {taskId: undefined}. The IPC consumer
+    // side uses `typeof data.taskId === 'string' && data.taskId` so absence
+    // vs undefined are equivalent here, but absence is the contract.
+    expect('taskId' in data).toBe(false);
+  });
+
+  test('currentTaskId undefined → data has NO taskId key', () => {
+    const ctx = baseCtx({ currentTaskId: undefined });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'hi' });
+    expect('taskId' in data).toBe(false);
+  });
+
+  test('currentTaskId empty string → data has NO taskId key (falsy gate)', () => {
+    const ctx = baseCtx({ currentTaskId: '' });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'hi' });
+    expect('taskId' in data).toBe(false);
+  });
+
+  test('isScheduledTask true → data has isScheduledTask: true', () => {
+    const ctx = baseCtx({ isScheduledTask: true });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'x' });
+    expect(data.isScheduledTask).toBe(true);
+  });
+
+  test('isScheduledTask false → data has NO isScheduledTask key', () => {
+    const ctx = baseCtx({ isScheduledTask: false });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'x' });
+    expect('isScheduledTask' in data).toBe(false);
+  });
+
+  test('both flags → data carries both taskId and isScheduledTask', () => {
+    const ctx = baseCtx({ isScheduledTask: true, currentTaskId: 'task-7' });
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'x' });
+    expect(data.isScheduledTask).toBe(true);
+    expect(data.taskId).toBe('task-7');
+  });
+
+  test('extras do not override chatJid/groupFolder (data starts with ctx values, extras spread after but do not collide)', () => {
+    // The impl spreads extras AFTER chatJid/groupFolder, so extras *could*
+    // technically override them. We pin the current behavior so any future
+    // change is reviewed.
+    const ctx = baseCtx({ chatJid: 'web:a', groupFolder: 'a' });
+    const data = buildSendMessageData(ctx, {
+      type: 'message',
+      text: 'hi',
+      // Intentionally include a timestamp override to exercise spread order.
+      timestamp: 'custom-ts',
+    });
+    expect(data.type).toBe('message');
+    expect(data.text).toBe('hi');
+    expect(data.timestamp).toBe('custom-ts');
+    expect(data.chatJid).toBe('web:a');
+    expect(data.groupFolder).toBe('a');
+  });
+
+  test('timestamp is stamped when extras do not override it', () => {
+    const ctx = baseCtx();
+    const data = buildSendMessageData(ctx, { type: 'message', text: 'x' });
+    expect(typeof data.timestamp).toBe('string');
+    expect((data.timestamp as string).length).toBeGreaterThan(0);
+  });
+
+  test('image payload: currentTaskId propagates through extras carrying imageBase64', () => {
+    // Exercises the send_image code path — same helper, different extras shape.
+    const ctx = baseCtx({ currentTaskId: 'task-42', isScheduledTask: true });
+    const data = buildSendMessageData(ctx, {
+      type: 'image',
+      imageBase64: 'AAA=',
+      mimeType: 'image/png',
+    });
+    expect(data.type).toBe('image');
+    expect(data.imageBase64).toBe('AAA=');
+    expect(data.mimeType).toBe('image/png');
+    expect(data.taskId).toBe('task-42');
+    expect(data.isScheduledTask).toBe(true);
+  });
+});

--- a/tests/task-meta.test.ts
+++ b/tests/task-meta.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Isolate DB to a temp dir — mock config.js before importing db.js so STORE_DIR
+// points at a fresh directory owned by this test run.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-meta-test-'));
+const tmpStoreDir = path.join(tmpDir, 'db');
+const tmpGroupsDir = path.join(tmpDir, 'groups');
+fs.mkdirSync(tmpStoreDir, { recursive: true });
+fs.mkdirSync(tmpGroupsDir, { recursive: true });
+
+vi.mock('../src/config.js', async () => {
+  // Keep any other unused exports benign; db.ts only reads STORE_DIR + GROUPS_DIR.
+  return {
+    STORE_DIR: tmpStoreDir,
+    GROUPS_DIR: tmpGroupsDir,
+  };
+});
+
+// Dynamic import AFTER the mock so db.ts picks up the mocked STORE_DIR.
+const {
+  initDatabase,
+  ensureChatExists,
+  storeMessageDirect,
+  getMessagesSince,
+  getNewMessages,
+} = await import('../src/db.js');
+
+beforeAll(() => {
+  initDatabase();
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+const EMPTY_CURSOR = { timestamp: '', id: '' };
+
+describe('storeMessageDirect + task_id propagation', () => {
+  test('scenario A: meta.taskId is persisted and returned by getMessagesSince', () => {
+    const chatJid = 'web:task-meta-A';
+    ensureChatExists(chatJid);
+    storeMessageDirect(
+      'm-A-1',
+      chatJid,
+      'system',
+      'scheduler',
+      'prompt for task t1',
+      '2026-04-17T00:00:00.000Z',
+      false,
+      { meta: { sourceKind: 'scheduled_task_prompt', taskId: 't1' } },
+    );
+
+    const rows = getMessagesSince(chatJid, EMPTY_CURSOR);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('m-A-1');
+    expect(rows[0].task_id).toBe('t1');
+  });
+
+  test('scenario B: meta without taskId leaves task_id null', () => {
+    const chatJid = 'web:task-meta-B';
+    ensureChatExists(chatJid);
+    storeMessageDirect(
+      'm-B-1',
+      chatJid,
+      'user-1',
+      'Alice',
+      'regular message, no task',
+      '2026-04-17T00:00:01.000Z',
+      false,
+      { meta: { sourceKind: 'legacy' } },
+    );
+    // Also store a message with no meta at all to confirm the default is null.
+    storeMessageDirect(
+      'm-B-2',
+      chatJid,
+      'user-1',
+      'Alice',
+      'another plain message',
+      '2026-04-17T00:00:02.000Z',
+      false,
+    );
+
+    const rows = getMessagesSince(chatJid, EMPTY_CURSOR);
+    expect(rows).toHaveLength(2);
+    // sqlite returns NULL → better-sqlite3 surfaces it as `null`; assert null-ish.
+    for (const r of rows) {
+      expect(r.task_id == null).toBe(true); // matches null or undefined
+    }
+  });
+
+  test('scenario C: getNewMessages returns task_id column on surfaced rows', () => {
+    // getNewMessages filters out 'scheduled_task_prompt' + 'user_command' rows,
+    // but the SELECT still projects task_id so any non-prompt row that carries
+    // task_id (e.g. a future migration) is available to the caller.
+    const chatJid = 'web:task-meta-C';
+    ensureChatExists(chatJid);
+    // A regular IM message (legacy source_kind) carrying a taskId — not filtered.
+    storeMessageDirect(
+      'm-C-1',
+      chatJid,
+      'user-2',
+      'Carol',
+      'message tagged with task id',
+      '2026-04-17T00:00:03.000Z',
+      false,
+      { meta: { sourceKind: 'legacy', taskId: 't2' } },
+    );
+    // A scheduled_task_prompt row — should be filtered out by getNewMessages.
+    storeMessageDirect(
+      'm-C-2',
+      chatJid,
+      'system',
+      'scheduler',
+      'prompt for task t2',
+      '2026-04-17T00:00:04.000Z',
+      false,
+      { meta: { sourceKind: 'scheduled_task_prompt', taskId: 't2' } },
+    );
+
+    const { messages } = getNewMessages([chatJid], EMPTY_CURSOR);
+    const ids = messages.map((m) => m.id);
+    expect(ids).toContain('m-C-1');
+    expect(ids).not.toContain('m-C-2'); // scheduled_task_prompt is filtered
+    const surfaced = messages.find((m) => m.id === 'm-C-1');
+    expect(surfaced!.task_id).toBe('t2');
+  });
+
+  test('scenario D: mixed rows — task_id is per-message, not sticky', () => {
+    const chatJid = 'web:task-meta-D';
+    ensureChatExists(chatJid);
+    storeMessageDirect(
+      'm-D-1',
+      chatJid,
+      'system',
+      'scheduler',
+      'task prompt',
+      '2026-04-17T00:00:10.000Z',
+      false,
+      { meta: { sourceKind: 'scheduled_task_prompt', taskId: 't3' } },
+    );
+    storeMessageDirect(
+      'm-D-2',
+      chatJid,
+      'user-9',
+      'Bob',
+      'follow-up regular message',
+      '2026-04-17T00:00:11.000Z',
+      false,
+    );
+    storeMessageDirect(
+      'm-D-3',
+      chatJid,
+      'system',
+      'scheduler',
+      'another task prompt',
+      '2026-04-17T00:00:12.000Z',
+      false,
+      { meta: { sourceKind: 'scheduled_task_prompt', taskId: 't4' } },
+    );
+
+    const rows = getMessagesSince(chatJid, EMPTY_CURSOR);
+    const byId = new Map(rows.map((r) => [r.id, r.task_id]));
+    expect(byId.get('m-D-1')).toBe('t3');
+    expect(byId.get('m-D-2') == null).toBe(true);
+    expect(byId.get('m-D-3')).toBe('t4');
+  });
+});

--- a/tests/task-routing-decision.test.ts
+++ b/tests/task-routing-decision.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  resolveBroadcastFolder,
+  resolveTaskRoutingDecision,
+  type IpcMessageInputs,
+  type ResolveTaskRoutingDeps,
+  type TaskRecordForRouting,
+} from '../src/task-routing.js';
+
+/**
+ * Regression tests covering the decision branch at src/index.ts:4170-4222
+ * (message) and src/index.ts:4337-4377 (image). Helper-level unit tests in
+ * tests/extractLastTaskId / broadcastToOwnerIMChannels cover the inputs, but
+ * without resolveTaskRoutingDecision extracted, someone reverting the
+ * dual-gate (`||` → single-flag) or swapping ipcTaskId precedence would not
+ * trip any test. These tests lock the gate and precedence.
+ *
+ * Mutation checks (run by QA): flipping `||` to `&&` or to isScheduledTask-
+ * only should turn at least one of these tests red.
+ */
+
+function makeDeps(
+  taskRecords: Record<string, TaskRecordForRouting | null>,
+  imJids: ReadonlySet<string>,
+): ResolveTaskRoutingDeps {
+  return {
+    getTaskById: vi.fn((id: string) => taskRecords[id] ?? null),
+    getChannelType: vi.fn((jid: string) => (imJids.has(jid) ? 'feishu' : null)),
+  };
+}
+
+describe('resolveTaskRoutingDecision — dual-gate (isScheduledTask || taskId)', () => {
+  test('isScheduledTask=true alone → enters task routing', () => {
+    // Legacy isolated-run flag path (pre-B/C/D/E, still supported).
+    const data: IpcMessageInputs = { isScheduledTask: true };
+    const deps = makeDeps({}, new Set());
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('broadcast');
+  });
+
+  test('taskId alone (group-mode output) → enters task routing', () => {
+    // The load-bearing case for fix B/C/D/E. If someone reverts the `||`
+    // back to single-gate `isScheduledTask`, this test must fail.
+    const data: IpcMessageInputs = { taskId: 't-abc' };
+    const deps = makeDeps(
+      { 't-abc': { notify_channels: null, chat_jid: null } },
+      new Set(),
+    );
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('broadcast');
+    if (decision.mode === 'broadcast') {
+      expect(decision.effectiveTaskId).toBe('t-abc');
+    }
+  });
+
+  test('neither flag set → mode none (falls through to regular routing)', () => {
+    const data: IpcMessageInputs = {};
+    const deps = makeDeps({}, new Set());
+    expect(
+      resolveTaskRoutingDecision(data, null, true, deps).mode,
+    ).toBe('none');
+  });
+
+  test('taskId set but hasCreatedBy false → mode none', () => {
+    // Owner attribution is required; without it the broadcast lookup can't
+    // resolve notify channels, so we must not enter the task branch even
+    // though the gate flag is present.
+    const data: IpcMessageInputs = { taskId: 't-abc' };
+    const deps = makeDeps({}, new Set());
+    expect(
+      resolveTaskRoutingDecision(data, null, false, deps).mode,
+    ).toBe('none');
+  });
+});
+
+describe('resolveTaskRoutingDecision — effectiveTaskId precedence', () => {
+  test('data.taskId wins over ipcTaskId', () => {
+    // Per-message taskId (emitted by group-mode turn) supersedes the IPC
+    // directory-derived ipcTaskId (legacy isolated-run namespace). Reverting
+    // the precedence would cause group-mode outputs to look up the wrong
+    // task record.
+    const data: IpcMessageInputs = { taskId: 'msg-task', isScheduledTask: true };
+    const deps = makeDeps(
+      {
+        'msg-task': { notify_channels: ['feishu'], chat_jid: null },
+        'ipc-task': { notify_channels: ['telegram'], chat_jid: null },
+      },
+      new Set(),
+    );
+    const decision = resolveTaskRoutingDecision(data, 'ipc-task', true, deps);
+    expect(decision.mode).toBe('broadcast');
+    if (decision.mode === 'broadcast') {
+      expect(decision.effectiveTaskId).toBe('msg-task');
+      expect(decision.notifyChannels).toEqual(['feishu']);
+    }
+  });
+
+  test('falls back to ipcTaskId when data.taskId is empty string', () => {
+    // Empty-string taskId is treated as absent (matches extractLastTaskId
+    // truthy semantics — see container-input-taskid.test.ts).
+    const data: IpcMessageInputs = { taskId: '', isScheduledTask: true };
+    const deps = makeDeps(
+      { 'ipc-task': { notify_channels: ['telegram'], chat_jid: null } },
+      new Set(),
+    );
+    const decision = resolveTaskRoutingDecision(data, 'ipc-task', true, deps);
+    expect(decision.mode).toBe('broadcast');
+    if (decision.mode === 'broadcast') {
+      expect(decision.effectiveTaskId).toBe('ipc-task');
+      expect(decision.notifyChannels).toEqual(['telegram']);
+    }
+  });
+
+  test('effectiveTaskId is undefined when neither data.taskId nor ipcTaskId is set', () => {
+    // Legacy isolated-run flag without a resolvable task record: still
+    // broadcast, but notifyChannels is undefined (fan out to everything).
+    const data: IpcMessageInputs = { isScheduledTask: true };
+    const deps = makeDeps({}, new Set());
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('broadcast');
+    if (decision.mode === 'broadcast') {
+      expect(decision.effectiveTaskId).toBeUndefined();
+      expect(decision.notifyChannels).toBeUndefined();
+    }
+  });
+});
+
+describe('resolveTaskRoutingDecision — direct vs broadcast', () => {
+  test('task with IM-valid chat_jid → mode direct', () => {
+    const data: IpcMessageInputs = { taskId: 't1' };
+    const deps = makeDeps(
+      { t1: { notify_channels: ['feishu'], chat_jid: 'oc_group_123' } },
+      new Set(['oc_group_123']),
+    );
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('direct');
+    if (decision.mode === 'direct') {
+      expect(decision.taskChatJid).toBe('oc_group_123');
+      expect(decision.effectiveTaskId).toBe('t1');
+      expect(decision.notifyChannels).toEqual(['feishu']);
+    }
+  });
+
+  test('task with non-IM chat_jid (e.g. web:main) → mode broadcast', () => {
+    // getChannelType returns null for web-prefixed jids, so the task has no
+    // valid IM target and we must fall back to broadcast.
+    const data: IpcMessageInputs = { taskId: 't1' };
+    const deps = makeDeps(
+      { t1: { notify_channels: null, chat_jid: 'web:main' } },
+      new Set(), // no IM jids registered
+    );
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('broadcast');
+  });
+
+  test('task with null chat_jid → mode broadcast', () => {
+    const data: IpcMessageInputs = { taskId: 't1' };
+    const deps = makeDeps(
+      { t1: { notify_channels: ['telegram'], chat_jid: null } },
+      new Set(),
+    );
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('broadcast');
+  });
+
+  test('missing task record → mode broadcast with undefined notify channels', () => {
+    // Task was deleted between prompt injection and output emission. We
+    // still attempt to deliver the output (broadcast everywhere) rather
+    // than swallowing it.
+    const data: IpcMessageInputs = { taskId: 'deleted-task' };
+    const deps = makeDeps({ 'deleted-task': null }, new Set());
+    const decision = resolveTaskRoutingDecision(data, null, true, deps);
+    expect(decision.mode).toBe('broadcast');
+    if (decision.mode === 'broadcast') {
+      expect(decision.effectiveTaskId).toBe('deleted-task');
+      expect(decision.notifyChannels).toBeUndefined();
+    }
+  });
+});
+
+/**
+ * Regression tests for fix F: the broadcast folder must be the emitting
+ * workspace's own folder (`sourceFolder`), NEVER the owner's home folder.
+ *
+ * Why this exists: `broadcastToOwnerIMChannels` itself is folder-agnostic —
+ * it does whatever matching the caller asks for. The bug was in the caller
+ * (src/index.ts processGroupIpc) passing the wrong folder. Before this
+ * helper was extracted, a mutation flipping the call site back to owner
+ * home would silently pass CI (QA confirmed: 0/99 red). These tests lock
+ * the choice inside the helper so such a regression shows up as a
+ * functional change to resolveBroadcastFolder, not an innocent-looking
+ * one-line edit at the call site.
+ */
+describe('resolveBroadcastFolder', () => {
+  test('returns sourceFolder when ownerHome differs — home MUST NOT win', () => {
+    // Scenario: user has a non-home workspace `ws-x` bound to a Feishu group.
+    // Before fix F, the code returned ownerHome.folder (='home-u1'), which
+    // meant the Feishu group on `ws-x` never received task results.
+    expect(resolveBroadcastFolder('ws-x', 'home-u1')).toBe('ws-x');
+  });
+
+  test('returns sourceFolder when ownerHome is null', () => {
+    // Happens when sourceGroupEntry.created_by is unset (legacy rows).
+    expect(resolveBroadcastFolder('ws-x', null)).toBe('ws-x');
+  });
+
+  test('returns sourceFolder when ownerHome is undefined', () => {
+    // Happens when getUserHomeGroup returns undefined.
+    expect(resolveBroadcastFolder('ws-x', undefined)).toBe('ws-x');
+  });
+
+  test('returns sourceFolder even when it coincidentally equals ownerHome', () => {
+    // For admin on home workspace, both candidates are the same folder.
+    // Behaviorally correct either way, but we still commit to sourceFolder.
+    expect(resolveBroadcastFolder('main', 'main')).toBe('main');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Scope vitest's root-level discovery to project tests only.
+// `data/` holds the user's agent scratch workspaces (gitignored) which can
+// contain nested projects with their own test suites; vitest does not respect
+// .gitignore, so we must exclude explicitly.
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', 'data/**', '.claude/**'],
+  },
+});

--- a/web/src/components/tasks/CreateTaskForm.tsx
+++ b/web/src/components/tasks/CreateTaskForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Loader2, Sparkles, X, SlidersHorizontal } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -15,6 +15,9 @@ import { api } from '../../api/client';
 import { showToast } from '../../utils/toast';
 import { INTERVAL_UNITS, CHANNEL_OPTIONS, toggleNotifyChannel } from '../../utils/task-utils';
 import { useConnectedChannels } from '../../hooks/useConnectedChannels';
+import { useTasksStore } from '../../stores/tasks';
+import { useGroupsStore } from '../../stores/groups';
+import { CHANNEL_LABEL } from '../settings/channel-meta';
 
 interface CreateTaskFormProps {
   onSubmit: (data: {
@@ -25,6 +28,8 @@ interface CreateTaskFormProps {
     executionMode?: 'host' | 'container';
     scriptCommand: string;
     notifyChannels: string[] | null;
+    chatJid?: string;
+    contextMode?: 'group' | 'isolated';
   }) => Promise<void>;
   onClose: () => void;
   isAdmin?: boolean;
@@ -56,9 +61,98 @@ export function CreateTaskForm({ onSubmit, onClose, isAdmin }: CreateTaskFormPro
 
   // --- Shared state ---
   const [notifyChannels, setNotifyChannels] = useState<string[] | null>(null);
+  const [chatJid, setChatJid] = useState<string>('');
+  const [contextMode, setContextMode] = useState<'group' | 'isolated'>('group');
+  const [executionModeExplicit, setExecutionModeExplicit] = useState<boolean>(false);
   const connectedChannels = useConnectedChannels();
 
+  const groupNames = useTasksStore((s) => s.groupNames);
+  const loadTasks = useTasksStore((s) => s.loadTasks);
+  const groups = useGroupsStore((s) => s.groups);
+  const loadGroups = useGroupsStore((s) => s.loadGroups);
+
+  useEffect(() => {
+    if (Object.keys(groupNames).length === 0) {
+      loadTasks();
+    }
+    if (Object.keys(groups).length === 0) {
+      loadGroups();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync executionMode from selected workspace when user hasn't manually overridden.
+  // For the "default" option (empty chatJid), fall back to a role-based placeholder
+  // that matches what the backend infers for the user's own home workspace.
+  useEffect(() => {
+    if (executionModeExplicit) return;
+    const sourceMode = chatJid ? groups[chatJid]?.execution_mode : undefined;
+    const next = sourceMode ?? (isAdmin ? 'host' : 'container');
+    setFormData((prev) =>
+      prev.executionMode === next ? prev : { ...prev, executionMode: next },
+    );
+  }, [chatJid, groups, executionModeExplicit, isAdmin]);
+
   const isScript = formData.executionType === 'script';
+
+  const sortedGroupEntries = Object.entries(groupNames).sort(([a], [b]) => {
+    const aWeb = a.startsWith('web:') ? 0 : 1;
+    const bWeb = b.startsWith('web:') ? 0 : 1;
+    if (aWeb !== bWeb) return aWeb - bWeb;
+    return a.localeCompare(b);
+  });
+
+  const formatGroupLabel = (jid: string, name: string) => {
+    const channelType = jid.split(':')[0];
+    const channelLabel = CHANNEL_LABEL[channelType] || (channelType === 'web' ? 'Web' : channelType);
+    const shortId = jid.split(':').slice(1).join(':');
+    return `[${channelLabel}] ${name} (${shortId})`;
+  };
+
+  const renderTargetWorkspace = () => (
+    <div>
+      <label className="block text-sm font-medium text-foreground mb-2">消息目标</label>
+      <Select
+        value={chatJid || '__default__'}
+        onValueChange={(value) => setChatJid(value === '__default__' ? '' : value)}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__default__">默认（我的主工作区）</SelectItem>
+          {sortedGroupEntries.map(([jid, name]) => (
+            <SelectItem key={jid} value={jid}>
+              {formatGroupLabel(jid, name)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="mt-1 text-xs text-muted-foreground">
+        选择任务结果投递的目标工作区；默认落到你的主工作区
+      </p>
+    </div>
+  );
+
+  const renderContextMode = () => (
+    <div>
+      <label className="block text-sm font-medium text-foreground mb-2">上下文模式</label>
+      <Select value={contextMode} onValueChange={(value) => setContextMode(value as 'group' | 'isolated')}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="group">复用源工作区（group）</SelectItem>
+          <SelectItem value="isolated">独立临时工作区（isolated）</SelectItem>
+        </SelectContent>
+      </Select>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {contextMode === 'group'
+          ? '任务复用源工作区的会话、记忆和 skills，prompt 作为新消息注入'
+          : '每次执行创建新的 task-xxxx 工作区，fresh session，与源工作区隔离'}
+      </p>
+    </div>
+  );
 
   const connectedKeys = CHANNEL_OPTIONS.filter((c) => connectedChannels[c.key]).map((c) => c.key);
 
@@ -76,10 +170,18 @@ export function CreateTaskForm({ onSubmit, onClose, isAdmin }: CreateTaskFormPro
     if (!aiDescription.trim()) return;
     setAiSubmitting(true);
     try {
-      await api.post('/api/tasks/ai', {
+      // AI mode always sends context_mode — the execution_type (agent/script)
+      // is decided by the backend parser, not the client. If the parser
+      // resolves to script, the backend ignores context_mode server-side.
+      const body: Record<string, unknown> = {
         description: aiDescription.trim(),
         notify_channels: notifyChannels,
-      });
+        context_mode: contextMode,
+      };
+      if (chatJid) {
+        body.chat_jid = chatJid;
+      }
+      await api.post('/api/tasks/ai', body);
       showToast('任务已创建', 'AI 正在后台解析调度参数，稍后自动激活');
       onClose();
     } catch (error) {
@@ -134,16 +236,27 @@ export function CreateTaskForm({ onSubmit, onClose, isAdmin }: CreateTaskFormPro
       finalScheduleValue = new Date(onceDateTime).toISOString();
     }
     setSubmitting(true);
+    // Clear any lingering store error so we can detect whether this submit failed.
+    useTasksStore.setState({ error: null });
     try {
       await onSubmit({
         prompt: formData.prompt,
         scheduleType: formData.scheduleType,
         scheduleValue: finalScheduleValue,
         executionType: formData.executionType,
-        executionMode: formData.executionMode,
+        executionMode: executionModeExplicit ? formData.executionMode : undefined,
         scriptCommand: formData.scriptCommand,
         notifyChannels,
+        chatJid: chatJid || undefined,
+        contextMode: !isScript ? contextMode : undefined,
       });
+      // The store swallows API errors into state.error; surface it as a toast
+      // so the user sees why the submit failed. TasksPage keeps the form open
+      // whenever state.error is set.
+      const storeError = useTasksStore.getState().error;
+      if (storeError) {
+        showToast('创建失败', storeError);
+      }
     } catch (error) {
       console.error('Failed to create task:', error);
     } finally {
@@ -252,6 +365,9 @@ export function CreateTaskForm({ onSubmit, onClose, isAdmin }: CreateTaskFormPro
               </p>
             </div>
 
+            {renderTargetWorkspace()}
+            {renderContextMode()}
+
             {renderNotifyChannels()}
 
             {/* Actions */}
@@ -318,9 +434,10 @@ export function CreateTaskForm({ onSubmit, onClose, isAdmin }: CreateTaskFormPro
                 </label>
                 <Select
                   value={formData.executionMode}
-                  onValueChange={(value) =>
-                    setFormData({ ...formData, executionMode: value as 'host' | 'container' })
-                  }
+                  onValueChange={(value) => {
+                    setExecutionModeExplicit(true);
+                    setFormData({ ...formData, executionMode: value as 'host' | 'container' });
+                  }}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue />
@@ -331,10 +448,15 @@ export function CreateTaskForm({ onSubmit, onClose, isAdmin }: CreateTaskFormPro
                   </SelectContent>
                 </Select>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  宿主机模式直接在服务器上运行，Docker 容器模式在隔离环境中运行
+                  {executionModeExplicit
+                    ? '已手动指定执行模式，不再跟随源工作区'
+                    : '默认继承源工作区的执行模式，选择后将锁定不再自动同步'}
                 </p>
               </div>
             )}
+
+            {renderTargetWorkspace()}
+            {!isScript && renderContextMode()}
 
             {/* Script Command */}
             {isScript && (

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -36,6 +36,8 @@ export function TasksPage() {
     executionMode?: 'host' | 'container';
     scriptCommand: string;
     notifyChannels: string[] | null;
+    chatJid?: string;
+    contextMode?: 'group' | 'isolated';
   }) => {
     await createTask(
       data.prompt,
@@ -45,8 +47,14 @@ export function TasksPage() {
       data.executionMode,
       data.scriptCommand,
       data.notifyChannels,
+      data.chatJid,
+      data.contextMode,
     );
-    setShowCreateForm(false);
+    // Only close the form when the store reports no error — failures surface
+    // as a toast inside CreateTaskForm and the form stays open for retry.
+    if (!useTasksStore.getState().error) {
+      setShowCreateForm(false);
+    }
   };
 
   const handlePause = async (id: string) => {

--- a/web/src/stores/tasks.ts
+++ b/web/src/stores/tasks.ts
@@ -49,6 +49,8 @@ interface TasksState {
     executionMode?: 'host' | 'container',
     scriptCommand?: string,
     notifyChannels?: string[] | null,
+    chatJid?: string,
+    contextMode?: 'group' | 'isolated',
   ) => Promise<void>;
   updateTaskStatus: (id: string, status: 'active' | 'paused') => Promise<void>;
   updateTask: (id: string, fields: Record<string, unknown>) => Promise<void>;
@@ -98,6 +100,8 @@ export const useTasksStore = create<TasksState>((set, get) => ({
     executionMode?: 'host' | 'container',
     scriptCommand?: string,
     notifyChannels?: string[] | null,
+    chatJid?: string,
+    contextMode?: 'group' | 'isolated',
   ) => {
     try {
       const normalizedScheduleValue =
@@ -121,6 +125,12 @@ export const useTasksStore = create<TasksState>((set, get) => ({
       }
       if (notifyChannels !== undefined) {
         body.notify_channels = notifyChannels;
+      }
+      if (chatJid) {
+        body.chat_jid = chatJid;
+      }
+      if (contextMode) {
+        body.context_mode = contextMode;
       }
       await api.post('/api/tasks', body);
       set({ error: null });


### PR DESCRIPTION
## Motivation

定时任务在群聊中执行完成后，**回复不会转发到工作区绑定的 IM 群**。用户把飞书群绑到非 home 工作区用来接收任务结果的场景完全不 work。另外，创建任务的 UI 没有"消息目标"下拉，用户只能按默认（home 工作区）建完、再点进去编辑——割裂的体验。

## 问题表现

用户视角下的两个具体场景都失败：

| 用户选的"消息目标" | 执行位置 | 结果投递 |
|-------------------|---------|---------|
| 工作区 JID（web:xxx，绑了飞书群 F）| ✅ 在该工作区 | ❌ 只写工作区聊天历史，不推到 F |
| 飞书群 JID | ❌ 执行到了用户 home 工作区 | ✅ 能发到飞书 |

附带发现（同一个 bug 家族）：
- 群聊 @ 机器人用 MCP `schedule_task` 创建的任务 DB 里 `execution_mode=null`，TaskDetail UI 直接隐藏"执行模式"字段——用户以为没设置。
- 创建任务界面完全不暴露 `chat_jid` 和 `context_mode`——这两个字段 c34c4b6 移除 UI 的理由（"每个任务独立工作区，不需要"）在 faa052b 引入 `context_mode='group'` 后失效了，UI 没跟上。

## 根因

**根因 1：group 模式 IM 转发静默失效**
`src/task-scheduler.ts:713` `runGroupModeTask` 复用普通消息管道（`enqueueMessageCheck`）执行，`ContainerInput` 里**没有** `isScheduledTask` 标志——全仓库唯一塞入 `isScheduledTask: true` 的位置是 `src/task-scheduler.ts:418`（只在 isolated 路径的 `runTask`）。`src/index.ts:4404` 的 IM 路由分支 `if (data.isScheduledTask && ...)` 因此在 group 模式下永远不进入。

**根因 2：Fallback 硬编码到用户 home folder**
- `src/index.ts:4339-4341` `ownerHomeFolderForIm` 写死 `getUserHomeGroup(sourceGroupEntry.created_by).folder`
- `src/index.ts:8270-8282` `storeResultAndNotify` 同样用 `getUserHomeGroup(ownerId).folder`
- `broadcastToOwnerIMChannels` 只匹配 `folder === sourceFolder` 的 IM 群——**非 home 工作区绑的 IM 群永远匹配不上**。

**根因 3：execution_mode 不继承源工作区**
- MCP `schedule_task` 路径不提供 execution_mode 时存 null。
- Web `POST /api/tasks` 路径 admin 硬编码默认 host，不看源工作区。
- PATCH `/api/tasks/:id` 没有"execution_mode 和 chat_jid 一致性"校验。
- AI 路径 `POST /api/tasks/ai` 也是硬编码。
- 结果：admin 在 docker 工作区建的任务可能被判成 host 运行（反之亦然），和源工作区不一致。

**根因 4：UI 不暴露 chat_jid / context_mode**
`CreateTaskForm` 只有 prompt/schedule/notify_channels。原作者 c34c4b6 移除了工作区选择和上下文模式 UI，理由是"每个任务独立工作区不需要选"。但之后 faa052b 引入 `context_mode='group'`（注入源工作区、复用 session/skills/历史），两种模式有了语义差异——UI 没跟上。

## 方案

### 1. per-message `taskId` 打通 group 模式 IM 转发

- `messages` 表 v34→v35 加 `task_id TEXT` 列（`ensureColumn` 幂等迁移）。
- `storePromptMessage` 签名加 `taskId?`，把 `task.id` 随 prompt 一起写进 meta。
- `ContainerInput.messageTaskId` 字段（src + agent-runner 两端同步）。
- `processGroupMessages` 从 `missedMessages` 扫描最后一条 `task_id` 设到 ContainerInput。
- `McpContext.currentTaskId` 可变字段；agent-runner 主循环 + interrupt-resume 两点**每 turn 清理**（防止任务完成后普通用户消息也被误标 taskId）。
- `send_message` / `send_image` MCP 工具输出若 `ctx.currentTaskId` 非空则带 `data.taskId`。
- `src/index.ts:4404` IPC 消费者改 dual-gate：`(data.isScheduledTask || data.taskId) && ...`，优先用 `data.taskId` 查 task 路由。
- 抽取 `src/task-routing.ts` 纯函数模块（`extractLastTaskId` / `resolveTaskRoutingDecision` / `broadcastToOwnerIMChannels`），让路由决策可被单测锁定。

### 2. broadcast folder 用源工作区而非 home

- `src/index.ts:4339-4341` `ownerHomeFolderForIm` 改为直接用 `sourceGroup`（即 IPC 消息来源的 folder 本身）。
- `storeResultAndNotify` 加 `workspaceFolder` 参数，调用方（runTask / runScriptTask）传 `workspace.folder` 或 `task.group_folder`。
- 新增 `resolveBroadcastFolder(sourceFolder, ownerHomeFolder)` helper，用"witness 参数"设计：**永远返回 sourceFolder，即便显式传入 ownerHomeFolder 也不让它胜出**。配合单测锁定此语义——任何试图把 fix 改回 pre-fix-F 行为都会 CI 红。

### 3. execution_mode 按源工作区推断（四条路径对齐）

统一规则——**消息目标工作区的 executionMode 决定任务可用的模式，role 不参与判断**：

| 源工作区 | 任务默认 | 允许显式设 | admin 也不行 |
|---------|---------|-----------|-------------|
| Docker | container | 仅 container | ❌ 不能设 host |
| Host | host | host 或 container | — |

四条路径同步：
- MCP `schedule_task`（`src/index.ts`）：agent 请求 host 但源是 docker → warn 降级 + 继续执行。
- Web `POST /api/tasks`（`src/routes/tasks.ts`）：请求 host 但源是 docker → 400（即便 admin）。
- Web `PATCH /api/tasks/:id`：改 chat_jid 到 docker 工作区但 execution_mode=host → 400（最终状态一致性校验）。
- AI `POST /api/tasks/ai`：源工作区继承 + 同样的 host 拒绝逻辑。

### 4. 创建表单补齐两个下拉 + 联动

- `CreateTaskForm` 加"消息目标"和"上下文模式"下拉（AI + 手动模式都暴露）；script 模式下 context_mode 隐藏。
- `executionMode` 按所选工作区自动同步（`useGroupsStore.groups[chatJid].execution_mode`，空 chatJid 时 fallback role 默认 placeholder）；用户显式切过后不再自动覆盖；提交时若未显式切则省略字段让后端 infer。
- 手动模式提交失败显示 toast、保留表单内容（和 AI 模式对称；之前手动模式静默关表单，Claude reviewer 发现）。
- `GET /api/tasks` 构建 `groupNames` 时对非 admin 过滤 host 工作区，避免 UI 权限泄露（Codex reviewer 发现；后端 POST 硬校验仍在，这只是视觉对齐）。

## 质量门禁

- **103 个单测全绿**（新增 45 个，覆盖 DB roundtrip / helper / mixed-batch / MCP 输出契约 / 路由决策 3 路分支 / broadcastFolder witness 语义）
- **Mutation testing 验证**（QA 独立跑过 3 个 mutation）：
  - dual-gate `||` → `&&`：8/11 用例红
  - 删 `|| data.taskId`：5/11 用例红
  - `resolveBroadcastFolder` 改回 pre-fix-F：1/4 用例红（witness 参数设计有效）
- **两轮独立 review**：
  - Round 1（后端路由）：Claude reviewer + Codex 都 pass（Codex 原提 conditional，强制条件已整改：抽 `resolveTaskRoutingDecision` + mixed-batch 锁定测试 + 重命名）。
  - Round 2（UI 补齐）：Claude reviewer 通过 + 建议（minor UX 已修）；Codex conditional pass 的两个条件（非 admin 看到 host 工作区、executionMode 切回默认残留）已修。
- `make typecheck` 后端 + 前端 + agent-runner 全绿。
- `cd web && npm run build` 全绿。

## Commits（3 个逻辑切片）

1. `修复: 定时任务消息路由到绑定 IM 群 + 创建表单补齐消息目标/上下文模式`
   —— 13 文件 +656/-119：后端路由、执行模式推断、前端 UI 补齐、task-routing.ts 抽取
2. `测试: 新增 45 个单测覆盖定时任务路由决策 / mixed-batch / helper 函数`
   —— 5 个新测试文件 +818
3. `配置: vitest 排除 data/** 避免嵌套项目测试干扰`
   —— vitest.config.ts +11

## 已知的非阻断小问题（下个 PR 可顺手清理）

- `CreateTaskForm.tsx` `handleAiCreate` 里 nit2 注释措辞精度：写了"the backend ignores context_mode server-side"，严格讲应该是"the script execution path ignores"——字段还是会存入 DB，只是 script 执行路径不读它。
- `src/routes/tasks.ts` 新加的 host 过滤注释 "Mirror the visibility rule used by GET /api/groups"——实际我们对 host 工作区比 groups.ts 更严格（后者允许非 admin 看到自己的 home 即便 host 模式，前者在任务下拉里完全隐藏）。注释字面略不严谨。

## Out of scope（可作后续 PR）

- TaskDetail.tsx 编辑模式也应做 execution_mode 自动联动（目前只有创建表单）。
- 前端引入 vitest + @testing-library/react 测试框架；现状 UI 行为改动只靠后端测试 + 人工验证。
- `messages.task_id` 的 orphan 清理：任务删除时不会把历史 `messages.task_id` 清 NULL（当前代码对 orphan 安全，fallback 广播，但数据卫生可以改）。
- `drainIpcInput` 里的 `taskId` 透传是前瞻性的，当前 `GroupQueue.sendMessage` 不写入 IPC taskId。