### PR TITLE
修复: AI 流式输出时用户滚动被强制拉回底部的问题 (#453)

### DIFF
--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -60,6 +60,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   const aiColor = currentUser?.ai_avatar_color || appearance?.aiAvatarColor;
   const aiImageUrl = currentUser?.ai_avatar_url;
   const parentRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const scrollStateRef = useRef({ autoScroll: true, atTop: false });
   const [autoScroll, setAutoScroll] = useState(true);
   const [atTop, setAtTop] = useState(false);
@@ -147,21 +148,39 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
     overscan: window.innerWidth < 1024 ? 12 : 8,
   });
 
-  // 检测向上滚动触发 loadMore + 保存滚动位置
+  // IntersectionObserver detects when the sentinel element (at the very bottom of
+  // content) enters or leaves the viewport. This replaces the manual isAtBottom
+  // threshold and eliminates the race condition where setInterval fires before
+  // React state has propagated setAutoScroll(false).
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const parent = parentRef.current;
+    if (!sentinel || !parent) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const isVisible = entry.isIntersecting;
+        if (scrollStateRef.current.autoScroll !== isVisible) {
+          scrollStateRef.current.autoScroll = isVisible;
+          setAutoScroll(isVisible);
+        }
+      },
+      { root: parent, threshold: 0 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 检测向上滚动触发 loadMore + 检测到顶
   useEffect(() => {
     const parent = parentRef.current;
     if (!parent) return;
 
     const handleScroll = () => {
-      const { scrollTop, scrollHeight, clientHeight } = parent;
-      const isAtBottom = scrollHeight - scrollTop - clientHeight < 100;
+      const { scrollTop } = parent;
       const isAtTop = scrollTop < 50;
 
-      // Only trigger setState when value actually changes
-      if (scrollStateRef.current.autoScroll !== isAtBottom) {
-        scrollStateRef.current.autoScroll = isAtBottom;
-        setAutoScroll(isAtBottom);
-      }
       if (scrollStateRef.current.atTop !== isAtTop) {
         scrollStateRef.current.atTop = isAtTop;
         setAtTop(isAtTop);
@@ -180,7 +199,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   useEffect(() => {
     if (autoScroll && messages.length > prevMessageCount.current) {
       requestAnimationFrame(() => {
-        parentRef.current?.scrollTo({ top: parentRef.current.scrollHeight, behavior: 'smooth' });
+        sentinelRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
       });
     }
     prevMessageCount.current = messages.length;
@@ -189,9 +208,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   // 外部触发滚到底部（发送消息后）
   useEffect(() => {
     if (scrollTrigger && scrollTrigger > 0) {
+      scrollStateRef.current.autoScroll = true;
       setAutoScroll(true);
       requestAnimationFrame(() => {
-        parentRef.current?.scrollTo({ top: parentRef.current.scrollHeight, behavior: 'smooth' });
+        sentinelRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
       });
     }
   }, [scrollTrigger]);
@@ -246,25 +266,30 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
 
   // Auto-scroll when streaming content is active — poll-based to avoid
   // re-rendering on every text_delta (the streaming object changes very frequently).
+  // Checks scrollStateRef (updated synchronously by IntersectionObserver) instead
+  // of the autoScroll state to eliminate the race condition where the interval
+  // fires before React has propagated setAutoScroll(false) after user scrolls up.
   const hasStreaming = useChatStore(s =>
     agentId ? !!s.agentStreaming[agentId] : !!s.streaming[groupJid ?? '']
   );
   useEffect(() => {
-    if (!autoScroll || !hasStreaming) return;
+    if (!hasStreaming) return;
     const id = setInterval(() => {
-      parentRef.current?.scrollTo({ top: parentRef.current.scrollHeight });
+      if (scrollStateRef.current.autoScroll) {
+        sentinelRef.current?.scrollIntoView({ block: 'end' });
+      }
     }, 100);
     return () => clearInterval(id);
-  }, [hasStreaming, autoScroll]);
+  }, [hasStreaming]);
 
   const scrollToTop = useCallback(() => {
     parentRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
 
   const scrollToBottom = useCallback(() => {
-    const parent = parentRef.current;
-    if (!parent) return;
-    parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
+    scrollStateRef.current.autoScroll = true;
+    setAutoScroll(true);
+    sentinelRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
   }, []);
 
   const showScrollButtons = messages.length > 0;
@@ -476,6 +501,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
         {groupJid && !agentId && spawnAgents.map(a => (
           <StreamingDisplay key={a.id} groupJid={groupJid} isWaiting={true} agentId={a.id} senderName={a.name} />
         ))}
+
+        {/* Sentinel element observed by IntersectionObserver to detect whether the
+            user is at the bottom. Visible → autoScroll=true; off-screen → false. */}
+        <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
 
         </div>
       </div>


### PR DESCRIPTION
## 问题描述

关闭 #453。

AI 流式输出期间，用户向上滚动后会被强制拉回底部，无法阅读历史内容。

**根因**：`setInterval`（100ms）在 `autoScroll` 状态未完成 React 更新前就执行了滚动，产生竞态。用户滚动触发 `setAutoScroll(false)` 需要一个渲染周期，这期间 interval 仍读到旧的 `true` 状态。

## 修复方案

### `web/src/components/chat/MessageList.tsx`

- **引入 `IntersectionObserver` 监听 sentinel 元素**：在滚动容器底部放置一个 1px 的 sentinel `<div>`，用 IO 观察它的可见性。IO 回调同步更新 `scrollStateRef.current.autoScroll`，消除与 React 状态的竞态
- **setInterval 改为检查 ref 而非 state**：`scrollStateRef.current.autoScroll` 由 IO 同步写入，interval tick 读取时已是最新值，滚动后立即停止跟随
- **简化 `handleScroll`**：移除 `isAtBottom` 计算和 `autoScroll` 逻辑，仅保留 `atTop` 检测和 `onLoadMore` 触发
- **统一使用 `sentinel.scrollIntoView`**：新消息自动滚动、`scrollTrigger`、`scrollToBottom` 按钮均改为 scrollIntoView，与 sentinel 位置保持一致