### PR TITLE
fix: 修复 docker 容器发送消息不响应

### DIFF
--- a/container/.dockerignore
+++ b/container/.dockerignore
@@ -1,0 +1,2 @@
+agent-runner/node_modules
+agent-runner/dist

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -33,6 +33,16 @@ fi
 # 导致 "Native CLI binary for linux-x64 not found" 启动失败。
 export PATH="/app/node_modules/.bin:${PATH}"
 
+# CLAUDE_CONFIG_DIR: CLI 默认用 $HOME/.claude.json 作为身份文件，但该文件被
+# readonly 挂载（避免容器篡改宿主机配置）。CLI 启动时尝试写入（更新 numStartups
+# 等计数器），readonly 导致静默失败 → query() 返回 0 messages。
+# 显式设 CLAUDE_CONFIG_DIR 让 CLI 改读写 /home/node/.claude/.claude.json（session
+# 目录，可写），与宿主机模式的 hostEnv['CLAUDE_CONFIG_DIR'] 保持一致。
+export CLAUDE_CONFIG_DIR=/home/node/.claude
+
+# IS_SANDBOX: Claude Code 2.1.114+ 要求 IS_SANDBOX=1 才允许 --dangerously-skip-permissions。
+# 与宿主机模式的 hostEnv['IS_SANDBOX'] = '1' 保持一致。
+export IS_SANDBOX=1
 # Discover and link skills (builtin → project → user, higher priority overwrites)
 # Only remove entries that conflict with mounted skills (non-symlink with same name),
 # preserving any skills the agent created directly in .claude/skills/.


### PR DESCRIPTION
## 修复 Docker 模式 Claude Code 启动失败

### 问题描述：

Docker 模式下 Agent 容器收到消息后存在两类启动失败表现：一类是 Claude Agent SDK 的 query() 调用返回 0 messages、0 results，前端表现为消息发出后没有回复；另一类是容器内 Claude Code 子进程快速退出，前端持续显示 Container exited with code 1，日志里只能看到 Claude Code process exited with code 2。宿主机模式不受影响。

#### 根因一：
Docker 容器内没有显式设置 CLAUDE_CONFIG_DIR。Claude Code CLI 默认会触碰 /home/node/.claude.json，而该文件来自 getContainerClaudeJsonPath() 生成的精简身份文件，并以 readonly 方式挂载。CLI 启动时会尝试更新 numStartups、tipsHistory 等状态，写 readonly 文件失败后不会给 SDK 抛出清晰错误，query() 的 AsyncIterable 可能不 yield 任何 message，最终表现为 Query done. Messages: 0, results: 0。

#### 根因二：
Docker build context 把宿主机的 container/agent-runner/node_modules 一起 COPY 进镜像。Dockerfile 前面已经在 Linux 镜像内 npm install 了正确依赖，但后续 COPY agent-runner/ ./ 会被本机 macOS 的 node_modules 覆盖，导致 /app/node_modules/.bin/claude 指向 claude-code-darwin-arm64。Linux 容器执行该二进制时触发 Exec format error，SDK 只包装成 Claude Code process exited with code 2。

为什么 host 模式正常：runHostAgent 中会把 CLAUDE_CONFIG_DIR 设置到 groupSessionsDir，并设置 IS_SANDBOX=1。CLI 读写的是可写 session 目录里的 .claude.json，不会触碰 readonly 的 HOME 级身份文件；同时新版本 Claude Code 允许在受控沙箱里使用 bypassPermissions。Docker 模式此前遗漏了这两个环境变量，并且镜像构建还会被宿主机依赖污染。

#### 修复方式：

在 container/entrypoint.sh 中导出 CLAUDE_CONFIG_DIR=/home/node/.claude，使 CLI 在可写 session 目录下读写 .claude.json；同时导出 IS_SANDBOX=1，兼容 Claude Code 2.1.114+ 对 --dangerously-skip-permissions 的沙箱要求。新增 container/.dockerignore，排除 agent-runner/node_modules 和 agent-runner/dist，确保镜像内依赖始终由 Dockerfile 在 Linux 环境重新安装，避免 macOS 构建产物覆盖容器依赖。

兼容性说明：CLAUDE_CONFIG_DIR 是 Claude Code CLI 早期版本已支持的标准环境变量，在容器内设置为 /home/node/.claude 与默认配置目录路径一致，只改变身份文件写入位置，避免 readonly 文件；IS_SANDBOX 对旧版本 CLI 无感知，对新版本 CLI 则是允许 bypassPermissions 的必要标志。两者对已知版本均无回退风险。

验证结果：修复前失败日志可见 Query done. Messages: 0, results: 0 或 Claude Code process exited with code 2；修复后重建 happyclaw-agent:latest，容器内 claude --version 正常返回 2.1.119，/app/node_modules/@anthropic-ai/claude-code/bin/claude.exe 为 Linux ARM ELF；使用同一失败工作区挂载执行 Docker smoke test，agent 成功返回 pong，Query done. Messages: 4, results: 1。