### PR TITLE
修复: 第三方 provider 配置变更后 session 未清理导致模型冲突

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -80,7 +80,10 @@ function ensureHostClaudeJson(): string {
  * 为 Docker 容器生成精简版 .claude.json。
  * 宿主机 ~/.claude.json 中的 cachedGrowthBookFeatures 含 tengu_bridge_repl_v2 等
  * feature flags，SDK 初始化时会据此尝试建立 bridge 连接，在容器网络环境中无法完成
- * 导致进程挂起。剥离该字段后其余内容原样保留（oauthAccount、userID 等）。
+ * 导致进程挂起。剥离该字段后其余内容原样保留（userID 等）。
+ * 同时剥离 oauthAccount：容器内不走宿主机的 OAuth 登录态，认证完全由
+ * ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY 环境变量控制，避免 SDK 误检
+ * OAuth 凭据后跳过标准 Bearer header（第三方 provider 返回 404）。
  */
 function getContainerClaudeJsonPath(): string {
   const containerJsonDir = path.join(DATA_DIR, 'config');
@@ -91,6 +94,7 @@ function getContainerClaudeJsonPath(): string {
     const hostJson = JSON.parse(fs.readFileSync(getHostClaudeJsonPath(), 'utf-8'));
     const stripped = { ...hostJson };
     delete stripped.cachedGrowthBookFeatures;
+    delete stripped.oauthAccount;
     stripped.autoUpdates = false;
     fs.writeFileSync(containerJsonPath, JSON.stringify(stripped, null, 2) + '\n', { mode: 0o644 });
   } catch {
@@ -532,6 +536,15 @@ function buildVolumeMounts(
         'Failed to write .credentials.json',
       );
     }
+  }
+
+  // Third-party provider: remove any stale .credentials.json so the SDK
+  // does not detect OAuth credentials from a previous official-provider run.
+  if (mergedConfig.anthropicBaseUrl) {
+    try {
+      const staleCreds = path.join(groupSessionsDir, '.credentials.json');
+      if (fs.existsSync(staleCreds)) fs.unlinkSync(staleCreds);
+    } catch { /* ignore */ }
   }
 
   // Mount agent-runner source from host — recompiled on container startup.
@@ -1238,6 +1251,47 @@ export async function runHostAgent(
       const eqIdx = line.indexOf('=');
       if (eqIdx > 0) {
         hostEnv[line.slice(0, eqIdx)] = line.slice(eqIdx + 1);
+      }
+    }
+
+    // Third-party provider: ANTHROPIC_AUTH_TOKEN inherited from the host
+    // (~/.claude/settings.json) forces the SDK down the OAuth code path,
+    // which skips the standard Bearer header and causes 404 on non-Anthropic
+    // endpoints. Unset it so the injected ANTHROPIC_API_KEY takes effect.
+    if (hostEnv['ANTHROPIC_BASE_URL']) {
+      delete hostEnv['ANTHROPIC_AUTH_TOKEN'];
+
+      // Also strip oauthAccount from session .claude.json: the SDK detects
+      // OAuth credentials in .claude.json and takes the OAuth code path even
+      // when ANTHROPIC_AUTH_TOKEN is absent. This causes the same 404 on
+      // third-party endpoints. Remove the symlink and write a standalone
+      // .claude.json without oauthAccount so the SDK falls back to API key mode.
+      try {
+        const sessionClaudeJson = path.join(groupSessionsDir, '.claude.json');
+        try { fs.unlinkSync(sessionClaudeJson); } catch { /* ignore */ }
+        let claudeJson: Record<string, unknown> = {};
+        try {
+          claudeJson = JSON.parse(fs.readFileSync(getHostClaudeJsonPath(), 'utf-8'));
+        } catch { /* ignore */ }
+        delete claudeJson.oauthAccount;
+        fs.writeFileSync(sessionClaudeJson, JSON.stringify(claudeJson, null, 2) + '\n', { mode: 0o600 });
+      } catch (err) {
+        logger.warn(
+          { folder: group.folder, err },
+          'Failed to strip oauthAccount from session .claude.json',
+        );
+      }
+
+      // Also remove .credentials.json: it contains valid OAuth tokens that the
+      // SDK uses regardless of env vars, forcing the OAuth auth path.
+      try {
+        const credsPath = path.join(groupSessionsDir, '.credentials.json');
+        if (fs.existsSync(credsPath)) fs.unlinkSync(credsPath);
+      } catch (err) {
+        logger.warn(
+          { folder: group.folder, err },
+          'Failed to remove .credentials.json for third-party provider',
+        );
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7821,6 +7821,7 @@ async function main(): Promise<void> {
   startWebServer({
     queue,
     getRegisteredGroups: () => registeredGroups,
+    sessions,
     getSessions: () => sessions,
     processGroupMessages,
     ensureTerminalContainerStarted,

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -16,6 +16,7 @@ import {
   setRegisteredGroup,
   updateChatName,
   getAgent,
+  deleteAllSessionsForFolder,
   VALID_ACTIVATION_MODES,
 } from '../db.js';
 import { authMiddleware, systemConfigMiddleware } from '../middleware/auth.js';
@@ -164,6 +165,15 @@ async function applyClaudeConfigToAllGroups(
   );
   const failedCount = results.filter((r) => r.status === 'rejected').length;
   const stoppedCount = groupJids.length - failedCount;
+
+  // 清除所有 session 记录，确保配置变更后下次启动创建全新 session
+  const registeredGroups = deps.getRegisteredGroups();
+  for (const [_, group] of Object.entries(registeredGroups) as [string, RegisteredGroup][]) {
+    if (group.folder) {
+      deleteAllSessionsForFolder(group.folder);
+      delete deps.sessions[group.folder];
+    }
+  }
 
   appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
     stoppedCount,

--- a/src/routes/workspace-config.ts
+++ b/src/routes/workspace-config.ts
@@ -187,7 +187,7 @@ function resolveGroup(
   const jid = c.req.param('jid');
   const authUser = c.get('user') as AuthUser;
 
-  const group = getRegisteredGroup(jid);
+  const group = getRegisteredGroup(jid!);
   if (!group) {
     return null;
   }

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -2325,9 +2325,19 @@ export function buildClaudeEnvLines(
     );
   }
   if (config.anthropicAuthToken) {
-    lines.push(
-      `ANTHROPIC_AUTH_TOKEN=${sanitizeEnvValue(config.anthropicAuthToken)}`,
-    );
+    if (config.anthropicBaseUrl) {
+      // Third-party provider: the SDK treats ANTHROPIC_AUTH_TOKEN as an OAuth
+      // legacy token and skips the standard Bearer header, causing 404 on
+      // non-Anthropic endpoints. Use ANTHROPIC_API_KEY instead so the SDK
+      // sends the correct Authorization header.
+      lines.push(
+        `ANTHROPIC_API_KEY=${sanitizeEnvValue(config.anthropicAuthToken)}`,
+      );
+    } else {
+      lines.push(
+        `ANTHROPIC_AUTH_TOKEN=${sanitizeEnvValue(config.anthropicAuthToken)}`,
+      );
+    }
   }
   if (config.anthropicModel) {
     lines.push(`ANTHROPIC_MODEL=${sanitizeEnvValue(config.anthropicModel)}`);
@@ -2611,7 +2621,7 @@ export function mergeClaudeEnvConfig(
   global: ClaudeProviderConfig,
   override: ContainerEnvConfig,
 ): ClaudeProviderConfig {
-  return {
+  const merged: ClaudeProviderConfig = {
     anthropicBaseUrl: override.anthropicBaseUrl || global.anthropicBaseUrl,
     anthropicAuthToken:
       override.anthropicAuthToken || global.anthropicAuthToken,
@@ -2623,6 +2633,16 @@ export function mergeClaudeEnvConfig(
     anthropicModel: override.anthropicModel || global.anthropicModel,
     updatedAt: global.updatedAt,
   };
+
+  // Third-party provider: strip OAuth credentials so the SDK does not try
+  // the OAuth auth path (which skips the standard Bearer header and causes
+  // 404 on non-Anthropic endpoints like Kimi).
+  if (merged.anthropicBaseUrl) {
+    merged.claudeOAuthCredentials = null;
+    merged.claudeCodeOauthToken = '';
+  }
+
+  return merged;
 }
 
 // ─── Registration config (plain JSON, no encryption) ─────────────

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -25,6 +25,7 @@ export interface WsClientInfo {
 export interface WebDeps {
   queue: GroupQueue;
   getRegisteredGroups: () => Record<string, RegisteredGroup>;
+  sessions: Record<string, string>;
   getSessions: () => Record<string, string>;
   processGroupMessages: (chatJid: string) => Promise<boolean>;
   ensureTerminalContainerStarted: (chatJid: string) => boolean;


### PR DESCRIPTION
## 问题描述

修改 `anthropicModel` 等 provider 配置后，`applyClaudeConfigToAllGroups()` 只调用 `stopGroup()` 停止容器，不清理数据库中的 session 记录。下次启动 agent-runner 时恢复旧 session，Claude CLI 检测到模型名与 session 创建时不一致，抛出错误：

```
There's an issue with the selected model (K2.6). It may not exist or you may not have access to it.
```

## 修复方案

### 1. `applyClaudeConfigToAllGroups()` 增加 session 清理

`src/routes/config.ts`: 在 `stopGroup` 之后遍历所有 registered groups，调用 `deleteAllSessionsForFolder()` 并清除内存缓存 `deps.sessions`，确保配置变更后创建全新 session。

### 2. `WebDeps` 接口暴露 `sessions` 属性

`src/web-context.ts` / `src/index.ts`: `WebDeps` 增加 `sessions: Record<string, string>`，修复 `delete deps.sessions[folder]` 的 TypeError（原接口只有 `getSessions()` 方法）。

### 3. 第三方 provider OAuth 路径修复

`src/runtime-config.ts`: `third_party` provider 的 `anthropicAuthToken` 映射为 `ANTHROPIC_API_KEY`，避免 SDK 将其当作 OAuth token 处理（跳过标准 Bearer header，导致 404）。

`src/container-runner.ts`: 容器内剥离 `oauthAccount` 和 `.credentials.json`，防止第三方 provider 被误判为 OAuth 模式。

### 4. 类型修复

`src/routes/workspace-config.ts`: `getRegisteredGroup(jid!)` 参数类型修复。

## 测试验证

1. Web UI 修改 provider 模型名（如从 `kimi-for-coding` 改为 `K2.6`）
2. 发送消息，确认 agent 正常回复（无 "selected model" 错误）
3. 数据库 `sessions` 表中 session_id 已更新为新值

🤖 Generated with [Claude Code](https://claude.com/claude-code)