### PR TITLE
修复: 移除飞书卡片 header 的 standard_icon 避免破图

### DIFF
--- a/src/feishu-cards/sections.ts
+++ b/src/feishu-cards/sections.ts
@@ -133,11 +133,6 @@ export function buildHeader(input: AgentCardInput): El {
   const header: El = {
     title: { tag: 'plain_text', content: displayTitle },
     template: theme.template,
-    icon: {
-      tag: 'standard_icon',
-      token: theme.iconToken,
-      color: theme.iconColor,
-    },
   };
   if (input.subtitle) {
     (header as { subtitle?: unknown }).subtitle = {

--- a/src/feishu-cards/status-theme.ts
+++ b/src/feishu-cards/status-theme.ts
@@ -5,10 +5,6 @@ export interface StatusTheme {
   template: 'blue' | 'violet' | 'orange' | 'red';
   tagColor: 'blue' | 'violet' | 'orange' | 'red';
   tagText: string;
-  /** Feishu standard_icon token rendered in header.icon (left of the title). */
-  iconToken: string;
-  /** Icon accent color — picked to match the header template. */
-  iconColor: 'blue' | 'violet' | 'orange' | 'red' | 'white';
 }
 
 const STATUS_THEMES: Record<CardStatus, StatusTheme> = {
@@ -16,29 +12,21 @@ const STATUS_THEMES: Record<CardStatus, StatusTheme> = {
     template: 'blue',
     tagColor: 'blue',
     tagText: '生成中',
-    iconToken: 'loading_outlined',
-    iconColor: 'white',
   },
   done: {
     template: 'violet',
     tagColor: 'violet',
     tagText: '完成',
-    iconToken: 'check-circle_filled',
-    iconColor: 'white',
   },
   warning: {
     template: 'orange',
     tagColor: 'orange',
     tagText: '部分成功',
-    iconToken: 'warning_filled',
-    iconColor: 'white',
   },
   error: {
     template: 'red',
     tagColor: 'red',
     tagText: '失败',
-    iconToken: 'close-circle_filled',
-    iconColor: 'white',
   },
 };
 

--- a/tests/feishu-card.test.ts
+++ b/tests/feishu-card.test.ts
@@ -257,7 +257,7 @@ describe('formatters', () => {
 // ─── buildAgentReplyCard shape ─────────────────────────────────
 
 describe('buildAgentReplyCard', () => {
-  test('minimal card: v2 schema + violet done template + icon', () => {
+  test('minimal card: v2 schema + violet done template', () => {
     const card = buildAgentReplyCard({ status: 'done', text: 'Hello world' });
     expect(card.schema).toBe('2.0');
     const config = card.config as Record<string, unknown>;
@@ -268,10 +268,7 @@ describe('buildAgentReplyCard', () => {
 
     const header = card.header as Record<string, unknown>;
     expect(header.template).toBe('violet');
-    // header.icon must be a v2 standard_icon
-    const icon = header.icon as Record<string, unknown>;
-    expect(icon.tag).toBe('standard_icon');
-    expect(icon.token).toBe('check-circle_filled');
+    // header.icon removed — standard_icon tokens are not supported on all clients
 
     const tags = header.text_tag_list as Array<Record<string, unknown>>;
     expect(tags.length).toBeGreaterThan(0);
@@ -282,21 +279,21 @@ describe('buildAgentReplyCard', () => {
     expect(body.direction).toBe('vertical');
   });
 
-  test('header.icon reflects CardStatus', () => {
+  test('header.template reflects CardStatus', () => {
     const cases: Array<[
       'running' | 'done' | 'warning' | 'error',
       string,
     ]> = [
-      ['running', 'loading_outlined'],
-      ['done', 'check-circle_filled'],
-      ['warning', 'warning_filled'],
-      ['error', 'close-circle_filled'],
+      ['running', 'blue'],
+      ['done', 'violet'],
+      ['warning', 'orange'],
+      ['error', 'red'],
     ];
-    for (const [status, token] of cases) {
+    for (const [status, template] of cases) {
       const card = buildAgentReplyCard({ status, text: 'x' });
       const header = card.header as Record<string, unknown>;
-      const icon = header.icon as Record<string, unknown>;
-      expect(icon.token).toBe(token);
+      expect(header.template).toBe(template);
+      expect(header.icon).toBeUndefined();
     }
   });
 
@@ -588,13 +585,10 @@ describe('buildStreamingAgentCard', () => {
     expect(body.vertical_spacing).toBe('medium');
   });
 
-  test('streaming header gets a status icon', () => {
+  test('streaming header has no icon (removed to avoid broken images)', () => {
     const card = buildStreamingAgentCard({ initialText: '' });
     const header = card.header as Record<string, unknown>;
-    const icon = header.icon as Record<string, unknown>;
-    expect(icon.tag).toBe('standard_icon');
-    // running → loading_outlined
-    expect(icon.token).toBe('loading_outlined');
+    expect(header.icon).toBeUndefined();
   });
 
   test('rich streaming card element_ids are unique', () => {


### PR DESCRIPTION
## 问题描述

关闭 #(无)

飞书卡片 header 左侧的 `standard_icon`（如 `check-circle_filled`、`close-circle_filled` 等）在部分飞书客户端版本不支持，显示为破图。

## 修复方案

### `src/feishu-cards/status-theme.ts`
- 移除 `StatusTheme` 接口中的 `iconToken` / `iconColor` 字段
- 移除各状态主题中对应的 icon 配置

### `src/feishu-cards/sections.ts`
- 移除 `buildHeader()` 中的 `icon` 属性

### `tests/feishu-card.test.ts`
- 更新对应测试，移除对 header icon 的断言

状态已通过 header 颜色模板（`STATUS_THEMES` 的 `template`）和 `text_tag_list`（"完成"/"生成中" 等标签）标识，不需要额外图标。