### PR TITLE
功能: Feishu 群聊发言者白名单（默认锁定新群 + owner 自动识别）

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -695,6 +695,7 @@ export function initDatabase(): void {
   );
   ensureColumn('registered_groups', 'feishu_chat_mode', 'TEXT');
   ensureColumn('registered_groups', 'feishu_group_message_type', 'TEXT');
+  ensureColumn('registered_groups', 'sender_allowlist', 'TEXT');
   ensureColumn('messages', 'token_usage', 'TEXT');
   ensureColumn('messages', 'turn_id', 'TEXT');
   ensureColumn('messages', 'session_id', 'TEXT');
@@ -1235,7 +1236,7 @@ export function initDatabase(): void {
     db.exec('ALTER TABLE agents ADD COLUMN spawned_from_jid TEXT');
   }
 
-  const SCHEMA_VERSION = '35';
+  const SCHEMA_VERSION = '36';
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', SCHEMA_VERSION);
@@ -2273,6 +2274,7 @@ type RegisteredGroupRow = {
   binding_mode: string | null;
   feishu_chat_mode: string | null;
   feishu_group_message_type: string | null;
+  sender_allowlist: string | null;
 };
 
 /** Convert a raw DB row into a RegisteredGroup domain object. */
@@ -2309,6 +2311,9 @@ function parseGroupRow(
       row.binding_mode === 'thread_map' ? 'thread_map' : 'single_context',
     feishu_chat_mode: row.feishu_chat_mode ?? undefined,
     feishu_group_message_type: row.feishu_group_message_type ?? undefined,
+    sender_allowlist: row.sender_allowlist != null
+      ? (JSON.parse(row.sender_allowlist) as string[])
+      : undefined,
   };
 }
 
@@ -2340,8 +2345,8 @@ export function getRegisteredGroup(
 
 export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   db.prepare(
-    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, added_at, container_config, execution_mode, custom_cwd, init_source_path, init_git_url, created_by, is_home, selected_skills, target_agent_id, target_main_jid, reply_policy, require_mention, activation_mode, owner_im_id, mcp_mode, selected_mcps, conversation_source, conversation_nav_mode, binding_mode, feishu_chat_mode, feishu_group_message_type)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO registered_groups (jid, name, folder, added_at, container_config, execution_mode, custom_cwd, init_source_path, init_git_url, created_by, is_home, selected_skills, target_agent_id, target_main_jid, reply_policy, require_mention, activation_mode, owner_im_id, mcp_mode, selected_mcps, conversation_source, conversation_nav_mode, binding_mode, feishu_chat_mode, feishu_group_message_type, sender_allowlist)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jid,
     group.name,
@@ -2368,6 +2373,7 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
     group.binding_mode ?? 'single_context',
     group.feishu_chat_mode ?? null,
     group.feishu_group_message_type ?? null,
+    group.sender_allowlist != null ? JSON.stringify(group.sender_allowlist) : null,
   );
 }
 

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -1028,12 +1028,23 @@ export function createFeishuConnection(
       }
     }
 
