### PR TITLE
修复: 移除输入框旁的清除上下文按钮，避免误触

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 import { useChatStore } from '../../stores/chat';
 import { useAuthStore } from '../../stores/auth';
 import { MessageList } from './MessageList';
@@ -8,7 +7,6 @@ import { MessageInput } from './MessageInput';
 import { FilePanel } from './FilePanel';
 import { ContainerEnvPanel } from './ContainerEnvPanel';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { PromptDialog } from '@/components/common/PromptDialog';
 import { ArrowLeft, FolderOpen, Link, MessageSquare, Monitor, Moon, MoreHorizontal, PanelRightClose, PanelRightOpen, Puzzle, Server, Sun, Terminal, Users, Variable, X } from 'lucide-react';
 import { useDisplayMode } from '../../hooks/useDisplayMode';
@@ -60,9 +58,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const [mobilePanel, setMobilePanel] = useState<SidebarTab | null>(null);
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('files');
   const [panelOpen, setPanelOpen] = useState(false);
-  const [showResetConfirm, setShowResetConfirm] = useState(false);
-  const [resetLoading, setResetLoading] = useState(false);
-  const [resetAgentId, setResetAgentId] = useState<string | null>(null);
   // Desktop: visible controls panel height, mounted controls terminal lifecycle.
   const [terminalVisible, setTerminalVisible] = useState(false);
   const [terminalMounted, setTerminalMounted] = useState(false);
@@ -101,7 +96,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const refreshMessages = useChatStore(s => s.refreshMessages);
   const sendMessage = useChatStore(s => s.sendMessage);
   const interruptQuery = useChatStore(s => s.interruptQuery);
-  const resetSession = useChatStore(s => s.resetSession);
   const handleStreamEvent = useChatStore(s => s.handleStreamEvent);
   const handleWsNewMessage = useChatStore(s => s.handleWsNewMessage);
   const handleStreamSnapshot = useChatStore(s => s.handleStreamSnapshot);
@@ -351,17 +345,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const handleLoadMore = () => {
     if (hasMoreMessages && !loading) {
       loadMessages(groupJid, true);
-    }
-  };
-
-  const handleResetSession = async () => {
-    setResetLoading(true);
-    const ok = await resetSession(groupJid, resetAgentId ?? undefined);
-    setResetLoading(false);
-    setShowResetConfirm(false);
-    setResetAgentId(null);
-    if (!ok) {
-      toast.error('清除上下文失败，请稍后重试');
     }
   };
 
@@ -674,7 +657,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                         return ok;
                       }}
                       groupJid={groupJid}
-                      onResetSession={() => { setResetAgentId(activeAgentTab); setShowResetConfirm(true); }}
                     />
                   </>
                 ) : (
@@ -710,7 +692,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                   return ok;
                 }}
                 groupJid={groupJid}
