### PR TITLE
功能: QQ C2C 私聊流式消息（打字机效果）

### DIFF
--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -42,13 +42,15 @@ import {
 } from './feishu-streaming-card.js';
 import type { DingTalkStreamingCardController } from './dingtalk-streaming-card.js';
 import type { DiscordStreamingEditController } from './discord-streaming-edit.js';
+import type { QQStreamingController } from './qq-streaming-card.js';
 import { CHANNEL_PREFIXES } from './channel-prefixes.js';
 
-/** Union type for any streaming card controller (Feishu, DingTalk, or Discord) */
+/** Union type for any streaming card controller (Feishu, DingTalk, Discord, or QQ) */
 export type StreamingSession =
   | StreamingCardController
   | DingTalkStreamingCardController
-  | DiscordStreamingEditController;
+  | DiscordStreamingEditController
+  | QQStreamingController;
 
 // ─── Unified Interface ──────────────────────────────────────────
 
@@ -505,6 +507,28 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
 
     isConnected(): boolean {
       return inner?.isConnected() ?? false;
+    },
+
+    async createStreamingSession(
+      chatId: string,
+      _onCardCreated?: (messageId: string) => void,
+    ): Promise<StreamingSession | undefined> {
+      if (!inner) return undefined;
+      // Stream messages only work for C2C (private chat)
+      if (chatId.startsWith('group:')) return undefined;
+
+      const { QQStreamingController } = await import('./qq-streaming-card.js');
+      const openid = chatId.startsWith('c2c:') ? chatId.slice(4) : chatId;
+      const chatKey = `c2c:${openid}`;
+      const msgSeq = inner.getNextMsgSeq(chatKey);
+      const conn = inner;
+
+      return new QQStreamingController({
+        openid,
+        msgSeq,
+        sendStreamChunk: (oid, params) => conn.sendStreamMessage(oid, params),
+        fallbackSend: (text) => conn.sendMessage(chatKey, text),
+      });
     },
   };
 

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -521,13 +521,25 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       const openid = chatId.startsWith('c2c:') ? chatId.slice(4) : chatId;
       const chatKey = `c2c:${openid}`;
       const msgSeq = inner.getNextMsgSeq(chatKey);
+      const passiveMsgId = inner.getLastIncomingMsgId(openid);
       const conn = inner;
