### PR TITLE
新增: WhatsApp IM 通道脚手架（PR 1/N，待接入 Baileys）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 HappyClaw 是一个自托管的多用户 AI Agent 系统：
 
-- **输入**：飞书 / Telegram / QQ / 钉钉 / Web 界面消息（每个用户可独立配置 IM 通道）
+- **输入**：飞书 / Telegram / QQ / 钉钉 / WhatsApp（骨架，待接入 Baileys）/ Web 界面消息（每个用户可独立配置 IM 通道）
 - **执行**：Docker 容器或宿主机进程中运行 Claude Agent（基于 Claude Agent SDK），每个用户拥有独立主容器
 - **输出**：飞书富文本卡片 / Telegram HTML / QQ 纯文本 / Web 实时流式推送
 - **记忆**：Agent 自主维护 `CLAUDE.md` 和工作区文件，实现跨会话持久记忆
@@ -22,7 +22,7 @@ HappyClaw 是一个自托管的多用户 AI Agent 系统：
 | `src/routes/auth.ts` | 认证：登录 / 登出 / 注册、`GET /api/auth/me`（含 `setupStatus`）、设置向导、RBAC、邀请码 |
 | `src/routes/groups.ts` | 群组 CRUD、消息分页、会话重置（重建工作区）、群组级容器环境变量 |
 | `src/routes/files.ts` | 文件上传（50MB 限制）/ 下载 / 删除、目录管理、路径遍历防护 |
-| `src/routes/config.ts` | Claude / 飞书配置（AES-256-GCM 加密存储）、连通性测试、批量应用到所有容器、per-user IM 通道配置（`/api/config/user-im/feishu`、`/api/config/user-im/telegram`、`/api/config/user-im/qq`、`/api/config/user-im/dingtalk`） |
+| `src/routes/config.ts` | Claude / 飞书配置（AES-256-GCM 加密存储）、连通性测试、批量应用到所有容器、per-user IM 通道配置（`/api/config/user-im/feishu`、`/api/config/user-im/telegram`、`/api/config/user-im/qq`、`/api/config/user-im/dingtalk`、`/api/config/user-im/whatsapp` 骨架） |
 | `src/routes/monitor.ts` | 系统状态：容器列表、队列状态、健康检查（`GET /api/health` 无需认证） |
 | `src/routes/memory.ts` | 记忆文件读写（`groups/global/` + `groups/{folder}/`）、全文检索 |
 | `src/routes/tasks.ts` | 定时任务 CRUD + 执行日志查询 |
@@ -35,9 +35,10 @@ HappyClaw 是一个自托管的多用户 AI Agent 系统：
 | `src/telegram.ts` | Telegram 连接工厂（`createTelegramConnection`）：Bot API Long Polling、Markdown → HTML 转换、长消息分片（3800 字符）；`message:photo` 下载为 base64 供 Vision；`message:document` 下载文件到工作区 |
 | `src/qq.ts` | QQ 连接工厂（`createQQConnection`）：Bot API v2 WebSocket 长连接、OAuth Token 管理、C2C 私聊 + 群聊 @Bot、消息去重（LRU 1000 条 / 30min TTL）、Markdown → 纯文本、长消息分片（5000 字符）、图片下载为 base64 供 Vision |
 | `src/dingtalk.ts` | 钉钉连接工厂（`createDingTalkConnection`）：Stream 协议长连接、消息去重（LRU 1000 条 / 30min TTL）；支持 `text`、`picture`（通过 downloadCode 下载）和 `image`（通过 contentUrl 下载）；图片超过 5MB 不发 base64，仅保存到 `downloads/dingtalk/` |
+| `src/whatsapp.ts` | **WhatsApp 通道骨架（PR 1/N）** —— 仅暴露与其他通道一致的工厂签名 `createWhatsAppConnection()`，所有方法抛 `NOT_IMPLEMENTED`。后续 PR 接入 `@whiskeysockets/baileys` 实现 WhatsApp Web 协议、QR 扫码登录、消息收发与媒体下载。详见 §8.13 |
 | `src/dingtalk-streaming-card.ts` | 钉钉 AI Card 流式响应控制器（打字机效果） |
 | `src/im-downloader.ts` | IM 文件下载工具：`saveDownloadedFile()` 将 Buffer 写入 `downloads/{channel}/{YYYY-MM-DD}/`，支持 `feishu`/`telegram`/`qq`/`dingtalk` 通道，处理路径安全、文件名冲突和 50MB 限制 |
-| `src/im-manager.ts` | IM 连接池管理器（`IMConnectionManager`）：per-user 飞书/Telegram/QQ/钉钉连接管理、热重连、批量断开 |
+| `src/im-manager.ts` | IM 连接池管理器（`IMConnectionManager`）：per-user 飞书/Telegram/QQ/钉钉/Discord/WhatsApp（骨架）连接管理、热重连、批量断开 |
 | `src/container-runner.ts` | 容器生命周期：Docker run + 宿主机进程模式、卷挂载构建（isAdminHome 区分权限）、环境变量注入 |
 | `src/agent-output-parser.ts` | Agent 输出解析：OUTPUT_MARKER 流式输出解析、stdout/stderr 处理、进程生命周期回调（从 container-runner.ts 提取的共享逻辑） |
 | `src/group-queue.ts` | 并发控制：最大 20 容器 + 最大 5 宿主机进程、会话级队列、任务优先于消息、指数退避重试 |
@@ -481,7 +482,7 @@ WebSocket：`/ws`（协议详见 §3.6）。
 
 ### 8.10 IM 通道热管理
 
-通过 `PUT /api/config/user-im/feishu`、`PUT /api/config/user-im/telegram`、`PUT /api/config/user-im/qq` 或 `PUT /api/config/user-im/dingtalk` 更新 IM 配置后：
+通过 `PUT /api/config/user-im/feishu`、`PUT /api/config/user-im/telegram`、`PUT /api/config/user-im/qq`、`PUT /api/config/user-im/dingtalk` 或 `PUT /api/config/user-im/whatsapp`（骨架）更新 IM 配置后：
 - 保存配置到 `data/config/user-im/{userId}/` 目录（AES-256-GCM 加密）
 - 断开该用户的旧连接
 - 如果新配置有效（`enabled=true` 且凭据非空），立即建立新连接
