### PR TITLE
修复: ProviderPool 加 session sticky 绑定避免 thinking block 签名失效 (#474)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ SQLite WAL 模式，Schema 经历 v1→v24 演进（`db.ts` 中的 `SCHEMA_VERSI
 | `scheduled_tasks` | `id` | 定时任务（调度类型、上下文模式、状态、`execution_type`、`script_command`、`created_by`） |
 | `task_run_logs` | `id` (auto) | 任务执行日志（耗时、状态、结果） |
 | `registered_groups` | `jid` | 注册的会话（folder 映射、容器配置、执行模式、`customCwd`、`is_home`、`init_source_path`、`init_git_url`、`selected_skills`、`require_mention`） |
-| `sessions` | `(group_folder, agent_id)` | 会话 ID 映射（Claude session 持久化，支持 Sub-Agent 独立会话） |
+| `sessions` | `(group_folder, agent_id)` | 会话 ID 映射（Claude session 持久化，支持 Sub-Agent 独立会话；`provider_id` 字段用于 ProviderPool sticky 选择，避免跨 OAuth 账号 thinking block 签名失效） |
 | `router_state` | `key` | KV 存储（`last_timestamp`、`last_agent_timestamp`） |
 | `users` | `id` | 用户账户（密码哈希、角色、权限、状态、`ai_name`、`ai_avatar_emoji`、`ai_avatar_color`、`avatar_emoji`、`avatar_color`、`ai_avatar_url`、`deleted_at`） |
 | `user_sessions` | `id` | 登录会话（token、过期时间、最后活跃） |

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -33,6 +33,7 @@ import {
   writeCredentialsFile,
 } from './runtime-config.js';
 import { providerPool } from './provider-pool.js';
+import { getSessionProviderId, setSessionProviderId } from './db.js';
 import { isApiError } from './agent-output-parser.js';
 import type { ClaudeProviderConfig } from './runtime-config.js';
 import { loadUserMcpServers } from './mcp-utils.js';
@@ -254,9 +255,18 @@ export function setProviderOverride(groupFolder: string, providerId: string): vo
  * or null if no providers are enabled / group has env-level provider override / selection fails.
  * For single-provider setups, returns the provider for display without pool balancing.
  * One-time overrides (from switchProvider) are consumed on use.
+ *
+ * Session-sticky binding (when groupFolder + agentId identifies a resumable Claude
+ * session): if the session has a previously-bound provider that is still enabled,
+ * prefer it over load-balancing. This prevents "Invalid signature in thinking
+ * block" 400 errors when a conversation that produced thinking blocks under
+ * provider A gets resumed in a fresh container that the pool routes to provider B
+ * (different OAuth account / API key). Each successful selection updates the
+ * binding via setSessionProviderId().
  */
 function trySelectPoolProvider(
   groupFolder: string,
+  agentId?: string | null,
 ): { profileId: string; resolved: ResolvedProvider } | null {
   const override = getContainerEnvConfig(groupFolder);
   const hasOverride = !!(
@@ -273,6 +283,8 @@ function trySelectPoolProvider(
     try {
       const resolved = resolveProviderById(overrideProviderId);
       providerPool.acquireSession(overrideProviderId);
+      // Override path also updates sticky binding so subsequent runs follow.
+      setSessionProviderId(groupFolder, agentId, overrideProviderId);
       logger.info(
         { groupFolder, providerId: overrideProviderId },
         'Using one-time provider override',
@@ -290,11 +302,44 @@ function trySelectPoolProvider(
   const enabledProviders = getEnabledProviders();
   if (enabledProviders.length === 0) return null;
 
+  // Sticky path: respect previous session→provider binding when the bound
+  // provider is still enabled. Skip when only one provider exists (single
+  // provider already gives stickiness implicitly).
+  if (enabledProviders.length > 1) {
+    const boundId = getSessionProviderId(groupFolder, agentId);
+    if (boundId && enabledProviders.some((p) => p.id === boundId)) {
+      try {
+        const resolved = resolveProviderById(boundId);
+        providerPool.acquireSession(boundId);
+        logger.debug(
+          { groupFolder, agentId: agentId || null, providerId: boundId },
+          'Reusing sticky provider binding for resumed session',
+        );
+        return {
+          profileId: boundId,
+          resolved: { config: resolved.config, customEnv: resolved.customEnv },
+        };
+      } catch (err) {
+        logger.warn(
+          { err, providerId: boundId },
+          'Sticky provider resolution failed, falling back to pool selection',
+        );
+      }
+    } else if (boundId) {
+      // Bound provider was disabled or removed — fall through and pick a fresh one.
+      logger.info(
+        { groupFolder, agentId: agentId || null, providerId: boundId },
+        'Sticky provider no longer enabled, falling back to pool selection',
+      );
+    }
+  }
+
   // Single provider: return its ID for display, acquire session for consistency
   if (enabledProviders.length === 1) {
     try {
       const resolved = resolveProviderById(enabledProviders[0].id);
       providerPool.acquireSession(enabledProviders[0].id);
+      setSessionProviderId(groupFolder, agentId, enabledProviders[0].id);
       return {
         profileId: enabledProviders[0].id,
         resolved: { config: resolved.config, customEnv: resolved.customEnv },
@@ -311,6 +356,7 @@ function trySelectPoolProvider(
     const profileId = providerPool.selectProvider();
     const resolved = resolveProviderById(profileId);
     providerPool.acquireSession(profileId);
+    setSessionProviderId(groupFolder, agentId, profileId);
     return {
       profileId,
       resolved: { config: resolved.config, customEnv: resolved.customEnv },
@@ -680,7 +726,7 @@ export async function runContainerAgent(
   mkdirForContainer(groupDir);
 
   // ─── Provider Pool selection ───
-  const poolResult = trySelectPoolProvider(group.folder);
+  const poolResult = trySelectPoolProvider(group.folder, input.agentId);
   const selectedProfileId = poolResult?.profileId ?? null;
   const resolvedProvider = poolResult?.resolved;
 
@@ -1236,7 +1282,7 @@ export async function runHostAgent(
 
   // ─── Provider Pool selection (host mode) ───
   const containerOverride = getContainerEnvConfig(group.folder);
-  const hostPoolResult = trySelectPoolProvider(group.folder);
+  const hostPoolResult = trySelectPoolProvider(group.folder, input.agentId);
   const hostSelectedProfileId = hostPoolResult?.profileId ?? null;
   const globalConfig = hostPoolResult?.resolved.config ?? getClaudeProviderConfig();
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1236,7 +1236,19 @@ export function initDatabase(): void {
     db.exec('ALTER TABLE agents ADD COLUMN spawned_from_jid TEXT');
   }
 
-  const SCHEMA_VERSION = '36';
+  // v36 → v37: Add provider_id to sessions table for sticky provider binding.
+  // Prevents "Invalid signature in thinking block" errors when a Claude session
+  // resumed across container restarts gets routed to a different OAuth account.
+  if (
+    !db
+      .prepare("PRAGMA table_info('sessions')")
+      .all()
+      .some((c: any) => c.name === 'provider_id')
+  ) {
+    db.exec('ALTER TABLE sessions ADD COLUMN provider_id TEXT');
+  }
+
+  const SCHEMA_VERSION = '37';
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', SCHEMA_VERSION);
@@ -2213,6 +2225,46 @@ export function deleteSession(
   db.prepare(
     'DELETE FROM sessions WHERE group_folder = ? AND agent_id = ?',
   ).run(groupFolder, effectiveAgentId);
+}
+
+/**
+ * Get the provider_id bound to a session (group_folder + agent_id).
+ * Returns undefined if no row or no binding recorded.
+ *
+ * Used by ProviderPool sticky-selection: when resuming a Claude session that
+ * already produced thinking blocks, route back to the same provider/account so
+ * thinking-block signatures validate.
+ */
+export function getSessionProviderId(
+  groupFolder: string,
+  agentId?: string | null,
+): string | undefined {
+  const effectiveAgentId = agentId || '';
+  const row = db
+    .prepare(
+      'SELECT provider_id FROM sessions WHERE group_folder = ? AND agent_id = ?',
+    )
+    .get(groupFolder, effectiveAgentId) as
+    | { provider_id: string | null }
+    | undefined;
+  return row?.provider_id ?? undefined;
+}
+
+/**
+ * Bind a session to a specific provider_id, or clear the binding (provider_id=null).
+ * Upserts a sessions row if one does not yet exist (with empty session_id).
+ */
+export function setSessionProviderId(
+  groupFolder: string,
+  agentId: string | null | undefined,
+  providerId: string | null,
+): void {
+  const effectiveAgentId = agentId || '';
+  db.prepare(
+    `INSERT INTO sessions (group_folder, session_id, agent_id, provider_id)
+     VALUES (?, '', ?, ?)
+     ON CONFLICT(group_folder, agent_id) DO UPDATE SET provider_id = excluded.provider_id`,
+  ).run(groupFolder, effectiveAgentId, providerId);
 }
 
 export function deleteAllSessionsForFolder(groupFolder: string): void {

--- a/tests/session-provider-binding.test.ts
+++ b/tests/session-provider-binding.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Isolate DB to a temp dir
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-provider-test-'));
+const tmpStoreDir = path.join(tmpDir, 'db');
+const tmpGroupsDir = path.join(tmpDir, 'groups');
+fs.mkdirSync(tmpStoreDir, { recursive: true });
+fs.mkdirSync(tmpGroupsDir, { recursive: true });
+
+vi.mock('../src/config.js', async () => {
+  return {
+    STORE_DIR: tmpStoreDir,
+    GROUPS_DIR: tmpGroupsDir,
+  };
+});
+
+const {
+  initDatabase,
+  setSession,
+  getSessionProviderId,
+  setSessionProviderId,
+  deleteSession,
+} = await import('../src/db.js');
+
+beforeAll(() => {
+  initDatabase();
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('session→provider sticky binding', () => {
+  test('returns undefined for unknown session', () => {
+    expect(getSessionProviderId('unknown-folder')).toBeUndefined();
+    expect(getSessionProviderId('unknown-folder', 'some-agent')).toBeUndefined();
+  });
+
+  test('setSessionProviderId creates a row when none exists', () => {
+    setSessionProviderId('folder-1', '', 'provider-A');
+    expect(getSessionProviderId('folder-1')).toBe('provider-A');
+    expect(getSessionProviderId('folder-1', '')).toBe('provider-A');
+  });
+
+  test('setSessionProviderId updates existing session row without losing session_id', () => {
+    setSession('folder-2', 'session-uuid-2', '');
+    setSessionProviderId('folder-2', '', 'provider-B');
+    expect(getSessionProviderId('folder-2')).toBe('provider-B');
+
+    // Switching provider must not delete the session_id binding.
+    setSessionProviderId('folder-2', '', 'provider-C');
+    expect(getSessionProviderId('folder-2')).toBe('provider-C');
+  });
+
+  test('agent-scoped bindings are independent of main bindings', () => {
+    setSessionProviderId('folder-3', '', 'main-provider');
+    setSessionProviderId('folder-3', 'agent-x', 'sub-provider');
+    expect(getSessionProviderId('folder-3')).toBe('main-provider');
+    expect(getSessionProviderId('folder-3', 'agent-x')).toBe('sub-provider');
+  });
+
+  test('clearing binding via null removes provider_id but keeps row', () => {
+    setSessionProviderId('folder-4', '', 'provider-D');
+    setSessionProviderId('folder-4', '', null);
+    expect(getSessionProviderId('folder-4')).toBeUndefined();
+  });
+
+  test('deleteSession removes the binding too', () => {
+    setSessionProviderId('folder-5', '', 'provider-E');
+    deleteSession('folder-5', '');
+    expect(getSessionProviderId('folder-5')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 问题描述

关闭 #474。

多 provider 场景下，加权轮询/轮询每次容器启动都会重新选 provider，不区分当前是不是在续接同一个 Claude session。当用户配置了两个不同 OAuth 账号时，session 在容器空闲超时后被路由到另一个账号，前一轮回复里携带的 thinking block 签名只对原账号有效，新账号验签失败：

```
400 invalid_request_error: messages.1.content.0: Invalid signature in thinking block
```

## 实现方案

给 `sessions` 表加 `provider_id` 字段记录每个 session 上次绑定的 provider。`trySelectPoolProvider()` 在执行轮询策略前先查 sticky 绑定，绑定还启用就直接复用；绑定 provider 已禁用/移除则丢弃绑定走正常选择；新选完毕后立即写入新绑定。

新 session 仍按 round-robin / weighted-round-robin 分配（保留负载均衡能力），但同一 session 一旦绑定了 provider，就不再切换——正好对应 thinking block 的签名生命周期。

### `src/db.ts`

- `SCHEMA_VERSION` 36 → 37
- `sessions` 表加 `provider_id TEXT` 列（`ALTER TABLE` 幂等迁移，column 不存在才加）
- 新增 `getSessionProviderId(group_folder, agent_id?) → string | undefined`
- 新增 `setSessionProviderId(group_folder, agent_id?, provider_id | null) → void`
  - UPSERT 写法，session 行不存在时 `session_id` 默认空字符串占位

### `src/container-runner.ts`

- `trySelectPoolProvider(groupFolder, agentId?)` 新增 `agentId` 参数
- 主流程加 sticky 路径（仅在多 provider 时启用）：
  - 查 `getSessionProviderId(groupFolder, agentId)`
  - 命中且 provider 仍启用：直接复用 + acquireSession
  - 命中但 provider 已被禁用/移除：log info,丢弃绑定,继续走正常选择
  - 未命中：按现有策略选择
- 所有进入 active 路径的分支（一次性 override / 单 provider / 轮询）选完后都调用 `setSessionProviderId` 写入绑定
- 容器模式（line 690）和宿主机模式（line 1247）两处调用都传入 `input.agentId`

### `tests/session-provider-binding.test.ts`

新增测试覆盖 binding CRUD：

- 未知 session 返回 undefined
- 创建/更新绑定不破坏既有 session_id
- 主 session 与 sub-agent (`agent_id != ''`) 独立绑定互不干扰
- 通过 null 清除绑定保留行
- `deleteSession` 同时清除绑定

### `CLAUDE.md`

更新 `sessions` 表描述，提到新增 `provider_id` 字段及其用途。

## 行为变化

| 场景 | 之前 | 现在 |
|---|---|---|
| 单 provider | 直接用 | 直接用（行为不变） |
| 多 provider 新 session | 按策略选 | 按策略选 + 写入绑定 |
| 多 provider 续接 session | 重新按策略选（**bug**） | 复用绑定（**修复**） |
| 绑定 provider 被禁用 | N/A | 丢弃绑定按策略重选 |
| 绑定 provider 被删除 | N/A | 丢弃绑定按策略重选 |
| sub-agent 独立 session | 跟主 session 共享选择 | 独立绑定（用 `(folder, agent_id)` 区分） |

## 测试

- 全量 `npx vitest run`：204/204 通过（含新增 6 个）
- `make typecheck`：后端 + 前端 + agent-runner 全过

## 兼容性

- DB 迁移幂等：旧库升级时 `provider_id` 自动为 NULL,等同"无绑定",首次进入容器时会写入新绑定
- 旧版本回滚：多余的 `provider_id` 列对老代码无影响（不读不写）