-                onResetSession={() => { setResetAgentId(activeAgentTab); setShowResetConfirm(true); }}
               />
             </>
           ) : (
@@ -730,7 +711,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
               <MessageInput
                 onSend={handleSend}
                 groupJid={groupJid}
-                onResetSession={() => { setResetAgentId(null); setShowResetConfirm(true); }}
                 onToggleTerminal={canUseTerminal ? handleTerminalToggle : undefined}
               />
             </>
@@ -964,21 +944,6 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
           </div>
         </SheetContent>
       </Sheet>
-
-      {/* Reset session confirm dialog */}
-      <ConfirmDialog
-        open={showResetConfirm}
-        onClose={() => setShowResetConfirm(false)}
-        onConfirm={handleResetSession}
-        title="清除上下文"
-        message={resetAgentId
-          ? '将清除该子对话的 Claude 会话上下文，下次发送消息时将开始全新会话。聊天记录不受影响。'
-          : '将清除主会话的 Claude 上下文并停止运行中的主工作区进程，下次发送消息时将开始全新会话。聊天记录和子对话不受影响。'
-        }
-        confirmText="清除"
-        confirmVariant="danger"
-        loading={resetLoading}
-      />
 
       {/* IM binding dialog */}
       {bindingAgentId && (

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -3,7 +3,6 @@ import { useKeyboardHeight } from '@/hooks/useKeyboardHeight';
 import { successTap } from '../../hooks/useHaptic';
 import {
   ArrowUp,
-  Brush,
   FileUp,
   FolderUp,
   X,
@@ -44,7 +43,6 @@ interface MessageInputProps {
   ) => Promise<boolean> | boolean;
   groupJid?: string;
   disabled?: boolean;
-  onResetSession?: () => void;
   onToggleTerminal?: () => void;
 }
 
@@ -52,7 +50,6 @@ export function MessageInput({
   onSend,
   groupJid,
   disabled = false,
-  onResetSession,
   onToggleTerminal,
 }: MessageInputProps) {
   const [content, setContent] = useState('');
@@ -525,6 +522,30 @@ export function MessageInput({
             </div>
           )}
 
+          {/* Slash command hint — discoverability for /clear */}
+          {content.startsWith('/') && !content.includes(' ') && !content.includes('\n') && (() => {
+            const SLASH_COMMANDS = [
+              { cmd: '/clear', desc: '清除当前会话的 Claude 上下文（聊天记录不受影响）' },
+            ];
+            const matches = SLASH_COMMANDS.filter(c => c.cmd.startsWith(content));
+            if (matches.length === 0) return null;
+            return (
+              <div className="mx-3 mt-2 rounded-md border border-border bg-popover/95 backdrop-blur-sm shadow-sm overflow-hidden">
+                {matches.map((c) => (
+                  <button
+                    key={c.cmd}
+                    type="button"
+                    onClick={() => { setContent(c.cmd); textareaRef.current?.focus(); }}
+                    className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-accent transition-colors cursor-pointer"
+                  >
+                    <code className="text-sm font-mono text-teal-600 dark:text-teal-400">{c.cmd}</code>
+                    <span className="text-xs text-muted-foreground truncate">{c.desc}</span>
+                  </button>
+                ))}
+              </div>
+            );
+          })()}
+
           {/* Textarea */}
           <div className="px-4 pt-3 pb-1">
             <textarea
@@ -564,16 +585,6 @@ export function MessageInput({
                   aria-label="添加文件"
                 >
                   <Paperclip className="w-4.5 h-4.5" />
-                </button>
-              )}
-              {onResetSession && (
-                <button
-                  type="button"
-                  onClick={onResetSession}
-                  className="w-10 h-10 rounded-lg flex items-center justify-center hover:bg-amber-50 dark:hover:bg-amber-950/40 text-muted-foreground hover:text-amber-600 dark:hover:text-amber-400 transition-all cursor-pointer"
-                  title="清除上下文"
-                >
-                  <Brush className="w-4.5 h-4.5" />
                 </button>
               )}
               {onToggleTerminal && (


### PR DESCRIPTION
## 用户现象

`MessageInput` 输入框左侧的 brush 图标按钮（清除上下文）位置**过于方便**，手机 PWA 上手指贴着输入框时**极易误触**，导致 Claude 会话上下文被意外清空。

## 根因

按钮紧邻附件、图片、终端等常用按钮，单击虽然弹出确认对话框——但移动端盲目点击按钮的概率本身就不低，一旦触发就容易条件反射点「确认」。

业界普遍做法：**清除上下文由 slash 命令触发**，不在输入区放常驻按钮。

| 产品 | 清除上下文方式 |
|------|-------------|
| Claude Code | `/clear` 命令 |
| ChatGPT | 顶部独立 "New chat" 按钮（远离输入） |
| Cursor | Cmd+L / Cmd+R 快捷键 + 命令面板 |
| Zed | `/clear` agent command |

核心思路：**把破坏性操作和高频交互物理隔离**。

## 修复方案（A + D）

### A — 删除常驻按钮

- `MessageInput.tsx` 移除 `onResetSession` prop、brush 按钮、`Brush` icon import
- `ChatView.tsx` 移除：
  - `showResetConfirm` / `resetAgentId` / `resetLoading` 三个 state
  - `handleResetSession` 回调
  - `ConfirmDialog` 渲染
  - `onResetSession` 的 3 处 prop 传递
- 清理已不需要的 `toast` / `ConfirmDialog` / `resetSession` store selector imports

### D — 保留发现性

后端 WebSocket 已经拦截 `/clear` 命令（`src/web.ts:843` → `executeSessionReset`），所以**命令本身就能工作**。本 PR 在前端输入框新增 **slash 命令提示气泡**：

- 当输入框内容以 `/` 开头且还没输入空格/换行时
- 在 textarea 上方显示匹配命令列表（当前仅 `/clear`，带中文说明）
- 点击提示自动填入命令，用户按 Enter 发送即可

这样**老用户可继续用命令**、**新用户输入 `/` 就能发现**。

## 不改动

- `resetSession` store action 保留，仍可被其他路径调用
- 后端 `/clear` 命令逻辑完全不变
- 业务能力零损失，只是入口从 UI 按钮改为命令

## 效果对比

| | 改动前 | 改动后 |
|---|------|------|
| 桌面端清除上下文 | 点 brush 按钮 → 确认 | 输入 `/clear` → 发送 |
| 手机 PWA 清除上下文 | 点按钮 → 确认（易误触） | 同上 |
| 移动端误触风险 | **高** | **消除** |
| 命令发现性 | —— | 输入 `/` 即提示 |
| 输入栏视觉噪音 | +1 图标 | 减少一个图标 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)