### PR TITLE
修复: 加权轮询权重字段提升可发现性 (#472)

### DIFF
--- a/web/src/components/settings/BalancingSettings.tsx
+++ b/web/src/components/settings/BalancingSettings.tsx
@@ -65,6 +65,12 @@ export function BalancingSettings({ balancing, onChange, disabled }: BalancingSe
                   ? '根据提供商的权重值按比例分配请求'
                   : '优先使用第一个健康的提供商，失败时自动切换到下一个'}
             </p>
+            {balancing.strategy === 'weighted-round-robin' && (
+              <div className="mt-2 px-3 py-2 rounded-md border border-teal-200 dark:border-teal-900/40 bg-teal-50 dark:bg-teal-950/30 text-xs text-teal-800 dark:text-teal-300">
+                💡 上方提供商列表已显示每家的「权重」徽标。点击对应提供商的「编辑」按钮可调整。
+                所有提供商默认权重为 1（均匀分配），调整权重后流量按比例分配。
+              </div>
+            )}
           </div>
 
           {/* 高级参数 */}

--- a/web/src/components/settings/ClaudeProviderSection.tsx
+++ b/web/src/components/settings/ClaudeProviderSection.tsx
@@ -247,6 +247,7 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
       {/* 提供商列表 */}
       <ProviderList
         providers={providers}
+        balancingStrategy={balancing.strategy}
         onEdit={(p) => {
           setEditingProvider(p);
           setEditorOpen(true);
@@ -322,6 +323,7 @@ export function ClaudeProviderSection({ setNotice, setError }: ClaudeProviderSec
       <ProviderEditor
         open={editorOpen}
         provider={editingProvider}
+        balancingStrategy={balancing.strategy}
         onSave={handleEditorSave}
         onCancel={handleEditorCancel}
         setNotice={setNotice}

--- a/web/src/components/settings/ProviderEditor.tsx
+++ b/web/src/components/settings/ProviderEditor.tsx
@@ -59,6 +59,8 @@ interface ProviderEditorProps {
   open: boolean;
   /** null 表示创建模式 */
   provider: ProviderWithHealth | null;
+  /** 当前负载均衡策略，影响权重字段的展示和提示 */
+  balancingStrategy?: 'round-robin' | 'weighted-round-robin' | 'failover';
   onSave: () => void;
   onCancel: () => void;
   setNotice: (msg: string | null) => void;
@@ -68,6 +70,7 @@ interface ProviderEditorProps {
 export function ProviderEditor({
   open,
   provider,
+  balancingStrategy,
   onSave,
   onCancel,
   setNotice,
@@ -81,7 +84,6 @@ export function ProviderEditor({
   const [baseUrl, setBaseUrl] = useState('');
   const [model, setModel] = useState('');
   const [weight, setWeight] = useState(1);
-  const [showAdvanced, setShowAdvanced] = useState(false);
 
   // 官方认证
   const [authTab, setAuthTab] = useState<OfficialAuthTab>('oauth');
@@ -115,7 +117,6 @@ export function ProviderEditor({
       setBaseUrl('');
       setModel('');
       setWeight(1);
-      setShowAdvanced(false);
       setAuthTab('oauth');
       setSetupToken('');
       setApiKey('');
@@ -131,7 +132,6 @@ export function ProviderEditor({
       setBaseUrl(provider.anthropicBaseUrl || '');
       setModel(provider.anthropicModel || '');
       setWeight(provider.weight);
-      setShowAdvanced(provider.weight !== 1);
       setAuthTab('oauth');
       setSetupToken('');
       setApiKey('');
@@ -740,34 +740,30 @@ export function ProviderEditor({
             )}
           </div>
 
-          {/* ─── 高级设置 ─── */}
+          {/* ─── 权重 ─── */}
           <div className="border-t border-border pt-3">
-            <button
-              type="button"
-              className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
-              onClick={() => setShowAdvanced(!showAdvanced)}
-            >
-              {showAdvanced ? '收起高级设置' : '展开高级设置'}
-            </button>
-            {showAdvanced && (
-              <div className="mt-2">
-                <label className="block text-xs text-muted-foreground mb-1">
-                  权重（用于加权轮询策略）
-                </label>
-                <Input
-                  type="number"
-                  min={1}
-                  max={100}
-                  value={weight}
-                  onChange={(e) => setWeight(Math.max(1, Math.min(100, parseInt(e.target.value) || 1)))}
-                  disabled={saving}
-                  className="w-24"
-                />
-                <p className="text-xs text-muted-foreground mt-1">
-                  仅当负载均衡策略为「加权轮询」时生效，值越大分配到的请求越多。
-                </p>
-              </div>
-            )}
+            <div className="flex items-center gap-2 mb-1">
+              <label className="block text-sm font-medium">权重</label>
+              {balancingStrategy === 'weighted-round-robin' && (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium bg-teal-100 text-teal-800">
+                  当前策略生效中
+                </span>
+              )}
+            </div>
+            <Input
+              type="number"
+              min={1}
+              max={100}
+              value={weight}
+              onChange={(e) => setWeight(Math.max(1, Math.min(100, parseInt(e.target.value) || 1)))}
+              disabled={saving}
+              className="w-24"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              {balancingStrategy === 'weighted-round-robin'
+                ? '值越大分配到的请求越多。例如三家分别设 5/3/2，流量比例就是 5:3:2。'
+                : '仅当负载均衡策略为「加权轮询」时生效（当前策略未生效）。范围 1–100。'}
+            </p>
           </div>
 
           {/* ─── 操作按钮 ─── */}

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -17,6 +17,8 @@ import { UsageBars } from './UsageBars';
 
 interface ProviderListProps {
   providers: ProviderWithHealth[];
+  /** 当前负载均衡策略，决定权重徽标是否显示 */
+  balancingStrategy?: 'round-robin' | 'weighted-round-robin' | 'failover';
   onEdit: (provider: ProviderWithHealth) => void;
   onDelete: (provider: ProviderWithHealth) => void;
   onToggle: (provider: ProviderWithHealth) => void;
@@ -101,6 +103,7 @@ function CredentialBadges({ provider }: { provider: ProviderWithHealth }) {
 
 export function ProviderList({
   providers,
+  balancingStrategy,
   onEdit,
   onDelete,
   onToggle,
@@ -111,6 +114,7 @@ export function ProviderList({
   deletingId,
   disabled,
 }: ProviderListProps) {
+  const showWeight = balancingStrategy === 'weighted-round-robin';
   return (
     <div className="space-y-4">
       <div className="rounded-xl border border-border overflow-hidden">
@@ -155,6 +159,14 @@ export function ProviderList({
                       >
                         {provider.type === 'official' ? '官方' : '第三方'}
                       </span>
+                      {showWeight && (
+                        <span
+                          className="text-[11px] px-1.5 py-0.5 rounded shrink-0 bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300 font-mono"
+                          title="当前负载均衡策略为加权轮询，点击编辑可调整权重"
+                        >
+                          权重 {provider.weight}
+                        </span>
+                      )}
                     </div>
 
                     <div className="flex items-center gap-1.5 shrink-0">


### PR DESCRIPTION
## 问题描述

关闭 #472。

权重字段原本被折叠在「展开高级设置」面板里，且只有 `weight !== 1` 时才默认展开。用户切换到加权轮询策略后，找不到权重配置入口，误以为功能缺失或不工作。

## 修复方案

让权重字段在「加权轮询」策略下变得显眼且可发现。

### `web/src/components/settings/ProviderEditor.tsx`

- 移除 `showAdvanced` 折叠面板，权重字段独立成常规字段始终可见
- 接收 `balancingStrategy` prop
- 当 `balancingStrategy === 'weighted-round-robin'` 时，在权重字段标签旁显示「当前策略生效中」徽标
- 帮助文案根据当前策略动态切换：生效中提示比例示例（5/3/2 → 5:3:2），未生效时明确说明「当前策略未生效」

### `web/src/components/settings/ProviderList.tsx`

- 接收 `balancingStrategy` prop
- 当策略为 `weighted-round-robin` 时，在每个 provider 卡片的标题行显示 `权重 N` 徽标（teal 色，等宽字体），用户一眼就能看出权重分布

### `web/src/components/settings/BalancingSettings.tsx`

- 切到加权轮询策略时，在策略说明下方显示引导提示框（teal 边框 + 浅色背景），告诉用户上方列表已显示权重徽标、点编辑可调整、默认权重为 1

### `web/src/components/settings/ClaudeProviderSection.tsx`

- 把 `balancing.strategy` 透传给 `ProviderList` 和 `ProviderEditor`

## 测试

- `npx tsc --noEmit` 通过
- 手动验证三种策略（轮询 / 加权轮询 / 故障转移）下 weight 字段的展示行为正确
- 切换策略后实时刷新（已有 `loadProviders()` 流程不受影响）

## 影响范围

仅前端 UI 改动，不修改任何后端逻辑、API 协议、数据库 schema。已部署的实例升级后 weight 字段值不变，只是展示方式变化。