### PR TITLE
fix: 修复软链接到外部目录的 skill 内容无法展示

### DIFF
--- a/src/skill-utils.ts
+++ b/src/skill-utils.ts
@@ -30,14 +30,13 @@ export function validateSkillPath(
   skillsRoot: string,
   skillDir: string,
 ): boolean {
-  try {
-    const realSkillsRoot = fs.realpathSync(skillsRoot);
-    const realSkillDir = fs.realpathSync(skillDir);
-    const relative = path.relative(realSkillsRoot, realSkillDir);
-    return !relative.startsWith('..') && !path.isAbsolute(relative);
-  } catch {
-    return false;
-  }
+  // Use path.resolve (not fs.realpathSync) so symlinked skills whose targets
+  // live outside skillsRoot still pass validation.  Path traversal is already
+  // prevented by validateSkillId ([\w\-]+ only).
+  const normalizedRoot = path.resolve(skillsRoot);
+  const normalizedDir = path.resolve(skillDir);
+  const relative = path.relative(normalizedRoot, normalizedDir);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
 }
 
 export function parseFrontmatter(content: string): Record<string, string> {


### PR DESCRIPTION
软链接到外部目录的 skill 内容无法展示，但是不影响使用
<img width="2536" height="722" alt="image" src="https://github.com/user-attachments/assets/1ae9fbef-7774-4b06-abc7-0338ead5ed34" />



根本原因：validateSkillPath 使用 fs.realpathSync 将 symlink 解析到真实路径，然后检查真实路径是否在 skillsRoot 下。当 skill 是通过 symlink 加载的（如 ~/.claude/skills/my-skill → ~/.agents/skills/my-skill），真实路径位于 skillsRoot 外部，导致验证失败。

调用链：

列表页（GET /api/skills）→ scanSkillDirectory → 不调用 validateSkillPath → 正常显示
详情页（GET /api/skills/:id）→ getSkillDetail → 调用 validateSkillPath → 返回 false → 返回 null → API 404 → 前端显示 "加载失败"
修复：将 fs.realpathSync（解析 symlink）改为 path.resolve（仅规范化路径，不解析 symlink）。安全性由 validateSkillId 保证（只允许 [\w\-]+），不可能构造出 ../ 路径穿越。