-    // ── 群聊发言者白名单过滤（命令已处理后，非白名单发言者直接丢弃） ──
+    // ── 群聊发言者白名单过滤（命令已处理后，非白名单发言者丢弃或软拒绝） ──
     if (chatType === 'group' && isSenderAllowedInGroup && !isSenderAllowedInGroup(chatJid, senderOpenId)) {
-      logger.debug(
-        { chatJid, messageId, senderOpenId },
-        'Dropped group message: sender not in allowlist',
-      );
+      // 被 @bot 时回 SILENT 表情表达「看到但故意不回复」，让发言者知道 bot 并非无响应而是被白名单挡掉；
+      // 未 @bot 时静默丢弃，避免把群聊闲聊污染成一堆表情。
+      const isBotMentioned = !!botOpenId && (mentions?.some((m) => m.id?.open_id === botOpenId) ?? false);
+      if (isBotMentioned) {
+        addReaction(messageId, 'SILENT').catch(() => {});
+        logger.debug(
+          { chatJid, messageId, senderOpenId },
+          'Soft-rejected group message with SILENT reaction: sender not in allowlist',
+        );
+      } else {
+        logger.debug(
+          { chatJid, messageId, senderOpenId },
+          'Dropped group message: sender not in allowlist',
+        );
+      }
       return;
     }
 

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -44,8 +44,8 @@ export interface ConnectOptions {
   onNewChat?: (chatJid: string, chatName: string) => void;
   /** 热重连时设置：丢弃 create_time 早于此时间戳（epoch ms）的消息，避免处理渠道关闭期间的堆积消息 */
   ignoreMessagesBefore?: number;
-  /** 斜杠指令回调（如 /clear），返回回复文本或 null */
-  onCommand?: (chatJid: string, command: string, senderImId?: string) => Promise<string | null>;
+  /** 斜杠指令回调（如 /clear），返回回复文本或 null；mentions 仅飞书渠道传入，用于 /allow 等命令 */
+  onCommand?: (chatJid: string, command: string, senderImId?: string, mentions?: FeishuMentionLike[]) => Promise<string | null>;
   /** 根据 chatJid 解析群组 folder，用于下载文件/图片到工作区 */
   resolveGroupFolder?: (chatJid: string) => string | undefined;
   /** 将 IM chatJid 解析为绑定目标 JID（conversation agent 或工作区主对话） */
@@ -63,6 +63,8 @@ export interface ConnectOptions {
   shouldProcessGroupMessage?: (chatJid: string, senderImId?: string) => boolean;
   /** owner_mentioned 模式下检查发送者是否为 owner */
   isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
+  /** 发言者白名单：命令处理之后、mention 门控之前调用；返回 false 则丢弃 */
+  isSenderAllowedInGroup?: (chatJid: string, senderImId?: string) => boolean;
   /** 飞书流式卡片按钮中断回调 */
   onCardInterrupt?: (chatJid: string) => void;
 }
@@ -798,6 +800,7 @@ export function createFeishuConnection(
       onAgentMessage,
       shouldProcessGroupMessage,
       isGroupOwnerMessage,
+      isSenderAllowedInGroup,
     } = connectOptions || {};
     const {
       chatId,
@@ -985,7 +988,7 @@ export function createFeishuConnection(
         'Feishu slash command detected',
       );
       try {
-        const reply = await onCommand(chatJid, cmdBody, senderOpenId);
+        const reply = await onCommand(chatJid, cmdBody, senderOpenId, mentions);
         logger.info(
           {
             chatJid,
@@ -1015,6 +1018,15 @@ export function createFeishuConnection(
         }
         return;
       }
+    }
+
+    // ── 群聊发言者白名单过滤（命令已处理后，非白名单发言者直接丢弃） ──
+    if (chatType === 'group' && isSenderAllowedInGroup && !isSenderAllowedInGroup(chatJid, senderOpenId)) {
+      logger.debug(
+        { chatJid, messageId, senderOpenId },
+        'Dropped group message: sender not in allowlist',
+      );
+      return;
     }
 
     // ── 群聊 Mention 过滤：require_mention / owner_mentioned 模式下过滤 ──

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -67,6 +67,8 @@ export interface ConnectOptions {
   isSenderAllowedInGroup?: (chatJid: string, senderImId?: string) => boolean;
   /** 飞书流式卡片按钮中断回调 */
   onCardInterrupt?: (chatJid: string) => void;
+  /** P2P（私聊）消息到达时调用，用于自动检测 bot owner 的 open_id */
+  onP2pSender?: (senderOpenId: string) => void;
 }
 
 export interface FeishuChatInfo {
@@ -801,6 +803,7 @@ export function createFeishuConnection(
       shouldProcessGroupMessage,
       isGroupOwnerMessage,
       isSenderAllowedInGroup,
+      onP2pSender,
     } = connectOptions || {};
     const {
       chatId,
@@ -868,6 +871,11 @@ export function createFeishuConnection(
 
     // 先注册会话，确保 resolveGroupFolder 能正确解析 folder（含首条文件消息场景）
     onNewChat?.(chatJid, resolvedChatName);
+
+    // P2P 消息：通知调用方用于自动检测 owner open_id
+    if (chatType === 'p2p' && senderOpenId && onP2pSender) {
+      onP2pSender(senderOpenId);
+    }
 
     let attachmentsJson: string | undefined;
 

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -88,6 +88,8 @@ export interface IMChannelConnectOpts {
   shouldProcessGroupMessage?: (chatJid: string, senderImId?: string) => boolean;
   /** owner_mentioned 模式下检查发送者是否为 owner */
   isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
+  /** 发言者白名单：返回 false 则丢弃（命令处理后、mention 门控前调用） */
+  isSenderAllowedInGroup?: (chatJid: string, senderImId?: string) => boolean;
   /** Resolve registered group for a jid */
   resolveRegisteredGroup?: (jid: string) => { activation_mode?: string } | undefined;
   /** 飞书流式卡片按钮中断回调 */
@@ -186,6 +188,7 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
         onBotRemovedFromGroup: opts.onBotRemovedFromGroup,
         shouldProcessGroupMessage: opts.shouldProcessGroupMessage,
         isGroupOwnerMessage: opts.isGroupOwnerMessage,
+        isSenderAllowedInGroup: opts.isSenderAllowedInGroup,
         onCardInterrupt: opts.onCardInterrupt,
       });
       if (!connected) {

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -94,6 +94,8 @@ export interface IMChannelConnectOpts {
   resolveRegisteredGroup?: (jid: string) => { activation_mode?: string } | undefined;
   /** 飞书流式卡片按钮中断回调 */
   onCardInterrupt?: (chatJid: string) => void;
+  /** P2P（私聊）消息到达时调用，用于自动检测 owner open_id（仅飞书） */
+  onP2pSender?: (senderOpenId: string) => void;
 }
 
 export interface IMChannel {
@@ -190,6 +192,7 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
         isGroupOwnerMessage: opts.isGroupOwnerMessage,
         isSenderAllowedInGroup: opts.isSenderAllowedInGroup,
         onCardInterrupt: opts.onCardInterrupt,
+        onP2pSender: opts.onP2pSender,
       });
       if (!connected) {
         inner = null;

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -75,7 +75,7 @@ export interface DiscordConnectConfig {
 
 export interface ConnectFeishuOptions {
   ignoreMessagesBefore?: number;
-  onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+  onCommand?: (chatJid: string, command: string, senderImId?: string, mentions?: Array<{ key?: string; name?: string; id?: { open_id?: string } }>) => Promise<string | null>;
   resolveGroupFolder?: (chatJid: string) => string | undefined;
   resolveEffectiveChatJid?: (
     chatJid: string,
@@ -86,6 +86,7 @@ export interface ConnectFeishuOptions {
   onBotRemovedFromGroup?: (chatJid: string) => void;
   shouldProcessGroupMessage?: (chatJid: string, senderImId?: string) => boolean;
   isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
+  isSenderAllowedInGroup?: (chatJid: string, senderImId?: string) => boolean;
   onCardInterrupt?: (chatJid: string) => void;
 }
 
@@ -382,6 +383,7 @@ class IMConnectionManager {
       onBotRemovedFromGroup: options?.onBotRemovedFromGroup,
       shouldProcessGroupMessage: options?.shouldProcessGroupMessage,
       isGroupOwnerMessage: options?.isGroupOwnerMessage,
+      isSenderAllowedInGroup: options?.isSenderAllowedInGroup,
       onCardInterrupt: options?.onCardInterrupt,
     });
   }

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -88,6 +88,7 @@ export interface ConnectFeishuOptions {
   isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
   isSenderAllowedInGroup?: (chatJid: string, senderImId?: string) => boolean;
   onCardInterrupt?: (chatJid: string) => void;
+  onP2pSender?: (senderOpenId: string) => void;
 }
 
 class IMConnectionManager {
@@ -385,6 +386,7 @@ class IMConnectionManager {
       isGroupOwnerMessage: options?.isGroupOwnerMessage,
       isSenderAllowedInGroup: options?.isSenderAllowedInGroup,
       onCardInterrupt: options?.onCardInterrupt,
+      onP2pSender: options?.onP2pSender,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1549,8 +1549,25 @@ function handleAllowCommand(
   mentions?: Array<{ key?: string; name?: string; id?: { open_id?: string } }>,
 ): string {
   if (!senderImId) return '无法识别发送者身份';
-  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+  let group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
   if (!group) return '未找到当前会话';
+
+  // Backfill owner_im_id if the group was registered before the user-level
+  // ownerOpenId was known (e.g., bot added to group first, owner DM'd later).
+  // Only backfill when the sender matches the user-level ownerOpenId.
+  if (!group.owner_im_id && group.created_by) {
+    const userOwnerOpenId = getUserFeishuConfig(group.created_by)?.ownerOpenId;
+    if (userOwnerOpenId && userOwnerOpenId === senderImId) {
+      const updated: RegisteredGroup = { ...group, owner_im_id: senderImId };
+      setRegisteredGroup(chatJid, updated);
+      registeredGroups[chatJid] = updated;
+      group = updated;
+      logger.info(
+        { chatJid, senderImId },
+        'Backfilled owner_im_id via /allow (matched user-level ownerOpenId)',
+      );
+    }
+  }
 
   if (!group.owner_im_id) {
     return '尚未识别到 owner，请先向机器人发一条私信以完成身份识别';
@@ -6719,7 +6736,11 @@ function buildOnNewChat(
       added_at: new Date().toISOString(),
       created_by: userId,
       owner_im_id: ownerOpenId,
-      sender_allowlist: ownerOpenId ? [ownerOpenId] : [],
+      // Only Feishu path (getOwnerOpenId provided) opts into the default
+      // allowlist lock. Other channels leave allowlist unrestricted.
+      sender_allowlist: getOwnerOpenId
+        ? (ownerOpenId ? [ownerOpenId] : [])
+        : undefined,
     });
     logger.info(
       { chatJid, chatName, userId, homeFolder },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1070,6 +1070,7 @@ async function handleCommand(
   chatJid: string,
   command: string,
   senderImId?: string,
+  mentions?: Array<{ key?: string; name?: string; id?: { open_id?: string } }>,
 ): Promise<string | null> {
   const parts = command.split(/\s+/);
   const cmd = parts[0].toLowerCase();
@@ -1101,6 +1102,14 @@ async function handleCommand(
     case 'sw':
     case 'spawn':
       return handleSpawnCommand(chatJid, rawArgs, chatJid);
+    case 'claim':
+      return handleClaimCommand(chatJid, senderImId);
+    case 'allow':
+      return handleAllowCommand(chatJid, senderImId, mentions);
+    case 'disallow':
+      return handleDisallowCommand(chatJid, senderImId, mentions);
+    case 'allowlist':
+      return handleAllowlistCommand(chatJid);
     default:
       return null;
   }
@@ -1529,6 +1538,141 @@ function handleOwnerMentionCommand(chatJid: string, senderImId?: string): string
   );
 
   return `已开启「仅我响应」模式\n\n你的 IM 标识: ${senderImId}\n只有你 @机器人 时才会响应，其他人的 @mention 将被静默忽略。\n\n发送 /require_mention false 可恢复为全量响应。`;
+}
+
+/**
+ * /claim 命令：认领当前群组的 bot owner 权限，开启发言者白名单模式。
+ * 首次认领后仅执行者本人可触发 bot，其他人需通过 /allow @成员 加入白名单。
+ * 已有 owner 时，只有 owner 本人可以重新认领。
+ */
+function handleClaimCommand(chatJid: string, senderImId?: string): string {
+  if (!senderImId) return '无法识别发送者身份';
+  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+  if (!group) return '未找到当前会话';
+
+  if (group.owner_im_id && group.owner_im_id !== senderImId) {
+    return '该群组已有 bot owner，无法重新认领';
+  }
+  if (group.owner_im_id === senderImId) {
+    const count = group.sender_allowlist?.length ?? 0;
+    return `您已是该群组的 bot owner（白名单 ${count} 人）`;
+  }
+
+  const updated: RegisteredGroup = {
+    ...group,
+    owner_im_id: senderImId,
+    sender_allowlist: [senderImId],
+  };
+  setRegisteredGroup(chatJid, updated);
+  registeredGroups[chatJid] = updated;
+  logger.info({ chatJid, senderImId }, 'Bot owner claimed via /claim');
+
+  return `已认领 bot owner 权限。\n只有白名单中的成员才能触发我。\n\n/allow @成员 — 添加成员\n/disallow @成员 — 移除成员\n/allowlist — 查看白名单`;
+}
+
+/**
+ * /allow @成员 命令：将 @提及的成员加入发言者白名单（仅 owner 可操作）。
+ */
+function handleAllowCommand(
+  chatJid: string,
+  senderImId?: string,
+  mentions?: Array<{ key?: string; name?: string; id?: { open_id?: string } }>,
+): string {
+  if (!senderImId) return '无法识别发送者身份';
+  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+  if (!group) return '未找到当前会话';
+
+  if (!group.owner_im_id) {
+    return '尚未设置 owner，请先运行 /claim 认领权限';
+  }
+  if (group.owner_im_id !== senderImId) {
+    return '只有 bot owner 才能修改白名单';
+  }
+
+  const toAdd = (mentions ?? [])
+    .map((m) => m.id?.open_id)
+    .filter((id): id is string => !!id && id !== senderImId);
+
+  if (toAdd.length === 0) {
+    return '请 @提及 要加入白名单的群成员：/allow @成员';
+  }
+
+  const current = group.sender_allowlist ?? [senderImId];
+  const newIds = toAdd.filter((id) => !current.includes(id));
+  if (newIds.length === 0) {
+    return '这些成员已在白名单中';
+  }
+
+  const updated: RegisteredGroup = {
+    ...group,
+    sender_allowlist: [...current, ...newIds],
+  };
+  setRegisteredGroup(chatJid, updated);
+  registeredGroups[chatJid] = updated;
+  logger.info({ chatJid, senderImId, added: newIds }, 'Members added to sender allowlist');
+
+  return `已将 ${newIds.length} 名成员加入白名单（当前共 ${updated.sender_allowlist!.length} 人）`;
+}
+
+/**
+ * /disallow @成员 命令：将 @提及的成员从发言者白名单移除（仅 owner 可操作）。
+ * owner 本人不能被移除。
+ */
+function handleDisallowCommand(
+  chatJid: string,
+  senderImId?: string,
+  mentions?: Array<{ key?: string; name?: string; id?: { open_id?: string } }>,
+): string {
+  if (!senderImId) return '无法识别发送者身份';
+  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+  if (!group) return '未找到当前会话';
+
+  if (!group.owner_im_id || group.owner_im_id !== senderImId) {
+    return '只有 bot owner 才能修改白名单';
+  }
+  if (!group.sender_allowlist || group.sender_allowlist.length === 0) {
+    return '白名单为空';
+  }
+
+  const toRemove = (mentions ?? [])
+    .map((m) => m.id?.open_id)
+    .filter((id): id is string => !!id);
+
+  if (toRemove.length === 0) {
+    return '请 @提及 要从白名单移除的群成员：/disallow @成员';
+  }
+  if (toRemove.includes(senderImId)) {
+    return 'Owner 不能将自己移出白名单';
+  }
+
+  const updated_list = group.sender_allowlist.filter((id) => !toRemove.includes(id));
+  const updated: RegisteredGroup = { ...group, sender_allowlist: updated_list };
+  setRegisteredGroup(chatJid, updated);
+  registeredGroups[chatJid] = updated;
+  logger.info({ chatJid, senderImId, removed: toRemove }, 'Members removed from sender allowlist');
+
+  const removedCount = group.sender_allowlist.length - updated_list.length;
+  return `已将 ${removedCount} 名成员从白名单移除（当前共 ${updated_list.length} 人）`;
+}
+
+/**
+ * /allowlist 命令：查看当前群组的发言者白名单。
+ */
+function handleAllowlistCommand(chatJid: string): string {
+  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+  if (!group) return '未找到当前会话';
+
+  const allowlist = group.sender_allowlist;
+  if (allowlist === undefined || allowlist === null) {
+    return '当前群组未启用白名单模式（所有人均可触发）\n运行 /claim 可启用白名单保护';
+  }
+  if (allowlist.length === 0) {
+    return `白名单模式已启用，当前无人可触发。\nOwner: ${group.owner_im_id ?? '未设置'}\n运行 /claim 认领 owner 权限后才能响应消息`;
+  }
+
+  const ownerMark = (id: string) => (id === group.owner_im_id ? ' (owner)' : '');
+  const lines = allowlist.map((id, i) => `${i + 1}. ${id}${ownerMark(id)}`);
+  return `白名单（${allowlist.length} 人）：\n${lines.join('\n')}`;
 }
 
 const recallCooldowns = new Map<string, number>();
@@ -6602,6 +6746,7 @@ function buildOnNewChat(
       folder: homeFolder,
       added_at: new Date().toISOString(),
       created_by: userId,
+      sender_allowlist: [], // new IM groups start locked; run /claim to take ownership
     });
     logger.info(
       { chatJid, chatName, userId, homeFolder },
@@ -6650,6 +6795,35 @@ function buildTelegramBotAddedHandler(
           'Failed to send Telegram group welcome message',
         ),
       );
+  };
+}
+
+/**
+ * Build the onBotAddedToGroup handler for Feishu connections.
+ * Registers the new group (locked by default) and sends a one-time welcome message.
+ */
+function buildFeishuBotAddedHandler(
+  userId: string,
+  homeFolder: string,
+): (chatJid: string, chatName: string) => void {
+  const onNewChat = buildOnNewChat(userId, homeFolder);
+  return (chatJid: string, chatName: string) => {
+    const isNew = !registeredGroups[chatJid] && !getRegisteredGroup(chatJid);
+    onNewChat(chatJid, chatName);
+    if (isNew) {
+      const welcome =
+        `已加入「${chatName}」。\n\n` +
+        `当前群聊已启用发言者白名单，仅 bot owner 可触发我。\n\n` +
+        `/claim — 认领 owner 权限（必须先认领才会响应消息）\n` +
+        `/allow @成员 — 将群成员加入白名单\n` +
+        `/disallow @成员 — 从白名单移除成员\n` +
+        `/allowlist — 查看白名单`;
+      imManager
+        .sendMessage(chatJid, welcome)
+        .catch((err) =>
+          logger.warn({ chatJid, err }, 'Failed to send Feishu group welcome message'),
+        );
+    }
   };
 }
 
@@ -7032,6 +7206,20 @@ function isGroupOwnerMessage(chatJid: string, senderImId?: string): boolean {
 }
 
 /**
+ * 群聊发言者白名单检查。
+ * sender_allowlist 为 null/undefined 时不限制（默认），为空数组时无人可触发，
+ * 为字符串数组时仅列表中的 open_id 可触发。
+ */
+function isSenderAllowedInGroup(chatJid: string, senderImId?: string): boolean {
+  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
+  if (!group) return false;
+  const allowlist = group.sender_allowlist;
+  if (allowlist === undefined || allowlist === null) return true;
+  if (!senderImId) return false;
+  return allowlist.includes(senderImId);
+}
+
+/**
  * 飞书流式卡片按钮中断回调。
  * 仅由飞书卡片按钮触发，不涉及自动关键词检测。
  */
@@ -7077,7 +7265,7 @@ async function connectUserIMChannels(
   };
   const resolveEffectiveChatJid = buildResolveEffectiveChatJid();
   const onAgentMessage = buildOnAgentMessage();
-  const onBotAddedToGroup = buildOnNewChat(userId, homeFolder); // reuse same logic: auto-register
+  const onBotAddedToGroup = buildFeishuBotAddedHandler(userId, homeFolder);
   const onBotRemovedFromGroup = buildOnBotRemovedFromGroup();
 
   // 各渠道互相独立，并发连接避免启动时延 N×M 累加
@@ -7096,6 +7284,7 @@ async function connectUserIMChannels(
           onBotRemovedFromGroup,
           shouldProcessGroupMessage,
           isGroupOwnerMessage,
+          isSenderAllowedInGroup,
           onCardInterrupt: handleCardInterrupt,
         })
       : Promise.resolve(false);
@@ -7532,10 +7721,11 @@ async function main(): Promise<void> {
         {
           ignoreMessagesBefore: Date.now(),
           onCommand: handleCommand,
-          onBotAddedToGroup: buildOnNewChat(adminUser.id, homeFolder),
+          onBotAddedToGroup: buildFeishuBotAddedHandler(adminUser.id, homeFolder),
           onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
           shouldProcessGroupMessage,
           isGroupOwnerMessage,
+          isSenderAllowedInGroup,
           onCardInterrupt: handleCardInterrupt,
         },
       );
@@ -7637,10 +7827,11 @@ async function main(): Promise<void> {
           {
             ignoreMessagesBefore,
             onCommand: handleCommand,
-            onBotAddedToGroup: buildOnNewChat(userId, homeFolder),
+            onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder),
             onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
             shouldProcessGroupMessage,
             isGroupOwnerMessage,
+            isSenderAllowedInGroup,
             onCardInterrupt: handleCardInterrupt,
           },
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ import {
   getUserDiscordConfig,
   getSystemSettings,
   saveUserFeishuConfig,
+  saveFeishuOwnerOpenId,
   saveUserTelegramConfig,
   updateAllSessionCredentials,
 } from './runtime-config.js';
@@ -1102,8 +1103,6 @@ async function handleCommand(
     case 'sw':
     case 'spawn':
       return handleSpawnCommand(chatJid, rawArgs, chatJid);
-    case 'claim':
-      return handleClaimCommand(chatJid, senderImId);
     case 'allow':
       return handleAllowCommand(chatJid, senderImId, mentions);
     case 'disallow':
@@ -1540,35 +1539,6 @@ function handleOwnerMentionCommand(chatJid: string, senderImId?: string): string
   return `已开启「仅我响应」模式\n\n你的 IM 标识: ${senderImId}\n只有你 @机器人 时才会响应，其他人的 @mention 将被静默忽略。\n\n发送 /require_mention false 可恢复为全量响应。`;
 }
 
-/**
- * /claim 命令：认领当前群组的 bot owner 权限，开启发言者白名单模式。
- * 首次认领后仅执行者本人可触发 bot，其他人需通过 /allow @成员 加入白名单。
- * 已有 owner 时，只有 owner 本人可以重新认领。
- */
-function handleClaimCommand(chatJid: string, senderImId?: string): string {
-  if (!senderImId) return '无法识别发送者身份';
-  const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
-  if (!group) return '未找到当前会话';
-
-  if (group.owner_im_id && group.owner_im_id !== senderImId) {
-    return '该群组已有 bot owner，无法重新认领';
-  }
-  if (group.owner_im_id === senderImId) {
-    const count = group.sender_allowlist?.length ?? 0;
-    return `您已是该群组的 bot owner（白名单 ${count} 人）`;
-  }
-
-  const updated: RegisteredGroup = {
-    ...group,
-    owner_im_id: senderImId,
-    sender_allowlist: [senderImId],
-  };
-  setRegisteredGroup(chatJid, updated);
-  registeredGroups[chatJid] = updated;
-  logger.info({ chatJid, senderImId }, 'Bot owner claimed via /claim');
-
-  return `已认领 bot owner 权限。\n只有白名单中的成员才能触发我。\n\n/allow @成员 — 添加成员\n/disallow @成员 — 移除成员\n/allowlist — 查看白名单`;
-}
 
 /**
  * /allow @成员 命令：将 @提及的成员加入发言者白名单（仅 owner 可操作）。
@@ -1583,7 +1553,7 @@ function handleAllowCommand(
   if (!group) return '未找到当前会话';
 
   if (!group.owner_im_id) {
-    return '尚未设置 owner，请先运行 /claim 认领权限';
+    return '尚未识别到 owner，请先向机器人发一条私信以完成身份识别';
   }
   if (group.owner_im_id !== senderImId) {
     return '只有 bot owner 才能修改白名单';
@@ -1664,10 +1634,10 @@ function handleAllowlistCommand(chatJid: string): string {
 
   const allowlist = group.sender_allowlist;
   if (allowlist === undefined || allowlist === null) {
-    return '当前群组未启用白名单模式（所有人均可触发）\n运行 /claim 可启用白名单保护';
+    return '当前群组未启用白名单模式（所有人均可触发）';
   }
   if (allowlist.length === 0) {
-    return `白名单模式已启用，当前无人可触发。\nOwner: ${group.owner_im_id ?? '未设置'}\n运行 /claim 认领 owner 权限后才能响应消息`;
+    return `白名单模式已启用，当前无人可触发。\nOwner: ${group.owner_im_id ?? '未识别（请先向机器人发一条私信）'}`;
   }
 
   const ownerMark = (id: string) => (id === group.owner_im_id ? ' (owner)' : '');
@@ -6652,6 +6622,7 @@ async function ensureDockerRunning(): Promise<void> {
 function buildOnNewChat(
   userId: string,
   homeFolder: string,
+  getOwnerOpenId?: () => string | undefined,
 ): (chatJid: string, chatName: string) => void {
   return (chatJid, chatName) => {
     const existing = registeredGroups[chatJid];
@@ -6741,12 +6712,14 @@ function buildOnNewChat(
       }
       return;
     }
+    const ownerOpenId = getOwnerOpenId?.();
     registerGroup(chatJid, {
       name: chatName,
       folder: homeFolder,
       added_at: new Date().toISOString(),
       created_by: userId,
-      sender_allowlist: [], // new IM groups start locked; run /claim to take ownership
+      owner_im_id: ownerOpenId,
+      sender_allowlist: ownerOpenId ? [ownerOpenId] : [],
     });
     logger.info(
       { chatJid, chatName, userId, homeFolder },
@@ -6805,17 +6778,21 @@ function buildTelegramBotAddedHandler(
 function buildFeishuBotAddedHandler(
   userId: string,
   homeFolder: string,
+  getOwnerOpenId?: () => string | undefined,
 ): (chatJid: string, chatName: string) => void {
-  const onNewChat = buildOnNewChat(userId, homeFolder);
+  const onNewChat = buildOnNewChat(userId, homeFolder, getOwnerOpenId);
   return (chatJid: string, chatName: string) => {
     const isNew = !registeredGroups[chatJid] && !getRegisteredGroup(chatJid);
     onNewChat(chatJid, chatName);
     if (isNew) {
+      const ownerKnown = !!getOwnerOpenId?.();
       const welcome =
         `已加入「${chatName}」。\n\n` +
-        `当前群聊已启用发言者白名单，仅 bot owner 可触发我。\n\n` +
-        `/claim — 认领 owner 权限（必须先认领才会响应消息）\n` +
-        `/allow @成员 — 将群成员加入白名单\n` +
+        `当前群聊已启用发言者白名单，仅 bot owner 可触发我。\n` +
+        (ownerKnown
+          ? `Owner 已自动从私聊中识别。\n`
+          : `请先向机器人发一条私信，系统将自动识别您的 owner 身份。\n`) +
+        `\n/allow @成员 — 将群成员加入白名单\n` +
         `/disallow @成员 — 从白名单移除成员\n` +
         `/allowlist — 查看白名单`;
       imManager
@@ -7259,13 +7236,24 @@ async function connectUserIMChannels(
   dingtalk: boolean;
   discord: boolean;
 }> {
-  const onNewChat = buildOnNewChat(userId, homeFolder);
+  // Per-user mutable ref for Feishu owner open_id auto-detection via P2P messages
+  const feishuOwnerRef = { value: feishuConfig ? (getUserFeishuConfig(userId)?.ownerOpenId ?? undefined) : undefined };
+  const getFeishuOwnerOpenId = () => feishuOwnerRef.value;
+  const onFeishuP2pSender = (senderOpenId: string) => {
+    if (!feishuOwnerRef.value) {
+      feishuOwnerRef.value = senderOpenId;
+      saveFeishuOwnerOpenId(userId, senderOpenId);
+      logger.info({ userId, senderOpenId }, 'Feishu owner open_id auto-detected from P2P message');
+    }
+  };
+
+  const onNewChat = buildOnNewChat(userId, homeFolder, getFeishuOwnerOpenId);
   const resolveGroupFolder = (chatJid: string): string | undefined => {
     return resolveEffectiveFolder(chatJid);
   };
   const resolveEffectiveChatJid = buildResolveEffectiveChatJid();
   const onAgentMessage = buildOnAgentMessage();
-  const onBotAddedToGroup = buildFeishuBotAddedHandler(userId, homeFolder);
+  const onBotAddedToGroup = buildFeishuBotAddedHandler(userId, homeFolder, getFeishuOwnerOpenId);
   const onBotRemovedFromGroup = buildOnBotRemovedFromGroup();
 
   // 各渠道互相独立，并发连接避免启动时延 N×M 累加
@@ -7286,6 +7274,7 @@ async function connectUserIMChannels(
           isGroupOwnerMessage,
           isSenderAllowedInGroup,
           onCardInterrupt: handleCardInterrupt,
+          onP2pSender: onFeishuP2pSender,
         })
       : Promise.resolve(false);
 
@@ -7713,7 +7702,16 @@ async function main(): Promise<void> {
     if (config.enabled !== false && config.appId && config.appSecret) {
       const homeGroup = getUserHomeGroup(adminUser.id);
       const homeFolder = homeGroup?.folder || MAIN_GROUP_FOLDER;
-      const onNewChat = buildOnNewChat(adminUser.id, homeFolder);
+      const adminOwnerRef = { value: getUserFeishuConfig(adminUser.id)?.ownerOpenId ?? undefined };
+      const getAdminOwnerOpenId = () => adminOwnerRef.value;
+      const onAdminP2pSender = (senderOpenId: string) => {
+        if (!adminOwnerRef.value) {
+          adminOwnerRef.value = senderOpenId;
+          saveFeishuOwnerOpenId(adminUser.id, senderOpenId);
+          logger.info({ userId: adminUser.id, senderOpenId }, 'Feishu owner open_id auto-detected from P2P message');
+        }
+      };
+      const onNewChat = buildOnNewChat(adminUser.id, homeFolder, getAdminOwnerOpenId);
       const connected = await imManager.connectUserFeishu(
         adminUser.id,
         config,
@@ -7721,12 +7719,13 @@ async function main(): Promise<void> {
         {
           ignoreMessagesBefore: Date.now(),
           onCommand: handleCommand,
-          onBotAddedToGroup: buildFeishuBotAddedHandler(adminUser.id, homeFolder),
+          onBotAddedToGroup: buildFeishuBotAddedHandler(adminUser.id, homeFolder, getAdminOwnerOpenId),
           onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
           shouldProcessGroupMessage,
           isGroupOwnerMessage,
           isSenderAllowedInGroup,
           onCardInterrupt: handleCardInterrupt,
+          onP2pSender: onAdminP2pSender,
         },
       );
       if (connected) {
@@ -7808,8 +7807,8 @@ async function main(): Promise<void> {
       return false;
     }
     const homeFolder = homeGroup.folder;
-    const onNewChat = buildOnNewChat(userId, homeFolder);
     const ignoreMessagesBefore = Date.now();
+    const onNewChat = buildOnNewChat(userId, homeFolder);
 
     if (channel === 'feishu') {
       await imManager.disconnectUserFeishu(userId);
@@ -7820,6 +7819,16 @@ async function main(): Promise<void> {
         config.appId &&
         config.appSecret
       ) {
+        const reloadOwnerRef = { value: config.ownerOpenId ?? undefined };
+        const getReloadOwnerOpenId = () => reloadOwnerRef.value;
+        const onReloadP2pSender = (senderOpenId: string) => {
+          if (!reloadOwnerRef.value) {
+            reloadOwnerRef.value = senderOpenId;
+            saveFeishuOwnerOpenId(userId, senderOpenId);
+            logger.info({ userId, senderOpenId }, 'Feishu owner open_id auto-detected from P2P message');
+          }
+        };
+        const onNewChat = buildOnNewChat(userId, homeFolder, getReloadOwnerOpenId);
         const connected = await imManager.connectUserFeishu(
           userId,
           config,
@@ -7827,12 +7836,13 @@ async function main(): Promise<void> {
           {
             ignoreMessagesBefore,
             onCommand: handleCommand,
-            onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder),
+            onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder, getReloadOwnerOpenId),
             onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
             shouldProcessGroupMessage,
             isGroupOwnerMessage,
             isSenderAllowedInGroup,
             onCardInterrupt: handleCardInterrupt,
+            onP2pSender: onReloadP2pSender,
           },
         );
         logger.info(

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -230,6 +230,7 @@ interface StoredFeishuProviderConfigV1 {
   appId: string;
   enabled?: boolean;
   updatedAt: string;
+  ownerOpenId?: string;
   secret: EncryptedSecrets;
 }
 
@@ -3011,6 +3012,7 @@ export interface UserFeishuConfig {
   appSecret: string;
   enabled?: boolean;
   updatedAt: string | null;
+  ownerOpenId?: string; // auto-detected from first DM; used as sender_allowlist seed for new groups
 }
 
 export interface UserTelegramConfig {
@@ -3101,6 +3103,7 @@ export function getUserFeishuConfig(userId: string): UserFeishuConfig | null {
       appSecret: secret.appSecret,
       enabled: stored.enabled,
       updatedAt: stored.updatedAt || null,
+      ownerOpenId: stored.ownerOpenId || undefined,
     };
   } catch (err) {
     logger.warn({ err, userId }, 'Failed to read user Feishu config');
@@ -3117,6 +3120,7 @@ export function saveUserFeishuConfig(
     appSecret: normalizeSecret(next.appSecret, 'appSecret'),
     enabled: next.enabled,
     updatedAt: new Date().toISOString(),
+    ownerOpenId: next.ownerOpenId,
   };
 
   const payload: StoredFeishuProviderConfigV1 = {
@@ -3124,6 +3128,7 @@ export function saveUserFeishuConfig(
     appId: normalized.appId,
     enabled: normalized.enabled,
     updatedAt: normalized.updatedAt || new Date().toISOString(),
+    ownerOpenId: normalized.ownerOpenId,
     secret: encryptChannelSecret<FeishuSecretPayload>({
       appSecret: normalized.appSecret,
     }),
@@ -3136,6 +3141,24 @@ export function saveUserFeishuConfig(
   fs.writeFileSync(tmp, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
   fs.renameSync(tmp, filePath);
   return normalized;
+}
+
+/**
+ * Update only the ownerOpenId in an existing Feishu config file, preserving the encrypted secret.
+ */
+export function saveFeishuOwnerOpenId(userId: string, openId: string): void {
+  const filePath = path.join(userImDir(userId), 'feishu.json');
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    parsed.ownerOpenId = openId;
+    const tmp = `${filePath}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, filePath);
+    logger.info({ userId, openId }, 'Feishu owner open_id saved');
+  } catch (err) {
+    logger.warn({ err, userId }, 'Failed to save Feishu owner open_id');
+  }
 }
 
 export function getUserTelegramConfig(

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface RegisteredGroup {
   require_mention?: boolean; // 群聊是否需要 @机器人 才响应（默认 false）
   activation_mode?: 'auto' | 'always' | 'when_mentioned' | 'owner_mentioned' | 'disabled'; // 消息门控模式（默认 'auto'，兼容 require_mention）
   owner_im_id?: string; // activation_mode 为 'owner_mentioned' 时，仅此 IM 标识符的发送者被响应
+  sender_allowlist?: string[] | null; // null/undefined = 不限制，[] = 仅 owner 可触发（未 /claim 时无人可触发），[ids] = 白名单
   mcp_mode?: 'inherit' | 'custom'; // MCP 配置模式（默认 'inherit' 继承用户配置）
   selected_mcps?: string[] | null; // custom 模式下选中的 MCP server IDs
   conversation_source?: ConversationSource; // 工作区会话来源（默认 manual）


### PR DESCRIPTION
## 用户场景

### 痛点
Bot 被拉进群后默认对所有成员开放，带来两类问题：
1. **消耗配额**：群里随便有人 @bot 闲聊就吃掉 API token
2. **被调戏**：陌生群成员用 prompt injection 测试 bot 边界，甚至套取 system prompt
3. **误触发**：群里成员打算 @另一个同名 bot，结果我们的 bot 回了

### 典型场景（按本 PR 支持的程度）
- **私人小群（owner 专用）**：拉 bot 进自己的工作群，希望只有自己能用 → 新群默认 `sender_allowlist = [ownerOpenId]`，其他人被挡在门外
- **协作团队群**：想让几个同事一起用 → owner 发 `/allow @同事`，对方加入白名单即可触发
- **陌生群误拉**：同事不小心把 bot 拉进一个陌生群 → bot 默认锁定，谁都触发不了，owner 不作任何操作也不会被滥用
- **老群迁移**：已经在用的群（`sender_allowlist=null`） → 保持原行为，不影响任何现有功能

### Owner 识别
首次使用时 owner 可能还没被 bot「认识」。本 PR 采用**首条私信自动识别**的策略，零配置：
- Owner 向 bot 发一条私信 → 系统自动把 `sender` 的 open_id 记为 owner，持久化到 `data/config/user-im/{userId}/feishu.json`
- 之后拉 bot 进群 → 自动带上 `owner_im_id` 和 `sender_allowlist = [ownerOpenId]`

Edge case：如果 owner 先拉 bot 进群后才首次私信，该群会短暂处于 `sender_allowlist=[]`（完全锁定）状态，欢迎消息会提示 owner 先发一条私信完成识别。识别后下次再拉新群自动生效。

## 实现方案

### 数据模型
`registered_groups` 新增字段 `sender_allowlist: string[] | null`（TEXT，JSON 序列化）：
- `null` / `undefined` → 不启用白名单（老群默认，向后兼容）
- `[]` → 锁定，谁都不能触发
- `[openId1, openId2, ...]` → 白名单

Schema 版本 v35 → v36，通过 `ensureColumn` 非破坏式迁移。

### 门控顺序（`feishu.ts: handleIncomingMessage`）
```
群聊消息
  ├─ 1. 命令检测（/allow, /list...）──→ 有命令 → 直接处理 + return（不受门控约束）
  ├─ 2. sender_allowlist 过滤 ────── 本 PR 新增
  │     非白名单成员 @bot → 加 SILENT 表情（软拒绝，让发言者知道被挡下）
  │     非白名单成员 未 @bot → 静默丢弃
  ├─ 3. activation_mode / require_mention 过滤（原有）
  └─ 4. 正常处理
```

两道门独立正交，AND 串联。命令通道永远畅通，即使 `sender_allowlist=[]` 完全锁定的群，owner 仍可发 `/allow @成员` 解锁（前提是 `owner_im_id` 已知）。

### Owner 自动识别
新增 `onP2pSender` 回调链：
- `feishu.ts`：P2P 消息到达时调用回调
- `im-channel.ts` / `im-manager.ts`：透传
- `index.ts`：在 `connectUserIMChannels` / 两处 hot-reload 处维护 per-user `ownerOpenIdRef`，首次检测自动写入 `data/config/user-im/{userId}/feishu.json`（`saveFeishuOwnerOpenId` 原子 patch，不重新加密 secret）

### 新增命令
| 命令 | 功能 | 权限 |
|------|------|------|
| `/allow @成员` | 加入白名单 | owner |
| `/disallow @成员` | 移出白名单 | owner（不能移除自己） |
| `/allowlist` | 查看当前白名单 | 任何人（查询） |

## 改动范围

| 文件 | 改动 |
|------|------|
| `src/types.ts` | 新增 `sender_allowlist?: string[] \| null` |
| `src/db.ts` | Schema v35→v36 migration，`parseGroupRow` / `setRegisteredGroup` 处理新字段 |
| `src/feishu.ts` | 新增 `onP2pSender`、`isSenderAllowedInGroup` 回调；白名单门控；SILENT reack |
| `src/im-channel.ts` / `src/im-manager.ts` | 透传 `onP2pSender` / `isSenderAllowedInGroup` |
| `src/index.ts` | 新增 `handleAllowCommand` / `handleDisallowCommand` / `handleAllowlistCommand`；`buildOnNewChat` / `buildFeishuBotAddedHandler` 接入 owner getter；三处 Feishu 连接点（loadState / admin reload / per-user reload）维护 `ownerOpenIdRef` + `onP2pSender` |
| `src/runtime-config.ts` | `UserFeishuConfig.ownerOpenId` + `saveFeishuOwnerOpenId()` |

## 向后兼容性
- 老群 `sender_allowlist IS NULL` → `null` → 行为完全不变
- DB migration 通过 `ensureColumn` 非破坏式升级
- 所有现有命令 / 交互不变

## 测试
- 全量 190 个现有测试通过（`make test`）
- TypeScript 编译通过（后端 + 前端 + agent-runner 均 OK）
- 注：upstream/main 存在一个预存在的 `ThinkingAdaptive.display` 属性 typecheck 错误（SDK `"*"` wildcard 拉了新版 SDK 后该属性被移除），与本 PR 无关

## 设计参考
调研了 OpenClaw（`extensions/whatsapp/src/auto-reply/monitor/group-gating.ts`）和 ttmate（`bot/bot.js` `receive_message`）两个成熟方案的身份模型，最终采用：
- 从 ttmate 借鉴 `SILENT` reaction 软拒绝（替代静默丢弃）
- 不走 OpenClaw 的静态配置路线，采用 P2P 自动识别（零配置体验）
- 保留 per-group 白名单粒度（而非 OpenClaw 的账户级）以支持多群不同配置