### PR TITLE
修复: 移动端对话 tab 误触删除 + 统一交互到上下文菜单

### DIFF
--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { Plus, X, Link, MessageSquare, Pencil, Trash2 } from 'lucide-react';
+import { Plus, Link, MessageSquare, Pencil, Trash2 } from 'lucide-react';
 import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, horizontalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -33,9 +33,10 @@ interface ContextMenuState {
   y: number;
 }
 
-function ContextMenuOverlay({ menu, onRename, onDelete, onClose }: {
+function ContextMenuOverlay({ menu, onRename, onBindIm, onDelete, onClose }: {
   menu: ContextMenuState;
   onRename?: () => void;
+  onBindIm?: () => void;
   onDelete: () => void;
   onClose: () => void;
 }) {
@@ -72,6 +73,15 @@ function ContextMenuOverlay({ menu, onRename, onDelete, onClose }: {
           重命名
         </button>
       )}
+      {onBindIm && (
+        <button
+          onClick={onBindIm}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground cursor-pointer"
+        >
+          <Link className="w-3.5 h-3.5" />
+          绑定 IM 群组
+        </button>
+      )}
       <button
         onClick={onDelete}
         className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30 cursor-pointer"
@@ -83,15 +93,13 @@ function ContextMenuOverlay({ menu, onRename, onDelete, onClose }: {
   );
 }
 
-function SortableTab({ agent, isActive, onSelect, onContextMenu, onTouchStart, onTouchEnd, onBindIm, onDeleteAgent }: {
+function SortableTab({ agent, isActive, onSelect, onContextMenu, onTouchStart, onTouchEnd }: {
   agent: AgentInfo;
   isActive: boolean;
   onSelect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
   onTouchStart: (e: React.TouchEvent) => void;
   onTouchEnd: () => void;
-  onBindIm?: (agentId: string) => void;
-  onDeleteAgent: (agentId: string) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: agent.id });
   const style = {
@@ -136,22 +144,6 @@ function SortableTab({ agent, isActive, onSelect, onContextMenu, onTouchStart, o
         </span>
       )}
       <span className="truncate max-w-[120px]">{agent.name}</span>
-      {onBindIm && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onBindIm(agent.id); }}
-          className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-          title="绑定 IM 群组"
-        >
-          <Link className="w-3 h-3" />
-        </button>
-      )}
-      <button
-        onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}
-        className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-accent transition-all cursor-pointer"
-        title="关闭对话"
-      >
-        <X className="w-3 h-3" />
-      </button>
     </div>
   );
 }
@@ -261,8 +253,6 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onR
                 onContextMenu={(e) => handleContextMenu(e, agent)}
                 onTouchStart={(e) => handleTouchStart(agent, e)}
                 onTouchEnd={handleTouchEnd}
-                onBindIm={onBindIm}
-                onDeleteAgent={onDeleteAgent}
               />
             ))}
           </SortableContext>
@@ -287,6 +277,10 @@ export function AgentTabBar({ agents, activeTab, onSelectTab, onDeleteAgent, onR
           menu={contextMenu}
           onRename={onRenameAgent ? () => {
             onRenameAgent(contextMenu.agentId, contextMenu.agentName);
+            setContextMenu(null);
+          } : undefined}
+          onBindIm={onBindIm ? () => {
+            onBindIm(contextMenu.agentId);
             setContextMenu(null);
           } : undefined}
           onDelete={() => {


### PR DESCRIPTION
## 用户现象

手机 PWA 下，对话 tab 右侧的关闭（X）和绑定（链接图标）按钮**不显示**，但点击 tab 切换对话时，手指常常落到按钮位置，**导致对话被意外删除**，无法恢复。

PC 端也有个副作用：hover 显示的按钮占位布局，tab 永远预留按钮宽度，名字短时右侧出现大片空白。

## 根因

`AgentTabBar` 中关闭和绑定按钮的样式是 `opacity-0 group-hover:opacity-100`：

- **桌面**：鼠标悬停 → `opacity-100` → 显示且可点击 ✅
- **移动**：没有 hover 事件 → `opacity-0` 保持 → 按钮不可见，**但 DOM 仍在，点击区域仍然生效** → 误触 ❌
- 即使透明，`opacity-0` 元素仍占布局空间 → tab 永远预留两个按钮的宽度

## 修复方案

统一到**上下文菜单**（PC 右键 + 移动端长按）。项目已有 `ContextMenuOverlay` 组件，只需扩充一个选项：

| 平台 | 操作 | 结果 |
|------|------|------|
| 桌面 | 右键 tab | 弹出菜单（重命名 / 绑定 IM 群组 / 删除） |
| 移动 | 长按 tab | 同上 |

改动：
- 移除 tab 内的 inline hover 按钮（关闭、绑定）
- 上下文菜单扩充「绑定 IM 群组」选项（原有「重命名 / 删除」）
- tab 宽度只由名字决定，无右侧空白
- 移动端不再有"不可见但可点击"的热区，消除误触

## 改动

### `web/src/components/chat/AgentTabBar.tsx`

- `ContextMenuOverlay` 新增 `onBindIm` prop 和对应菜单项（使用 `Link` icon）
- `SortableTab` 移除 `onBindIm` / `onDeleteAgent` props 及 inline 按钮
- `AgentTabBar` 渲染 `ContextMenuOverlay` 时传入 `onBindIm` 回调
- 移除未使用的 `X` icon import

## 验证

- PWA 下长按 tab 弹出完整菜单（重命名 / 绑定 / 删除）
- 桌面右键同样弹出菜单
- tab 宽度随名字自适应，无右侧空白

🤖 Generated with [Claude Code](https://claude.com/claude-code)