+
+      if (!passiveMsgId) {
+        // QQ stream_messages endpoint rejects requests without a passive
+        // msg_id reference. Without it there's no point starting a session.
+        logger.debug(
+          { openid },
+          'QQ streaming session skipped: no incoming msg_id yet',
+        );
+        return undefined;
+      }
 
       return new QQStreamingController({
         openid,
         msgSeq,
         sendStreamChunk: (oid, params) => conn.sendStreamMessage(oid, params),
         fallbackSend: (text) => conn.sendMessage(chatKey, text),
+        passiveMsgId,
       });
     },
   };

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -260,7 +260,7 @@ class IMConnectionManager {
     onCardCreated?: (messageId: string) => void,
   ): Promise<StreamingSession | undefined> {
     const channelType = getChannelType(jid);
-    if (channelType !== 'feishu' && channelType !== 'dingtalk' && channelType !== 'discord')
+    if (channelType !== 'feishu' && channelType !== 'dingtalk' && channelType !== 'discord' && channelType !== 'qq')
       return undefined;
 
     // Check DingTalk streaming mode: if text mode, skip streaming session creation

--- a/src/qq-streaming-card.ts
+++ b/src/qq-streaming-card.ts
@@ -1,0 +1,448 @@
+/**
+ * QQ C2C Streaming Message Controller
+ *
+ * Implements typewriter-style progressive message delivery using
+ * QQ Bot API v2's stream_messages endpoint (C2C only).
+ *
+ * Protocol:
+ *   POST /v2/users/{openid}/stream_messages
+ *   - input_mode: "replace" (each chunk replaces entire message)
+ *   - input_state: 1 (GENERATING) / 10 (DONE)
+ *   - First chunk returns stream_msg_id; subsequent chunks must include it
+ *   - msg_seq: shared across all chunks in the same session
+ *
+ * Lifecycle: idle → streaming → completed / aborted
+ * Fallback: if stream API fails, falls back to plain sendQQMessage()
+ */
+
+import { logger } from './logger.js';
+import { markdownToPlainText } from './im-utils.js';
+
+// ─── Constants ───────────────────────────────────────────────
+
+const STREAM_UPDATE_INTERVAL = 500; // ms — throttle between API calls
+
+// ─── Types ───────────────────────────────────────────────────
+
+/** Callback to send a stream chunk via QQ API */
+export type SendStreamChunkFn = (
+  openid: string,
+  params: {
+    input_mode: string;
+    input_state: number;
+    content_type: string;
+    content_raw: string;
+    msg_seq: number;
+    index: number;
+    stream_msg_id?: string;
+  },
+) => Promise<{ id?: string }>;
+
+/** Callback to send a plain message (fallback) */
+export type FallbackSendFn = (text: string) => Promise<void>;
+
+type StreamingState = 'idle' | 'streaming' | 'completed' | 'aborted';
+
+// ─── Controller ──────────────────────────────────────────────
+
+export class QQStreamingController {
+  private state: StreamingState = 'idle';
+  private accumulatedText = '';
+
+  // Stream session state
+  private streamMsgId: string | null = null;
+  private msgSeq: number;
+  private streamIndex = 0;
+  private sentChunkCount = 0;
+
+  // Throttle
+  private lastUpdateTime = 0;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Dependencies
+  private openid: string;
+  private sendStreamChunk: SendStreamChunkFn;
+  private fallbackSend: FallbackSendFn;
+  private fallbackUsed = false;
+
+  // Auxiliary state (thinking, tools, status)
+  private thinking = false;
+  private thinkingText = '';
+  private systemStatus: string | null = null;
+  private tools = new Map<
+    string,
+    {
+      name: string;
+      status: 'running' | 'complete' | 'error';
+      startTime: number;
+      summary?: string;
+    }
+  >();
+  private recentEvents: string[] = [];
+
+  // Auxiliary flush throttle
+  private auxFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastAuxFlushTime = 0;
+  private static readonly AUX_FLUSH_INTERVAL = 1500; // ms
+
+  // Display limits
+  private static readonly MAX_THINKING_CHARS = 500;
+  private static readonly MAX_TOOLS_DISPLAY = 5;
+  private static readonly MAX_TOOL_SUMMARY_CHARS = 60;
+  private static readonly MAX_RECENT_EVENTS = 5;
+
+  constructor(opts: {
+    openid: string;
+    msgSeq: number;
+    sendStreamChunk: SendStreamChunkFn;
+    fallbackSend: FallbackSendFn;
+  }) {
+    this.openid = opts.openid;
+    this.msgSeq = opts.msgSeq;
+    this.sendStreamChunk = opts.sendStreamChunk;
+    this.fallbackSend = opts.fallbackSend;
+  }
+
+  // ─── StreamingSession interface ─────────────────────────────
+
+  isActive(): boolean {
+    return this.state === 'idle' || this.state === 'streaming';
+  }
+
+  append(text: string): void {
+    if (!this.isActive()) return;
+    this.accumulatedText = text;
+    this.thinkingText = '';
+    this.thinking = false;
+    this.scheduleFlush();
+  }
+
+  async complete(finalText: string): Promise<void> {
+    if (this.state === 'completed' || this.state === 'aborted') return;
+    this.accumulatedText = finalText;
+    this.clearTimers();
+
+    if (!finalText.trim()) {
+      this.state = 'completed';
+      return;
+    }
+
+    // If we never managed to start a stream, use fallback
+    if (this.state === 'idle' || this.sentChunkCount === 0) {
+      await this.tryStartStream(finalText);
+      if (!this.streamMsgId) {
+        await this.tryFallback(finalText);
+        this.state = 'completed';
+        return;
+      }
+    }
+
+    try {
+      const content = markdownToPlainText(finalText);
+      await this.doSendChunk(content, 10); // DONE
+      this.state = 'completed';
+      logger.info(
+        { openid: this.openid, chunks: this.sentChunkCount },
+        'QQ streaming completed',
+      );
+    } catch (err: any) {
+      logger.warn(
+        { err: err.message, openid: this.openid },
+        'QQ streaming finalize failed, using fallback',
+      );
+      await this.tryFallback(finalText);
+      this.state = 'completed';
+    }
+  }
+
+  async abort(reason?: string): Promise<void> {
+    if (this.state === 'completed' || this.state === 'aborted') return;
+    this.clearTimers();
+
+    if (this.streamMsgId) {
+      const abortText = this.accumulatedText
+        ? markdownToPlainText(this.accumulatedText) + `\n\n⚠️ 已中断: ${reason ?? '用户取消'}`
+        : `⚠️ 已中断: ${reason ?? '用户取消'}`;
+      try {
+        await this.doSendChunk(abortText, 10); // DONE
+      } catch (err: any) {
+        logger.debug({ err: err.message }, 'QQ streaming abort chunk failed');
+      }
+    }
+    this.state = 'aborted';
+  }
+
+  dispose(): void {
+    this.clearTimers();
+  }
+
+  // ─── Auxiliary display methods ──────────────────────────────
+
+  setThinking(): void {
+    this.thinking = true;
+  }
+
+  appendThinking(text: string): void {
+    this.thinkingText += text;
+    if (this.thinkingText.length > QQStreamingController.MAX_THINKING_CHARS) {
+      this.thinkingText =
+        '...' +
+        this.thinkingText.slice(-(QQStreamingController.MAX_THINKING_CHARS - 3));
+    }
+    this.thinking = true;
+
+    // Show thinking state via streaming if already active
+    if (this.state === 'streaming') {
+      this.scheduleAuxFlush();
+    }
+  }
+
+  setSystemStatus(status: string | null): void {
+    this.systemStatus = status;
+    if (this.state === 'streaming') this.scheduleAuxFlush();
+  }
+
+  setHook(_hook: { hookName: string; hookEvent: string } | null): void {
+    // Not meaningful for QQ plain text
+  }
+
+  setTodos(
+    _todos: Array<{ id: string; content: string; status: string }>,
+  ): void {
+    // Too verbose for plain text
+  }
+
+  pushRecentEvent(text: string): void {
+    this.recentEvents.push(text);
+    if (this.recentEvents.length > QQStreamingController.MAX_RECENT_EVENTS) {
+      this.recentEvents = this.recentEvents.slice(
+        -QQStreamingController.MAX_RECENT_EVENTS,
+      );
+    }
+  }
+
+  startTool(toolId: string, toolName: string): void {
+    this.tools.set(toolId, {
+      name: toolName,
+      status: 'running',
+      startTime: Date.now(),
+    });
+    if (this.state === 'streaming') this.scheduleAuxFlush();
+  }
+
+  endTool(toolId: string, isError: boolean): void {
+    const tc = this.tools.get(toolId);
+    if (tc) {
+      tc.status = isError ? 'error' : 'complete';
+      this.purgeOldTools();
+      if (this.state === 'streaming') this.scheduleAuxFlush();
+    }
+  }
+
+  updateToolSummary(toolId: string, summary: string): void {
+    const tc = this.tools.get(toolId);
+    if (tc) {
+      tc.summary = summary;
+      if (this.state === 'streaming') this.scheduleAuxFlush();
+    }
+  }
+
+  getToolInfo(toolId: string): { name: string } | undefined {
+    return this.tools.get(toolId);
+  }
+
+  async patchUsageNote(_usage: {
+    inputTokens: number;
+    outputTokens: number;
+    costUSD: number;
+    durationMs: number;
+    numTurns: number;
+  }): Promise<void> {}
+
+  getAllMessageIds(): string[] {
+    return [];
+  }
+
+  // ─── Internal: auxiliary prefix ─────────────────────────────
+
+  private buildAuxPrefix(): string {
+    const parts: string[] = [];
+
+    if (this.systemStatus) {
+      parts.push(`⏳ ${this.systemStatus}`);
+    }
+
+    if (this.thinkingText) {
+      const label = this.thinking ? '💭 思考中...' : '💭 思考完成';
+      const truncated =
+        this.thinkingText.length > QQStreamingController.MAX_THINKING_CHARS
+          ? '...' +
+            this.thinkingText.slice(-(QQStreamingController.MAX_THINKING_CHARS - 3))
+          : this.thinkingText;
+      parts.push(`${label}\n${truncated}`);
+    } else if (this.thinking) {
+      parts.push('💭 思考中...');
+    }
+
+    const now = Date.now();
+    const display: string[] = [];
+    for (const [, tc] of this.tools) {
+      if (display.length >= QQStreamingController.MAX_TOOLS_DISPLAY) break;
+      const elapsed = QQStreamingController.formatElapsed(now - tc.startTime);
+      const icon =
+        tc.status === 'running' ? '🔄' : tc.status === 'complete' ? '✅' : '❌';
+      const summary = tc.summary
+        ? `  ${tc.summary.length > QQStreamingController.MAX_TOOL_SUMMARY_CHARS ? tc.summary.slice(0, QQStreamingController.MAX_TOOL_SUMMARY_CHARS) + '...' : tc.summary}`
+        : '';
+      display.push(`${icon} ${tc.name} (${elapsed})${summary}`);
+    }
+    if (display.length > 0) {
+      parts.push(display.join('\n'));
+    }
+
+    return parts.length > 0 ? parts.join('\n\n') + '\n\n---\n\n' : '';
+  }
+
+  private static formatElapsed(ms: number): string {
+    if (ms < 1000) return `${ms}ms`;
+    const sec = ms / 1000;
+    if (sec < 60) return `${sec.toFixed(1)}s`;
+    const min = Math.floor(sec / 60);
+    return `${min}m ${Math.floor(sec % 60)}s`;
+  }
+
+  private purgeOldTools(): void {
+    const cutoff = Date.now() - 30_000;
+    for (const [id, tc] of this.tools) {
+      if (tc.status !== 'running' && tc.startTime < cutoff) {
+        this.tools.delete(id);
+      }
+    }
+  }
+
+  // ─── Internal: streaming ────────────────────────────────────
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    const elapsed = Date.now() - this.lastUpdateTime;
+    const delay = Math.max(0, STREAM_UPDATE_INTERVAL - elapsed);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.doFlush().catch((err: any) => {
+        logger.debug({ err: err.message }, 'QQ streaming flush failed');
+      });
+    }, delay);
+  }
+
+  private scheduleAuxFlush(): void {
+    if (this.auxFlushTimer) return;
+    const elapsed = Date.now() - this.lastAuxFlushTime;
+    const delay = Math.max(
+      0,
+      QQStreamingController.AUX_FLUSH_INTERVAL - elapsed,
+    );
+    this.auxFlushTimer = setTimeout(() => {
+      this.auxFlushTimer = null;
+      this.lastAuxFlushTime = Date.now();
+      const content = this.buildAuxPrefix() + markdownToPlainText(this.accumulatedText);
+      if (this.streamMsgId) {
+        this.doSendChunk(content, 1).catch((err: any) => {
+          logger.debug({ err: err.message }, 'QQ streaming aux flush failed');
+        });
+      }
+    }, delay);
+  }
+
+  private async doFlush(): Promise<void> {
+    const rawText = this.accumulatedText;
+    if (!rawText.trim() && !this.thinking && !this.thinkingText) return;
+
+    const content = this.buildAuxPrefix() + markdownToPlainText(rawText);
+
+    if (!this.streamMsgId) {
+      await this.tryStartStream(content);
+      if (!this.streamMsgId) return; // Failed, will retry next flush
+    } else {
+      try {
+        await this.doSendChunk(content, 1); // GENERATING
+        this.lastUpdateTime = Date.now();
+      } catch (err: any) {
+        logger.debug({ err: err.message }, 'QQ streaming chunk failed');
+      }
+    }
+  }
+
+  private async tryStartStream(content: string): Promise<void> {
+    try {
+      const plainContent = content.includes('---\n\n')
+        ? content // Already built with aux prefix
+        : markdownToPlainText(content);
+      // Show at least a "thinking" placeholder if content is empty
+      const displayContent = plainContent.trim() || '💭 思考中...';
+      const resp = await this.sendStreamChunk(this.openid, {
+        input_mode: 'replace',
+        input_state: 1, // GENERATING
+        content_type: 'markdown',
+        content_raw: displayContent,
+        msg_seq: this.msgSeq,
+        index: this.streamIndex++,
+      });
+
+      if (resp.id) {
+        this.streamMsgId = resp.id;
+        this.state = 'streaming';
+        this.sentChunkCount++;
+        this.lastUpdateTime = Date.now();
+        logger.info(
+          { openid: this.openid, streamMsgId: resp.id },
+          'QQ streaming started',
+        );
+      } else {
+        logger.warn({ openid: this.openid }, 'QQ stream API returned no id');
+      }
+    } catch (err: any) {
+      logger.warn(
+        { err: err.message, openid: this.openid },
+        'QQ streaming start failed',
+      );
+      // Stay in idle, will retry or fallback
+    }
+  }
+
+  private async doSendChunk(
+    content: string,
+    inputState: number,
+  ): Promise<void> {
+    await this.sendStreamChunk(this.openid, {
+      input_mode: 'replace',
+      input_state: inputState,
+      content_type: 'markdown',
+      content_raw: content,
+      msg_seq: this.msgSeq,
+      index: this.streamIndex++,
+      stream_msg_id: this.streamMsgId ?? undefined,
+    });
+    this.sentChunkCount++;
+  }
+
+  private async tryFallback(text: string): Promise<void> {
+    if (this.fallbackUsed) return;
+    this.fallbackUsed = true;
+    try {
+      await this.fallbackSend(text);
+    } catch (err: any) {
+      logger.warn({ err: err.message }, 'QQ streaming fallback send also failed');
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.auxFlushTimer) {
+      clearTimeout(this.auxFlushTimer);
+      this.auxFlushTimer = null;
+    }
+  }
+}

