### PR TITLE
支持飞书 IM 按聊天隔离上下文

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -3965,8 +3965,8 @@ export function getUserMemberFolders(
 
 export function createAgent(agent: SubAgent): void {
   db.prepare(
-    `INSERT INTO agents (id, group_folder, chat_jid, name, prompt, status, kind, created_by, created_at, completed_at, result_summary, spawned_from_jid, source_kind, thread_id, root_message_id, title_source, last_active_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO agents (id, group_folder, chat_jid, name, prompt, status, kind, created_by, created_at, completed_at, result_summary, spawned_from_jid, source_kind, thread_id, root_message_id, title_source, last_active_at, last_im_jid)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     agent.id,
     agent.group_folder,
@@ -3985,6 +3985,7 @@ export function createAgent(agent: SubAgent): void {
     agent.root_message_id ?? null,
     agent.title_source ?? null,
     agent.last_active_at ?? null,
+    agent.last_im_jid ?? null,
   );
 }
 
@@ -4189,7 +4190,7 @@ function mapAgentRow(row: Record<string, unknown>): SubAgent {
       typeof row.spawned_from_jid === 'string' ? row.spawned_from_jid : null,
     source_kind:
       typeof row.source_kind === 'string'
-        ? (row.source_kind as 'manual' | 'feishu_thread')
+        ? (row.source_kind as 'manual' | 'feishu_thread' | 'auto_im')
         : null,
     thread_id: typeof row.thread_id === 'string' ? row.thread_id : null,
     root_message_id:

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -867,7 +867,9 @@ export function createFeishuConnection(
 
     const chatJid = `feishu:${chatId}`;
     const resolvedSenderName = senderName || getSenderName(senderOpenId);
-    const resolvedChatName = chatType === 'p2p' ? '飞书私聊' : '飞书群聊';
+    const resolvedChatName = chatType === 'p2p'
+      ? (resolvedSenderName ? `飞书 · ${resolvedSenderName}` : '飞书私聊')
+      : '飞书群聊';
 
     // 先注册会话，确保 resolveGroupFolder 能正确解析 folder（含首条文件消息场景）
     onNewChat?.(chatJid, resolvedChatName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5522,8 +5522,9 @@ async function processAgentConversation(
   // Persist the IM routing target so it survives service restarts.
   if (replySourceImJid) {
     updateAgentLastImJid(agentId, replySourceImJid);
-    // Also publish to activeImReplyRoutes so send_file/send_image IPC can route to IM.
-    activeImReplyRoutes.set(effectiveGroup.folder, replySourceImJid);
+    // Publish to activeImReplyRoutes so send_file/send_image IPC can route to IM.
+    // Only use virtualChatJid key (per-agent) — folder-level key would collide
+    // when multiple auto_im agents share the same workspace folder.
     activeImReplyRoutes.set(virtualChatJid, replySourceImJid);
   }
 
@@ -6732,6 +6733,13 @@ function buildOnNewChat(
           setRegisteredGroup(chatJid, existing);
           registeredGroups[chatJid] = existing;
           logger.debug({ chatJid, chatName: trimmed }, 'Updated IM group name (buildOnNewChat)');
+          if (existing.target_agent_id) {
+            const agent = getAgent(existing.target_agent_id);
+            if (agent?.source_kind === 'auto_im') {
+              updateAgentContextInfo(existing.target_agent_id, { name: trimmed });
+              updateChatName(`${agent.chat_jid}#agent:${existing.target_agent_id}`, trimmed);
+            }
+          }
         }
         return;
       }
@@ -6826,7 +6834,138 @@ function buildOnNewChat(
       { chatJid, chatName, userId, homeFolder },
       'Auto-registered IM chat',
     );
+
+    if (getChannelType(chatJid) === 'feishu') {
+      const feishuConfig = getUserFeishuConfig(userId);
+      if (feishuConfig?.autoIsolateContext) {
+        const registered = registeredGroups[chatJid]!;
+        ensureAutoImConversationBinding(chatJid, registered, userId, chatName);
+      }
+    }
   };
