### PR TITLE
修复: QQ 重命名被后续消息覆盖回 "QQ用户"

### DIFF
--- a/src/qq.ts
+++ b/src/qq.ts
@@ -14,7 +14,12 @@ import fs from 'node:fs';
 import http from 'node:http';
 import https from 'node:https';
 import WebSocket from 'ws';
-import { storeChatMetadata, storeMessageDirect, updateChatName } from './db.js';
+import {
+  getRegisteredGroup,
+  storeChatMetadata,
+  storeMessageDirect,
+  updateChatName,
+} from './db.js';
 import { notifyNewImMessage } from './message-notifier.js';
 import { broadcastNewMessage } from './web.js';
 import { logger } from './logger.js';
@@ -1324,7 +1329,8 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       if (!userOpenId) return;
 
       const jid = `qq:c2c:${userOpenId}`;
-      const senderName = data.author?.username || `QQ用户`;
+      const realName = (data.author?.username || '').trim();
+      const senderName = realName || `QQ用户`;
       const chatName = senderName;
 
       // Strip bot mention from content
@@ -1365,8 +1371,21 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
       // ── Authorized: process message ──
       storeChatMetadata(jid, new Date().toISOString());
-      updateChatName(jid, chatName);
-      opts.onNewChat(jid, chatName);
+
+      // QQ C2C payloads usually omit author.username, so naively writing
+      // chatName here would clobber user-set names (the rename API writes
+      // to both chats.name and registered_groups.name).  Only persist when
+      // the platform gave us a real username; otherwise pass the existing
+      // registered name through so buildOnNewChat's diff guard leaves it
+      // untouched, and fall back to the placeholder only for first-time
+      // registration.
+      if (realName) {
+        updateChatName(jid, realName);
+        opts.onNewChat(jid, realName);
+      } else {
+        const existing = getRegisteredGroup(jid);
+        opts.onNewChat(jid, existing?.name ?? chatName);
+      }
 
       // Handle slash commands
       const slashMatch = content.match(/^\/(\S+)(?:\s+(.*))?$/i);
@@ -1517,8 +1536,17 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
       // ── Authorized: process message ──
       storeChatMetadata(jid, new Date().toISOString());
-      updateChatName(jid, chatName);
-      opts.onNewChat(jid, chatName);
+
+      // QQ group payloads don't carry a group name; chatName is always a
+      // placeholder derived from groupOpenId.  Only write it on first-time
+      // registration — otherwise we'd clobber user-set names (rename API).
+      const existing = getRegisteredGroup(jid);
+      if (!existing) {
+        updateChatName(jid, chatName);
+        opts.onNewChat(jid, chatName);
+      } else {
+        opts.onNewChat(jid, existing.name ?? chatName);
+      }
 
       // Handle slash commands
       const slashMatch = content.match(/^\/(\S+)(?:\s+(.*))?$/i);


### PR DESCRIPTION
## 问题描述

QQ 配对聊天的重命名功能（#420 / 291bb25e）上线后，用户反馈改名能成功但**过段时间会自动变回「QQ用户」**。经排查是每条 QQ 消息到达时的处理路径会覆盖自定义名字。

## 根因

`src/qq.ts` 的 `handleC2CMessage()` 和 `handleGroupMessage()` 都有同一模式：

```ts
updateChatName(jid, chatName);
opts.onNewChat(jid, chatName);
```

### C2C 私聊

```ts
const senderName = data.author?.username || `QQ用户`;
```

QQ Open Platform 的 C2C 私聊 payload **通常不携带 `author.username`**（群消息才有），每次消息到达都 fallback 到字面量 `"QQ用户"`。随后：

1. `updateChatName(jid, "QQ用户")` 覆盖 `chats.name`
2. `onNewChat(jid, "QQ用户")` 进入 `buildOnNewChat`（`src/index.ts:6443-6449`），看到 `existing.name !== "QQ用户"` → 覆盖 `registered_groups.name`

两张表都被冲回占位符，UI 上表现为改名回滚。

### 群聊

```ts
const chatName = `QQ群 ${groupOpenId.slice(0, 8)}`;
```

`chatName` 永远是 groupOpenId 派生的占位符，没有「真名」可用。每条群消息同样会把用户改过的群名冲回占位符。

## 修复方案

### `src/qq.ts` · C2C 分支

- 引入 `realName = (data.author?.username || '').trim()` 区分「平台给了真名」与「fallback 占位符」
- 仅当 `realName` 非空时写入 `chats` 表（`updateChatName`）并传给 `onNewChat`
- 否则查 `getRegisteredGroup(jid)?.name` 作为 `onNewChat` 入参 —— 这样 `buildOnNewChat` 里 `existing.name !== trimmed` 的差异守卫会判定无变化而跳过
- 首次注册（无 existing）时仍用占位符，保持原行为

### `src/qq.ts` · Group 分支

- 群消息没有平台真名，`chatName` 始终是占位符
- 仅在首次注册时写入占位符；已注册的群保留用户名字不动

### 为什么不改 `buildOnNewChat`

一开始考虑在 `src/index.ts` 的 `buildOnNewChat` 里加「不允许用 `"QQ用户"` 覆盖已有名字」的防御，但这样会把 QQ 语义耦合进通用路由逻辑。源头一致性更干净，所以只改 `qq.ts`。

## 自测

- `make typecheck` 通过（后端 + 前端 + agent-runner）
- 目标场景手工复盘：
  - rename → 发新消息 → 改名不再被覆盖 ✅
  - 首次配对的新 QQ 私聊 → 注册为 `"QQ用户"`（原行为保留）✅
  - rename → 重启服务 → 改名保持 ✅（`chats.name` 和 `registered_groups.name` 都不再被后续消息覆盖）
  - 群聊同样通过 rename API 改名 → 后续消息不再冲回占位符 ✅

## 风险评估

- 改动仅限 `src/qq.ts` 两处 QQ 专属路径，其他 IM 渠道不受影响
- 首次注册路径未改动（仍以 platform / 占位符为名）
- 无数据迁移需求