### PR TITLE
修复: 孤立模式定时任务执行结果未推送到 IM 的问题 (#459)

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -521,7 +521,10 @@ async function runTask(
           ownerId: workspaceGroup.created_by || undefined,
           notifyChannels: task.notify_channels,
           sourceKind: 'sdk_final',
-          workspaceFolder: workspace.folder,
+          // Use source workspace folder for IM routing — isolated tasks run in
+          // ephemeral workspaces (task-xxxxxx) that have no IM group bindings.
+          // task.group_folder is the workspace where the task was created.
+          workspaceFolder: task.group_folder || undefined,
         });
       } catch (err) {
         logger.error(


### PR DESCRIPTION
## 问题描述

关闭 #459。

`context_mode=isolated` 的定时任务执行完成后，结果消息不会推送到用户绑定的 IM 渠道（飞书/Telegram/QQ/钉钉）。

## 根因

`src/task-scheduler.ts` 的 `runTask()` 函数在调用 `storeResultAndNotify` 时，传入了 `workspaceFolder: workspace.folder`。对于孤立模式任务，`workspace.folder` 是临时执行工作区（形如 `task-xxxxxx`），没有任何 IM 群与该文件夹绑定。因此 `broadcastToOwnerIMChannels` 按 `effectiveFolder === workspace.folder` 匹配时找不到任何渠道，IM 通知静默失败。

## 修复方案

### `src/task-scheduler.ts`

将 `storeResultAndNotify` 调用中的 `workspaceFolder` 从 `workspace.folder`（执行工作区）改为 `task.group_folder`（任务创建来源工作区）。

来源工作区是用户绑定 IM 群的实际工作区，`broadcastToOwnerIMChannels` 能正确匹配到对应渠道。若 `task.group_folder` 为空，`storeResultAndNotify` 内部已有 fallback 逻辑（使用 owner 主工作区）。

## 验证

- `make build` 全绿（后端 + 前端 + agent-runner）
- `make test` 190 个单测全绿