### PR TITLE
修复: agent-runner thinking 配置移除 display 字段以适配最新 SDK

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1327,7 +1327,7 @@ async function runQuery(
       systemPrompt: { type: 'preset' as const, preset: 'claude_code' as const, append: systemPromptAppend },
       allowedTools,
       ...(disallowedTools && { disallowedTools }),
-      thinking: { type: 'adaptive' as const, display: 'summarized' as const },
+      thinking: { type: 'adaptive' as const },
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       agentProgressSummaries: true,


### PR DESCRIPTION
## 问题描述

最新版 \`@anthropic-ai/claude-agent-sdk\` 简化了 \`ThinkingAdaptive\` 类型为 \`{ type: 'adaptive' }\`，移除了 \`display\` 字段。容器内 \`entrypoint.sh\` 每次启动都会跑 \`npx tsc\` 编译 hot-mounted 的 \`src/index.ts\`，编译时拿到的是镜像内新版 SDK 的类型定义，因此报：

\`\`\`
src/index.ts(1330,46): error TS2353: Object literal may only specify known properties,
and 'display' does not exist in type 'ThinkingAdaptive'.
\`\`\`

容器以 exit code 2 退出，**所有 docker 模式的会话**（member 用户主容器、所有 flow- 群组）每次发消息都立刻挂掉，进入 GroupQueue 的指数退避重试循环。admin host 模式跑预编译的 \`container/agent-runner/dist/\` 不走容器内 tsc，所以 admin 自己感知不到。

## 用户现象

- member 用户在飞书 / Web 端发消息后无任何响应
- 容器日志（\`data/groups/{folder}/logs/container-*.log\`）显示 \`Exit Code: 2\` + 上述 TS 报错
- 高频重试（5s→10s→20s→40s→80s 退避后停止）

## 根因

提交 \`7416456\`（_修复: 恢复 thinking display='summarized' 保持 Opus 4.7 Reasoning 卡片_）当时 SDK 仍支持 \`display\` 字段。之后 SDK 在 npm 上发了新版本（移除 \`display\`），由于 \`agent-runner/package.json\` 把 SDK 标记为 \`"*"\` + 无 lockfile + Dockerfile 用 \`CACHEBUST\` 触发 \`npm install\` 重跑，下一次镜像重建就会装到无 \`display\` 字段的新版 SDK，导致编译挂掉。

## 修复方案

\`container/agent-runner/src/index.ts:1330\` 去掉 \`display: 'summarized' as const\`，仅保留 \`{ type: 'adaptive' as const }\`。Opus 4.7 思考内容展示由 SDK 默认行为接管。

## 验证

- 本地 \`npx tsc --noEmit\` 通过（agent-runner 子项目）
- 修改源码后 hot-mounted 容器立即生效，新启动的容器 Exit Code 0，TS 报错消失
- 已在生产环境（自己 fork 的部署）验证 member 用户容器恢复正常

## Test plan

- [ ] CI typecheck 通过
- [ ] 重建 happyclaw-agent 镜像（\`./container/build.sh\`）后 docker 模式会话能正常处理消息
- [ ] Opus 4.7 模型下 Reasoning 卡片仍能展示（依赖 SDK 默认行为）