### PR TITLE
新增: 工作区文件列表按钮复制 Agent 视角绝对路径

### DIFF
--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -20,6 +20,7 @@ export interface FileEntry {
   size: number;
   modifiedAt: string;
   isSystem: boolean;
+  absolutePath?: string; // Agent 视角的绝对路径（container 模式为 /workspace/group/...，host 模式为宿主机路径）
 }
 
 // 常量

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -19,6 +19,7 @@ import {
   MAX_FILE_SIZE,
   getGroupStorageUsage,
   invalidateGroupStorageUsage,
+  getFileRoot,
 } from '../file-manager.js';
 import { checkStorageLimit, isBillingEnabled } from '../billing.js';
 import { execFile } from 'node:child_process';
@@ -138,6 +139,24 @@ function getFileRootOverride(group: RegisteredGroup): string | undefined {
     : undefined;
 }
 
+/**
+ * 计算 Agent 视角的绝对路径（供前端"复制路径"功能使用）。
+ * - container 模式：容器内挂载路径 /workspace/group/<relative>
+ * - host 模式：宿主机绝对路径（customCwd 或 data/groups/{folder}）+ relative
+ */
+function getAgentAbsolutePath(
+  group: RegisteredGroup,
+  relativePath: string,
+): string {
+  if (group.executionMode === 'host') {
+    const base = getFileRoot(group.folder, getFileRootOverride(group));
+    return relativePath ? path.join(base, relativePath) : base;
+  }
+  return relativePath
+    ? path.posix.join('/workspace/group', relativePath)
+    : '/workspace/group';
+}
+
 function buildAttachmentContentDisposition(fileName: string): string {
   const sanitized = fileName.replace(/["\\\r\n]/g, '_');
   const asciiFallback = sanitized.replace(/[^\x20-\x7E]/g, '_') || 'download';
@@ -238,7 +257,11 @@ fileRoutes.get('/:jid/files', authMiddleware, (c) => {
 
   try {
     const result = listFiles(group.folder, subPath, getFileRootOverride(group));
-    return c.json(result);
+    const files = result.files.map((entry) => ({
+      ...entry,
+      absolutePath: getAgentAbsolutePath(group, entry.path),
+    }));
+    return c.json({ ...result, files });
   } catch (error) {
     logger.error({ err: error }, `Failed to list files for ${jid}`);
     return c.json({ error: 'Failed to list files' }, 500);

--- a/web/src/components/chat/FilePanel.tsx
+++ b/web/src/components/chat/FilePanel.tsx
@@ -22,6 +22,7 @@ import {
   Film,
   Music,
   AlertCircle,
+  Copy,
 } from 'lucide-react';
 import { useFileStore, FileEntry, toBase64Url } from '../../stores/files';
 import { useChatStore } from '../../stores/chat';
@@ -31,6 +32,7 @@ import { api } from '../../api/client';
 import { withBasePath } from '../../utils/url';
 import { downloadFromUrl } from '../../utils/download';
 import { showToast } from '../../utils/toast';
+import { copyToClipboard } from '../../utils/clipboard';
 import {
   Dialog,
   DialogContent,
@@ -904,6 +906,19 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
     });
   };
 
+  const handleCopyPath = (item: FileEntry) => {
+    const target = item.absolutePath || item.path;
+    copyToClipboard(target)
+      .then(() => showToast('已复制', target))
+      .catch((err) => {
+        console.error('Copy failed:', err);
+        showToast(
+          '复制失败',
+          err instanceof Error ? err.message : '无法写入剪贴板',
+        );
+      });
+  };
+
   const handleDeleteClick = (item: FileEntry) => {
     setDeleteModal({
       open: true,
@@ -1100,52 +1115,40 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                   </div>
 
                   {/* Actions */}
-                  {!item.isSystem && (
-                    <div className="flex-shrink-0 flex items-center gap-0.5">
-                      {/* Edit button for text files */}
-                      {item.type === 'file' &&
-                        TEXT_EXTENSIONS.has(getFileExt(item.name)) && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setPreview({ kind: 'edit', file: item });
-                            }}
-                            className="p-2.5 rounded hover:bg-brand-100 text-muted-foreground hover:text-primary transition-colors cursor-pointer"
-                            title="编辑"
-                            aria-label="编辑文件"
-                          >
-                            <Pencil className="w-3.5 h-3.5" />
-                          </button>
-                        )}
-                      {item.type === 'file' && (
+                  <div className="flex-shrink-0 flex items-center gap-0.5">
+                    {/* Copy absolute path (always available) */}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleCopyPath(item);
+                      }}
+                      className="p-2.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                      title={
+                        item.absolutePath
+                          ? `复制路径：${item.absolutePath}`
+                          : '复制路径'
+                      }
+                      aria-label="复制绝对路径"
+                    >
+                      <Copy className="w-3.5 h-3.5" />
+                    </button>
+                    {/* Edit button for non-system text files */}
+                    {!item.isSystem &&
+                      item.type === 'file' &&
+                      TEXT_EXTENSIONS.has(getFileExt(item.name)) && (
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            handleDownload(item);
+                            setPreview({ kind: 'edit', file: item });
                           }}
-                          className="p-2.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                          title="下载"
-                          aria-label="下载文件"
+                          className="p-2.5 rounded hover:bg-brand-100 text-muted-foreground hover:text-primary transition-colors cursor-pointer"
+                          title="编辑"
+                          aria-label="编辑文件"
                         >
-                          <Download className="w-3.5 h-3.5" />
+                          <Pencil className="w-3.5 h-3.5" />
                         </button>
                       )}
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDeleteClick(item);
-                        }}
-                        className="p-2.5 rounded hover:bg-red-100 dark:hover:bg-red-950/40 text-muted-foreground hover:text-red-600 dark:hover:text-red-400 transition-colors cursor-pointer"
-                        title="删除"
-                        aria-label="删除文件"
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
-                    </div>
-                  )}
-                  {/* System files: download only */}
-                  {item.isSystem && item.type === 'file' && (
-                    <div className="flex-shrink-0">
+                    {item.type === 'file' && (
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1157,8 +1160,21 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                       >
                         <Download className="w-3.5 h-3.5" />
                       </button>
-                    </div>
-                  )}
+                    )}
+                    {!item.isSystem && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteClick(item);
+                        }}
+                        className="p-2.5 rounded hover:bg-red-100 dark:hover:bg-red-950/40 text-muted-foreground hover:text-red-600 dark:hover:text-red-400 transition-colors cursor-pointer"
+                        title="删除"
+                        aria-label="删除文件"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                  </div>
                 </div>
               );
             })}

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -8,6 +8,7 @@ export interface FileEntry {
   size: number;
   modifiedAt: string;
   isSystem: boolean;
+  absolutePath?: string;
 }
 
 export interface UploadProgress {


### PR DESCRIPTION
## 问题描述

在【工作区文件管理】面板里，每一个文件/文件夹只能看到名称，想把某个文件发给 Agent 让它精确定位时，需要手动拼路径（容器路径 vs 宿主机路径还要区分执行模式），体验繁琐。

## 实现方案

为每个文件/文件夹行新增"复制路径"按钮，点击即把 Agent 视角的绝对路径写入剪贴板，可直接粘贴到对话里。

路径按群组执行模式生成：
- `container` 模式 → `/workspace/group/<relative>`（容器内挂载路径）
- `host` 模式 → `customCwd || data/groups/<folder>` 拼接 relative 后的宿主机绝对路径

复制按钮对所有条目（含系统文件夹 `logs/`、`.claude/` 等）都显示 — 复制是纯读操作，Agent 偶尔也需要指向系统目录。

### `src/file-manager.ts`
- `FileEntry` 接口新增可选字段 `absolutePath`

### `src/routes/files.ts`
- 新增 `getAgentAbsolutePath()`，按执行模式生成容器 / 宿主机绝对路径
- `GET /:jid/files` 响应为每个 entry 附加 `absolutePath`

### `web/src/stores/files.ts`
- `FileEntry` 接口同步新增 `absolutePath` 字段

### `web/src/components/chat/FilePanel.tsx`
- 引入 `Copy` 图标 + `copyToClipboard` 工具
- 新增 `handleCopyPath()` 处理点击事件并 toast 提示复制内容
- 统一行级 Actions 区：复制按钮对所有条目可见，编辑/下载/删除按钮按原规则展示

## 测试

- `make typecheck` 通过（后端 + 前端 + agent-runner）
- `make test` 通过（53/53）

🤖 Generated with [Claude Code](https://claude.com/claude-code)