@@ -513,6 +514,17 @@ WebSocket：`/ws`（协议详见 §3.6）。
 **实现原理**：连接飞书时通过 Bot Info API 获取 bot 的 `open_id`，收到群消息后检查 `mentions[].id.open_id` 是否包含 bot。如果 bot 未被 @mention 且该群 `require_mention=true`，则静默丢弃该消息。
 
 **前置条件**：飞书应用需要 `im:message.group_msg` 敏感权限（实时接收群里所有消息）。`im:message:readonly` 仅控制 REST API 读取历史消息，不影响 WebSocket 实时推送。没有 `im:message.group_msg` 权限时，平台层只推送 @消息，`require_mention=false` 无法生效。
+
+### 8.13 WhatsApp 通道（骨架，多步骤 PR）
+
+为响应海外用户使用 WhatsApp 的需求，新增 WhatsApp IM 通道。考虑到完整集成涉及大量代码（参考 OpenClaw extensions/whatsapp/ 约 16K 行非测试代码 + 14K 行测试），分多个 PR 推进：
+
+- **PR 1（当前）**：脚手架。`src/whatsapp.ts` 提供与其他通道一致的 `createWhatsAppConnection()` 工厂，但所有方法抛 `NOT_IMPLEMENTED`。打通 `channel-prefixes` / `im-channel`（适配器）/ `im-manager`（连接池方法）/ `runtime-config`（per-user 配置加密落盘）/ `schemas`（zod 校验）/ `routes/config`（GET / PUT `/api/config/user-im/whatsapp`）/ 前端占位卡（`WhatsAppChannelCard.tsx` 标 "骨架开发中"）/ `loadState` 与 `reloadUserIMConfig` 联动。Typecheck 通过，配置可保存，但启用后 connect 永远返回 false。
+- **PR 2**：接入 `@whiskeysockets/baileys`。实现 multi-file auth state、QR 码生成 + WebSocket 推流、扫码登录状态机、消息收发、文件下载到 `downloads/whatsapp/{YYYY-MM-DD}/`、长消息分片。
+- **PR 3**：群组策略、白名单、媒体矩阵（图/视频/语音/文档/位置/反应/引用）、心跳与掉线重连。
+- **PR 4**：测试 + 文档完善。
+
+**风险提示**：Baileys 是社区逆向工程的 WhatsApp Web 协议库，Meta 在 2025-2026 收紧识别（握手时序、加密时序），封号率显著上升。同 OpenClaw / Wechaty puppet 等同类逆向方案共享相同风险。商用场景应使用 Meta 官方 Cloud API（需要 Facebook Business 验证、按模板消息计费）。
 
 ## 9. 环境变量
 

--- a/src/channel-prefixes.ts
+++ b/src/channel-prefixes.ts
@@ -6,6 +6,7 @@ export const CHANNEL_PREFIXES: Record<string, string> = {
   wechat: 'wechat:',
   dingtalk: 'dingtalk:',
   discord: 'discord:',
+  whatsapp: 'whatsapp:',
 };
 
 /** Determine the channel type from a JID string. Returns 'web' for unrecognized prefixes. */

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -34,6 +34,11 @@ import {
   type DiscordConnection,
   type DiscordConnectionConfig,
 } from './discord.js';
+import {
+  createWhatsAppConnection,
+  type WhatsAppConnection,
+  type WhatsAppConnectionConfig,
+} from './whatsapp.js';
 import { logger } from './logger.js';
 import type { FeishuMessageMeta } from './types.js';
 import {
@@ -853,5 +858,104 @@ export function createDiscordChannel(
       return inner.createStreamingSession(chatId, onCardCreated);
     },
   };
+  return channel;
+}
+
+// ─── WhatsApp Adapter ───────────────────────────────────────────
+
+export function createWhatsAppChannel(
+  config: WhatsAppConnectionConfig,
+): IMChannel {
+  let inner: WhatsAppConnection | null = null;
+
+  const channel: IMChannel = {
+    channelType: 'whatsapp',
+
+    async connect(opts: IMChannelConnectOpts): Promise<boolean> {
+      inner = createWhatsAppConnection(config);
+      try {
+        await inner.connect({
+          onReady: opts.onReady,
+          onNewChat: opts.onNewChat,
+          onCommand: opts.onCommand,
+          ignoreMessagesBefore: opts.ignoreMessagesBefore,
+          resolveGroupFolder: opts.resolveGroupFolder,
+          resolveEffectiveChatJid: opts.resolveEffectiveChatJid,
+          onAgentMessage: opts.onAgentMessage,
+        });
+        return inner.isConnected();
+      } catch (err) {
+        // Skeleton always throws — log at info level so it doesn't spam error
+        // channel until Baileys integration lands.
+        logger.info({ err }, 'WhatsApp channel skeleton connect rejected');
+        inner = null;
+        return false;
+      }
+    },
+
+    async disconnect(): Promise<void> {
+      if (inner) {
+        await inner.disconnect();
+        inner = null;
+      }
+    },
+
+    async sendMessage(
+      chatId: string,
+      text: string,
+      localImagePaths?: string[],
+    ): Promise<void> {
+      if (!inner) {
+        logger.warn(
+          { chatId },
+          'WhatsApp channel not connected, skip sending message',
+        );
+        return;
+      }
+      await inner.sendMessage(chatId, text, localImagePaths);
+    },
+
+    async sendImage(
+      chatId: string,
+      imageBuffer: Buffer,
+      mimeType: string,
+      caption?: string,
+      fileName?: string,
+    ): Promise<void> {
+      if (!inner) {
+        logger.warn(
+          { chatId },
+          'WhatsApp channel not connected, skip sending image',
+        );
+        return;
+      }
+      await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
+    },
+
+    async sendFile(
+      chatId: string,
+      filePath: string,
+      fileName: string,
+    ): Promise<void> {
+      if (!inner) {
+        logger.warn(
+          { chatId },
+          'WhatsApp channel not connected, skip sending file',
+        );
+        return;
+      }
+      await inner.sendFile(chatId, filePath, fileName);
+    },
+
+    async setTyping(chatId: string, isTyping: boolean): Promise<void> {
+      if (!inner) return;
+      await inner.sendTyping(chatId, isTyping);
+    },
+
+    isConnected(): boolean {
+      return inner?.isConnected() ?? false;
+    },
+  };
+
   return channel;
 }

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -16,6 +16,7 @@ import {
   createWeChatChannel,
   createDingTalkChannel,
   createDiscordChannel,
+  createWhatsAppChannel,
 } from './im-channel.js';
 import { parseFeishuRouteTarget, type FeishuConnectionConfig } from './feishu.js';
 import type { TelegramConnectionConfig } from './telegram.js';
