### PR TITLE
性能: Docker 构建时 apt-get 系统包层缓存频繁失效 (#403)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,11 +3,10 @@
 
 FROM node:22-slim
 
-# Copy uv from official image (multi-arch, no extra download)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
-
 # Install system packages (organized by category)
+# NOTE: Keep this layer BEFORE `COPY --from=ghcr.io/astral-sh/uv:latest` so that
+# uv:latest digest churn (frequent releases) does not invalidate this ~440MB layer.
+# See issue #403.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # --- Browser & fonts ---
     chromium \
@@ -84,6 +83,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && sed -i '/en_US.UTF-8/s/^# //' /etc/locale.gen && locale-gen \
     # Symlink fd-find → fd (Debian names it fdfind)
     && ln -sf /usr/bin/fdfind /usr/local/bin/fd
+
+# Copy uv from official image (multi-arch, no extra download).
+# Placed AFTER the apt-get layer: uv:latest releases frequently, so its digest
+# changes invalidate this layer on most rebuilds. Keeping the heavy apt-get
+# layer above ensures it stays cached across uv version bumps. See issue #403.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 
 # Locale environment
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
## 问题描述

关闭 #403。

`container/Dockerfile` 中 `COPY --from=ghcr.io/astral-sh/uv:latest` 位于庞大的 `RUN apt-get install` 之前。Docker BuildKit 会把 `COPY --from` 引用的远程镜像 digest 作为该层的缓存键：每当 `uv:latest` tag 指向新版本（uv 发版非常频繁），这两行 COPY 层缓存失效，连带其下所有层——包括~440MB 的 apt-get 系统包层——一并重建。

用户 \`git pull\` 拉取项目更新后运行 \`make start\`，Docker 构建几乎每次都要重新下载并安装 463 个系统包。在网络不稳定的环境下超时率高，失败后 \`.docker-build-sentinel\` 不更新，下次启动继续重试，形成用户感知的“死循环”。

## 修复方案

调整 Dockerfile 层顺序，让稳定的 apt-get 层留在上面、频繁变动的 uv COPY 层移到下面。

### \`container/Dockerfile\`

- 把两行 \`COPY --from=ghcr.io/astral-sh/uv:latest ...\` 从 \`FROM node:22-slim\` 之后、\`RUN apt-get install\` 之前，移到 apt-get 层**之后**、\`ENV LANG=...\` 之前
- 在 apt-get 层和 uv COPY 块上分别加注释，说明顺序对缓存命中率的重要性，并引用 issue #403

### 效果

- apt-get 层只在 Dockerfile 中 apt-get 指令自身变化时失效，用户日常 \`git pull\` 后的构建可以秒跳过 440MB 系统包层
- uv COPY 层失效只影响其后的 \`ARG CACHEBUST\` + \`npm install\` 等层；这些层本就每次构建都重跑（\`CACHEBUST=\$(date +%s)\`），不造成额外成本
- uv 二进制只在容器运行时使用，放到 apt-get 之后不影响任何构建阶段

## 验证

- \`make typecheck\` 通过
- \`make test\` 全部通过（198 tests / 12 files）
- 未实际触发 Docker 构建，但本改动为纯顺序调整，层内容与 ENV/PATH 依赖不变，对运行时行为无影响