### PR TITLE
feat: agent docker 运行模式可选支持 per-user 配置 SSH 密钥和支持配置网络模式

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -33,6 +33,13 @@ fi
 # 导致 "Native CLI binary for linux-x64 not found" 启动失败。
 export PATH="/app/node_modules/.bin:${PATH}"
 
+# SSH key setup: if .ssh is mounted (read-only), configure git to use it.
+# The mount is read-only so we can't chown; use GIT_SSH_COMMAND to bypass
+# OpenSSH's strict permission checks on the key file.
+if [ -d /home/node/.ssh ] && ls /home/node/.ssh/id_* >/dev/null 2>&1; then
+  export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/home/node/.ssh/known_hosts -o IdentitiesOnly=yes"
+fi
+
 # Discover and link skills (builtin → project → user, higher priority overwrites)
 # Only remove entries that conflict with mounted skills (non-symlink with same name),
 # preserving any skills the agent created directly in .claude/skills/.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -484,6 +484,20 @@ function buildVolumeMounts(
     readonly: false,
   });
 
+  // Per-user SSH keys: mount user's SSH directory (read-only) for git clone via SSH
+  if (ownerId) {
+    const userSshDir = path.join(DATA_DIR, 'config', 'user-ssh', ownerId);
+    if (fs.existsSync(userSshDir) && fs.readdirSync(userSshDir).some(
+      (f) => f.startsWith('id_'),
+    )) {
+      mounts.push({
+        hostPath: userSshDir,
+        containerPath: '/home/node/.ssh',
+        readonly: true,
+      });
+    }
+  }
+
   // Per-container environment file (keeps credentials out of process listings)
   // Global config merged with per-container overrides.
   const envDir = path.join(DATA_DIR, 'env', group.folder);