--- a/src/qq-streaming-card.ts
+++ b/src/qq-streaming-card.ts
@@ -16,7 +16,6 @@
  */
 
 import { logger } from './logger.js';
-import { markdownToPlainText } from './im-utils.js';
 
 // ─── Constants ───────────────────────────────────────────────
 
@@ -35,6 +34,8 @@ export type SendStreamChunkFn = (
     msg_seq: number;
     index: number;
     stream_msg_id?: string;
+    msg_id?: string;
+    event_id?: string;
   },
 ) => Promise<{ id?: string }>;
 
@@ -58,12 +59,15 @@ export class QQStreamingController {
   // Throttle
   private lastUpdateTime = 0;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private currentFlushPromise: Promise<void> | null = null;
+  private flushPending = false;
 
   // Dependencies
   private openid: string;
   private sendStreamChunk: SendStreamChunkFn;
   private fallbackSend: FallbackSendFn;
   private fallbackUsed = false;
+  private passiveMsgId: string | undefined;
 
   // Auxiliary state (thinking, tools, status)
   private thinking = false;
@@ -96,11 +100,14 @@ export class QQStreamingController {
     msgSeq: number;
     sendStreamChunk: SendStreamChunkFn;
     fallbackSend: FallbackSendFn;
+    /** Latest incoming msg_id from this openid. Required by QQ stream API. */
+    passiveMsgId?: string;
   }) {
     this.openid = opts.openid;
     this.msgSeq = opts.msgSeq;
     this.sendStreamChunk = opts.sendStreamChunk;
     this.fallbackSend = opts.fallbackSend;
+    this.passiveMsgId = opts.passiveMsgId;
   }
 
   // ─── StreamingSession interface ─────────────────────────────