+}
+
+function resolveAutoImWorkspace(userId: string, folder: string): { jid: string; folder: string } | null {
+  const jids = getJidsByFolder(folder);
+  for (const jid of jids) {
+    if (!jid.startsWith('web:')) continue;
+    const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
+    if (group) return { jid, folder: group.folder };
+  }
+  const homeGroup = getUserHomeGroup(userId);
+  return homeGroup ? { jid: homeGroup.jid, folder: homeGroup.folder } : null;
+}
+
+function createAutoImConversationAgent(input: {
+  userId: string;
+  sourceJid: string;
+  groupFolder: string;
+  name: string;
+}): { agentId: string; workspaceJid: string; workspaceFolder: string } | null {
+  const workspace = resolveAutoImWorkspace(input.userId, input.groupFolder);
+  if (!workspace) {
+    logger.warn(
+      { userId: input.userId, sourceJid: input.sourceJid, groupFolder: input.groupFolder },
+      'Cannot create auto IM conversation agent: workspace not found',
+    );
+    return null;
+  }
+
+  const agentId = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const agentName = input.name || input.sourceJid;
+  createAgent({
+    id: agentId,
+    group_folder: workspace.folder,
+    chat_jid: workspace.jid,
+    name: agentName,
+    prompt: '',
+    status: 'idle',
+    kind: 'conversation',
+    created_by: input.userId,
+    created_at: now,
+    completed_at: null,
+    result_summary: null,
+    last_im_jid: input.sourceJid,
+    spawned_from_jid: null,
+    source_kind: 'auto_im',
+    last_active_at: now,
+  });
+  ensureAgentDirectories(workspace.folder, agentId);
+  const virtualChatJid = `${workspace.jid}#agent:${agentId}`;
+  ensureChatExists(virtualChatJid);
+  updateChatName(virtualChatJid, agentName);
+  updateAgentLastImJid(agentId, input.sourceJid);
+  broadcastAgentStatus(workspace.jid, agentId, 'idle', agentName, '', undefined, 'conversation');
+
+  logger.info(
+    { sourceJid: input.sourceJid, agentId, userId: input.userId },
+    'Auto-created isolated conversation agent for Feishu IM chat',
+  );
+  return { agentId, workspaceJid: workspace.jid, workspaceFolder: workspace.folder };
+}
+
+function ensureAutoImConversationBinding(
+  jid: string,
+  group: RegisteredGroup,
+  userId: string,
+  name: string,
+): boolean {
+  if (group.target_main_jid) return false;
+  if (group.target_agent_id) {
+    const existingAgent = getAgent(group.target_agent_id);
+    if (existingAgent?.source_kind === 'auto_im') {
+      ensureAgentDirectories(existingAgent.group_folder, existingAgent.id);
+      updateAgentLastImJid(existingAgent.id, jid);
+      return false;
+    }
+    return false;
+  }
+
+  const created = createAutoImConversationAgent({
+    userId,
+    sourceJid: jid,
+    groupFolder: group.folder,
+    name: name || group.name || jid,
+  });
+  if (!created) return false;
+
+  group.target_agent_id = created.agentId;
+  setRegisteredGroup(jid, group);
+  registeredGroups[jid] = group;
+  return true;
+}
+
+/**
+ * Batch-apply autoIsolateContext toggle for a user's existing Feishu IM chats.
+ * enable=true:  create conversation agents for unbound Feishu chats
+ * enable=false: remove auto_im agent bindings (manual bindings untouched)
+ */
+function applyAutoIsolateContext(userId: string, enable: boolean): number {
+  let count = 0;
+  const groups = getAllRegisteredGroups();
+
+  for (const [jid, group] of Object.entries(groups)) {
+    if (getChannelType(jid) !== 'feishu') continue;
+    if (group.created_by !== userId) continue;
+
+    if (enable) {
+      if (group.target_agent_id || group.target_main_jid) continue;
+      if (ensureAutoImConversationBinding(jid, group, userId, group.name || jid)) count++;
+    } else {
+      if (!group.target_agent_id) continue;
+      const agentToRemove = getAgent(group.target_agent_id);
+      if (agentToRemove?.source_kind !== 'auto_im') continue;
+
+      broadcastAgentStatus(agentToRemove.chat_jid, group.target_agent_id, 'idle', agentToRemove.name, '', '__removed__', 'conversation');
+
+      group.target_agent_id = undefined;
+      setRegisteredGroup(jid, group);
+      registeredGroups[jid] = group;
+      count++;
+    }
+  }
+  return count;
 }
 
 /**
@@ -7081,12 +7220,18 @@ function buildResolveEffectiveChatJid(): (
 ) => { effectiveJid: string; agentId: string | null } | null {
   return (chatJid: string, messageMeta) => {
     const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
-    if (!group) return null;
+    if (!group) {
+      logger.debug({ chatJid }, 'resolveEffectiveChatJid: group not found');
+      return null;
+    }
 
     // Agent binding takes priority
     if (group.target_agent_id) {
       const agent = getAgent(group.target_agent_id);
-      if (!agent) return null;
+      if (!agent) {
+        logger.warn({ chatJid, targetAgentId: group.target_agent_id }, 'resolveEffectiveChatJid: agent not found for target_agent_id');
+        return null;
+      }
       // Use the agent's actual chat_jid (the workspace's registered JID) as the
       // base for the virtual JID.  Previously we constructed web:${folder} which
       // doesn't match any registered group for non-main workspaces (folder ≠ JID).
@@ -7134,6 +7279,10 @@ function buildResolveEffectiveChatJid(): (
       return { effectiveJid, agentId: null };
     }
 
+    logger.debug(
+      { chatJid, targetAgentId: group.target_agent_id, targetMainJid: group.target_main_jid },
+      'resolveEffectiveChatJid: no binding found',
+    );
     return null;
   };
 }
@@ -7937,6 +8086,10 @@ async function main(): Promise<void> {
           {
             ignoreMessagesBefore,
             onCommand: handleCommand,
+            resolveGroupFolder: (chatJid: string) =>
+              resolveEffectiveFolder(chatJid),
+            resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
+            onAgentMessage: buildOnAgentMessage(),
             onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder, getReloadOwnerOpenId),
             onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
             shouldProcessGroupMessage,
@@ -8162,6 +8315,8 @@ async function main(): Promise<void> {
       activeRouteUpdaters.get(folder)?.(sourceJid);
     },
     handleSpawnCommand,
+    applyAutoIsolateContext: (userId: string, enable: boolean) =>
+      applyAutoIsolateContext(userId, enable),
   });
 
   // Clean expired sessions every hour
@@ -8619,7 +8774,28 @@ async function main(): Promise<void> {
   }
 
   // Run health check once on startup to clean up orphaned bindings, then periodically
-  void checkImBindingsHealth();
+  void checkImBindingsHealth().then(() => {
+    // After health check, ensure auto_im agents exist for users with autoIsolateContext enabled
+    const groups = getAllRegisteredGroups();
+    const userIds = new Set<string>();
+    for (const [jid, group] of Object.entries(groups)) {
+      if (getChannelType(jid) === 'feishu' && group.created_by) {
+        userIds.add(group.created_by);
+      }
+    }
+    for (const uid of userIds) {
+      const cfg = getUserFeishuConfig(uid);
+      if (cfg?.autoIsolateContext) {
+        const migrated = applyAutoIsolateContext(uid, true);
+        if (migrated > 0) {
+          logger.info(
+            { userId: uid, migrated },
+            'Startup: restored auto_im agents for user with autoIsolateContext enabled',
+          );
+        }
+      }
+    }
+  });
   const IM_BINDING_HEALTH_CHECK_INTERVAL = 30 * 60 * 1000; // 30 min
   setInterval(() => {
     void checkImBindingsHealth();
@@ -8659,6 +8835,21 @@ async function checkImBindingsHealth(): Promise<void> {
     if (group.target_agent_id) {
       const agent = getAgent(group.target_agent_id);
       if (!agent) {
+        // For auto_im agents, re-create instead of unbinding if toggle is still on
+        const userId = group.created_by;
+        if (userId && getChannelType(jid) === 'feishu') {
+          const feishuConfig = getUserFeishuConfig(userId);
+          if (feishuConfig?.autoIsolateContext) {
+            const unbound: RegisteredGroup = { ...group, target_agent_id: undefined };
+            if (ensureAutoImConversationBinding(jid, unbound, userId, group.name || jid)) {
+              logger.info(
+                { jid, userId },
+                'Health check: re-created auto_im agent (previous agent lost)',
+              );
+              continue;
+            }
+          }
+        }
         unbindImGroup(
           jid,
           `Orphaned agent binding: agent ${group.target_agent_id} no longer exists`,

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1347,11 +1347,13 @@ configRoutes.get('/user-im/feishu', authMiddleware, (c) => {
         enabled: false,
         updatedAt: null,
         connected,
+        autoIsolateContext: false,
       });
     }
     return c.json({
       ...toPublicFeishuProviderConfig(config, 'runtime'),
       connected,
+      autoIsolateContext: config.autoIsolateContext ?? false,
     });
   } catch (err) {
     logger.error({ err }, 'Failed to load user Feishu config');
@@ -1386,11 +1388,12 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
   }
 
   const current = getUserFeishuConfig(user.id);
-  const next = {
+  const next: Record<string, unknown> = {
     appId: current?.appId || '',
     appSecret: current?.appSecret || '',
     enabled: current?.enabled ?? true,
     updatedAt: current?.updatedAt || null,
+    autoIsolateContext: current?.autoIsolateContext ?? false,
   };
   if (typeof validation.data.appId === 'string') {
     const appId = validation.data.appId.trim();
@@ -1408,13 +1411,28 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
     // First-time config with credentials should connect immediately.
     next.enabled = true;
   }
+  if (typeof validation.data.autoIsolateContext === 'boolean') {
+    next.autoIsolateContext = validation.data.autoIsolateContext;
+  }
 
   try {
     const saved = saveUserFeishuConfig(user.id, {
-      appId: next.appId,
-      appSecret: next.appSecret,
-      enabled: next.enabled,
+      appId: next.appId as string,
+      appSecret: next.appSecret as string,
+      enabled: next.enabled as boolean | undefined,
+      autoIsolateContext: next.autoIsolateContext as boolean | undefined,
     });
+
+    // Migrate existing Feishu chats when autoIsolateContext toggle changes
+    const oldAutoIsolate = current?.autoIsolateContext ?? false;
+    const newAutoIsolate = saved.autoIsolateContext ?? false;
+    if (oldAutoIsolate !== newAutoIsolate && deps?.applyAutoIsolateContext) {
+      const migrated = deps.applyAutoIsolateContext(user.id, newAutoIsolate);
+      logger.info(
+        { userId: user.id, enable: newAutoIsolate, migrated },
+        'Applied autoIsolateContext to existing Feishu chats',
+      );
+    }
 
     // Hot-reload: reconnect user's Feishu channel
     if (deps?.reloadUserIMConfig) {
@@ -1432,6 +1450,7 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
     return c.json({
       ...toPublicFeishuProviderConfig(saved, 'runtime'),
       connected,
+      autoIsolateContext: saved.autoIsolateContext ?? false,
     });
   } catch (err) {
     const message =

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -231,6 +231,7 @@ interface StoredFeishuProviderConfigV1 {
   enabled?: boolean;
   updatedAt: string;
   ownerOpenId?: string;
+  autoIsolateContext?: boolean;
   secret: EncryptedSecrets;
 }
 
@@ -3033,6 +3034,7 @@ export interface UserFeishuConfig {
   enabled?: boolean;
   updatedAt: string | null;
   ownerOpenId?: string; // auto-detected from first DM; used as sender_allowlist seed for new groups
+  autoIsolateContext?: boolean; // auto-create isolated conversation for each new IM chat
 }
 
 export interface UserTelegramConfig {
@@ -3124,6 +3126,7 @@ export function getUserFeishuConfig(userId: string): UserFeishuConfig | null {
       enabled: stored.enabled,
       updatedAt: stored.updatedAt || null,
       ownerOpenId: stored.ownerOpenId || undefined,
+      autoIsolateContext: stored.autoIsolateContext ?? false,
     };
   } catch (err) {
     logger.warn({ err, userId }, 'Failed to read user Feishu config');
@@ -3141,6 +3144,7 @@ export function saveUserFeishuConfig(
     enabled: next.enabled,
     updatedAt: new Date().toISOString(),
     ownerOpenId: next.ownerOpenId,
+    autoIsolateContext: next.autoIsolateContext,
   };
 
   const payload: StoredFeishuProviderConfigV1 = {
@@ -3149,6 +3153,7 @@ export function saveUserFeishuConfig(
     enabled: normalized.enabled,
     updatedAt: normalized.updatedAt || new Date().toISOString(),
     ownerOpenId: normalized.ownerOpenId,
+    autoIsolateContext: normalized.autoIsolateContext,
     secret: encryptChannelSecret<FeishuSecretPayload>({
       appSecret: normalized.appSecret,
     }),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -387,13 +387,15 @@ export const FeishuConfigSchema = z
     appSecret: z.string().max(2000).optional(),
     clearAppSecret: z.boolean().optional(),
     enabled: z.boolean().optional(),
+    autoIsolateContext: z.boolean().optional(),
   })
   .refine(
     (data) =>
       typeof data.appId === 'string' ||
       typeof data.appSecret === 'string' ||
       data.clearAppSecret === true ||
-      typeof data.enabled === 'boolean',
+      typeof data.enabled === 'boolean' ||
+      typeof data.autoIsolateContext === 'boolean',
     { message: 'At least one config field must be provided' },
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,7 +321,7 @@ export interface SubAgent {
   last_im_jid: string | null;
   /** 发起 /spawn 命令的源会话 JID，用于完成后结果回注 */
   spawned_from_jid: string | null;
