### PR TITLE
功能: Agent 对话首条回复后异步用 LLM 生成标题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1697,12 +1697,20 @@ async function generateAndApplyLLMTitle(
       .split('\n')[0]
       .replace(/^["'「『《【\[(]+|["'」』》】\])]+$/g, '')
       .trim()
-      .slice(0, 30);
+      .slice(0, 20);
     if (!cleaned) return;
 
-    updateAgentContextInfo(agentId, { name: cleaned });
-    updateChatName(virtualChatJid, cleaned);
-    finalName = cleaned;
+    // Re-check title_source: user may have manually renamed during the LLM window.
+    const currentAgent = getAgent(agentId);
+    if (currentAgent?.title_source !== 'auto') {
+      logger.info(
+        `[llm-title] skip applying generated title for agent=${agentId} because title_source=${currentAgent?.title_source}`,
+      );
+    } else {
+      updateAgentContextInfo(agentId, { name: cleaned });
+      updateChatName(virtualChatJid, cleaned);
+      finalName = cleaned;
+    }
   } catch (err) {
     logger.warn(
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1642,6 +1642,93 @@ async function summarizeWithClaude(transcript: string): Promise<string | null> {
   return sdkQuery(prompt, { model, timeout: 30_000 });
 }
 
+/**
+ * After an agent conversation's first reply finalizes, upgrade the placeholder
+ * title to an LLM-generated one. Fire-and-forget; optimistically flips
+ * title_source to 'auto' up-front so concurrent replies don't double-trigger.
+ */
+async function generateAndApplyLLMTitle(
+  agentId: string,
+  chatJid: string,
+  virtualChatJid: string,
+): Promise<void> {
+  updateAgentContextInfo(agentId, { title_source: 'auto' });
+
+  // Notify clients that title generation has started → show loading indicator.
+  const startAgent = getAgent(agentId);
+  if (startAgent) {
+    broadcastAgentStatus(
+      chatJid,
+      agentId,
+      startAgent.status as import('./types.js').AgentStatus,
+      startAgent.name,
+      startAgent.prompt,
+      undefined,
+      undefined,
+      true,
+    );
+  }
+
+  let finalName: string | undefined;
+  try {
+    const recent = getMessagesPage(virtualChatJid, undefined, 6)
+      .slice()
+      .reverse();
+    const firstUser = recent.find((m) => !m.is_from_me);
+    const firstAI = recent.find((m) => m.is_from_me);
+    if (!firstUser) return;
+
+    const userText = (firstUser.content || '').slice(0, 500);
+    const aiText = (firstAI?.content || '').slice(0, 500);
+    const prompt =
+      `根据以下对话生成一个简洁的中文标题，用于在会话列表中展示。要求：\n` +
+      `- 不超过 16 个字符\n` +
+      `- 概括用户的核心诉求\n` +
+      `- 不要加标点、引号、emoji、括号\n` +
+      `- 直接输出标题，不要解释\n\n` +
+      `用户: ${userText}\n` +
+      (aiText ? `AI: ${aiText}\n` : '');
+
+    const raw = await sdkQuery(prompt, { timeout: 20_000 });
+    if (!raw) return;
+
+    const cleaned = raw
+      .trim()
+      .split('\n')[0]
+      .replace(/^["'「『《【\[(]+|["'」』》】\])]+$/g, '')
+      .trim()
+      .slice(0, 30);
+    if (!cleaned) return;
+
+    updateAgentContextInfo(agentId, { name: cleaned });
+    updateChatName(virtualChatJid, cleaned);
+    finalName = cleaned;
+  } catch (err) {
+    logger.warn(
+      {
+        err: (err as Error).message?.slice(0, 200),
+        agentId,
+      },
+      'LLM title generation failed',
+    );
+  } finally {
+    // Always clear loading indicator, whether LLM succeeded, returned empty, or threw.
+    const endAgent = getAgent(agentId);
+    if (endAgent) {
+      broadcastAgentStatus(
+        chatJid,
+        agentId,
+        endAgent.status as import('./types.js').AgentStatus,
+        finalName ?? endAgent.name,
+        endAgent.prompt,
+        undefined,
+        undefined,
+        false,
+      );
+    }
+  }
+}
+
 // ─── /sw & /spawn: parallel task spawning ────────────────────────
 
 interface SpawnWorkspace {
@@ -5587,6 +5674,14 @@ async function processAgentConversation(
           },
           agentId,
         );
+
+        // Async LLM title upgrade after the first substantive reply.
+        if (isFirstReply && agent.kind === 'conversation') {
+          const fresh = getAgent(agentId);
+          if (fresh?.title_source === 'auto_pending') {
+            void generateAndApplyLLMTitle(agentId, chatJid, virtualChatJid);
+          }
+        }
 
         const localImagePaths = extractLocalImImagePaths(
           text,

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,6 +379,7 @@ export type WsMessageOut =
       name: string;
       prompt: string;
       resultSummary?: string;
+      titleGenerating?: boolean;
     }
   | {
       type: 'runner_state';

--- a/src/web.ts
+++ b/src/web.ts
@@ -453,11 +453,13 @@ async function handleAgentConversationMessage(
   );
   updateAgentContextInfo(agentId, { last_active_at: timestamp });
 
-  // Auto-title: generate title from first user message
+  // Auto-title: show a quick placeholder derived from the first user message.
+  // Keep title_source='auto_pending' so processAgentConversation() can upgrade
+  // it to an LLM-generated title after the first reply finalizes.
   if (agent.title_source === 'auto_pending') {
     const autoTitle = generateAutoTitle(content);
     if (autoTitle) {
-      updateAgentContextInfo(agentId, { name: autoTitle, title_source: 'auto' });
+      updateAgentContextInfo(agentId, { name: autoTitle });
       updateChatName(virtualChatJid, autoTitle);
       broadcastAgentStatus(chatJid, agentId, agent.status as import('./types.js').AgentStatus, autoTitle, agent.prompt);
     }
@@ -1604,6 +1606,7 @@ export function broadcastAgentStatus(
   prompt: string,
   resultSummary?: string,
   kind?: import('./types.js').AgentKind,
+  titleGenerating?: boolean,
 ): void {
   const jid = normalizeHomeJid(chatJid);
   const allowedUserIds = getGroupAllowedUserIds(chatJid);
@@ -1618,6 +1621,7 @@ export function broadcastAgentStatus(
     name,
     prompt,
     resultSummary,
+    titleGenerating,
   };
   safeBroadcast(msg, isHostGroupJid(chatJid), allowedUserIds);
 }

--- a/web/src/components/chat/AgentTabBar.tsx
+++ b/web/src/components/chat/AgentTabBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { Plus, X, Link, MessageSquare, Pencil, Trash2 } from 'lucide-react';
+import { Plus, X, Link, MessageSquare, Pencil, Trash2, Loader2 } from 'lucide-react';
 import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, horizontalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -127,9 +127,14 @@ function SortableTab({ agent, isActive, onSelect, onContextMenu, onTouchStart, o
       onTouchEnd={mergedOnTouchEnd}
       onTouchMove={mergedOnTouchMove}
     >
-      {agent.status === 'running' && (
+      {agent.title_generating ? (
+        <Loader2
+          className="w-3 h-3 animate-spin text-teal-500 flex-shrink-0"
+          aria-label="正在生成标题"
+        />
+      ) : agent.status === 'running' ? (
         <span className="w-1.5 h-1.5 rounded-full bg-teal-500 animate-pulse flex-shrink-0" />
-      )}
+      ) : null}
       {hasLinked && (
         <span title={`已绑定: ${agent.linked_im_groups!.map(g => g.name).join(', ')}`}>
           <MessageSquare className="w-3 h-3 text-teal-500 flex-shrink-0" />

--- a/web/src/components/chat/TopicSidebar.tsx
+++ b/web/src/components/chat/TopicSidebar.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { X, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { AgentInfo } from '../../types';
 
@@ -59,13 +59,19 @@ export function TopicSidebar({
                 <button
                   onClick={() => onSelectAgent(agent.id)}
                   className={cn(
-                    'min-w-0 flex-1 px-3 py-2 text-left text-sm truncate cursor-pointer',
+                    'min-w-0 flex-1 px-3 py-2 text-left text-sm cursor-pointer flex items-center gap-1.5',
                     active
                       ? 'font-medium text-primary'
                       : 'text-foreground',
                   )}
                 >
-                  {agent.name}
+                  {agent.title_generating && (
+                    <Loader2
+                      className="h-3 w-3 shrink-0 animate-spin text-teal-500"
+                      aria-label="正在生成标题"
+                    />
+                  )}
+                  <span className="truncate">{agent.name}</span>
                 </button>
                 <button
                   onClick={(e) => { e.stopPropagation(); onDeleteAgent(agent.id); }}

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -89,6 +89,7 @@ export function AppLayout() {
         useChatStore.getState().handleAgentStatus(
           data.chatJid, data.agentId, data.status,
           data.name, data.prompt, data.resultSummary, data.kind,
+          data.titleGenerating,
         );
       }
     });

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -196,7 +196,7 @@ interface ChatState {
   deleteFlow: (jid: string) => Promise<void>;
   handleStreamEvent: (chatJid: string, event: StreamEvent, agentId?: string) => void;
   handleWsNewMessage: (chatJid: string, wsMsg: any, agentId?: string, source?: string) => void;
-  handleAgentStatus: (chatJid: string, agentId: string, status: AgentInfo['status'], name: string, prompt: string, resultSummary?: string, kind?: AgentInfo['kind']) => void;
+  handleAgentStatus: (chatJid: string, agentId: string, status: AgentInfo['status'], name: string, prompt: string, resultSummary?: string, kind?: AgentInfo['kind'], titleGenerating?: boolean) => void;
   clearStreaming: (
     chatJid: string,
     options?: { preserveThinking?: boolean },
@@ -1779,7 +1779,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   // 处理子 Agent 状态变更事件
-  handleAgentStatus: (chatJid, agentId, status, name, prompt, resultSummary?, kind?) => {
+  handleAgentStatus: (chatJid, agentId, status, name, prompt, resultSummary?, kind?, titleGenerating?) => {
     set((s) => {
       const existing = s.agents[chatJid] || [];
 
@@ -1828,6 +1828,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         created_at: previous?.created_at || new Date().toISOString(),
         completed_at: (status === 'completed' || status === 'error') ? new Date().toISOString() : undefined,
         result_summary: resultSummary,
+        title_generating: typeof titleGenerating === 'boolean' ? titleGenerating : previous?.title_generating,
       };
       const updated = idx >= 0
         ? existing.map((a, i) => (i === idx ? agentInfo : a))
@@ -1869,10 +1870,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       // Conversation agent started running: reset agentWaiting so stream events
       // are accepted (mirrors handleRunnerState for the main conversation).
-      // Without this, Feishu-sourced messages (which skip sendAgentMessage) would
-      // leave agentWaiting=false and cause all streaming events to be dropped.
+      // Skip for title-only broadcasts (titleGenerating set) — those carry the
+      // persistent running status but shouldn't re-open the "waiting" window
+      // after the reply has already finalized.
       const nextAgentWaiting =
-        (resolvedKind === 'conversation' || resolvedKind === 'spawn') && status === 'running'
+        (resolvedKind === 'conversation' || resolvedKind === 'spawn') &&
+        status === 'running' &&
+        typeof titleGenerating !== 'boolean'
           ? { ...s.agentWaiting, [agentId]: true }
           : s.agentWaiting;
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -35,6 +35,7 @@ export interface AgentInfo {
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;
+  title_generating?: boolean;
   last_active_at?: string | null;
   latest_message?: { content: string; timestamp: string } | null;
 }


### PR DESCRIPTION
## 问题描述

Agent 对话的自动命名目前只截取首条用户消息的前 20 字符（`src/web.ts` `generateAutoTitle`），语义化程度低。例如用户输入"帮我看看 happyclaw 的 auto-title 逻辑是怎么走的…" 会被截成 `帮我看看 happyclaw 的 auto-t…`，在会话列表里难以快速识别主题。

## 实现方案

**新流程**：
1. 用户发首条消息 → 立即显示 20 字截断作为**占位符**（旧行为保留，保证瞬时反馈），`title_source` 保持 `auto_pending`
2. Agent 首条回复 broadcast 完成瞬间 → 触发异步 LLM 标题生成
3. LLM 生成期间侧栏 Tab/标题左侧显示青色旋转 spinner（替代原 running 脉冲点）
4. ~4-6s 后标题跳变为 LLM 生成的 ≤16 字中文短句，spinner 消失

**LLM 调用**：复用现有 `sdkQuery`（走 Web 端配置的 Claude provider，与 `/recall` 同一机制），prompt 要求 ≤16 字、无标点/引号/emoji。清洗首尾引号后截 30 字作为兜底。失败/空返回静默降级（占位符保留，`title_source` 翻到 `'auto'` 防重试）。

### \`src/index.ts\`
- 新增 \`generateAndApplyLLMTitle()\`：开头立即翻转 \`title_source='auto'\` 防重入，首尾广播 \`titleGenerating\` 标志驱动前端 loading
- 触发点：\`processAgentConversation()\` 在首条 reply \`broadcastNewMessage()\` 之后判断 \`isFirstReply && agent.kind==='conversation' && title_source==='auto_pending'\`，fire-and-forget 调用生成函数

### \`src/web.ts\` / \`src/types.ts\`
- \`broadcastAgentStatus()\` 增加可选 \`titleGenerating\` 参数
- \`agent_status\` WS 消息新增 \`titleGenerating?: boolean\` 字段

### \`web/src/stores/chat.ts\`
- \`handleAgentStatus()\` 接收 \`titleGenerating\` 并保留到 \`AgentInfo.title_generating\`
- 关键守卫：原本 \`status==='running'\` 会重置 \`agentWaiting=true\`，现在加 \`typeof titleGenerating !== 'boolean'\` 守卫——title-only 广播不重开 waiting 窗口（否则回复完成后"正在思考"会因为 title-gen 广播再次出现）

### \`web/src/components/chat/AgentTabBar.tsx\` / \`TopicSidebar.tsx\`
- \`title_generating\` 时渲染 \`Loader2\` spinner（\`text-teal-500\`，与原 running 脉冲点同色，dark/light 均可见），位于标题左侧，与 running 点**互斥**显示

### \`web/src/components/layout/AppLayout.tsx\` / \`web/src/types.ts\`
- 全局 \`agent_status\` 监听透传 \`titleGenerating\`；\`AgentInfo\` 增加 \`title_generating?: boolean\`

## 测试

- **离线 sdkQuery 效果**：3 个真实 prompt 生成标题：\`happyclaw自动标题逻辑分析\`（17 字）/ \`Python大文件下载进度条显示\`（16 字）/ \`周末爬香山装备建议\`（9 字），耗时 4-5s，引号清洗生效
- **DB e2e**：种入 \`auto_pending\` agent + 模拟消息 → sdkQuery → 清洗 → UPDATE → \`title_source\` 翻转链路通
- **浏览器 UI**：新建对话 → 首条消息 → 回复完成 → 左侧青色 spinner → 标题跳变，"正在思考"不再残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)