@@ -111,9 +118,16 @@ export class QQStreamingController {
 
   append(text: string): void {
     if (!this.isActive()) return;
+    const isFirst = this.accumulatedText.length === 0;
     this.accumulatedText = text;
     this.thinkingText = '';
     this.thinking = false;
+    if (isFirst) {
+      logger.info(
+        { openid: this.openid, textLen: text.length },
+        'QQ streaming first append()',
+      );
+    }
     this.scheduleFlush();
   }
 
@@ -121,6 +135,21 @@ export class QQStreamingController {
     if (this.state === 'completed' || this.state === 'aborted') return;
     this.accumulatedText = finalText;
     this.clearTimers();
+
+    // Wait for any in-flight flush to settle so we don't race the DONE chunk
+    if (this.currentFlushPromise) {
+      await this.currentFlushPromise.catch(() => {});
+    }
+
+    logger.info(
+      {
+        openid: this.openid,
+        state: this.state,
+        sentChunks: this.sentChunkCount,
+        textLen: finalText.length,
+      },
+      'QQ streaming complete() entry',
+    );
 
     if (!finalText.trim()) {
       this.state = 'completed';
@@ -131,6 +160,10 @@ export class QQStreamingController {
     if (this.state === 'idle' || this.sentChunkCount === 0) {
       await this.tryStartStream(finalText);
       if (!this.streamMsgId) {
+        logger.warn(
+          { openid: this.openid },
+          'QQ streaming never started, falling back to plain message',
+        );
         await this.tryFallback(finalText);
         this.state = 'completed';
         return;
@@ -138,8 +171,7 @@ export class QQStreamingController {
     }
 
     try {
-      const content = markdownToPlainText(finalText);
-      await this.doSendChunk(content, 10); // DONE
+      await this.doSendChunk(finalText, 10); // DONE — raw text, monotonic with prior chunks
       this.state = 'completed';
       logger.info(
         { openid: this.openid, chunks: this.sentChunkCount },
@@ -159,9 +191,13 @@ export class QQStreamingController {
     if (this.state === 'completed' || this.state === 'aborted') return;
     this.clearTimers();
 
+    if (this.currentFlushPromise) {
+      await this.currentFlushPromise.catch(() => {});
+    }
+
     if (this.streamMsgId) {
       const abortText = this.accumulatedText
-        ? markdownToPlainText(this.accumulatedText) + `\n\n⚠️ 已中断: ${reason ?? '用户取消'}`
+        ? this.accumulatedText + `\n\n⚠️ 已中断: ${reason ?? '用户取消'}`
         : `⚠️ 已中断: ${reason ?? '用户取消'}`;
       try {
         await this.doSendChunk(abortText, 10); // DONE
@@ -323,62 +359,60 @@ export class QQStreamingController {
   // ─── Internal: streaming ────────────────────────────────────
 
   private scheduleFlush(): void {
-    if (this.flushTimer) return;
+    this.flushPending = true;
+    // Serialize: only one flush in-flight at a time.
+    // If another is running or scheduled, mark pending and let it reschedule itself.
+    if (this.flushTimer || this.currentFlushPromise) return;
     const elapsed = Date.now() - this.lastUpdateTime;
     const delay = Math.max(0, STREAM_UPDATE_INTERVAL - elapsed);
     this.flushTimer = setTimeout(() => {
       this.flushTimer = null;
-      this.doFlush().catch((err: any) => {
-        logger.debug({ err: err.message }, 'QQ streaming flush failed');
-      });
+      this.flushPending = false;
+      this.currentFlushPromise = this.doFlush()
+        .catch((err: any) => {
+          logger.debug({ err: err.message }, 'QQ streaming flush failed');
+        })
+        .finally(() => {
+          this.currentFlushPromise = null;
+          if (this.flushPending && this.isActive()) {
+            this.scheduleFlush();
+          }
+        });
     }, delay);
   }
 
   private scheduleAuxFlush(): void {
-    if (this.auxFlushTimer) return;
-    const elapsed = Date.now() - this.lastAuxFlushTime;
-    const delay = Math.max(
-      0,
-      QQStreamingController.AUX_FLUSH_INTERVAL - elapsed,
-    );
-    this.auxFlushTimer = setTimeout(() => {
-      this.auxFlushTimer = null;
-      this.lastAuxFlushTime = Date.now();
-      const content = this.buildAuxPrefix() + markdownToPlainText(this.accumulatedText);
-      if (this.streamMsgId) {
-        this.doSendChunk(content, 1).catch((err: any) => {
-          logger.debug({ err: err.message }, 'QQ streaming aux flush failed');
-        });
-      }
-    }, delay);
+    // Disabled: aux prefix (thinking/tools) mutates during stream, which
+    // breaks QQ's strict prefix-stability requirement. Aux state is tracked
+    // internally only; not surfaced to user during streaming.
   }
 
   private async doFlush(): Promise<void> {
     const rawText = this.accumulatedText;
-    if (!rawText.trim() && !this.thinking && !this.thinkingText) return;
+    if (!rawText.trim()) return;
 
-    const content = this.buildAuxPrefix() + markdownToPlainText(rawText);
-
+    // CRITICAL: QQ stream API requires strict prefix stability across chunks.
+    // - Never transform markdown (markdownToPlainText is non-monotonic:
+    //   incomplete `**bold` stays literal, later completed `**bold**` gets stripped).
+    // - Never prepend aux info (thinking/tools state changes during stream).
+    // Send raw text as-is; QQ renders content_type: markdown natively.
     if (!this.streamMsgId) {
-      await this.tryStartStream(content);
+      await this.tryStartStream(rawText);
       if (!this.streamMsgId) return; // Failed, will retry next flush
     } else {
       try {
-        await this.doSendChunk(content, 1); // GENERATING
+        await this.doSendChunk(rawText, 1); // GENERATING
         this.lastUpdateTime = Date.now();
       } catch (err: any) {
-        logger.debug({ err: err.message }, 'QQ streaming chunk failed');
+        logger.warn({ err: err.message, contentLen: rawText.length }, 'QQ streaming chunk failed');
       }
     }
   }
 
   private async tryStartStream(content: string): Promise<void> {
     try {
-      const plainContent = content.includes('---\n\n')
-        ? content // Already built with aux prefix
-        : markdownToPlainText(content);
-      // Show at least a "thinking" placeholder if content is empty
-      const displayContent = plainContent.trim() || '💭 思考中...';
+      // Raw content only — no transformation. Prefix must stay stable across chunks.
+      const displayContent = content.trim() || '💭 思考中...';
       const resp = await this.sendStreamChunk(this.openid, {
         input_mode: 'replace',
         input_state: 1, // GENERATING
@@ -386,6 +420,8 @@ export class QQStreamingController {
         content_raw: displayContent,
         msg_seq: this.msgSeq,
         index: this.streamIndex++,
+        msg_id: this.passiveMsgId,
+        event_id: this.passiveMsgId,
       });
 
       if (resp.id) {
@@ -398,7 +434,10 @@ export class QQStreamingController {
           'QQ streaming started',
         );
       } else {
-        logger.warn({ openid: this.openid }, 'QQ stream API returned no id');
+        logger.warn(
+          { openid: this.openid, resp },
+          'QQ stream API returned no id',
+        );
       }
     } catch (err: any) {
       logger.warn(
@@ -421,6 +460,8 @@ export class QQStreamingController {
       msg_seq: this.msgSeq,
       index: this.streamIndex++,
       stream_msg_id: this.streamMsgId ?? undefined,
+      msg_id: this.passiveMsgId,
+      event_id: this.passiveMsgId,
     });
     this.sentChunkCount++;
   }

--- a/src/qq-streaming-card.ts
+++ b/src/qq-streaming-card.ts
@@ -13,6 +13,28 @@
  *
  * Lifecycle: idle → streaming → completed / aborted
  * Fallback: if stream API fails, falls back to plain sendQQMessage()
+ *
+ * ─── Inactive aux-surface scaffolding (INTENTIONALLY UNUSED) ────
+ *
+ * The following members are reserved for a future auxiliary-display surface
+ * (thinking stream / tool activity / recent events / system status) but are
+ * currently NOT surfaced to the user during streaming:
+ *
+ *   - thinking / thinkingText
+ *   - systemStatus
+ *   - tools (Map) + purgeOldTools()
+ *   - recentEvents
+ *   - auxFlushTimer / lastAuxFlushTime / AUX_FLUSH_INTERVAL
+ *   - buildAuxPrefix() / formatElapsed()
+ *   - setThinking() / appendThinking() / setSystemStatus()
+ *   - startTool() / endTool() / updateToolSummary() / pushRecentEvent()
+ *
+ * Rationale for keeping this dormant: QQ's stream_messages endpoint enforces
+ * strict prefix stability across chunks — any mutation of an aux prefix
+ * mid-stream would break the protocol. These hooks are preserved so that a
+ * future out-of-band aux channel (e.g. a secondary message or sidebar card)
+ * can be wired in without reconstructing the tracking logic. `scheduleAuxFlush`
+ * is deliberately a no-op; see the comment at its definition.
  */
 
 import { logger } from './logger.js';
@@ -20,6 +42,7 @@ import { logger } from './logger.js';
 // ─── Constants ───────────────────────────────────────────────
 
 const STREAM_UPDATE_INTERVAL = 500; // ms — throttle between API calls
+const MAX_STREAM_CONTENT = 4500; // QQ content_raw conservative upper bound (leave small buffer under ~5000)
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -435,14 +458,37 @@ export class QQStreamingController {
   }
 
   private scheduleAuxFlush(): void {
-    // Disabled: aux prefix (thinking/tools) mutates during stream, which
-    // breaks QQ's strict prefix-stability requirement. Aux state is tracked
-    // internally only; not surfaced to user during streaming.
+    // intentionally no-op: aux surface disabled to protect prefix stability invariant; see comments at top of file.
+    // Aux state (thinking/tools/recentEvents/systemStatus) is still tracked
+    // internally via setThinking/startTool/etc so a future out-of-band surface
+    // can consume it without reconstructing tracking logic.
   }
 
   private async doFlush(): Promise<void> {
     const rawText = this.accumulatedText;
     if (!rawText.trim()) return;
+
+    // Length guard: QQ stream_messages caps content_raw (~5000 chars). Once we
+    // cross the conservative threshold, every subsequent chunk would hit the
+    // same upper-bound and fail in a tight loop. Switch to fallback once and
+    // stop streaming — fallbackUsed guard ensures only one plain message is
+    // sent even if this path is hit repeatedly before complete() fires.
+    if (rawText.length > MAX_STREAM_CONTENT) {
+      logger.warn(
+        {
+          openid: this.openid,
+          contentLen: rawText.length,
+          limit: MAX_STREAM_CONTENT,
+        },
+        'QQ streaming accumulated text exceeds per-chunk cap, switching to fallback',
+      );
+      this.clearTimers();
+      this.flushPending = false;
+      // Aborted (not completed) so complete() early-returns without sending DONE.
+      this.state = 'aborted';
+      await this.tryFallback(rawText);
+      return;
+    }
 
     // CRITICAL: QQ stream API requires strict prefix stability across chunks.
     // - Never transform markdown (markdownToPlainText is non-monotonic:

--- a/src/qq-streaming-card.ts
+++ b/src/qq-streaming-card.ts
@@ -42,7 +42,13 @@ export type SendStreamChunkFn = (
 /** Callback to send a plain message (fallback) */
 export type FallbackSendFn = (text: string) => Promise<void>;
 
-type StreamingState = 'idle' | 'streaming' | 'completed' | 'aborted';
+type StreamingState =
+  | 'idle'
+  | 'streaming'
+  | 'completing' // complete() in progress, awaiting in-flight flush
+  | 'aborting' // abort() in progress, awaiting in-flight flush
+  | 'completed'
+  | 'aborted';
 
 // ─── Controller ──────────────────────────────────────────────
 
@@ -113,6 +119,8 @@ export class QQStreamingController {
   // ─── StreamingSession interface ─────────────────────────────
 
   isActive(): boolean {
+    // Only idle/streaming accept new content. Once complete/abort starts,
+    // late-arriving append()s are ignored to keep the QQ baseline monotonic.
     return this.state === 'idle' || this.state === 'streaming';
   }
 
@@ -132,14 +140,44 @@ export class QQStreamingController {
   }
 
   async complete(finalText: string): Promise<void> {
-    if (this.state === 'completed' || this.state === 'aborted') return;
-    this.accumulatedText = finalText;
+    if (
+      this.state === 'completed' ||
+      this.state === 'aborted' ||
+      this.state === 'completing' ||
+      this.state === 'aborting'
+    ) {
+      return;
+    }
+    // Enter terminal-pending state IMMEDIATELY so any text_delta arriving
+    // during the awaits below is dropped by isActive(). Otherwise it would
+    // overwrite accumulatedText and schedule a flush that races the DONE
+    // chunk, breaking QQ's strict prefix-stability requirement.
+    this.state = 'completing';
     this.clearTimers();
 
     // Wait for any in-flight flush to settle so we don't race the DONE chunk
     if (this.currentFlushPromise) {
       await this.currentFlushPromise.catch(() => {});
     }
+
+    // Now safe to set baseline. accumulatedText is whatever the last
+    // successful flush sent (or finalText if none flushed yet).
+    const baseline = this.accumulatedText;
+    // DONE text must be an extension of the QQ baseline. If finalText
+    // diverges from what we've already streamed, fall back to baseline
+    // for the DONE chunk and let fallback path handle the difference.
+    const safeFinal = finalText.startsWith(baseline) ? finalText : baseline;
+    if (safeFinal !== finalText) {
+      logger.warn(
+        {
+          openid: this.openid,
+          baselineLen: baseline.length,
+          finalLen: finalText.length,
+        },
+        'QQ streaming finalText diverges from streamed baseline, using baseline for DONE',
+      );
+    }
+    this.accumulatedText = safeFinal;
 
     logger.info(
       {
@@ -156,9 +194,9 @@ export class QQStreamingController {
       return;
     }
 
-    // If we never managed to start a stream, use fallback
-    if (this.state === 'idle' || this.sentChunkCount === 0) {
-      await this.tryStartStream(finalText);
+    // If we never managed to start a stream, use fallback for the full text
+    if (this.sentChunkCount === 0) {
+      await this.tryStartStream(safeFinal);
       if (!this.streamMsgId) {
         logger.warn(
           { openid: this.openid },
@@ -171,7 +209,11 @@ export class QQStreamingController {
     }
 
     try {
-      await this.doSendChunk(finalText, 10); // DONE — raw text, monotonic with prior chunks
+      // Send DONE with the prefix-safe text. In the rare divergent case,
+      // safeFinal is the streamed baseline (a prefix of what we'd ideally
+      // send) — DONE succeeds and the user sees a slightly truncated final.
+      // Logged above; investigate via logs if it ever appears in production.
+      await this.doSendChunk(safeFinal, 10); // DONE
       this.state = 'completed';
       logger.info(
         { openid: this.openid, chunks: this.sentChunkCount },
@@ -188,7 +230,16 @@ export class QQStreamingController {
   }
 
   async abort(reason?: string): Promise<void> {
-    if (this.state === 'completed' || this.state === 'aborted') return;
+    if (
+      this.state === 'completed' ||
+      this.state === 'aborted' ||
+      this.state === 'completing' ||
+      this.state === 'aborting'
+    ) {
+      return;
+    }
+    // Same reasoning as complete(): block late append() during awaits below.
+    this.state = 'aborting';
     this.clearTimers();
 
     if (this.currentFlushPromise) {
@@ -196,6 +247,8 @@ export class QQStreamingController {
     }
 
     if (this.streamMsgId) {
+      // accumulatedText here reflects the last successfully-streamed baseline,
+      // so appending the abort notice keeps prefix stability.
       const abortText = this.accumulatedText
         ? this.accumulatedText + `\n\n⚠️ 已中断: ${reason ?? '用户取消'}`
         : `⚠️ 已中断: ${reason ?? '用户取消'}`;
@@ -426,7 +479,12 @@ export class QQStreamingController {
 
       if (resp.id) {
         this.streamMsgId = resp.id;
-        this.state = 'streaming';
+        // Only transition to 'streaming' from idle. If we're already in a
+        // terminal-pending state (completing/aborting), preserve it so late
+        // append() events stay blocked.
+        if (this.state === 'idle') {
+          this.state = 'streaming';
+        }
         this.sentChunkCount++;
         this.lastUpdateTime = Date.now();
         logger.info(

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -293,10 +293,14 @@ export interface QQConnection {
       msg_seq: number;
       index: number;
       stream_msg_id?: string;
+      msg_id?: string;
+      event_id?: string;
     },
   ): Promise<{ id?: string }>;
   /** Get next msg_seq for a chat (for stream session). */
   getNextMsgSeq(chatId: string): number;
+  /** Latest msg_id received from a C2C openid, for passive reply. */
+  getLastIncomingMsgId(openid: string): string | undefined;
 }
 
 interface TokenInfo {
@@ -353,6 +357,10 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
   // Per-chat msg_seq counter for active messages
   const msgSeqCounters = new Map<string, number>();
+
+  // Latest incoming msg_id per C2C openid, used as passive-reply reference
+  // for stream_messages (QQ API rejects the endpoint without msg_id).
+  const lastIncomingMsgId = new Map<string, string>();
 
   // Rate-limit rejection messages
   const rejectTimestamps = new Map<string, number>();
@@ -1338,6 +1346,10 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       const userOpenId = data.author?.id || data.author?.user_openid;
       if (!userOpenId) return;
 
+      // Remember the latest incoming msg_id so stream_messages can use it as
+      // the passive-reply reference (the endpoint rejects requests without one).
+      lastIncomingMsgId.set(userOpenId, msgId);
+
       const jid = `qq:c2c:${userOpenId}`;
       const senderName = data.author?.username || `QQ用户`;
       const chatName = senderName;
@@ -1784,6 +1796,8 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         msg_seq: number;
         index: number;
         stream_msg_id?: string;
+        msg_id?: string;
+        event_id?: string;
       },
     ): Promise<{ id?: string }> {
       const endpoint = `/v2/users/${openid}/stream_messages`;
@@ -1798,11 +1812,21 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       if (params.stream_msg_id) {
         body.stream_msg_id = params.stream_msg_id;
       }
+      if (params.msg_id) {
+        body.msg_id = params.msg_id;
+      }
+      if (params.event_id) {
+        body.event_id = params.event_id;
+      }
       return apiRequest<{ id?: string }>('POST', endpoint, body);
     },
 
     getNextMsgSeq(chatId: string): number {
       return getNextMsgSeq(chatId);
+    },
+
+    getLastIncomingMsgId(openid: string): string | undefined {
+      return lastIncomingMsgId.get(openid);
     },
   };
 

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -282,6 +282,21 @@ export interface QQConnection {
   sendFile(chatId: string, filePath: string, fileName: string): Promise<void>;
   sendChatAction(chatId: string, action: 'typing'): Promise<void>;
   isConnected(): boolean;
+  /** Send a C2C stream message chunk. Returns { id } on first chunk. */
+  sendStreamMessage(
+    openid: string,
+    params: {
+      input_mode: string;
+      input_state: number;
+      content_type: string;
+      content_raw: string;
+      msg_seq: number;
+      index: number;
+      stream_msg_id?: string;
+    },
+  ): Promise<{ id?: string }>;
+  /** Get next msg_seq for a chat (for stream session). */
+  getNextMsgSeq(chatId: string): number;
 }
 
 interface TokenInfo {
@@ -1757,6 +1772,37 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
     isConnected(): boolean {
       return ws !== null && ws.readyState === WebSocket.OPEN;
+    },
+
+    async sendStreamMessage(
+      openid: string,
+      params: {
+        input_mode: string;
+        input_state: number;
+        content_type: string;
+        content_raw: string;
+        msg_seq: number;
+        index: number;
+        stream_msg_id?: string;
+      },
+    ): Promise<{ id?: string }> {
+      const endpoint = `/v2/users/${openid}/stream_messages`;
+      const body: Record<string, unknown> = {
+        input_mode: params.input_mode,
+        input_state: params.input_state,
+        content_type: params.content_type,
+        content_raw: params.content_raw,
+        msg_seq: params.msg_seq,
+        index: params.index,
+      };
+      if (params.stream_msg_id) {
+        body.stream_msg_id = params.stream_msg_id;
+      }
+      return apiRequest<{ id?: string }>('POST', endpoint, body);
+    },
+
+    getNextMsgSeq(chatId: string): number {
+      return getNextMsgSeq(chatId);
     },
   };
 


### PR DESCRIPTION
## 问题描述

QQ 私聊收到 Agent 回复时需要等到完整输出后才能看到内容，长回复下体验较差。希望复用飞书卡片 / 钉钉 AI Card / Discord 的流式思路，在 QQ C2C 私聊提供打字机效果。

## 实现方案

基于 QQ Bot API v2 的 `/v2/users/{openid}/stream_messages` 端点实现，分片以 REPLACE 模式下发，客户端 markdown content_type 自动渲染。

### 新增 `src/qq-streaming-card.ts`（+547）

- `QQStreamingController` 状态机：`idle → streaming → completing/aborting → completed/aborted`
- 500ms 节流 flush，分片通过 `currentFlushPromise` 串行化
- 前缀稳定性加固：直接发送原始文本（不做 markdown→plain 转换，避免 `**bold` 闭合引发的非单调变换），DONE 前用 `finalText.startsWith(baseline)` 双重校验
- 失败路径自动 fallback 到普通消息发送

### `src/qq.ts`（+70）

- 新增 `sendStreamMessage()` 调用 `stream_messages` 端点
- 新增 `getNextMsgSeq()` 维护每会话 msg_seq 递增
- 新增 `getLastIncomingMsgId()`：记录最新 C2C 入站消息 ID，流式会话必须携带 passive msg_id（没有则 500）

### `src/im-channel.ts`（+40 / -2）

- `StreamingSession` union 增加 `QQStreamingController`
- `createQQChannel()` 实现 `createStreamingSession()`：仅 C2C 启用，群聊 / 无 passive msg_id 自动放弃流式，回退到普通消息
- 接口定义本身是 optional，对其他渠道零影响

### `src/im-manager.ts`（+1 / -1）

- `createStreamingSession()` 白名单扩展加入 `qq`，原有 feishu / dingtalk / discord 分支未改动

## 自测

- 本地灰度 4 天，覆盖普通对话、长回复、思考中、工具调用、多分片、中断场景
- 合并 upstream/main 最新 32 个 commit 预演：**零冲突**
- 共享文件 (`im-channel.ts` / `im-manager.ts`) 改动全部是单向扩展，不影响其他渠道既有路径

## 风险评估

- 群聊路径：显式 `chatId.startsWith('group:')` 直接 return undefined
- 无 passive msg_id：直接 return undefined
- 流式 API 500：自动 fallback 普通消息
- 前缀破坏：三重防御（不做 markdown 转换 + completing/aborting 中间态忽略 append + DONE 前 startsWith 校验）