### PR TITLE
修复: make dev/dev-backend 自动暂停 pm2 避免端口冲突

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,28 @@ endif
 
 # ─── Development ─────────────────────────────────────────────
 
-dev: ## 启动前后端（首次自动安装依赖和构建容器镜像）
+dev: ## 启动前后端（首次自动安装依赖和构建容器镜像）；自动暂停 pm2，退出后恢复
 	@if [ ! -d node_modules ] || [ package.json -nt node_modules ] || [ web/package.json -nt web/node_modules ] || [ container/agent-runner/package.json -nt container/agent-runner/node_modules ]; then echo "📦 依赖有更新，安装依赖..."; $(MAKE) install; fi
 	@$(MAKE) _ensure-docker-image
 	@$(PKG) --prefix container/agent-runner run build --silent 2>/dev/null || $(PKG) --prefix container/agent-runner run build
-	@echo "🚀 使用 $(PKG) 启动..."
+	@PM2_WAS_RUNNING=0; \
+	if command -v pm2 >/dev/null 2>&1 && pm2 show happyclaw 2>/dev/null | grep -q 'online'; then \
+	  PM2_WAS_RUNNING=1; \
+	  echo "⏸  暂停 pm2 happyclaw..."; \
+	  pm2 stop happyclaw; \
+	fi; \
+	trap "if [ \"$$PM2_WAS_RUNNING\" = '1' ]; then echo '▶  恢复 pm2 happyclaw...'; pm2 start happyclaw; fi" EXIT INT TERM; \
+	echo "🚀 使用 $(PKG) 启动..."; \
 	$(PKG) run dev:all
 
-dev-backend: ## 仅启动后端（bun 直接跑 TS，node 用 tsx）
+dev-backend: ## 仅启动后端（bun 直接跑 TS，node 用 tsx）；自动暂停 pm2，退出后恢复
+	@PM2_WAS_RUNNING=0; \
+	if command -v pm2 >/dev/null 2>&1 && pm2 show happyclaw 2>/dev/null | grep -q 'online'; then \
+	  PM2_WAS_RUNNING=1; \
+	  echo "⏸  暂停 pm2 happyclaw..."; \
+	  pm2 stop happyclaw; \
+	fi; \
+	trap "if [ \"$$PM2_WAS_RUNNING\" = '1' ]; then echo '▶  恢复 pm2 happyclaw...'; pm2 start happyclaw; fi" EXIT INT TERM; \
 	$(RUNNER)
 
 dev-web: ## 仅启动前端


### PR DESCRIPTION
## 问题描述

`make dev-backend` 和 `make dev` 直接启动服务时未先停 pm2 守护进程，导致两个进程同时争抢 3000 端口。pm2 检测到端口占用后立即 crash，再不断重启，形成死循环（实测累计重启 25000+ 次）。

## 修复方案

### `Makefile`

`dev` 和 `dev-backend` 目标增加如下逻辑：

- 启动前检测 pm2 `happyclaw` 进程是否在线，在线则先 `pm2 stop happyclaw`
- 通过 `trap EXIT INT TERM` 确保退出（含 Ctrl+C）后自动 `pm2 start happyclaw` 恢复守护进程

开发时终端会输出 `⏸ 暂停 pm2 happyclaw...`，退出后自动显示 `▶ 恢复 pm2 happyclaw...`。