### PR TITLE
修复: agent-runner 添加 @anthropic-ai/claude-code 直接依赖

### DIFF
--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "*",
+    "@anthropic-ai/claude-code": "*",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## 问题描述

`@anthropic-ai/claude-agent-sdk` 的 `optionalDependencies` 中声明的 native binary 包
（`@anthropic-ai/claude-agent-sdk-linux-x64` 等）在 npm 上全部为空包（版本 `0.0.0`，仅含 `LICENSE.md`），
导致 SDK 在运行时找不到 `claude` CLI 并报错：

```
Native CLI binary for linux-x64 not found. Reinstall @anthropic-ai/claude-agent-sdk without --omit=optional, or set options.pathToClaudeCodeExecutable.
```

## 修复方案

在 `container/agent-runner/package.json` 的 `dependencies` 中添加 `@anthropic-ai/claude-code` 作为直接依赖。
该包包含真实的 `claude` 二进制（版本 `*`，与 SDK 保持一致），确保 `npm install` 后 SDK 能正常找到 CLI。

## 测试计划

- [ ] `cd container/agent-runner && npm install && npm run build` 成功
- [ ] `make start` 启动后，宿主机 agent 不再报 "Native CLI binary not found" 错误
- [ ] 飞书/钉钉发送消息，agent 能正常回复

🤖 Generated with [Claude Code](https://claude.ai/code)