### PR TITLE
fix: agent-runner 通过 pathToClaudeCodeExecutable 传递 CLI 路径

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { execFileSync } from 'child_process';
 import { query, HookCallback, PreCompactHookInput, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { detectImageMimeTypeFromBase64Strict } from './image-detector.js';
 import { pruneProcessedHistoryImagesInTranscript as pruneProcessedHistoryImagesInTranscriptFile } from './history-image-prune.js';
@@ -1267,10 +1268,35 @@ async function runQuery(
     flagSettings.autoCompactWindow = autoCompactWindow;
   }
 
+  // Resolve the actual claude CLI path using `which`.
+  // SDK 的 optionalDependencies（@anthropic-ai/claude-agent-sdk-linux-x64 等）在 npm 上是空包，
+  // 无法通过 node_modules/.bin/ 找到 working binary。通过 which 找到实际路径后传给 SDK。
+  let pathToClaudeCodeExecutable: string | undefined;
+  try {
+    const resolvedPath = execFileSync('which', ['claude'], { timeout: 5_000, encoding: 'utf-8' }).trim();
+    if (resolvedPath) {
+      pathToClaudeCodeExecutable = resolvedPath;
+    }
+  } catch {
+    // Fallback: try to find it in common locations
+    const commonPaths = [
+      '/usr/local/bin/claude',
+      '/usr/bin/claude',
+      path.join(process.env.HOME || '/root', '.local/bin/claude'),
+    ];
+    for (const p of commonPaths) {
+      if (fs.existsSync(p)) {
+        pathToClaudeCodeExecutable = p;
+        break;
+      }
+    }
+  }
+
   try {
     const q = query({
     prompt: stream,
     options: {
+      ...(pathToClaudeCodeExecutable && { pathToClaudeCodeExecutable }),
       model: CLAUDE_MODEL,
       cwd: WORKSPACE_GROUP,
       additionalDirectories: extraDirs,

--- a/src/agent-capabilities.ts
+++ b/src/agent-capabilities.ts
@@ -31,6 +31,13 @@ export interface AgentCapability {
 
 export const AGENT_CAPABILITIES: AgentCapability[] = [
   {
+    name: 'claude-code',
+    binary: 'claude',
+    required: true,
+    installHint:
+      'See https://docs.claude.com/claude-code/install.html or: curl -fsSL https://claude.ai/install.sh | bash',
+  },
+  {
     name: 'feishu-cli',
     binary: 'feishu-cli',
     required: false,
@@ -69,11 +76,29 @@ async function isBinaryAvailable(binary: string): Promise<boolean> {
   }
 }
 
+/**
+ * Resolve the actual path of a binary using `which`.
+ * This is needed because `node_modules/.bin/` may contain stubs that shadow
+ * the actual working binary.
+ */
+async function resolveBinaryPath(binary: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('which', [binary], {
+      timeout: 5_000,
+    });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 export interface CapabilityCheckResult {
   available: AgentCapability[];
   missing: AgentCapability[];
   /** Env vars to inject into the host process (only for available tools) */
   envVars: Record<string, string>;
+  /** Resolved paths for specific binaries (keyed by binary name) */
+  resolvedPaths: Record<string, string>;
 }
 
 /** Detect which agent capabilities are present on the host. */
@@ -88,6 +113,7 @@ export async function checkHostCapabilities(): Promise<CapabilityCheckResult> {
   const available: AgentCapability[] = [];
   const missing: AgentCapability[] = [];
   const envVars: Record<string, string> = {};
+  const resolvedPaths: Record<string, string> = {};
 
   for (const { cap, available: ok } of results) {
     if (ok) {
@@ -95,12 +121,20 @@ export async function checkHostCapabilities(): Promise<CapabilityCheckResult> {
       if (cap.envVars) Object.assign(envVars, cap.envVars);
       const platformVars = cap.platformEnvVars?.[os.platform()];
       if (platformVars) Object.assign(envVars, platformVars);
+
+      // Resolve the actual path for claude specifically
+      if (cap.binary === 'claude') {
+        const resolvedPath = await resolveBinaryPath(cap.binary);
+        if (resolvedPath) {
+          resolvedPaths[cap.binary] = resolvedPath;
+        }
+      }
     } else {
       missing.push(cap);
     }
   }
 
-  return { available, missing, envVars };
+  return { available, missing, envVars, resolvedPaths };
 }
 
 /** Log preflight results — warnings for missing, nothing for available. */

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1332,6 +1332,20 @@ export async function runHostAgent(
       if (!hostEnv[key]) hostEnv[key] = value;
     }
 
+    // Ensure the resolved claude binary path takes precedence over any stub in node_modules/.bin/
+    // 新版本 SDK (0.2.114+) 内部使用 which 查找 claude CLI，但 node_modules/.bin/claude
+    // 可能是 stub。通过 which 找到的实际路径应该优先被找到。
+    if (capResult.resolvedPaths['claude']) {
+      const resolvedClaudeDir = path.dirname(capResult.resolvedPaths['claude']);
+      // 将 resolved claude 所在目录放到 PATH 最前面，确保优先找到
+      const currentPath = hostEnv['PATH'] || process.env.PATH || '';
+      hostEnv['PATH'] = `${resolvedClaudeDir}:${currentPath}`;
+      logger.info(
+        { group: group.name, resolvedClaudeDir, resolvedPath: capResult.resolvedPaths['claude'] },
+        'Host preflight: using resolved claude from which',
+      );
+    }
+
     // 6. 编译检查
     const projectRoot = process.cwd();
     const agentRunnerRoot = path.join(projectRoot, 'container', 'agent-runner');


### PR DESCRIPTION
## 问题描述

SDK 的 optionalDependencies（`@anthropic-ai/claude-agent-sdk-linux-x64` 等）在 npm 上是空包（版本 0.0.0，仅含 LICENSE.md），导致 SDK 运行时找不到 Claude CLI 并报错：

```
Native CLI binary for linux-x64 not found
```

**问题版本**：`@anthropic-ai/claude-agent-sdk >= 0.2.113`

## 修复方案

1. **agent-runner/index.ts**: 通过 `which claude` 找到实际 CLI 路径，通过 `pathToClaudeCodeExecutable` 选项直接传给 SDK
2. **agent-capabilities.ts**: 添加 `claude-code` 到 `AGENT_CAPABILITIES`，新增 `resolveBinaryPath()` 解析实际路径  
3. **container-runner.ts**: 将 resolved claude 目录添加到 PATH（host 模式保障）

## 根因

上游 `@anthropic-ai/claude-agent-sdk` 的 optionalDependencies 中的 native binary 包在 npm registry 上是空包，postinstall 脚本无法正确链接 working binary。建议下游直接依赖 `@anthropic-ai/claude-code` 以确保 CLI 可用。

## 测试

已在本地验证通过，服务正常启动并运行。

Co-Generated by Claude Opus 4.6