### PR TITLE
feat: 飞书支持按不同聊天独立上下文的 chat_map 模式

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2308,7 +2308,11 @@ function parseGroupRow(
         ? 'vertical_threads'
         : 'horizontal',
     binding_mode:
-      row.binding_mode === 'thread_map' ? 'thread_map' : 'single_context',
+      row.binding_mode === 'thread_map'
+        ? 'thread_map'
+        : row.binding_mode === 'chat_map'
+          ? 'chat_map'
+          : 'single_context',
     feishu_chat_mode: row.feishu_chat_mode ?? undefined,
     feishu_group_message_type: row.feishu_group_message_type ?? undefined,
     sender_allowlist: row.sender_allowlist != null
@@ -2438,9 +2442,10 @@ export function getGroupsByTargetMainJid(
 function mapImContextBindingRow(
   row: Record<string, unknown>,
 ): ImContextBinding {
+  const ct = String(row.context_type);
   return {
     source_jid: String(row.source_jid),
-    context_type: 'thread',
+    context_type: ct === 'chat' ? 'chat' : 'thread',
     context_id: String(row.context_id),
     workspace_jid: String(row.workspace_jid),
     agent_id: String(row.agent_id),
@@ -2455,7 +2460,7 @@ function mapImContextBindingRow(
 
 export function getImContextBinding(
   sourceJid: string,
-  contextType: 'thread',
+  contextType: 'thread' | 'chat',
   contextId: string,
 ): ImContextBinding | undefined {
   const row = db
@@ -2518,7 +2523,7 @@ export function deleteImContextBindingsByAgent(agentId: string): void {
 /** Lightweight update: only touch last_active_at + updated_at on an existing binding. */
 export function touchImContextBindingActivity(
   sourceJid: string,
-  contextType: 'thread',
+  contextType: 'thread' | 'chat',
   contextId: string,
   lastActiveAt: string,
 ): void {
@@ -2532,6 +2537,16 @@ export function listFeishuThreadAgentIds(workspaceJid: string): string[] {
   const rows = db
     .prepare(
       "SELECT id FROM agents WHERE chat_jid = ? AND source_kind = 'feishu_thread'",
+    )
+    .all(workspaceJid) as { id: string }[];
+  return rows.map((r) => r.id);
+}
+
+/** List feishu_chat agent IDs for a workspace JID (for cleanup on unbind). */
+export function listFeishuChatAgentIds(workspaceJid: string): string[] {
+  const rows = db
+    .prepare(
+      "SELECT id FROM agents WHERE chat_jid = ? AND source_kind = 'feishu_chat'",
     )
     .all(workspaceJid) as { id: string }[];
   return rows.map((r) => r.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6720,18 +6720,37 @@ function buildOnNewChat(
   userId: string,
   homeFolder: string,
   getOwnerOpenId?: () => string | undefined,
+  autoContextMode?: 'shared' | 'per_chat',
 ): (chatJid: string, chatName: string) => void {
   return (chatJid, chatName) => {
     const existing = registeredGroups[chatJid];
     if (existing) {
       // Already owned by this user — update name if changed (IM channel may now have real group name)
       if (existing.created_by === userId) {
+        let changed = false;
         const trimmed = chatName.trim();
         if (trimmed && existing.name !== trimmed) {
           existing.name = trimmed;
+          changed = true;
+        }
+        // Upgrade to chat_map if per_chat mode is active and group has no explicit binding
+        if (
+          autoContextMode === 'per_chat' &&
+          existing.binding_mode !== 'chat_map' &&
+          !existing.target_agent_id &&
+          !existing.target_main_jid
+        ) {
+          existing.target_main_jid = `web:${homeFolder}`;
+          existing.binding_mode = 'chat_map';
+          changed = true;
+          logger.info(
+            { chatJid, userId, homeFolder },
+            'Upgraded existing IM chat to chat_map (per_chat mode)',
+          );
+        }
+        if (changed) {
           setRegisteredGroup(chatJid, existing);
           registeredGroups[chatJid] = existing;
-          logger.debug({ chatJid, chatName: trimmed }, 'Updated IM group name (buildOnNewChat)');
         }
         return;
       }
@@ -6810,6 +6829,7 @@ function buildOnNewChat(
       return;
     }
     const ownerOpenId = getOwnerOpenId?.();
+    const perChat = autoContextMode === 'per_chat';
     registerGroup(chatJid, {
       name: chatName,
       folder: homeFolder,
@@ -6821,9 +6841,15 @@ function buildOnNewChat(
       sender_allowlist: getOwnerOpenId
         ? (ownerOpenId ? [ownerOpenId] : [])
         : undefined,
+      ...(perChat
+        ? {
+            target_main_jid: `web:${homeFolder}`,
+            binding_mode: 'chat_map' as const,
+          }
+        : {}),
     });
     logger.info(
-      { chatJid, chatName, userId, homeFolder },
+      { chatJid, chatName, userId, homeFolder, autoContextMode },
       'Auto-registered IM chat',
     );
   };
@@ -6880,8 +6906,9 @@ function buildFeishuBotAddedHandler(
   userId: string,
   homeFolder: string,
   getOwnerOpenId?: () => string | undefined,
+  autoContextMode?: 'shared' | 'per_chat',
 ): (chatJid: string, chatName: string) => void {
-  const onNewChat = buildOnNewChat(userId, homeFolder, getOwnerOpenId);
+  const onNewChat = buildOnNewChat(userId, homeFolder, getOwnerOpenId, autoContextMode);
   return (chatJid: string, chatName: string) => {
     const isNew = !registeredGroups[chatJid] && !getRegisteredGroup(chatJid);
     onNewChat(chatJid, chatName);
@@ -7070,6 +7097,106 @@ function resolveOrCreateThreadAgent(
 }
 
 /**
+ * Resolve or create a conversation agent for a Feishu chat (group or P2P).
+ * Each unique chatJid gets its own SubAgent under the target workspace.
+ * Creates the agent + binding on first message; updates activity on subsequent messages.
+ */
+function resolveOrCreateChatAgent(
+  chatJid: string,
+  workspaceJid: string,
+  workspace: RegisteredGroup,
+  group: RegisteredGroup,
+): { effectiveJid: string; agentId: string } {
+  const now = new Date().toISOString();
+  const chatId = extractChatId(chatJid);
+  // Build a distinguishable name: group name + short chatId suffix
+  const shortId = chatId.length > 6 ? chatId.slice(-6) : chatId;
+  const baseName = group.name || '飞书聊天';
+  const agentName = `${baseName} (${shortId})`;
+
+  let binding = getImContextBinding(chatJid, 'chat', chatId);
+  let agent = binding?.agent_id != null ? getAgent(binding.agent_id) : undefined;
+
+  if (!binding || !agent || agent.chat_jid !== workspaceJid) {
+    const agentId = crypto.randomUUID();
+    const name = binding?.title || agentName;
+    const newAgent: SubAgent = {
+      id: agentId,
+      group_folder: workspace.folder,
+      chat_jid: workspaceJid,
+      name,
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: workspace.created_by || group.created_by || null,
+      created_at: now,
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: chatJid,
+      spawned_from_jid: null,
+      source_kind: 'feishu_chat',
+      thread_id: null,
+      root_message_id: null,
+      title_source: 'manual',
+      last_active_at: now,
+    };
+    createAgent(newAgent);
+    ensureAgentDirectories(workspace.folder, agentId);
+    const virtualChatJid = `${workspaceJid}#agent:${agentId}`;
+    ensureChatExists(virtualChatJid);
+    updateChatName(virtualChatJid, name);
+    updateAgentLastImJid(agentId, chatJid);
+    broadcastAgentStatus(
+      workspaceJid,
+      agentId,
+      'idle',
+      name,
+      '',
+      undefined,
+      'conversation',
+    );
+    binding = {
+      source_jid: chatJid,
+      context_type: 'chat',
+      context_id: chatId,
+      workspace_jid: workspaceJid,
+      agent_id: agentId,
+      root_message_id: null,
+      title: name,
+      last_active_at: now,
+      created_at: now,
+      updated_at: now,
+    };
+    upsertImContextBinding(binding);
+    agent = newAgent;
+  }
+
+  // Update activity & title if group name changed
+  const resolvedTitle = group.name || binding.title || agentName;
+  if (resolvedTitle !== binding.title) {
+    upsertImContextBinding({
+      ...binding,
+      title: resolvedTitle,
+      last_active_at: now,
+      updated_at: now,
+    });
+    updateAgentContextInfo(binding.agent_id, {
+      name: resolvedTitle,
+      last_active_at: now,
+    });
+    updateChatName(`${workspaceJid}#agent:${binding.agent_id}`, resolvedTitle);
+  } else {
+    touchImContextBindingActivity(chatJid, 'chat', chatId, now);
+    updateAgentContextInfo(binding.agent_id, { last_active_at: now });
+  }
+  updateAgentLastImJid(binding.agent_id, chatJid);
+  return {
+    effectiveJid: `${workspaceJid}#agent:${binding.agent_id}`,
+    agentId: binding.agent_id,
+  };
+}
+
+/**
  * Build callback that resolves an IM chatJid to a bound target JID.
  * Supports both conversation agent binding (target_agent_id) and
  * workspace main conversation binding (target_main_jid).
@@ -7092,6 +7219,23 @@ function buildResolveEffectiveChatJid(): (
       // doesn't match any registered group for non-main workspaces (folder ≠ JID).
       const effectiveJid = `${agent.chat_jid}#agent:${group.target_agent_id}`;
       return { effectiveJid, agentId: group.target_agent_id };
+    }
+
+    // chat_map: each IM chat (group or P2P) gets its own SubAgent
+    if (group.binding_mode === 'chat_map' && group.target_main_jid) {
+      const workspaceJid = resolveWorkspaceJid(group.target_main_jid);
+      if (!workspaceJid) {
+        logger.warn(
+          { chatJid, targetMainJid: group.target_main_jid },
+          'chat_map resolveWorkspaceJid returned null — stale target_main_jid',
+        );
+        return null;
+      }
+      const workspace =
+        registeredGroups[workspaceJid] ?? getRegisteredGroup(workspaceJid);
+      if (!workspace) return null;
+
+      return resolveOrCreateChatAgent(chatJid, workspaceJid, workspace, group);
     }
 
     if (
@@ -7348,13 +7492,14 @@ async function connectUserIMChannels(
     }
   };
 
-  const onNewChat = buildOnNewChat(userId, homeFolder, getFeishuOwnerOpenId);
+  const feishuAutoContext = feishuConfig ? getUserFeishuConfig(userId)?.autoContextMode : undefined;
+  const onNewChat = buildOnNewChat(userId, homeFolder, getFeishuOwnerOpenId, feishuAutoContext);
   const resolveGroupFolder = (chatJid: string): string | undefined => {
     return resolveEffectiveFolder(chatJid);
   };
   const resolveEffectiveChatJid = buildResolveEffectiveChatJid();
   const onAgentMessage = buildOnAgentMessage();
-  const onBotAddedToGroup = buildFeishuBotAddedHandler(userId, homeFolder, getFeishuOwnerOpenId);
+  const onBotAddedToGroup = buildFeishuBotAddedHandler(userId, homeFolder, getFeishuOwnerOpenId, feishuAutoContext);
   const onBotRemovedFromGroup = buildOnBotRemovedFromGroup();
 
   // 各渠道互相独立，并发连接避免启动时延 N×M 累加
@@ -7812,7 +7957,8 @@ async function main(): Promise<void> {
           logger.info({ userId: adminUser.id, senderOpenId }, 'Feishu owner open_id auto-detected from P2P message');
         }
       };
-      const onNewChat = buildOnNewChat(adminUser.id, homeFolder, getAdminOwnerOpenId);
+      const adminFeishuAutoContext = getUserFeishuConfig(adminUser.id)?.autoContextMode;
+      const onNewChat = buildOnNewChat(adminUser.id, homeFolder, getAdminOwnerOpenId, adminFeishuAutoContext);
       const connected = await imManager.connectUserFeishu(
         adminUser.id,
         config,
@@ -7820,7 +7966,7 @@ async function main(): Promise<void> {
         {
           ignoreMessagesBefore: Date.now(),
           onCommand: handleCommand,
-          onBotAddedToGroup: buildFeishuBotAddedHandler(adminUser.id, homeFolder, getAdminOwnerOpenId),
+          onBotAddedToGroup: buildFeishuBotAddedHandler(adminUser.id, homeFolder, getAdminOwnerOpenId, adminFeishuAutoContext),
           onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
           shouldProcessGroupMessage,
           isGroupOwnerMessage,
@@ -7929,7 +8075,7 @@ async function main(): Promise<void> {
             logger.info({ userId, senderOpenId }, 'Feishu owner open_id auto-detected from P2P message');
           }
         };
-        const onNewChat = buildOnNewChat(userId, homeFolder, getReloadOwnerOpenId);
+        const onNewChat = buildOnNewChat(userId, homeFolder, getReloadOwnerOpenId, config.autoContextMode);
         const connected = await imManager.connectUserFeishu(
           userId,
           config,
@@ -7937,7 +8083,7 @@ async function main(): Promise<void> {
           {
             ignoreMessagesBefore,
             onCommand: handleCommand,
-            onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder, getReloadOwnerOpenId),
+            onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder, getReloadOwnerOpenId, config.autoContextMode),
             onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
             shouldProcessGroupMessage,
             isGroupOwnerMessage,

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -27,6 +27,7 @@ import {
   getMessagesPageMulti,
   deleteImContextBindingsByWorkspace,
   listFeishuThreadAgentIds,
+  listFeishuChatAgentIds,
 } from '../db.js';
 import { DATA_DIR } from '../config.js';
 import type { RegisteredGroup, SubAgent } from '../types.js';
@@ -160,9 +161,9 @@ router.post('/:jid/agents', authMiddleware, async (c) => {
   if (!canAccessGroup(user, { ...group, jid })) {
     return c.json({ error: 'Forbidden' }, 403);
   }
-  if (group.conversation_source === 'feishu_thread') {
+  if (group.conversation_source === 'feishu_thread' || group.conversation_source === 'feishu_chat') {
     return c.json(
-      { error: 'Feishu topic workspaces do not support manual conversations' },
+      { error: 'IM-driven workspaces do not support manual conversations' },
       400,
     );
   }
@@ -437,7 +438,7 @@ router.get('/:jid/im-groups', authMiddleware, async (c) => {
     name: string;
     bound_agent_id: string | null;
     bound_main_jid: string | null;
-    binding_mode: 'single_context' | 'thread_map';
+    binding_mode: 'single_context' | 'thread_map' | 'chat_map';
     reply_policy: 'source_only' | 'mirror';
     bound_target_name: string | null;
     bound_workspace_name: string | null;
@@ -850,7 +851,6 @@ router.delete('/:jid/im-binding/:imJid', authMiddleware, async (c) => {
     if (groups[imJid]) groups[imJid] = updated;
   }
   if (imGroup.binding_mode === 'thread_map') {
-    // Clean up feishu_thread agents and their bindings
     const threadAgentIds = listFeishuThreadAgentIds(jid);
     for (const agentId of threadAgentIds) {
       deleteAgent(agentId);
@@ -861,6 +861,13 @@ router.delete('/:jid/im-binding/:imJid', authMiddleware, async (c) => {
       conversation_source: 'manual',
       conversation_nav_mode: 'horizontal',
     });
+  }
+  if (imGroup.binding_mode === 'chat_map') {
+    const chatAgentIds = listFeishuChatAgentIds(jid);
+    for (const agentId of chatAgentIds) {
+      deleteAgent(agentId);
+    }
+    deleteImContextBindingsByWorkspace(jid);
   }
 
   logger.info(

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1347,11 +1347,13 @@ configRoutes.get('/user-im/feishu', authMiddleware, (c) => {
         enabled: false,
         updatedAt: null,
         connected,
+        autoContextMode: 'shared',
       });
     }
     return c.json({
       ...toPublicFeishuProviderConfig(config, 'runtime'),
       connected,
+      autoContextMode: config.autoContextMode || 'shared',
     });
   } catch (err) {
     logger.error({ err }, 'Failed to load user Feishu config');
@@ -1386,11 +1388,18 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
   }
 
   const current = getUserFeishuConfig(user.id);
-  const next = {
+  const next: {
+    appId: string;
+    appSecret: string;
+    enabled: boolean;
+    updatedAt: string | null;
+    autoContextMode?: 'shared' | 'per_chat';
+  } = {
     appId: current?.appId || '',
     appSecret: current?.appSecret || '',
     enabled: current?.enabled ?? true,
     updatedAt: current?.updatedAt || null,
+    autoContextMode: current?.autoContextMode,
   };
   if (typeof validation.data.appId === 'string') {
     const appId = validation.data.appId.trim();
@@ -1408,12 +1417,17 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
     // First-time config with credentials should connect immediately.
     next.enabled = true;
   }
+  if (typeof validation.data.autoContextMode === 'string') {
+    next.autoContextMode =
+      validation.data.autoContextMode === 'per_chat' ? 'per_chat' : 'shared';
+  }
 
   try {
     const saved = saveUserFeishuConfig(user.id, {
       appId: next.appId,
       appSecret: next.appSecret,
       enabled: next.enabled,
+      autoContextMode: next.autoContextMode,
     });
 
     // Hot-reload: reconnect user's Feishu channel
@@ -1432,6 +1446,7 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
     return c.json({
       ...toPublicFeishuProviderConfig(saved, 'runtime'),
       connected,
+      autoContextMode: saved.autoContextMode || 'shared',
     });
   } catch (err) {
     const message =

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -156,7 +156,7 @@ interface GroupPayloadItem {
   member_count?: number;
   pinned_at?: string;
   activation_mode?: 'auto' | 'always' | 'when_mentioned' | 'owner_mentioned' | 'disabled';
-  conversation_source?: 'manual' | 'feishu_thread';
+  conversation_source?: 'manual' | 'feishu_thread' | 'feishu_chat';
   conversation_nav_mode?: 'horizontal' | 'vertical_threads';
 }
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -231,6 +231,7 @@ interface StoredFeishuProviderConfigV1 {
   enabled?: boolean;
   updatedAt: string;
   ownerOpenId?: string;
+  autoContextMode?: 'shared' | 'per_chat';
   secret: EncryptedSecrets;
 }
 
@@ -3033,6 +3034,7 @@ export interface UserFeishuConfig {
   enabled?: boolean;
   updatedAt: string | null;
   ownerOpenId?: string; // auto-detected from first DM; used as sender_allowlist seed for new groups
+  autoContextMode?: 'shared' | 'per_chat'; // 'shared'（默认）= 所有聊天共享上下文；'per_chat' = 每个群聊/私聊独立 SubAgent
 }
 
 export interface UserTelegramConfig {
@@ -3124,6 +3126,7 @@ export function getUserFeishuConfig(userId: string): UserFeishuConfig | null {
       enabled: stored.enabled,
       updatedAt: stored.updatedAt || null,
       ownerOpenId: stored.ownerOpenId || undefined,
+      autoContextMode: stored.autoContextMode === 'per_chat' ? 'per_chat' : undefined,
     };
   } catch (err) {
     logger.warn({ err, userId }, 'Failed to read user Feishu config');
@@ -3141,6 +3144,7 @@ export function saveUserFeishuConfig(
     enabled: next.enabled,
     updatedAt: new Date().toISOString(),
     ownerOpenId: next.ownerOpenId,
+    autoContextMode: next.autoContextMode === 'per_chat' ? 'per_chat' : undefined,
   };
 
   const payload: StoredFeishuProviderConfigV1 = {
@@ -3149,6 +3153,7 @@ export function saveUserFeishuConfig(
     enabled: normalized.enabled,
     updatedAt: normalized.updatedAt || new Date().toISOString(),
     ownerOpenId: normalized.ownerOpenId,
+    autoContextMode: normalized.autoContextMode,
     secret: encryptChannelSecret<FeishuSecretPayload>({
       appSecret: normalized.appSecret,
     }),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -387,13 +387,15 @@ export const FeishuConfigSchema = z
     appSecret: z.string().max(2000).optional(),
     clearAppSecret: z.boolean().optional(),
     enabled: z.boolean().optional(),
+    autoContextMode: z.enum(['shared', 'per_chat']).optional(),
   })
   .refine(
     (data) =>
       typeof data.appId === 'string' ||
       typeof data.appSecret === 'string' ||
       data.clearAppSecret === true ||
-      typeof data.enabled === 'boolean',
+      typeof data.enabled === 'boolean' ||
+      typeof data.autoContextMode === 'string',
     { message: 'At least one config field must be provided' },
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,9 +34,9 @@ export interface ContainerConfig {
 }
 
 export type ExecutionMode = 'container' | 'host';
-export type ConversationSource = 'manual' | 'feishu_thread';
+export type ConversationSource = 'manual' | 'feishu_thread' | 'feishu_chat';
 export type ConversationNavMode = 'horizontal' | 'vertical_threads';
-export type ImBindingMode = 'single_context' | 'thread_map';
+export type ImBindingMode = 'single_context' | 'thread_map' | 'chat_map';
 
 /** 飞书消息的话题/线程元数据，用于 thread_map 路由 */
 export interface FeishuMessageMeta {
@@ -321,7 +321,7 @@ export interface SubAgent {
   last_im_jid: string | null;
   /** 发起 /spawn 命令的源会话 JID，用于完成后结果回注 */
   spawned_from_jid: string | null;
-  source_kind?: 'manual' | 'feishu_thread' | null;
+  source_kind?: 'manual' | 'feishu_thread' | 'feishu_chat' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;
@@ -330,7 +330,7 @@ export interface SubAgent {
 
 export interface ImContextBinding {
   source_jid: string;
-  context_type: 'thread';
+  context_type: 'thread' | 'chat';
   context_id: string;
   workspace_jid: string;
   agent_id: string;

--- a/web/src/components/settings/FeishuChannelCard.tsx
+++ b/web/src/components/settings/FeishuChannelCard.tsx
@@ -16,15 +16,18 @@ interface UserFeishuConfig {
   enabled: boolean;
   connected: boolean;
   updatedAt: string | null;
+  autoContextMode?: 'shared' | 'per_chat';
 }
 
 export function FeishuChannelCard() {
   const [config, setConfig] = useState<UserFeishuConfig | null>(null);
   const [appId, setAppId] = useState('');
   const [appSecret, setAppSecret] = useState('');
+  const [autoContextMode, setAutoContextMode] = useState<'shared' | 'per_chat'>('shared');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [toggling, setToggling] = useState(false);
+  const [savingContext, setSavingContext] = useState(false);
 
   const enabled = config?.enabled ?? false;
 
@@ -35,6 +38,7 @@ export function FeishuChannelCard() {
       setConfig(data);
       setAppId(data.appId || '');
       setAppSecret('');
+      setAutoContextMode(data.autoContextMode || 'shared');
     } catch {
       setConfig(null);
     } finally {
@@ -95,6 +99,21 @@ export function FeishuChannelCard() {
     }
   };
 
+  const handleContextModeChange = async (mode: 'shared' | 'per_chat') => {
+    setAutoContextMode(mode);
+    setSavingContext(true);
+    try {
+      const data = await api.put<UserFeishuConfig>('/api/config/user-im/feishu', { autoContextMode: mode });
+      setConfig(data);
+      toast.success(mode === 'per_chat' ? '已启用每聊天独立上下文' : '已切换为共享上下文');
+    } catch (err) {
+      toast.error(getErrorMessage(err, '保存上下文模式失败'));
+      setAutoContextMode(config?.autoContextMode || 'shared');
+    } finally {
+      setSavingContext(false);
+    }
+  };
+
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-border bg-muted/50">
@@ -145,6 +164,24 @@ export function FeishuChannelCard() {
                 保存飞书配置
               </Button>
             </div>
+
+            {config?.hasAppSecret && (
+              <div className="border-t border-border pt-4 space-y-2">
+                <Label className="text-xs font-medium">上下文隔离模式</Label>
+                <p className="text-xs text-muted-foreground">
+                  控制同一个 Bot 在不同群聊、不同用户私聊时是否共享对话上下文。切换后对新加入的群/私聊生效。
+                </p>
+                <select
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                  value={autoContextMode}
+                  onChange={(e) => handleContextModeChange(e.target.value as 'shared' | 'per_chat')}
+                  disabled={savingContext}
+                >
+                  <option value="shared">共享（默认）— 所有聊天共用一个上下文</option>
+                  <option value="per_chat">每聊天独立 — 每个群聊/私聊自动创建独立上下文</option>
+                </select>
+              </div>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## feat: 飞书支持按不同聊天独立上下文的 chat_map 模式

### 背景

之前飞书 Bot 加入多个群聊或私聊时，所有会话共享同一个对话上下文，导致不同群的消息互相干扰。本次新增 `chat_map` 绑定模式，使每个群聊/私聊自动创建独立的 SubAgent，实现上下文隔离。

### 变更概览

| 文件 | 改动说明 |
|------|---------|
| `src/types.ts` | 新增 `chat_map` 绑定模式、`feishu_chat` 来源类型、`chat` 上下文类型 |
| `src/schemas.ts` | `FeishuConfigSchema` 新增 `autoContextMode` 校验字段（`shared` / `per_chat`） |
| `src/runtime-config.ts` | 持久化存储 `autoContextMode` 配置项，读写时正确序列化/反序列化 |
| `src/db.ts` | `parseGroupRow` 支持解析 `chat_map`；`ImContextBinding` 支持 `chat` 上下文类型；新增 `listFeishuChatAgentIds()` 查询方法 |
| `src/index.ts` | 核心逻辑：新增 `resolveOrCreateChatAgent()` 函数，为每个 chatJid 创建独立 SubAgent 与绑定；`buildOnNewChat` / `buildFeishuBotAddedHandler` 透传 `autoContextMode`；解绑时清理 `chat_map` 下属 Agent |
| `src/routes/config.ts` | 飞书配置 API 读写支持 `autoContextMode` 字段 |
| `src/routes/groups.ts` | `conversation_source` 类型新增 `feishu_chat` |
| `web/src/components/settings/FeishuChannelCard.tsx` | 前端新增「上下文隔离模式」下拉选择器，支持 `shared` / `per_chat` 切换 |

### 核心设计

1. **新绑定模式 `chat_map`**：与已有的 `thread_map`（按话题线程隔离）并列，`chat_map` 按飞书聊天维度（群/私聊）隔离上下文。

2. **自动创建 SubAgent**：`resolveOrCreateChatAgent()` 在收到某个 chatJid 的首条消息时，自动在目标 workspace 下创建 `source_kind='feishu_chat'` 的 conversation Agent，并建立 `ImContextBinding`（`context_type='chat'`）。后续消息复用已有 Agent。

3. **用户配置 `autoContextMode`**：
   - `shared`（默认）：行为不变，所有聊天共用上下文
   - `per_chat`：新加入的群/私聊自动以 `chat_map` 模式注册，实现独立上下文

4. **存量群升级**：当用户开启 `per_chat` 后，已注册但未绑定的群在下次 `buildOnNewChat` 回调时自动升级为 `chat_map`。

5. **解绑清理**：解绑 `chat_map` 群组时，自动删除其下所有 `feishu_chat` SubAgent 及对应的 `ImContextBinding`。

### 前端变更

飞书设置卡片中，当已配置 App Secret 时，展示「上下文隔离模式」选择器：
- **共享（默认）**— 所有聊天共用一个上下文
- **每聊天独立**— 每个群聊/私聊自动创建独立上下文

切换即时保存，toast 提示操作结果。