@@ -636,6 +650,14 @@ function buildContainerArgs(
   tz: string,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
+
+  const networkMode = getSystemSettings().containerNetworkMode;
+  if (networkMode === 'host') {
+    args.push('--network', 'host');
+  } else {
+    // bridge 模式下添加 host.docker.internal 映射（Linux 原生 Docker 无此内置别名）
+    args.push('--add-host', 'host.docker.internal:host-gateway');
+  }
 
   // Set timezone so container Node.js processes use local time (Asia/Shanghai)
   args.push('-e', `TZ=${tz}`);

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -95,8 +95,11 @@ import {
   clearBillingEnabledCache,
 } from '../billing.js';
 import { providerPool } from '../provider-pool.js';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import fs from 'fs';
 import path from 'path';
+import { DATA_DIR } from '../config.js';
 
 const configRoutes = new Hono<{ Variables: Variables }>();
 
@@ -2712,6 +2715,147 @@ configRoutes.put('/user-im/bindings/:imJid', authMiddleware, async (c) => {
     { error: 'Must provide target_main_jid, target_agent_id, activation_mode, or unbind' },
     400,
   );
+});
+
+// ─── SSH Key Management ────────────────────────────────────────────
+// Per-user SSH keys for Docker containers to clone private repos via SSH.
+
+const SSH_BASE_DIR = path.join(DATA_DIR, 'config', 'user-ssh');
+const execFileAsync = promisify(execFile);
+
+function getUserSshDir(userId: string): string {
+  return path.join(SSH_BASE_DIR, userId);
+}
+
+function findPrivateKeyFile(dir: string): string | null {
+  if (!fs.existsSync(dir)) return null;
+  for (const name of ['id_ed25519', 'id_rsa', 'id_ecdsa', 'id_dsa']) {
+    if (fs.existsSync(path.join(dir, name))) return name;
+  }
+  return null;
+}
+
+function detectKeyType(content: string): string {
+  if (content.includes('BEGIN OPENSSH PRIVATE KEY')) return 'openssh';
+  if (content.includes('BEGIN RSA PRIVATE KEY')) return 'rsa';
+  if (content.includes('BEGIN EC PRIVATE KEY')) return 'ecdsa';
+  if (content.includes('BEGIN DSA PRIVATE KEY')) return 'dsa';
+  return 'unknown';
+}
+
+function keyTypeToFilename(content: string): string {
+  const type = detectKeyType(content);
+  if (type === 'rsa') return 'id_rsa';
+  if (type === 'ecdsa') return 'id_ecdsa';
+  if (type === 'dsa') return 'id_dsa';
+  return 'id_ed25519';
+}
+
+async function getPublicKeyFingerprint(
+  privateKeyPath: string,
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('ssh-keygen', [
+      '-l',
+      '-f',
+      privateKeyPath,
+    ]);
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+
+configRoutes.get('/user-ssh', authMiddleware, async (c) => {
+  const user = c.get('user');
+  const dir = getUserSshDir(user.id);
+  const keyFile = findPrivateKeyFile(dir);
+
+  if (!keyFile) {
+    return c.json({ configured: false });
+  }
+
+  const fingerprint = await getPublicKeyFingerprint(path.join(dir, keyFile));
+  return c.json({
+    configured: true,
+    keyType: keyFile.replace('id_', ''),
+    fingerprint,
+  });
+});
+
+configRoutes.put('/user-ssh', authMiddleware, async (c) => {
+  const user = c.get('user');
+  let body: { privateKey?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: '无效的请求体' }, 400);
+  }
+
+  const privateKey = body.privateKey?.trim();
+  if (!privateKey) {
+    return c.json({ error: '缺少 privateKey 字段' }, 400);
+  }
+
+  if (!privateKey.includes('-----BEGIN') || !privateKey.includes('PRIVATE KEY-----')) {
+    return c.json({ error: '无效的 SSH 私钥格式，需要 PEM 格式的私钥' }, 400);
+  }
+
+  const dir = getUserSshDir(user.id);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Remove any existing key files first
+  for (const name of ['id_ed25519', 'id_rsa', 'id_ecdsa', 'id_dsa']) {
+    const p = path.join(dir, name);
+    try { fs.unlinkSync(p); } catch { /* ok */ }
+    try { fs.unlinkSync(p + '.pub'); } catch { /* ok */ }
+  }
+
+  const filename = keyTypeToFilename(privateKey);
+  const keyPath = path.join(dir, filename);
+
+  // Ensure trailing newline (ssh-keygen requires it)
+  const content = privateKey.endsWith('\n') ? privateKey : privateKey + '\n';
+  fs.writeFileSync(keyPath, content, { mode: 0o600 });
+
+  // Generate public key from private key
+  try {
+    await execFileAsync('ssh-keygen', ['-y', '-f', keyPath], { timeout: 5000 })
+      .then(({ stdout }) => {
+        fs.writeFileSync(keyPath + '.pub', stdout.trim() + '\n', { mode: 0o644 });
+      });
+  } catch {
+    // Non-fatal: fingerprint just won't be available
+  }
+
+  // Write SSH config to prefer this key
+  fs.writeFileSync(
+    path.join(dir, 'config'),
+    `Host *\n  IdentityFile ~/.ssh/${filename}\n  StrictHostKeyChecking accept-new\n`,
+    { mode: 0o644 },
+  );
+
+  const fingerprint = await getPublicKeyFingerprint(keyPath);
+  logger.info({ userId: user.id, keyType: filename }, 'SSH key saved');
+
+  return c.json({
+    configured: true,
+    keyType: filename.replace('id_', ''),
+    fingerprint,
+  });
+});
+
+configRoutes.delete('/user-ssh', authMiddleware, (c) => {
+  const user = c.get('user');
+  const dir = getUserSshDir(user.id);
+
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+
+  logger.info({ userId: user.id }, 'SSH key deleted');
+  return c.json({ configured: false });
 });
 
 export default configRoutes;

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3510,6 +3510,8 @@ export interface SystemSettings {
   // 关闭 admin host 模式下 HappyClaw 自带的 memory 注入层（MCP 工具、模板 CLAUDE.md、WORKSPACE_GLOBAL/MEMORY env）
   // 启用后 admin 可以在 host 模式下完全按原生 Claude Code 的 Playbook 使用 ~/.claude/ 下的 memory/skills/rules
   disableMemoryLayerForAdminHost: boolean;
+  // Docker 容器网络模式：'bridge'（默认隔离网络）| 'host'（共享宿主机网络栈，容器内 localhost 即宿主机）
+  containerNetworkMode: 'bridge' | 'host';
 }
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -3530,6 +3532,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   externalClaudeDir: '',
   autoCompactWindow: 0,
   disableMemoryLayerForAdminHost: false,
+  containerNetworkMode: 'bridge',
 };
 
 function parseIntEnv(envVar: string | undefined, fallback: number): number {
@@ -3624,6 +3627,10 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       typeof raw.disableMemoryLayerForAdminHost === 'boolean'
         ? raw.disableMemoryLayerForAdminHost
         : DEFAULT_SYSTEM_SETTINGS.disableMemoryLayerForAdminHost,
+    containerNetworkMode:
+      raw.containerNetworkMode === 'host'
+        ? 'host'
+        : DEFAULT_SYSTEM_SETTINGS.containerNetworkMode,
   };
 }
 
@@ -3688,6 +3695,10 @@ function buildEnvFallbackSettings(): SystemSettings {
     disableMemoryLayerForAdminHost:
       process.env.DISABLE_MEMORY_LAYER_FOR_ADMIN_HOST === 'true' ||
       DEFAULT_SYSTEM_SETTINGS.disableMemoryLayerForAdminHost,
+    containerNetworkMode:
+      process.env.CONTAINER_NETWORK_MODE === 'host'
+        ? 'host'
+        : DEFAULT_SYSTEM_SETTINGS.containerNetworkMode,
   };
 }
 