@@ -23,6 +24,7 @@ import type { QQConnectionConfig } from './qq.js';
 import type { WeChatConnectionConfig } from './wechat.js';
 import type { DingTalkConnectionConfig } from './dingtalk.js';
 import type { DiscordConnectionConfig } from './discord.js';
+import type { WhatsAppConnectionConfig } from './whatsapp.js';
 import type { StreamingSession } from './im-channel.js';
 import { getRegisteredGroup, getJidsByFolder } from './db.js';
 import { getUserDingTalkConfig } from './runtime-config.js';
@@ -71,6 +73,14 @@ export interface DiscordConnectConfig {
   botToken: string;
   enabled?: boolean;
   streamingMode?: 'edit' | 'off';
+}
+
+export interface WhatsAppConnectConfig {
+  /** PR 1 占位：WhatsApp 通道骨架尚未接入 Baileys，连接永远失败 */
+  accountId?: string;
+  phoneNumber?: string;
+  authDir?: string;
+  enabled?: boolean;
 }
 
 export interface ConnectFeishuOptions {
@@ -548,6 +558,50 @@ class IMConnectionManager {
   }
 
   /**
+   * Connect a WhatsApp instance for a specific user.
+   *
+   * PR 1 阶段为骨架占位：始终返回 false，因 WhatsApp channel 尚未接入 Baileys。
+   * 接入路径已铺好，下一个 PR 替换 createWhatsAppChannel/createWhatsAppConnection
+   * 内部即可，无需改动本方法的签名或调用链。
+   */
+  async connectUserWhatsApp(
+    userId: string,
+    config: WhatsAppConnectConfig,
+    onNewChat: (chatJid: string, chatName: string) => void,
+    options?: {
+      ignoreMessagesBefore?: number;
+      onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+      resolveGroupFolder?: (jid: string) => string | undefined;
+      resolveEffectiveChatJid?: (
+        chatJid: string,
+      ) => { effectiveJid: string; agentId: string | null } | null;
+      onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+    },
+  ): Promise<boolean> {
+    const channel = createWhatsAppChannel({
+      accountId: config.accountId,
+      phoneNumber: config.phoneNumber,
+      authDir: config.authDir,
+    });
+
+    return this.connectChannel(userId, 'whatsapp', channel, {
+      onReady: () => {
+        logger.info({ userId }, 'User WhatsApp channel ready');
+      },
+      onNewChat,
+      ignoreMessagesBefore: options?.ignoreMessagesBefore,
+      onCommand: options?.onCommand,
+      resolveGroupFolder: options?.resolveGroupFolder,
+      resolveEffectiveChatJid: options?.resolveEffectiveChatJid,
+      onAgentMessage: options?.onAgentMessage,
+    });
+  }
+
+  async disconnectUserWhatsApp(userId: string): Promise<void> {
+    await this.disconnectChannel(userId, 'whatsapp');
+  }
+
+  /**
    * Connect a DingTalk Stream instance for a specific user.
    */
   async connectUserDingTalk(
@@ -764,6 +818,11 @@ class IMConnectionManager {
   isDiscordConnected(userId: string): boolean {
     const conn = this.connections.get(userId);
     return conn?.channels.get('discord')?.isConnected() ?? false;
+  }
+
+  isWhatsAppConnected(userId: string): boolean {
+    const conn = this.connections.get(userId);
+    return conn?.channels.get('whatsapp')?.isConnected() ?? false;
   }
 
   /** Get the Feishu channel for a user (for direct access like syncGroups) */

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ import {
   getUserWeChatConfig,
   getUserDingTalkConfig,
   getUserDiscordConfig,
+  getUserWhatsAppConfig,
   getSystemSettings,
   saveUserFeishuConfig,
   saveFeishuOwnerOpenId,
@@ -143,6 +144,7 @@ import type {
   WeChatConnectConfig,
   DingTalkConnectConfig,
   DiscordConnectConfig,
+  WhatsAppConnectConfig,
 } from './im-manager.js';
 import { GroupQueue } from './group-queue.js';
 import { startSchedulerLoop, triggerTaskNow } from './task-scheduler.js';
@@ -7328,6 +7330,7 @@ async function connectUserIMChannels(
   wechatConfig?: WeChatConnectConfig | null,
   dingtalkConfig?: DingTalkConnectConfig | null,
   discordConfig?: DiscordConnectConfig | null,
+  whatsappConfig?: WhatsAppConnectConfig | null,
   ignoreMessagesBefore?: number,
 ): Promise<{
   feishu: boolean;
@@ -7336,6 +7339,7 @@ async function connectUserIMChannels(
   wechat: boolean;
   dingtalk: boolean;
   discord: boolean;
+  whatsapp: boolean;
 }> {
   // Per-user mutable ref for Feishu owner open_id auto-detection via P2P messages
   const feishuOwnerRef = { value: feishuConfig ? (getUserFeishuConfig(userId)?.ownerOpenId ?? undefined) : undefined };
@@ -7471,16 +7475,29 @@ async function connectUserIMChannels(
         })
       : Promise.resolve(false);
 
-  const [feishu, telegram, qq, wechat, dingtalk, discord] = await Promise.all([
-    feishuTask,
-    telegramTask,
-    qqTask,
-    wechatTask,
-    dingtalkTask,
-    discordTask,
-  ]);
+  const whatsappTask =
+    whatsappConfig && whatsappConfig.enabled !== false
+      ? imManager.connectUserWhatsApp(userId, whatsappConfig, onNewChat, {
+          ignoreMessagesBefore,
+          onCommand: handleCommand,
+          resolveGroupFolder,
+          resolveEffectiveChatJid,
+          onAgentMessage,
+        })
+      : Promise.resolve(false);
 
-  return { feishu, telegram, qq, wechat, dingtalk, discord };
+  const [feishu, telegram, qq, wechat, dingtalk, discord, whatsapp] =
+    await Promise.all([
+      feishuTask,
+      telegramTask,
+      qqTask,
+      wechatTask,
+      dingtalkTask,
+      discordTask,
+      whatsappTask,
+    ]);
+
+  return { feishu, telegram, qq, wechat, dingtalk, discord, whatsapp };
 }
 
 function movePathWithFallback(src: string, dst: string): void {
@@ -7897,7 +7914,14 @@ async function main(): Promise<void> {
   // Reload a per-user IM channel (hot-reload on user-im config save)
   const reloadUserIMConfig = async (
     userId: string,
-    channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
+    channel:
+      | 'feishu'
+      | 'telegram'
+      | 'qq'
+      | 'wechat'
+      | 'dingtalk'
+      | 'discord'
+      | 'whatsapp',
   ): Promise<boolean> => {
     const homeGroup = getUserHomeGroup(userId);
     if (!homeGroup) {
@@ -8079,8 +8103,7 @@ async function main(): Promise<void> {
       }
       logger.info({ userId }, 'User Discord channel disabled via hot-reload');
       return false;
-    } else {
-      // WeChat
+    } else if (channel === 'wechat') {
       await imManager.disconnectUserWeChat(userId);
       const config = getUserWeChatConfig(userId);
       if (
@@ -8115,6 +8138,39 @@ async function main(): Promise<void> {
         return connected;
       }
       logger.info({ userId }, 'User WeChat channel disabled via hot-reload');
+      return false;
+    } else {
+      // WhatsApp (skeleton — Baileys integration pending in next PR)
+      await imManager.disconnectUserWhatsApp(userId);
+      const config = getUserWhatsAppConfig(userId);
+      if (config && config.enabled !== false) {
+        const connected = await imManager.connectUserWhatsApp(
+          userId,
+          {
+            accountId: config.accountId,
+            phoneNumber: config.phoneNumber,
+            enabled: config.enabled,
+          },
+          onNewChat,
+          {
+            ignoreMessagesBefore: Date.now(),
+            onCommand: handleCommand,
+            resolveGroupFolder: (chatJid: string) =>
+              resolveEffectiveFolder(chatJid),
+            resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
+            onAgentMessage: buildOnAgentMessage(),
+          },
+        );
+        logger.info(
+          { userId, connected },
+          'User WhatsApp connection hot-reloaded (skeleton)',
+        );
+        return connected;
+      }
+      logger.info(
+        { userId },
+        'User WhatsApp channel disabled via hot-reload',
+      );
       return false;
     }
   };
@@ -8152,6 +8208,8 @@ async function main(): Promise<void> {
       imManager.isDingTalkConnected(userId),
     isUserDiscordConnected: (userId: string) =>
       imManager.isDiscordConnected(userId),
+    isUserWhatsAppConnected: (userId: string) =>
+      imManager.isWhatsAppConnected(userId),
     processAgentConversation,
     getFeishuChatInfo: (userId: string, chatId: string) =>
       imManager.getFeishuChatInfo(userId, chatId),
@@ -8475,6 +8533,7 @@ async function main(): Promise<void> {
     const userWeChat = getUserWeChatConfig(user.id);
     const userDingTalk = getUserDingTalkConfig(user.id);
     const userDiscord = getUserDiscordConfig(user.id);
+    const userWhatsApp = getUserWhatsAppConfig(user.id);
 
     // Determine effective Feishu config: per-user > global (admin only)
     let effectiveFeishu: FeishuConnectConfig | null = null;
@@ -8556,13 +8615,24 @@ async function main(): Promise<void> {
       };
     }
 
+    // Determine effective WhatsApp config: per-user only, skeleton always disabled by default
+    let effectiveWhatsApp: WhatsAppConnectConfig | null = null;
+    if (userWhatsApp && userWhatsApp.enabled) {
+      effectiveWhatsApp = {
+        accountId: userWhatsApp.accountId,
+        phoneNumber: userWhatsApp.phoneNumber,
+        enabled: userWhatsApp.enabled,
+      };
+    }
+
     if (
       !effectiveFeishu &&
       !effectiveTelegram &&
       !effectiveQQ &&
       !effectiveWeChat &&
       !effectiveDingTalk &&
-      !effectiveDiscord
+      !effectiveDiscord &&
+      !effectiveWhatsApp
     )
       continue;
 
@@ -8576,6 +8646,7 @@ async function main(): Promise<void> {
         effectiveWeChat,
         effectiveDingTalk,
         effectiveDiscord,
+        effectiveWhatsApp,
         Date.now(),
       );
       if (result.feishu) anyFeishuConnected = true;
@@ -8588,6 +8659,7 @@ async function main(): Promise<void> {
           wechat: result.wechat,
           dingtalk: result.dingtalk,
           discord: result.discord,
+          whatsapp: result.whatsapp,
         },
         'User IM channels connected',
       );

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -28,6 +28,7 @@ import {
   WeChatConfigSchema,
   DingTalkConfigSchema,
   DiscordConfigSchema,
+  WhatsAppConfigSchema,
   RegistrationConfigSchema,
   AppearanceConfigSchema,
   SystemSettingsSchema,
@@ -78,6 +79,8 @@ import {
   saveUserDingTalkConfig,
   getUserDiscordConfig,
   saveUserDiscordConfig,
+  getUserWhatsAppConfig,
+  saveUserWhatsAppConfig,
   updateAllSessionCredentials,
 } from '../runtime-config.js';
 import type {
@@ -107,7 +110,14 @@ const configRoutes = new Hono<{ Variables: Variables }>();
  */
 function countOtherEnabledImChannels(
   userId: string,
-  excludeChannel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
+  excludeChannel:
+    | 'feishu'
+    | 'telegram'
+    | 'qq'
+    | 'wechat'
+    | 'dingtalk'
+    | 'discord'
+    | 'whatsapp',
 ): number {
   let count = 0;
   if (excludeChannel !== 'feishu' && getUserFeishuConfig(userId)?.enabled)
@@ -120,6 +130,8 @@ function countOtherEnabledImChannels(
   if (excludeChannel !== 'dingtalk' && getUserDingTalkConfig(userId)?.enabled)
     count++;
   if (excludeChannel !== 'discord' && getUserDiscordConfig(userId)?.enabled)
+    count++;
+  if (excludeChannel !== 'whatsapp' && getUserWhatsAppConfig(userId)?.enabled)
     count++;
   return count;
 }
@@ -2559,6 +2571,119 @@ configRoutes.post('/user-im/wechat/disconnect', authMiddleware, async (c) => {
       err instanceof Error ? err.message : 'Failed to disconnect WeChat';
     logger.error({ err }, 'WeChat disconnect failed');
     return c.json({ error: message }, 500);
+  }
+});
+
+// ─── WhatsApp (Skeleton — Baileys integration in next PR) ───────
+
+configRoutes.get('/user-im/whatsapp', authMiddleware, (c) => {
+  const user = c.get('user') as AuthUser;
+  try {
+    const config = getUserWhatsAppConfig(user.id);
+    const connected = deps?.isUserWhatsAppConnected?.(user.id) ?? false;
+    if (!config) {
+      return c.json({
+        accountId: 'default',
+        phoneNumber: '',
+        enabled: false,
+        paired: false,
+        updatedAt: null,
+        connected,
+        skeleton: true,
+      });
+    }
+    return c.json({
+      accountId: config.accountId || 'default',
+      phoneNumber: config.phoneNumber || '',
+      enabled: config.enabled ?? false,
+      paired: config.paired ?? false,
+      updatedAt: config.updatedAt,
+      connected,
+      skeleton: true,
+    });
+  } catch (err) {
+    logger.error({ err }, 'Failed to load user WhatsApp config');
+    return c.json({ error: 'Failed to load user WhatsApp config' }, 500);
+  }
+});
+
+configRoutes.put('/user-im/whatsapp', authMiddleware, async (c) => {
+  const user = c.get('user') as AuthUser;
+  const body = await c.req.json().catch(() => ({}));
+  const validation = WhatsAppConfigSchema.safeParse(body);
+  if (!validation.success) {
+    return c.json(
+      { error: 'Invalid request body', details: validation.error.format() },
+      400,
+    );
+  }
+
+  // Billing: check IM channel limit when enabling
+  if (validation.data.enabled === true && isBillingEnabled()) {
+    const currentWa = getUserWhatsAppConfig(user.id);
+    if (!currentWa?.enabled) {
+      const limit = checkImChannelLimit(
+        user.id,
+        user.role,
+        countOtherEnabledImChannels(user.id, 'whatsapp'),
+      );
+      if (!limit.allowed) {
+        return c.json({ error: limit.reason }, 403);
+      }
+    }
+  }
+
+  const current = getUserWhatsAppConfig(user.id);
+  const next = {
+    accountId: current?.accountId || 'default',
+    phoneNumber: current?.phoneNumber || '',
+    enabled: current?.enabled ?? false,
+    paired: current?.paired ?? false,
+  };
+
+  if (typeof validation.data.accountId === 'string') {
+    next.accountId = validation.data.accountId.trim() || 'default';
+  }
+  if (typeof validation.data.phoneNumber === 'string') {
+    next.phoneNumber = validation.data.phoneNumber.trim();
+  }
+  if (typeof validation.data.enabled === 'boolean') {
+    next.enabled = validation.data.enabled;
+  }
+  if (typeof validation.data.paired === 'boolean') {
+    next.paired = validation.data.paired;
+  }
+
+  try {
+    const saved = saveUserWhatsAppConfig(user.id, next);
+
+    // Hot-reload: reconnect user's WhatsApp channel (skeleton always returns false)
+    if (deps?.reloadUserIMConfig) {
+      try {
+        await deps.reloadUserIMConfig(user.id, 'whatsapp');
+      } catch (err) {
+        logger.warn(
+          { err, userId: user.id },
+          'Failed to hot-reload user WhatsApp connection',
+        );
+      }
+    }
+
+    const connected = deps?.isUserWhatsAppConnected?.(user.id) ?? false;
+    return c.json({
+      accountId: saved.accountId,
+      phoneNumber: saved.phoneNumber,
+      enabled: saved.enabled ?? false,
+      paired: saved.paired ?? false,
+      updatedAt: saved.updatedAt,
+      connected,
+      skeleton: true,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Invalid WhatsApp config payload';
+    logger.warn({ err }, 'Invalid WhatsApp config');
+    return c.json({ error: message }, 400);
   }
 });
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3385,6 +3385,80 @@ export function saveUserWeChatConfig(
   return normalized;
 }
 
+// ========== WhatsApp User IM Config ==========
+
+export interface UserWhatsAppConfig {
+  accountId: string;
+  phoneNumber: string;
+  enabled?: boolean;
+  /** Whether the user has completed Baileys QR pairing (set by future PR) */
+  paired?: boolean;
+  updatedAt: string | null;
+}
+
+interface StoredWhatsAppProviderConfigV1 {
+  version: 1;
+  accountId: string;
+  phoneNumber: string;
+  enabled?: boolean;
+  paired?: boolean;
+  updatedAt: string;
+}
+
+export function getUserWhatsAppConfig(
+  userId: string,
+): UserWhatsAppConfig | null {
+  const filePath = path.join(userImDir(userId), 'whatsapp.json');
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (parsed.version !== 1) return null;
+
+    const stored = parsed as unknown as StoredWhatsAppProviderConfigV1;
+    return {
+      accountId: ((stored.accountId as string) ?? 'default').trim(),
+      phoneNumber: ((stored.phoneNumber as string) ?? '').trim(),
+      enabled: stored.enabled,
+      paired: stored.paired,
+      updatedAt: stored.updatedAt || null,
+    };
+  } catch (err) {
+    logger.warn({ err, userId }, 'Failed to read user WhatsApp config');
+    return null;
+  }
+}
+
+export function saveUserWhatsAppConfig(
+  userId: string,
+  next: Omit<UserWhatsAppConfig, 'updatedAt'>,
+): UserWhatsAppConfig {
+  const normalized: UserWhatsAppConfig = {
+    accountId: (next.accountId ?? 'default').trim() || 'default',
+    phoneNumber: (next.phoneNumber ?? '').trim(),
+    enabled: next.enabled,
+    paired: next.paired,
+    updatedAt: new Date().toISOString(),
+  };
+
+  const payload: StoredWhatsAppProviderConfigV1 = {
+    version: 1,
+    accountId: normalized.accountId,
+    phoneNumber: normalized.phoneNumber,
+    enabled: normalized.enabled,
+    paired: normalized.paired,
+    updatedAt: normalized.updatedAt || new Date().toISOString(),
+  };
+
+  const dir = userImDir(userId);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, 'whatsapp.json');
+  const tmp = `${filePath}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmp, filePath);
+  return normalized;
+}
+
 // ========== DingTalk User IM Config ==========
 
 export function getUserDingTalkConfig(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -746,3 +746,20 @@ export const DiscordConfigSchema = z
       typeof data.streamingMode === 'string',
     { message: 'At least one config field must be provided' },
   );
+
+export const WhatsAppConfigSchema = z
+  .object({
+    accountId: z.string().max(64).optional(),
+    phoneNumber: z.string().max(32).optional(),
+    enabled: z.boolean().optional(),
+    /** 标记 Baileys 扫码完成 — 由后续 PR 在登录回调中写入，前端不应直接发 true */
+    paired: z.boolean().optional(),
+  })
+  .refine(
+    (data) =>
+      typeof data.accountId === 'string' ||
+      typeof data.phoneNumber === 'string' ||
+      typeof data.enabled === 'boolean' ||
+      typeof data.paired === 'boolean',
+    { message: 'At least one config field must be provided' },
+  );

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -44,7 +44,14 @@ export interface WebDeps {
   }) => Promise<boolean>;
   reloadUserIMConfig?: (
     userId: string,
-    channel: 'feishu' | 'telegram' | 'qq' | 'wechat' | 'dingtalk' | 'discord',
+    channel:
+      | 'feishu'
+      | 'telegram'
+      | 'qq'
+      | 'wechat'
+      | 'dingtalk'
+      | 'discord'
+      | 'whatsapp',
   ) => Promise<boolean>;
   isFeishuConnected?: () => boolean;
   isTelegramConnected?: () => boolean;
@@ -54,6 +61,7 @@ export interface WebDeps {
   isUserWeChatConnected?: (userId: string) => boolean;
   isUserDingTalkConnected?: (userId: string) => boolean;
   isUserDiscordConnected?: (userId: string) => boolean;
+  isUserWhatsAppConnected?: (userId: string) => boolean;
   processAgentConversation?: (
     chatJid: string,
     agentId: string,

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -1,0 +1,139 @@
+/**
+ * WhatsApp Channel — Skeleton (PR 1 of multi-PR series)
+ *
+ * 占位骨架：仅暴露与其他 IM 通道一致的工厂函数和接口契约，所有方法均抛出
+ * "not implemented yet" 错误。后续 PR 接入 Baileys（@whiskeysockets/baileys）
+ * 实现真正的 WhatsApp Web 协议连接、QR 码扫码登录、消息收发、媒体下载等。
+ *
+ * 设计目标：让 PR 1 通过 typecheck 并且端到端配置流程（保存/加载/启停）能跑通，
+ * 即使连接本身永远 false。后续 PR 只需替换 connect()/disconnect()/sendMessage()
+ * 等方法的内部实现，不需要再改任何外围接入点（im-manager / im-channel / index.ts
+ * / routes / schemas）。
+ */
+import { logger } from './logger.js';
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface WhatsAppConnectionConfig {
+  /** Account identifier — currently固定 'default'，未来扩展 multi-account 用 */
+  accountId?: string;
+  /** Optional phone number hint for display purposes (E.164 format, e.g. +15551234567) */
+  phoneNumber?: string;
+  /** Auth state directory override; defaults to data/config/user-im/{userId}/whatsapp-auth/ */
+  authDir?: string;
+}
+
+export interface WhatsAppConnectOpts {
+  onReady?: () => void;
+  onNewChat: (jid: string, name: string) => void;
+  ignoreMessagesBefore?: number;
+  onCommand?: (chatJid: string, command: string) => Promise<string | null>;
+  resolveGroupFolder?: (jid: string) => string | undefined;
+  resolveEffectiveChatJid?: (
+    chatJid: string,
+  ) => { effectiveJid: string; agentId: string | null } | null;
+  onAgentMessage?: (baseChatJid: string, agentId: string) => void;
+}
+
+export interface WhatsAppConnection {
+  connect(opts: WhatsAppConnectOpts): Promise<void>;
+  disconnect(): Promise<void>;
+  sendMessage(
+    chatId: string,
+    text: string,
+    localImagePaths?: string[],
+  ): Promise<void>;
+  sendImage(
+    chatId: string,
+    imageBuffer: Buffer,
+    mimeType: string,
+    caption?: string,
+    fileName?: string,
+  ): Promise<void>;
+  sendFile(
+    chatId: string,
+    filePath: string,
+    fileName: string,
+  ): Promise<void>;
+  sendTyping(chatId: string, isTyping: boolean): Promise<void>;
+  isConnected(): boolean;
+}
+
+const NOT_IMPLEMENTED =
+  'WhatsApp channel skeleton only — Baileys integration pending in next PR';
+
+// ─── Factory ────────────────────────────────────────────────────
+
+export function createWhatsAppConnection(
+  config: WhatsAppConnectionConfig,
+): WhatsAppConnection {
+  void config; // suppress unused warning until Baileys impl lands
+
+  return {
+    async connect(_opts: WhatsAppConnectOpts): Promise<void> {
+      void _opts;
+      logger.warn({ feature: 'whatsapp' }, NOT_IMPLEMENTED);
+      throw new Error(NOT_IMPLEMENTED);
+    },
+
+    async disconnect(): Promise<void> {
+      // No-op: nothing to disconnect from skeleton
+    },
+
+    async sendMessage(
+      chatId: string,
+      _text: string,
+      _localImagePaths?: string[],
+    ): Promise<void> {
+      void _text;
+      void _localImagePaths;
+      logger.warn(
+        { feature: 'whatsapp', chatId },
+        'sendMessage called on WhatsApp skeleton',
+      );
+      throw new Error(NOT_IMPLEMENTED);
+    },
+
+    async sendImage(
+      chatId: string,
+      _imageBuffer: Buffer,
+      _mimeType: string,
+      _caption?: string,
+      _fileName?: string,
+    ): Promise<void> {
+      void _imageBuffer;
+      void _mimeType;
+      void _caption;
+      void _fileName;
+      logger.warn(
+        { feature: 'whatsapp', chatId },
+        'sendImage called on WhatsApp skeleton',
+      );
+      throw new Error(NOT_IMPLEMENTED);
+    },
+
+    async sendFile(
+      chatId: string,
+      _filePath: string,
+      _fileName: string,
+    ): Promise<void> {
+      void _filePath;
+      void _fileName;
+      logger.warn(
+        { feature: 'whatsapp', chatId },
+        'sendFile called on WhatsApp skeleton',
+      );
+      throw new Error(NOT_IMPLEMENTED);
+    },
+
+    async sendTyping(_chatId: string, _isTyping: boolean): Promise<void> {
+      void _chatId;
+      void _isTyping;
+      // No-op for skeleton
+    },
+
+    isConnected(): boolean {
+      return false;
+    },
+  };
+}

--- a/web/src/components/settings/UserChannelsSection.tsx
+++ b/web/src/components/settings/UserChannelsSection.tsx
@@ -4,6 +4,7 @@ import { QQChannelCard } from './QQChannelCard';
 import { WeChatChannelCard } from './WeChatChannelCard';
 import { DingTalkChannelCard } from './DingTalkChannelCard';
 import { DiscordChannelCard } from './DiscordChannelCard';
+import { WhatsAppChannelCard } from './WhatsAppChannelCard';
 
 export function UserChannelsSection() {
   return (
@@ -17,6 +18,7 @@ export function UserChannelsSection() {
       <WeChatChannelCard />
       <DingTalkChannelCard />
       <DiscordChannelCard />
+      <WhatsAppChannelCard />
     </div>
   );
 }

--- a/web/src/components/settings/WhatsAppChannelCard.tsx
+++ b/web/src/components/settings/WhatsAppChannelCard.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { api } from '../../api/client';
+import { getErrorMessage } from './types';
+
+interface UserWhatsAppConfig {
+  accountId: string;
+  phoneNumber: string;
+  enabled: boolean;
+  paired: boolean;
+  connected: boolean;
+  updatedAt: string | null;
+  /** Server-side flag: backend is in skeleton phase, connect always fails */
+  skeleton?: boolean;
+}
+
+export function WhatsAppChannelCard() {
+  const [config, setConfig] = useState<UserWhatsAppConfig | null>(null);
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [toggling, setToggling] = useState(false);
+
+  const enabled = config?.enabled ?? false;
+  const isSkeleton = config?.skeleton ?? true;
+
+  const loadConfig = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.get<UserWhatsAppConfig>(
+        '/api/config/user-im/whatsapp',
+      );
+      setConfig(data);
+      setPhoneNumber('');
+    } catch {
+      setConfig(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  const handleToggle = async (newEnabled: boolean) => {
+    setToggling(true);
+    try {
+      const data = await api.put<UserWhatsAppConfig>(
+        '/api/config/user-im/whatsapp',
+        { enabled: newEnabled },
+      );
+      setConfig(data);
+      toast.success(`WhatsApp 渠道已${newEnabled ? '启用' : '停用'}`);
+    } catch (err) {
+      toast.error(getErrorMessage(err, '切换 WhatsApp 渠道状态失败'));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const trimmed = phoneNumber.trim();
+      const payload: Record<string, string | boolean> = {};
+      if (trimmed) payload.phoneNumber = trimmed;
+      if (Object.keys(payload).length === 0) {
+        toast.info('没有要保存的修改');
+        setSaving(false);
+        return;
+      }
+      const data = await api.put<UserWhatsAppConfig>(
+        '/api/config/user-im/whatsapp',
+        payload,
+      );
+      setConfig(data);
+      setPhoneNumber('');
+      toast.success('WhatsApp 配置已保存');
+    } catch (err) {
+      toast.error(getErrorMessage(err, '保存 WhatsApp 配置失败'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-border bg-muted/50">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-block w-2 h-2 rounded-full ${
+              config?.connected
+                ? 'bg-success'
+                : 'bg-muted-foreground/40'
+            }`}
+          />
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">
+              WhatsApp
+              <span className="ml-2 px-1.5 py-0.5 text-[10px] rounded bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20 align-middle">
+                骨架开发中
+              </span>
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              基于 Baileys 通过 WhatsApp Web 协议扫码登录（待接入）
+            </p>
+          </div>
+        </div>
+        <Switch
+          checked={enabled}
+          disabled={loading || toggling}
+          onCheckedChange={handleToggle}
+        />
+      </div>
+
+      <div
+        className={`px-5 py-4 space-y-4 transition-opacity ${
+          !enabled ? 'opacity-50 pointer-events-none' : ''
+        }`}
+      >
+        {loading ? (
+          <div className="text-sm text-muted-foreground">加载中...</div>
+        ) : (
+          <>
+            <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+              此渠道为多步骤 PR 的第 1 步——仅完成配置层和路由骨架。
+              QR 码扫码登录、消息收发、媒体处理将在后续 PR 接入 Baileys
+              （<code>@whiskeysockets/baileys</code>）后启用。
+              当前启用状态下后端会保存配置但不会建立真正的连接。
+            </div>
+
+            {config?.phoneNumber && (
+              <div className="text-xs text-muted-foreground">
+                当前手机号: {config.phoneNumber}
+              </div>
+            )}
+
+            <div>
+              <Label className="text-xs text-muted-foreground mb-1">
+                手机号（可选，用于显示提示）
+              </Label>
+              <Input
+                type="text"
+                inputMode="tel"
+                value={phoneNumber}
+                onChange={(e) => setPhoneNumber(e.target.value)}
+                placeholder={
+                  config?.phoneNumber
+                    ? '留空不修改'
+                    : '+15551234567（E.164 格式）'
+                }
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button onClick={handleSave} disabled={saving}>
+                {saving && <Loader2 className="size-4 animate-spin" />}
+                保存 WhatsApp 配置
+              </Button>
+              <Button variant="outline" disabled title="待接入 Baileys 后启用">
+                扫码登录（敬请期待）
+              </Button>
+            </div>
+
+            <div className="text-xs text-muted-foreground mt-2 space-y-1">
+              <p>
+                注意：WhatsApp Web 协议（Baileys）属于第三方逆向方案，
+                Meta 在 2025-2026 收紧了对非官方客户端的封禁，
+                同 OpenClaw 等其他基于 Baileys 的项目共享相同的封号风险。
+                商用场景建议使用 Meta 官方 Cloud API。
+              </p>
+              {isSkeleton && (
+                <p className="text-amber-600 dark:text-amber-400">
+                  当前为骨架占位实现（PR 1/N），后续 PR 才会接入 Baileys。
+                </p>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 背景

越来越多的海外用户使用 happyclaw，他们需要 WhatsApp 通道。目前 happyclaw 支持飞书、Telegram、QQ、钉钉、WeChat、Discord 六个 IM 通道，本 PR 起开始增加第七个：WhatsApp。

考虑到完整集成涉及大量代码（参考 OpenClaw \`extensions/whatsapp/\` 约 16K 行非测试代码 + 14K 行测试，分散在 230 个 TS 文件），按多个 PR 拆解推进，本 PR 只提交**脚手架**，让后续 Baileys 接入 PR 不需要再动任何外围接入点。

## PR 1（本 PR）覆盖范围

> 范围目标：通过 typecheck + test，配置可保存，但 connect 永远返回 false（骨架）。

### 后端

- \`src/channel-prefixes.ts\`：新增 \`whatsapp: 'whatsapp:'\` prefix
- \`src/whatsapp.ts\`（**新增**）：与其他通道一致的工厂签名 \`createWhatsAppConnection()\`，所有方法抛 \`NOT_IMPLEMENTED\` 错误
- \`src/im-channel.ts\`：\`createWhatsAppChannel\` 适配器（实现 \`IMChannel\` 接口）
- \`src/im-manager.ts\`：\`WhatsAppConnectConfig\` 类型 + \`connectUserWhatsApp\` / \`disconnectUserWhatsApp\` / \`isWhatsAppConnected\` 方法
- \`src/runtime-config.ts\`：\`UserWhatsAppConfig\` 类型 + \`getUserWhatsAppConfig\` / \`saveUserWhatsAppConfig\`，落盘到 \`data/config/user-im/{userId}/whatsapp.json\`
  - PR 1 阶段不存 secret：Baileys 用 file system auth state，不是 token
- \`src/schemas.ts\`：\`WhatsAppConfigSchema\` zod 校验
- \`src/routes/config.ts\`：\`GET / PUT /api/config/user-im/whatsapp\` 路由 + \`countOtherEnabledImChannels\` 加 whatsapp + 路由响应带 \`skeleton: true\` 提示前端
- \`src/index.ts\`：\`connectUserIMChannels\` 加 \`whatsappTask\` + \`loadState\` 加 \`effectiveWhatsApp\` + \`reloadUserIMConfig\` 加 whatsapp 分支 + \`WebDeps\` 注入 \`isUserWhatsAppConnected\`
- \`src/web-context.ts\`：\`WebDeps\` 类型扩展 \`reloadUserIMConfig\` channel 联合 + \`isUserWhatsAppConnected\`

### 前端

- \`web/src/components/settings/WhatsAppChannelCard.tsx\`（**新增**）：占位卡片
  - 标 **"骨架开发中"** 黄色徽章
  - 配置可保存（手机号 hint + 启用开关）
  - "扫码登录" 按钮 disabled，title="待接入 Baileys 后启用"
  - 文案明确说明 Baileys 封号风险
- \`web/src/components/settings/UserChannelsSection.tsx\`：注册 \`WhatsAppChannelCard\`

### 文档

- \`CLAUDE.md\`：通道列表更新 + 新增 §8.13 章节说明 PR 1/2/3/4 范围与封号风险

## 后续 PR 路线图

| PR | 范围 | 预估 |
|----|------|------|
| PR 2 | 接入 \`@whiskeysockets/baileys\`，multi-file auth state、QR 扫码登录状态机、消息收发、文件下载到 \`downloads/whatsapp/{YYYY-MM-DD}/\`、长消息分片 | ~10-15h |
| PR 3 | 群组策略、白名单、媒体矩阵（图/视频/语音/文档/位置/反应/引用）、心跳与掉线重连 | ~6-8h |
| PR 4 | 测试 + 文档完善 | ~3-5h |

## 风险提示

Baileys 是社区逆向工程的 WhatsApp Web 协议库，Meta 在 2025-2026 收紧识别（握手时序、加密时序），封号率显著上升（Baileys issue #1869、whatsmeow issue #810 都有报告）。同 OpenClaw / Wechaty puppet 等其他基于 Baileys 的项目共享相同风险。

**商用场景应使用 Meta 官方 Cloud API**（需要 Facebook Business 验证、按模板消息计费 \$0.005-0.025/条）。

PR 2 接入 Baileys 时建议同时考虑：
- 是否要支持 Cloud API 作为可选后端（用户在前端切换）？
- 默认开启 anti-ban 中间件
- 文档明确告知用户 "号随时会丢" 的预期

需要 maintainer 在合并 PR 1 之前对此路线达成共识，避免 PR 2 推翻重做。

## Test plan

- [x] \`make typecheck\` 通过（后端 + 前端 + agent-runner）
- [x] \`make test\` 通过（13 测试文件 / 204 测试）
- [ ] 部署到本地测试环境验证：
  - [ ] 前端 Settings 页能看到新 WhatsApp 卡片，标 "骨架开发中"
  - [ ] 启用开关 + 保存手机号，刷新后配置持久化
  - [ ] 启用后查看 \`data/config/user-im/{userId}/whatsapp.json\` 落盘正常
  - [ ] 服务启动日志显示 \`User WhatsApp channel ready\`，但 \`connected: false\`
  - [ ] 其他 6 个 IM 通道正常工作未受影响