-  source_kind?: 'manual' | 'feishu_thread' | null;
+  source_kind?: 'manual' | 'feishu_thread' | 'auto_im' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -77,6 +77,7 @@ export interface WebDeps {
     message: string,
     sourceImJid?: string,
   ) => Promise<string>;
+  applyAutoIsolateContext?: (userId: string, enable: boolean) => number;
 }
 
 export type Variables = {

--- a/web/src/components/settings/FeishuChannelCard.tsx
+++ b/web/src/components/settings/FeishuChannelCard.tsx
@@ -16,6 +16,7 @@ interface UserFeishuConfig {
   enabled: boolean;
   connected: boolean;
   updatedAt: string | null;
+  autoIsolateContext?: boolean;
 }
 
 export function FeishuChannelCard() {
@@ -54,6 +55,19 @@ export function FeishuChannelCard() {
       toast.success(`飞书渠道已${newEnabled ? '启用' : '停用'}`);
     } catch (err) {
       toast.error(getErrorMessage(err, '切换飞书渠道状态失败'));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleAutoIsolateToggle = async (newValue: boolean) => {
+    setToggling(true);
+    try {
+      const data = await api.put<UserFeishuConfig>('/api/config/user-im/feishu', { autoIsolateContext: newValue });
+      setConfig(data);
+      toast.success(`自动隔离上下文已${newValue ? '开启' : '关闭'}`);
+    } catch (err) {
+      toast.error(getErrorMessage(err, '切换自动隔离上下文失败'));
     } finally {
       setToggling(false);
     }
@@ -144,6 +158,17 @@ export function FeishuChannelCard() {
                 {saving && <Loader2 className="size-4 animate-spin" />}
                 保存飞书配置
               </Button>
+            </div>
+            <div className="border-t border-border pt-3 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-foreground">自动隔离上下文</p>
+                <p className="text-xs text-muted-foreground">不同私聊和群聊自动绑定独立对话，上下文互不干扰</p>
+              </div>
+              <Switch
+                checked={config?.autoIsolateContext ?? false}
+                disabled={toggling}
+                onCheckedChange={handleAutoIsolateToggle}
+              />
             </div>
           </>
         )}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -31,7 +31,7 @@ export interface AgentInfo {
   completed_at?: string;
   result_summary?: string;
   linked_im_groups?: Array<{ jid: string; name: string }>;
-  source_kind?: 'manual' | 'feishu_thread' | null;
+  source_kind?: 'manual' | 'feishu_thread' | 'auto_im' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;


### PR DESCRIPTION
动机：
飞书 IM 之前默认把同一个 bot 下的不同私聊和群聊都路由到用户主工作区。这个共享上下文行为需要继续保留为默认值，但新增需求要求在配置开启后，不同用户私聊、不同群聊能够复用各自已有对话，并且彼此隔离上下文。

原因：
上一版实现已经尝试自动创建独立 conversation agent，但存在几个隐患：自动创建的 agent 没有通过 createAgent() 持久化 last_im_jid，部分路径没有准备 IPC/session 目录，多个 IM 聊天共享同一 workspace 时媒体/文件回复路由可能互相覆盖，飞书热重载连接也没有完整传入有效路由回调。

改造点：
- 新增飞书用户 IM 配置中的按聊天上下文模式，并在设置页提供 shared/per_chat 选择；默认仍保持 shared，不改变原有 owner 白名单权限逻辑。
- 开启 per_chat 后，飞书新私聊/群聊自动注册为 chat_map 绑定，每个 chatJid 映射到目标 workspace 下独立的 conversation agent。
- 通过统一绑定表解析或创建飞书聊天级 conversation agent，确保重启后和后续消息能复用同一上下文。
- agent 回复媒体/文件时使用 agent 级 IM 路由，避免同一 workspace 下多个 IM 聊天互相串路由。
- createAgent() 写入 last_im_jid，并补齐 feishu_chat source_kind 的后端/前端类型映射。
- 飞书热重载连接补齐 resolveGroupFolder、resolveEffectiveChatJid、onAgentMessage，让配置更新后无需重启也能按绑定路由生效。