@@ -3782,6 +3793,11 @@ export function saveSystemSettings(
   } else if (merged.autoCompactWindow > 0) {
     if (merged.autoCompactWindow < 10000) merged.autoCompactWindow = 10000;
     if (merged.autoCompactWindow > 2000000) merged.autoCompactWindow = 2000000;
+  }
+
+  // Validate containerNetworkMode
+  if (merged.containerNetworkMode !== 'host') {
+    merged.containerNetworkMode = 'bridge';
   }
 
   // Validate externalClaudeDir: must be empty or an absolute directory path

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -245,6 +245,7 @@ export const SystemSettingsSchema = z.object({
     )
     .optional(),
   disableMemoryLayerForAdminHost: z.boolean().optional(),
+  containerNetworkMode: z.enum(['bridge', 'host']).optional(),
 });
 
 export const AppearanceConfigSchema = z.object({

--- a/web/src/components/settings/ProfileSection.tsx
+++ b/web/src/components/settings/ProfileSection.tsx
@@ -12,6 +12,7 @@ import { EmojiPicker } from '@/components/common/EmojiPicker';
 import { ColorPicker } from '@/components/common/ColorPicker';
 import { getErrorMessage } from './types';
 import { SettingsCard as Section } from './SettingsCard';
+import { SshKeySection } from './SshKeySection';
 
 /* ── Theme / Appearance selectors ─────────────────────────── */
 
@@ -419,7 +420,10 @@ export function ProfileSection() {
         </Button>
       </Section>
 
-      {/* ── 4. Password ── */}
+      {/* ── 4. SSH Key ── */}
+      <SshKeySection />
+
+      {/* ── 5. Password ── */}
       <Section icon={Lock} title="修改密码">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>

--- a/web/src/components/settings/SshKeySection.tsx
+++ b/web/src/components/settings/SshKeySection.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useRef, useState } from 'react';
+import { KeyRound, Loader2, Upload, Trash2, CheckCircle2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { api } from '../../api/client';
+import { getErrorMessage } from './types';
+import { SettingsCard as Section } from './SettingsCard';
+
+interface SshStatus {
+  configured: boolean;
+  keyType?: string;
+  fingerprint?: string | null;
+}
+
+export function SshKeySection() {
+  const [status, setStatus] = useState<SshStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [mode, setMode] = useState<'file' | 'paste'>('file');
+  const [pasteValue, setPasteValue] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const load = async () => {
+    try {
+      const data = await api.get<SshStatus>('/api/config/user-ssh');
+      setStatus(data);
+    } catch (err) {
+      toast.error(getErrorMessage(err, '加载 SSH 配置失败'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    await saveKey(text);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  const handlePaste = async () => {
+    if (!pasteValue.trim()) return;
+    await saveKey(pasteValue);
+  };
+
+  const saveKey = async (privateKey: string) => {
+    setSaving(true);
+    try {
+      const data = await api.put<SshStatus>('/api/config/user-ssh', { privateKey });
+      setStatus(data);
+      setPasteValue('');
+      toast.success('SSH 密钥已保存');
+    } catch (err) {
+      toast.error(getErrorMessage(err, '保存 SSH 密钥失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await api.delete('/api/config/user-ssh');
+      setStatus({ configured: false });
+      toast.success('SSH 密钥已删除');
+    } catch (err) {
+      toast.error(getErrorMessage(err, '删除 SSH 密钥失败'));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Section icon={KeyRound} title="SSH 密钥" desc="用于 Docker 容器内 git clone 私有仓库">
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+        </div>
+      </Section>
+    );
+  }
+
+  return (
+    <Section icon={KeyRound} title="SSH 密钥" desc="用于 Docker 容器内 git clone 私有仓库">
+      {status?.configured ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400">
+            <CheckCircle2 className="w-4 h-4" />
+            <span>已配置（{status.keyType}）</span>
+          </div>
+          {status.fingerprint && (
+            <div className="text-xs text-muted-foreground font-mono bg-muted/50 rounded px-3 py-2 break-all">
+              {status.fingerprint}
+            </div>
+          )}
+          <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleting}>
+            {deleting ? <Loader2 className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
+            删除密钥
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex gap-2 border-b border-border">
+            <button
+              className={`px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors ${mode === 'file' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+              onClick={() => setMode('file')}
+            >
+              选择文件
+            </button>
+            <button
+              className={`px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors ${mode === 'paste' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+              onClick={() => setMode('paste')}
+            >
+              粘贴私钥
+            </button>
+          </div>
+
+          {mode === 'file' ? (
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">
+                选择 SSH 私钥文件（如 ~/.ssh/id_ed25519）
+              </Label>
+              <input ref={fileRef} type="file" className="hidden" onChange={handleFileSelect} />
+              <Button variant="outline" size="sm" onClick={() => fileRef.current?.click()} disabled={saving}>
+                {saving ? <Loader2 className="size-4 animate-spin" /> : <Upload className="size-4" />}
+                选择私钥文件
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">
+                粘贴 SSH 私钥内容
+              </Label>
+              <textarea
+                className="w-full h-32 text-xs font-mono rounded-md border border-input bg-background px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;...&#10;-----END OPENSSH PRIVATE KEY-----"
+                value={pasteValue}
+                onChange={(e) => setPasteValue(e.target.value)}
+              />
+              <Button size="sm" onClick={handlePaste} disabled={saving || !pasteValue.trim()}>
+                {saving && <Loader2 className="size-4 animate-spin" />}
+                保存密钥
+              </Button>
+            </div>
+          )}
+
+          <p className="text-[11px] text-muted-foreground">
+            密钥以只读方式挂载到容器
+          </p>
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -153,6 +153,7 @@ export function SystemSettingsSection() {
   const [billingCurrencyRate, setBillingCurrencyRate] = useState(1);
   const [externalClaudeDir, setExternalClaudeDir] = useState('');
   const [disableMemoryLayerForAdminHost, setDisableMemoryLayerForAdminHost] = useState(false);
+  const [containerNetworkMode, setContainerNetworkMode] = useState<'bridge' | 'host'>('bridge');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -179,6 +180,7 @@ export function SystemSettingsSection() {
         setBillingCurrencyRate(data.billingCurrencyRate ?? 1);
         setExternalClaudeDir(data.externalClaudeDir ?? '');
         setDisableMemoryLayerForAdminHost(data.disableMemoryLayerForAdminHost ?? false);
+        setContainerNetworkMode(data.containerNetworkMode ?? 'bridge');
       } catch (err) {
         toast.error(getErrorMessage(err, '加载系统参数失败'));
       } finally {
@@ -225,6 +227,7 @@ export function SystemSettingsSection() {
         billingCurrencyRate,
         externalClaudeDir,
         disableMemoryLayerForAdminHost,
+        containerNetworkMode,
       };
       for (const f of fields) {
         const val = displayValues[f.key];
@@ -245,6 +248,7 @@ export function SystemSettingsSection() {
       setBillingCurrencyRate(data.billingCurrencyRate ?? 1);
       setExternalClaudeDir(data.externalClaudeDir ?? '');
       setDisableMemoryLayerForAdminHost(data.disableMemoryLayerForAdminHost ?? false);
+      setContainerNetworkMode(data.containerNetworkMode ?? 'bridge');
       // 刷新计费状态，更新导航栏可见性
       loadBillingStatus();
       toast.success('系统参数已保存，新参数将对后续启动的容器/进程生效');
@@ -421,6 +425,28 @@ export function SystemSettingsSection() {
             </div>
           </>
         )}
+      </div>
+
+      {/* Docker 容器网络模式 */}
+      <div className="border-t border-border pt-6 space-y-5">
+        <h3 className="text-sm font-semibold text-foreground">Docker 容器网络</h3>
+        <div className="flex items-center justify-between">
+          <div className="flex-1 pr-4">
+            <Label>容器网络模式</Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              bridge（默认）：容器使用独立网络，通过 host.docker.internal 访问宿主机。
+              host：容器直接共享宿主机网络栈，容器内 localhost 即宿主机，可直接使用宿主机代理。
+            </p>
+          </div>
+          <select
+            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+            value={containerNetworkMode}
+            onChange={(e) => setContainerNetworkMode(e.target.value as 'bridge' | 'host')}
+          >
+            <option value="bridge">bridge（默认）</option>
+            <option value="host">host</option>
+          </select>
+        </div>
       </div>
 
       {/* 禁用 HappyClaw 记忆层（admin 主容器专用） */}

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -105,6 +105,7 @@ export interface SystemSettings {
   externalClaudeDir: string;
   autoCompactWindow: number;
   disableMemoryLayerForAdminHost: boolean;
+  containerNetworkMode: 'bridge' | 'host';
 }
 
 // ─── OAuth Usage ────────────────────────────────────────────


### PR DESCRIPTION
- 新增 SSH 密钥管理 API（GET/PUT/DELETE /api/config/user-ssh），用户可上传私钥文件或粘贴，密钥以只读方式挂载到容器用于 git clone
- entrypoint.sh 中设置 GIT_SSH_COMMAND 绕过 SSH 对权限的严格检查
- 新增容器网络模式选项（bridge/host），host 模式共享宿主机网络栈，bridge 模式添加 host.docker.internal 映射
- 前端新增 SshKeySection 组件（文件上传/粘贴切换），SystemSettingsSection 新增网络模式下拉框