### PR TITLE
修复: Linux glibc 系统上 SDK 错选 musl binary 导致 host 模式 agent 启动失败

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { createRequire } from 'module';
 import { query, HookCallback, PreCompactHookInput, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { detectImageMimeTypeFromBase64Strict } from './image-detector.js';
 import { pruneProcessedHistoryImagesInTranscript as pruneProcessedHistoryImagesInTranscriptFile } from './history-image-prune.js';
@@ -55,6 +56,23 @@ const CLAUDE_MODEL = process.env.ANTHROPIC_MODEL || 'opus[1m]';
 const IPC_INPUT_DIR = path.join(WORKSPACE_IPC, 'input');
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_FALLBACK_POLL_MS = 5000; // 后备轮询间隔（仅防止 inotify 事件丢失）
+
+// SDK 0.2.116 在 linux 上优先解析 musl 变体（sdk.mjs:W7），只检查包存在、不验证 binary
+// 能执行；glibc 系统上 musl binary 缺 ld-musl 会 ENOENT。显式指向当前 libc 的变体。
+// 上游修复 libc 检测后可移除。
+const agentRunnerRequire = createRequire(import.meta.url);
+function resolveClaudeBinary(): string | undefined {
+  if (process.platform !== 'linux') return undefined;
+  const report = (process as { report?: { getReport?: () => { header?: { glibcVersionRuntime?: string } } } }).report?.getReport?.();
+  const isMusl = !report?.header?.glibcVersionRuntime;
+  const variant = isMusl ? `linux-${process.arch}-musl` : `linux-${process.arch}`;
+  try {
+    return agentRunnerRequire.resolve(`@anthropic-ai/claude-agent-sdk-${variant}/claude`);
+  } catch {
+    return undefined;
+  }
+}
+const CLAUDE_BINARY_PATH = resolveClaudeBinary();
 
 
 let needsMemoryFlush = false;
@@ -1271,6 +1289,7 @@ async function runQuery(
     const q = query({
     prompt: stream,
     options: {
+      ...(CLAUDE_BINARY_PATH && { pathToClaudeCodeExecutable: CLAUDE_BINARY_PATH }),
       model: CLAUDE_MODEL,
       cwd: WORKSPACE_GROUP,
       additionalDirectories: extraDirs,


### PR DESCRIPTION
claude-agent-sdk 0.2.116 的 native binary 选择函数（sdk.mjs W7）在 linux 上固定按 [musl, glibc] 顺序 require.resolve，只检查包是否存在、不验证 binary 能否执行。 glibc 系统同时装了两个 optional dep 时，musl 变体被返回给 spawn，因缺 /lib/ld-musl linker 而 ENOENT，SDK 报 "Claude Code native binary not found"，每次调用 5s 后 exit 1 进入指数退避重试。

容器内曾通过 Dockerfile symlink workaround（4612a9d）绕过，但该 commit 已被 3c66935 revert；且 workaround 只覆盖容器内，host 模式下宿主机仍错选 musl。

改为运行时用 process.report.getReport().header.glibcVersionRuntime 判定 libc， 通过 SDK 公开 option pathToClaudeCodeExecutable 显式指向正确变体。上游修复 libc 检测后可移除此层。