### PR TITLE
修复: agent-runner 新 query 初始化前 IPC 消息导致 ProcessTransport crash

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1107,6 +1107,9 @@ async function runQuery(
   let queryRef: { interrupt(): Promise<void> } | null = null;
   let messageCount = 0;
   let resultCount = 0;
+  // SDK transport is not ready until system/init is received. Piping user messages
+  // before init causes "ProcessTransport is not ready for writing" unhandled rejection.
+  let sdkTransportReady = false;
 
   const pollIpcDuringQuery = () => {
     if (!ipcPolling) return;
@@ -1171,6 +1174,13 @@ async function runQuery(
       log('Stream already ended, skipping IPC drain (messages will be picked up by waitForIpcMessage)');
       ipcPolling = false;
       ipcQueryWatcher.close();
+      return;
+    }
+
+    // Don't pipe user messages before system/init — the SDK ProcessTransport is not
+    // ready yet and streamInput() will throw "ProcessTransport is not ready for writing".
+    // IPC files remain on disk; we'll drain them once sdkTransportReady is set.
+    if (!sdkTransportReady) {
       return;
     }
 
@@ -1279,7 +1289,7 @@ async function runQuery(
       systemPrompt: { type: 'preset' as const, preset: 'claude_code' as const, append: systemPromptAppend },
       allowedTools,
       ...(disallowedTools && { disallowedTools }),
-      thinking: { type: 'adaptive' as const, display: 'summarized' as const },
+      thinking: { type: 'adaptive' as const },
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       agentProgressSummaries: true,
@@ -1417,6 +1427,9 @@ async function runQuery(
     if (message.type === 'system' && message.subtype === 'init') {
       newSessionId = message.session_id;
       log(`Session initialized: ${newSessionId}`);
+      // Mark transport ready and drain any IPC messages that arrived before init.
+      sdkTransportReady = true;
+      pollIpcDuringQuery();
 
       // Log skills and context usage for observability.
       // getContextUsage() is a newer SDK API; feature-detect to avoid spamming
@@ -2153,6 +2166,14 @@ process.on('unhandledRejection', (reason: unknown) => {
   }
   if (isWithinInterruptGraceWindow()) {
     console.error('Unhandled rejection during interrupt (non-fatal):', reason);
+    return;
+  }
+  // SDK throws this when streamInput() is called before the ProcessTransport is ready.
+  // The sdkTransportReady guard in pollIpcDuringQuery should prevent this, but catch
+  // it here as a safety net to avoid crashing the agent on any residual race windows.
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  if (msg.includes('ProcessTransport is not ready for writing')) {
+    console.error('Suppressing ProcessTransport race (non-fatal):', reason);
     return;
   }
   console.error('Unhandled rejection:', reason);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1289,7 +1289,7 @@ async function runQuery(
       systemPrompt: { type: 'preset' as const, preset: 'claude_code' as const, append: systemPromptAppend },
       allowedTools,
       ...(disallowedTools && { disallowedTools }),
-      thinking: { type: 'adaptive' as const },
+      thinking: { type: 'adaptive' as const, display: 'summarized' as const },
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       agentProgressSummaries: true,


### PR DESCRIPTION
## 问题描述

Host agent 在处理飞书私聊多轮对话时，偶发 exit code 1 崩溃，日志如下：

```
[agent-runner] Piping IPC message into active query (194 chars, 0 images)
Unhandled rejection: Error: ProcessTransport is not ready for writing
    at y4.write (sdk.mjs:19:7066)
    at h4.streamInput (sdk.mjs:22:2061)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
```

## 根因

竞态条件：

1. 新 query 启动，`ipcPolling = true`，IPC watcher 立即开始监听
2. SDK `ProcessTransport` 尚未就绪（`system/init` 消息还未收到）
3. 第二条 IPC 消息此时到达，`pollIpcDuringQuery` 触发
4. `stream.push()` 成功（`stream.done = false`），消息入队
5. SDK async iterator 唤醒，调用 `streamInput()` 写入未初始化的 transport
6. SDK 内部抛出 unhandled rejection → `process.exit(1)`

## 修复方案

### `container/agent-runner/src/index.ts`

**主防线**：引入 `sdkTransportReady` 标志

- `pollIpcDuringQuery` 在 `sdkTransportReady = false` 时跳过消息 drain，IPC 文件留在磁盘
- 收到 `system/init` 后设置 `sdkTransportReady = true`，并立即调用一次 `pollIpcDuringQuery()` 补充 drain 等待中的消息

**安全网**：`unhandledRejection` 捕获

- 检测 error message 是否包含 `"ProcessTransport is not ready for writing"`
- 若匹配，打日志但不 `process.exit(1)`，防止残余时序窗口仍导致崩溃