### PR TITLE
支持飞书 IM 按聊天隔离上下文

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -3965,8 +3965,8 @@ export function getUserMemberFolders(
 
 export function createAgent(agent: SubAgent): void {
   db.prepare(
-    `INSERT INTO agents (id, group_folder, chat_jid, name, prompt, status, kind, created_by, created_at, completed_at, result_summary, spawned_from_jid, source_kind, thread_id, root_message_id, title_source, last_active_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO agents (id, group_folder, chat_jid, name, prompt, status, kind, created_by, created_at, completed_at, result_summary, spawned_from_jid, source_kind, thread_id, root_message_id, title_source, last_active_at, last_im_jid)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     agent.id,
     agent.group_folder,
@@ -3985,6 +3985,7 @@ export function createAgent(agent: SubAgent): void {
     agent.root_message_id ?? null,
     agent.title_source ?? null,
     agent.last_active_at ?? null,
+    agent.last_im_jid ?? null,
   );
 }
 
@@ -4189,7 +4190,7 @@ function mapAgentRow(row: Record<string, unknown>): SubAgent {
       typeof row.spawned_from_jid === 'string' ? row.spawned_from_jid : null,
     source_kind:
       typeof row.source_kind === 'string'
-        ? (row.source_kind as 'manual' | 'feishu_thread')
+        ? (row.source_kind as 'manual' | 'feishu_thread' | 'auto_im')
         : null,
     thread_id: typeof row.thread_id === 'string' ? row.thread_id : null,
     root_message_id:

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -867,9 +867,7 @@ export function createFeishuConnection(
 
     const chatJid = `feishu:${chatId}`;
     const resolvedSenderName = senderName || getSenderName(senderOpenId);
-    const resolvedChatName = chatType === 'p2p'
-      ? (resolvedSenderName ? `飞书 · ${resolvedSenderName}` : '飞书私聊')
-      : '飞书群聊';
+    const resolvedChatName = chatType === 'p2p' ? '飞书私聊' : '飞书群聊';
 
     // 先注册会话，确保 resolveGroupFolder 能正确解析 folder（含首条文件消息场景）
     onNewChat?.(chatJid, resolvedChatName);

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -867,7 +867,9 @@ export function createFeishuConnection(
 
     const chatJid = `feishu:${chatId}`;
     const resolvedSenderName = senderName || getSenderName(senderOpenId);
-    const resolvedChatName = chatType === 'p2p' ? '飞书私聊' : '飞书群聊';
+    const resolvedChatName = chatType === 'p2p'
+      ? (resolvedSenderName ? `飞书 · ${resolvedSenderName}` : '飞书私聊')
+      : '飞书群聊';
 
     // 先注册会话，确保 resolveGroupFolder 能正确解析 folder（含首条文件消息场景）
     onNewChat?.(chatJid, resolvedChatName);

--- a/src/im-context-isolation.ts
+++ b/src/im-context-isolation.ts
@@ -1,0 +1,83 @@
+import type { RegisteredGroup, SubAgent } from './types.js';
+
+export interface ContextIsolationConfig {
+  enabled: boolean;
+  sourceKind: 'auto_im';
+}
+
+export interface ContextIsolationConfigDeps {
+  getUserFeishuConfig: (
+    userId: string,
+  ) => { autoIsolateContext?: boolean } | null;
+}
+
+export function getUserContextIsolationConfig(
+  userId: string,
+  channelType: string | null,
+  deps: ContextIsolationConfigDeps,
+): ContextIsolationConfig {
+  if (channelType === 'feishu') {
+    return {
+      enabled: deps.getUserFeishuConfig(userId)?.autoIsolateContext === true,
+      sourceKind: 'auto_im',
+    };
+  }
+
+  return { enabled: false, sourceKind: 'auto_im' };
+}
+
+export interface ApplyAutoIsolateContextDeps {
+  groups: Record<string, RegisteredGroup>;
+  channelType: string;
+  getChannelType: (jid: string) => string | null;
+  getAgent: (agentId: string) => SubAgent | undefined;
+  ensureBinding: (
+    jid: string,
+    group: RegisteredGroup,
+    userId: string,
+    name: string,
+  ) => boolean;
+  setGroup: (jid: string, group: RegisteredGroup) => void;
+  deleteAgent: (agentId: string) => void;
+  broadcastAgentRemoved: (
+    chatJid: string,
+    agentId: string,
+    name: string,
+  ) => void;
+}
+
+export function applyAutoIsolateContextForGroups(
+  userId: string,
+  enable: boolean,
+  deps: ApplyAutoIsolateContextDeps,
+): number {
+  let count = 0;
+
+  for (const [jid, group] of Object.entries(deps.groups)) {
+    if (deps.getChannelType(jid) !== deps.channelType) continue;
+    if (group.created_by !== userId) continue;
+
+    if (enable) {
+      if (group.target_agent_id || group.target_main_jid) continue;
+      if (deps.ensureBinding(jid, group, userId, group.name || jid)) count++;
+      continue;
+    }
+
+    if (!group.target_agent_id) continue;
+    const agentToRemove = deps.getAgent(group.target_agent_id);
+    if (agentToRemove?.source_kind !== 'auto_im') continue;
+
+    deps.broadcastAgentRemoved(
+      agentToRemove.chat_jid,
+      group.target_agent_id,
+      agentToRemove.name,
+    );
+    deps.deleteAgent(group.target_agent_id);
+
+    const updated: RegisteredGroup = { ...group, target_agent_id: undefined };
+    deps.setGroup(jid, updated);
+    count++;
+  }
+
+  return count;
+}

--- a/src/im-context-isolation.ts
+++ b/src/im-context-isolation.ts
@@ -81,3 +81,22 @@ export function applyAutoIsolateContextForGroups(
 
   return count;
 }
+
+export function clearTargetAgentBindingsForDeletedAgents(
+  groups: Record<string, RegisteredGroup>,
+  deletedAgentIds: ReadonlySet<string>,
+  setGroup: (jid: string, group: RegisteredGroup) => void,
+): number {
+  let count = 0;
+  if (deletedAgentIds.size === 0) return count;
+
+  for (const [jid, group] of Object.entries(groups)) {
+    if (!group.target_agent_id) continue;
+    if (!deletedAgentIds.has(group.target_agent_id)) continue;
+
+    setGroup(jid, { ...group, target_agent_id: undefined });
+    count++;
+  }
+
+  return count;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6743,6 +6743,20 @@ function buildOnNewChat(
             }
           }
         }
+        const channelType = getChannelType(chatJid);
+        const isolationConfig = getUserContextIsolationConfig(
+          userId,
+          channelType,
+          { getUserFeishuConfig },
+        );
+        if (isolationConfig.enabled) {
+          ensureAutoImConversationBinding(
+            chatJid,
+            existing,
+            userId,
+            trimmed || existing.name || chatJid,
+          );
+        }
         return;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5522,8 +5522,9 @@ async function processAgentConversation(
   // Persist the IM routing target so it survives service restarts.
   if (replySourceImJid) {
     updateAgentLastImJid(agentId, replySourceImJid);
-    // Also publish to activeImReplyRoutes so send_file/send_image IPC can route to IM.
-    activeImReplyRoutes.set(effectiveGroup.folder, replySourceImJid);
+    // Publish to activeImReplyRoutes so send_file/send_image IPC can route to IM.
+    // Only use virtualChatJid key (per-agent) — folder-level key would collide
+    // when multiple auto_im agents share the same workspace folder.
     activeImReplyRoutes.set(virtualChatJid, replySourceImJid);
   }
 
@@ -6732,6 +6733,13 @@ function buildOnNewChat(
           setRegisteredGroup(chatJid, existing);
           registeredGroups[chatJid] = existing;
           logger.debug({ chatJid, chatName: trimmed }, 'Updated IM group name (buildOnNewChat)');
+          if (existing.target_agent_id) {
+            const agent = getAgent(existing.target_agent_id);
+            if (agent?.source_kind === 'auto_im') {
+              updateAgentContextInfo(existing.target_agent_id, { name: trimmed });
+              updateChatName(`${agent.chat_jid}#agent:${existing.target_agent_id}`, trimmed);
+            }
+          }
         }
         return;
       }
@@ -6826,7 +6834,138 @@ function buildOnNewChat(
       { chatJid, chatName, userId, homeFolder },
       'Auto-registered IM chat',
     );
+
+    if (getChannelType(chatJid) === 'feishu') {
+      const feishuConfig = getUserFeishuConfig(userId);
+      if (feishuConfig?.autoIsolateContext) {
+        const registered = registeredGroups[chatJid]!;
+        ensureAutoImConversationBinding(chatJid, registered, userId, chatName);
+      }
+    }
   };
+}
+
+function resolveAutoImWorkspace(userId: string, folder: string): { jid: string; folder: string } | null {
+  const jids = getJidsByFolder(folder);
+  for (const jid of jids) {
+    if (!jid.startsWith('web:')) continue;
+    const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
+    if (group) return { jid, folder: group.folder };
+  }
+  const homeGroup = getUserHomeGroup(userId);
+  return homeGroup ? { jid: homeGroup.jid, folder: homeGroup.folder } : null;
+}
+
+function createAutoImConversationAgent(input: {
+  userId: string;
+  sourceJid: string;
+  groupFolder: string;
+  name: string;
+}): { agentId: string; workspaceJid: string; workspaceFolder: string } | null {
+  const workspace = resolveAutoImWorkspace(input.userId, input.groupFolder);
+  if (!workspace) {
+    logger.warn(
+      { userId: input.userId, sourceJid: input.sourceJid, groupFolder: input.groupFolder },
+      'Cannot create auto IM conversation agent: workspace not found',
+    );
+    return null;
+  }
+
+  const agentId = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const agentName = input.name || input.sourceJid;
+  createAgent({
+    id: agentId,
+    group_folder: workspace.folder,
+    chat_jid: workspace.jid,
+    name: agentName,
+    prompt: '',
+    status: 'idle',
+    kind: 'conversation',
+    created_by: input.userId,
+    created_at: now,
+    completed_at: null,
+    result_summary: null,
+    last_im_jid: input.sourceJid,
+    spawned_from_jid: null,
+    source_kind: 'auto_im',
+    last_active_at: now,
+  });
+  ensureAgentDirectories(workspace.folder, agentId);
+  const virtualChatJid = `${workspace.jid}#agent:${agentId}`;
+  ensureChatExists(virtualChatJid);
+  updateChatName(virtualChatJid, agentName);
+  updateAgentLastImJid(agentId, input.sourceJid);
+  broadcastAgentStatus(workspace.jid, agentId, 'idle', agentName, '', undefined, 'conversation');
+
+  logger.info(
+    { sourceJid: input.sourceJid, agentId, userId: input.userId },
+    'Auto-created isolated conversation agent for Feishu IM chat',
+  );
+  return { agentId, workspaceJid: workspace.jid, workspaceFolder: workspace.folder };
+}
+
+function ensureAutoImConversationBinding(
+  jid: string,
+  group: RegisteredGroup,
+  userId: string,
+  name: string,
+): boolean {
+  if (group.target_main_jid) return false;
+  if (group.target_agent_id) {
+    const existingAgent = getAgent(group.target_agent_id);
+    if (existingAgent?.source_kind === 'auto_im') {
+      ensureAgentDirectories(existingAgent.group_folder, existingAgent.id);
+      updateAgentLastImJid(existingAgent.id, jid);
+      return false;
+    }
+    return false;
+  }
+
+  const created = createAutoImConversationAgent({
+    userId,
+    sourceJid: jid,
+    groupFolder: group.folder,
+    name: name || group.name || jid,
+  });
+  if (!created) return false;
+
+  group.target_agent_id = created.agentId;
+  setRegisteredGroup(jid, group);
+  registeredGroups[jid] = group;
+  return true;
+}
+
+/**
+ * Batch-apply autoIsolateContext toggle for a user's existing Feishu IM chats.
+ * enable=true:  create conversation agents for unbound Feishu chats
+ * enable=false: remove auto_im agent bindings (manual bindings untouched)
+ */
+function applyAutoIsolateContext(userId: string, enable: boolean): number {
+  let count = 0;
+  const groups = getAllRegisteredGroups();
+
+  for (const [jid, group] of Object.entries(groups)) {
+    if (getChannelType(jid) !== 'feishu') continue;
+    if (group.created_by !== userId) continue;
+
+    if (enable) {
+      if (group.target_agent_id || group.target_main_jid) continue;
+      if (ensureAutoImConversationBinding(jid, group, userId, group.name || jid)) count++;
+    } else {
+      if (!group.target_agent_id) continue;
+      const agentToRemove = getAgent(group.target_agent_id);
+      if (agentToRemove?.source_kind !== 'auto_im') continue;
+
+      broadcastAgentStatus(agentToRemove.chat_jid, group.target_agent_id, 'idle', agentToRemove.name, '', '__removed__', 'conversation');
+
+      group.target_agent_id = undefined;
+      setRegisteredGroup(jid, group);
+      registeredGroups[jid] = group;
+      count++;
+    }
+  }
+  return count;
 }
 
 /**
@@ -7081,12 +7220,18 @@ function buildResolveEffectiveChatJid(): (
 ) => { effectiveJid: string; agentId: string | null } | null {
   return (chatJid: string, messageMeta) => {
     const group = registeredGroups[chatJid] ?? getRegisteredGroup(chatJid);
-    if (!group) return null;
+    if (!group) {
+      logger.debug({ chatJid }, 'resolveEffectiveChatJid: group not found');
+      return null;
+    }
 
     // Agent binding takes priority
     if (group.target_agent_id) {
       const agent = getAgent(group.target_agent_id);
-      if (!agent) return null;
+      if (!agent) {
+        logger.warn({ chatJid, targetAgentId: group.target_agent_id }, 'resolveEffectiveChatJid: agent not found for target_agent_id');
+        return null;
+      }
       // Use the agent's actual chat_jid (the workspace's registered JID) as the
       // base for the virtual JID.  Previously we constructed web:${folder} which
       // doesn't match any registered group for non-main workspaces (folder ≠ JID).
@@ -7134,6 +7279,10 @@ function buildResolveEffectiveChatJid(): (
       return { effectiveJid, agentId: null };
     }
 
+    logger.debug(
+      { chatJid, targetAgentId: group.target_agent_id, targetMainJid: group.target_main_jid },
+      'resolveEffectiveChatJid: no binding found',
+    );
     return null;
   };
 }
@@ -7937,6 +8086,10 @@ async function main(): Promise<void> {
           {
             ignoreMessagesBefore,
             onCommand: handleCommand,
+            resolveGroupFolder: (chatJid: string) =>
+              resolveEffectiveFolder(chatJid),
+            resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
+            onAgentMessage: buildOnAgentMessage(),
             onBotAddedToGroup: buildFeishuBotAddedHandler(userId, homeFolder, getReloadOwnerOpenId),
             onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
             shouldProcessGroupMessage,
@@ -8162,6 +8315,8 @@ async function main(): Promise<void> {
       activeRouteUpdaters.get(folder)?.(sourceJid);
     },
     handleSpawnCommand,
+    applyAutoIsolateContext: (userId: string, enable: boolean) =>
+      applyAutoIsolateContext(userId, enable),
   });
 
   // Clean expired sessions every hour
@@ -8619,7 +8774,28 @@ async function main(): Promise<void> {
   }
 
   // Run health check once on startup to clean up orphaned bindings, then periodically
-  void checkImBindingsHealth();
+  void checkImBindingsHealth().then(() => {
+    // After health check, ensure auto_im agents exist for users with autoIsolateContext enabled
+    const groups = getAllRegisteredGroups();
+    const userIds = new Set<string>();
+    for (const [jid, group] of Object.entries(groups)) {
+      if (getChannelType(jid) === 'feishu' && group.created_by) {
+        userIds.add(group.created_by);
+      }
+    }
+    for (const uid of userIds) {
+      const cfg = getUserFeishuConfig(uid);
+      if (cfg?.autoIsolateContext) {
+        const migrated = applyAutoIsolateContext(uid, true);
+        if (migrated > 0) {
+          logger.info(
+            { userId: uid, migrated },
+            'Startup: restored auto_im agents for user with autoIsolateContext enabled',
+          );
+        }
+      }
+    }
+  });
   const IM_BINDING_HEALTH_CHECK_INTERVAL = 30 * 60 * 1000; // 30 min
   setInterval(() => {
     void checkImBindingsHealth();
@@ -8659,6 +8835,21 @@ async function checkImBindingsHealth(): Promise<void> {
     if (group.target_agent_id) {
       const agent = getAgent(group.target_agent_id);
       if (!agent) {
+        // For auto_im agents, re-create instead of unbinding if toggle is still on
+        const userId = group.created_by;
+        if (userId && getChannelType(jid) === 'feishu') {
+          const feishuConfig = getUserFeishuConfig(userId);
+          if (feishuConfig?.autoIsolateContext) {
+            const unbound: RegisteredGroup = { ...group, target_agent_id: undefined };
+            if (ensureAutoImConversationBinding(jid, unbound, userId, group.name || jid)) {
+              logger.info(
+                { jid, userId },
+                'Health check: re-created auto_im agent (previous agent lost)',
+              );
+              continue;
+            }
+          }
+        }
         unbindImGroup(
           jid,
           `Orphaned agent binding: agent ${group.target_agent_id} no longer exists`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {
   updateAgentStatus,
   updateAgentLastImJid,
   updateAgentInfo,
+  deleteAgent,
   deleteCompletedAgents,
   getRunningTaskAgentsByChat,
   markRunningTaskAgentsAsError,
@@ -119,6 +120,10 @@ import {
   resolveBroadcastFolder,
   resolveTaskRoutingDecision,
 } from './task-routing.js';
+import {
+  applyAutoIsolateContextForGroups,
+  getUserContextIsolationConfig,
+} from './im-context-isolation.js';
 import { invalidateSessionCache, getWebDeps } from './web-context.js';
 import {
   getFeishuProviderConfigWithSource,
@@ -181,6 +186,7 @@ import {
   broadcastTyping,
   broadcastStreamEvent,
   broadcastAgentStatus,
+  broadcastAgentRemoved,
   broadcastTitleGenerating,
   broadcastGroupCreated,
   broadcastBillingUpdate,
@@ -559,11 +565,7 @@ function resolveImRoute(opts: {
 }): string | null {
   const { ipcAgentId, isHome, chatJid, sourceGroup } = opts;
   if (ipcAgentId) {
-    return (
-      activeImReplyRoutes.get(`${chatJid}#agent:${ipcAgentId}`) ??
-      activeImReplyRoutes.get(sourceGroup) ??
-      null
-    );
+    return activeImReplyRoutes.get(`${chatJid}#agent:${ipcAgentId}`) ?? null;
   }
   const imFromJid = getChannelType(chatJid) !== null ? chatJid : null;
   const imFromGroup = activeImReplyRoutes.get(sourceGroup) ?? null;
@@ -5344,12 +5346,12 @@ async function processTaskIpc(
               const warnMsg = `⚠️ 文件 "${data.fileName}" 未找到（路径 "${data.filePath}" 不存在）。请引导用户确认正确的文件路径，或使用 'send_file' 时提供正确的相对路径。`;
               broadcastToWebClients(sourceGroup, warnMsg);
               // Also notify via DingTalk for conversation agents bound to IM
-              const imRoute =
-                (ipcAgentId && data.chatJid
-                  ? activeImReplyRoutes.get(
-                      `${data.chatJid}#agent:${ipcAgentId}`,
-                    )
-                  : null) ?? activeImReplyRoutes.get(sourceGroup);
+              const imRoute = resolveImRoute({
+                ipcAgentId,
+                isHome,
+                chatJid: data.chatJid,
+                sourceGroup,
+              });
               if (imRoute) {
                 try {
                   await imManager.sendMessage(imRoute, warnMsg);
@@ -6835,25 +6837,25 @@ function buildOnNewChat(
       'Auto-registered IM chat',
     );
 
-    if (getChannelType(chatJid) === 'feishu') {
-      const feishuConfig = getUserFeishuConfig(userId);
-      if (feishuConfig?.autoIsolateContext) {
-        const registered = registeredGroups[chatJid]!;
-        ensureAutoImConversationBinding(chatJid, registered, userId, chatName);
-      }
+    const channelType = getChannelType(chatJid);
+    const isolationConfig = getUserContextIsolationConfig(userId, channelType, {
+      getUserFeishuConfig,
+    });
+    if (isolationConfig.enabled) {
+      const registered = registeredGroups[chatJid]!;
+      ensureAutoImConversationBinding(chatJid, registered, userId, chatName);
     }
   };
 }
 
-function resolveAutoImWorkspace(userId: string, folder: string): { jid: string; folder: string } | null {
+function resolveAutoImWorkspace(folder: string): { jid: string; folder: string } | null {
   const jids = getJidsByFolder(folder);
   for (const jid of jids) {
     if (!jid.startsWith('web:')) continue;
     const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
     if (group) return { jid, folder: group.folder };
   }
-  const homeGroup = getUserHomeGroup(userId);
-  return homeGroup ? { jid: homeGroup.jid, folder: homeGroup.folder } : null;
+  return null;
 }
 
 function createAutoImConversationAgent(input: {
@@ -6862,7 +6864,7 @@ function createAutoImConversationAgent(input: {
   groupFolder: string;
   name: string;
 }): { agentId: string; workspaceJid: string; workspaceFolder: string } | null {
-  const workspace = resolveAutoImWorkspace(input.userId, input.groupFolder);
+  const workspace = resolveAutoImWorkspace(input.groupFolder);
   if (!workspace) {
     logger.warn(
       { userId: input.userId, sourceJid: input.sourceJid, groupFolder: input.groupFolder },
@@ -6942,30 +6944,19 @@ function ensureAutoImConversationBinding(
  * enable=false: remove auto_im agent bindings (manual bindings untouched)
  */
 function applyAutoIsolateContext(userId: string, enable: boolean): number {
-  let count = 0;
-  const groups = getAllRegisteredGroups();
-
-  for (const [jid, group] of Object.entries(groups)) {
-    if (getChannelType(jid) !== 'feishu') continue;
-    if (group.created_by !== userId) continue;
-
-    if (enable) {
-      if (group.target_agent_id || group.target_main_jid) continue;
-      if (ensureAutoImConversationBinding(jid, group, userId, group.name || jid)) count++;
-    } else {
-      if (!group.target_agent_id) continue;
-      const agentToRemove = getAgent(group.target_agent_id);
-      if (agentToRemove?.source_kind !== 'auto_im') continue;
-
-      broadcastAgentStatus(agentToRemove.chat_jid, group.target_agent_id, 'idle', agentToRemove.name, '', '__removed__', 'conversation');
-
-      group.target_agent_id = undefined;
+  return applyAutoIsolateContextForGroups(userId, enable, {
+    groups: getAllRegisteredGroups(),
+    channelType: 'feishu',
+    getChannelType,
+    getAgent,
+    ensureBinding: ensureAutoImConversationBinding,
+    setGroup: (jid, group) => {
       setRegisteredGroup(jid, group);
       registeredGroups[jid] = group;
-      count++;
-    }
-  }
-  return count;
+    },
+    deleteAgent,
+    broadcastAgentRemoved,
+  });
 }
 
 /**
@@ -8784,8 +8775,10 @@ async function main(): Promise<void> {
       }
     }
     for (const uid of userIds) {
-      const cfg = getUserFeishuConfig(uid);
-      if (cfg?.autoIsolateContext) {
+      const isolationConfig = getUserContextIsolationConfig(uid, 'feishu', {
+        getUserFeishuConfig,
+      });
+      if (isolationConfig.enabled) {
         const migrated = applyAutoIsolateContext(uid, true);
         if (migrated > 0) {
           logger.info(
@@ -8837,9 +8830,12 @@ async function checkImBindingsHealth(): Promise<void> {
       if (!agent) {
         // For auto_im agents, re-create instead of unbinding if toggle is still on
         const userId = group.created_by;
-        if (userId && getChannelType(jid) === 'feishu') {
-          const feishuConfig = getUserFeishuConfig(userId);
-          if (feishuConfig?.autoIsolateContext) {
+        const channelType = getChannelType(jid);
+        if (userId && channelType) {
+          const isolationConfig = getUserContextIsolationConfig(userId, channelType, {
+            getUserFeishuConfig,
+          });
+          if (isolationConfig.enabled) {
             const unbound: RegisteredGroup = { ...group, target_agent_id: undefined };
             if (ensureAutoImConversationBinding(jid, unbound, userId, group.name || jid)) {
               logger.info(

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -377,15 +377,8 @@ router.delete('/:jid/agents/:agentId', authMiddleware, async (c) => {
   deleteAgent(agentId);
 
   // Broadcast removal
-  const { broadcastAgentStatus } = await import('../web.js');
-  broadcastAgentStatus(
-    jid,
-    agentId,
-    'error',
-    agent.name,
-    agent.prompt,
-    '__removed__',
-  );
+  const { broadcastAgentRemoved } = await import('../web.js');
+  broadcastAgentRemoved(jid, agentId, agent.name);
 
   logger.info({ agentId, jid, userId: user.id }, 'Agent deleted by user');
   return c.json({ success: true });

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1347,11 +1347,13 @@ configRoutes.get('/user-im/feishu', authMiddleware, (c) => {
         enabled: false,
         updatedAt: null,
         connected,
+        autoIsolateContext: false,
       });
     }
     return c.json({
       ...toPublicFeishuProviderConfig(config, 'runtime'),
       connected,
+      autoIsolateContext: config.autoIsolateContext ?? false,
     });
   } catch (err) {
     logger.error({ err }, 'Failed to load user Feishu config');
@@ -1386,11 +1388,12 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
   }
 
   const current = getUserFeishuConfig(user.id);
-  const next = {
+  const next: Record<string, unknown> = {
     appId: current?.appId || '',
     appSecret: current?.appSecret || '',
     enabled: current?.enabled ?? true,
     updatedAt: current?.updatedAt || null,
+    autoIsolateContext: current?.autoIsolateContext ?? false,
   };
   if (typeof validation.data.appId === 'string') {
     const appId = validation.data.appId.trim();
@@ -1408,13 +1411,28 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
     // First-time config with credentials should connect immediately.
     next.enabled = true;
   }
+  if (typeof validation.data.autoIsolateContext === 'boolean') {
+    next.autoIsolateContext = validation.data.autoIsolateContext;
+  }
 
   try {
     const saved = saveUserFeishuConfig(user.id, {
-      appId: next.appId,
-      appSecret: next.appSecret,
-      enabled: next.enabled,
+      appId: next.appId as string,
+      appSecret: next.appSecret as string,
+      enabled: next.enabled as boolean | undefined,
+      autoIsolateContext: next.autoIsolateContext as boolean | undefined,
     });
+
+    // Migrate existing Feishu chats when autoIsolateContext toggle changes
+    const oldAutoIsolate = current?.autoIsolateContext ?? false;
+    const newAutoIsolate = saved.autoIsolateContext ?? false;
+    if (oldAutoIsolate !== newAutoIsolate && deps?.applyAutoIsolateContext) {
+      const migrated = deps.applyAutoIsolateContext(user.id, newAutoIsolate);
+      logger.info(
+        { userId: user.id, enable: newAutoIsolate, migrated },
+        'Applied autoIsolateContext to existing Feishu chats',
+      );
+    }
 
     // Hot-reload: reconnect user's Feishu channel
     if (deps?.reloadUserIMConfig) {
@@ -1432,6 +1450,7 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
     return c.json({
       ...toPublicFeishuProviderConfig(saved, 'runtime'),
       connected,
+      autoIsolateContext: saved.autoIsolateContext ?? false,
     });
   } catch (err) {
     const message =

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -61,6 +61,7 @@ import {
   saveContainerEnvConfig,
   toPublicContainerEnvConfig,
 } from '../runtime-config.js';
+import { clearTargetAgentBindingsForDeletedAgents } from '../im-context-isolation.js';
 import {
   loadMountAllowlist,
   findAllowedRoot,
@@ -1187,15 +1188,43 @@ groupRoutes.post('/:jid/clear-history', authMiddleware, async (c) => {
     return c.json({ error: 'Failed to clear history' }, 500);
   }
 
-  // 4. Clear conversation agents and their messages.
+  // 4. Clear conversation agents and their messages, then unbind IM groups
+  // pointing at those deleted agents. Main-conversation bindings stay valid.
   try {
-    const agents = listAgentsByJid(jid);
+    const agentsById = new Map<
+      string,
+      ReturnType<typeof listAgentsByJid>[number]
+    >();
+    for (const siblingJid of siblingJids) {
+      if (!siblingJid.startsWith('web:')) continue;
+      for (const agent of listAgentsByJid(siblingJid)) {
+        agentsById.set(agent.id, agent);
+      }
+    }
+    const deletedAgentIds = new Set<string>();
+    const agents = Array.from(agentsById.values());
     for (const agent of agents) {
-      const virtualJid = `${jid}#agent:${agent.id}`;
+      const virtualJid = `${agent.chat_jid}#agent:${agent.id}`;
       deleteChatHistory(virtualJid);
       deleteAgent(agent.id);
+      deletedAgentIds.add(agent.id);
     }
+    const unboundCount = clearTargetAgentBindingsForDeletedAgents(
+      deps.getRegisteredGroups(),
+      deletedAgentIds,
+      (targetJid, updated) => {
+        setRegisteredGroup(targetJid, updated);
+        deps.getRegisteredGroups()[targetJid] = updated;
+        deps.clearImFailCounts?.(targetJid);
+      },
+    );
     deleteImContextBindingsByWorkspace(jid);
+    if (unboundCount > 0) {
+      logger.info(
+        { jid, folder: group.folder, unboundCount },
+        'Cleared IM agent bindings for rebuilt workspace',
+      );
+    }
   } catch (err) {
     logger.warn(
       { jid, err },

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -231,6 +231,7 @@ interface StoredFeishuProviderConfigV1 {
   enabled?: boolean;
   updatedAt: string;
   ownerOpenId?: string;
+  autoIsolateContext?: boolean;
   secret: EncryptedSecrets;
 }
 
@@ -3033,6 +3034,7 @@ export interface UserFeishuConfig {
   enabled?: boolean;
   updatedAt: string | null;
   ownerOpenId?: string; // auto-detected from first DM; used as sender_allowlist seed for new groups
+  autoIsolateContext?: boolean; // auto-create isolated conversation for each new IM chat
 }
 
 export interface UserTelegramConfig {
@@ -3124,6 +3126,7 @@ export function getUserFeishuConfig(userId: string): UserFeishuConfig | null {
       enabled: stored.enabled,
       updatedAt: stored.updatedAt || null,
       ownerOpenId: stored.ownerOpenId || undefined,
+      autoIsolateContext: stored.autoIsolateContext ?? false,
     };
   } catch (err) {
     logger.warn({ err, userId }, 'Failed to read user Feishu config');
@@ -3141,6 +3144,7 @@ export function saveUserFeishuConfig(
     enabled: next.enabled,
     updatedAt: new Date().toISOString(),
     ownerOpenId: next.ownerOpenId,
+    autoIsolateContext: next.autoIsolateContext,
   };
 
   const payload: StoredFeishuProviderConfigV1 = {
@@ -3149,6 +3153,7 @@ export function saveUserFeishuConfig(
     enabled: normalized.enabled,
     updatedAt: normalized.updatedAt || new Date().toISOString(),
     ownerOpenId: normalized.ownerOpenId,
+    autoIsolateContext: normalized.autoIsolateContext,
     secret: encryptChannelSecret<FeishuSecretPayload>({
       appSecret: normalized.appSecret,
     }),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -387,13 +387,15 @@ export const FeishuConfigSchema = z
     appSecret: z.string().max(2000).optional(),
     clearAppSecret: z.boolean().optional(),
     enabled: z.boolean().optional(),
+    autoIsolateContext: z.boolean().optional(),
   })
   .refine(
     (data) =>
       typeof data.appId === 'string' ||
       typeof data.appSecret === 'string' ||
       data.clearAppSecret === true ||
-      typeof data.enabled === 'boolean',
+      typeof data.enabled === 'boolean' ||
+      typeof data.autoIsolateContext === 'boolean',
     { message: 'At least one config field must be provided' },
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,7 +321,7 @@ export interface SubAgent {
   last_im_jid: string | null;
   /** 发起 /spawn 命令的源会话 JID，用于完成后结果回注 */
   spawned_from_jid: string | null;
-  source_kind?: 'manual' | 'feishu_thread' | null;
+  source_kind?: 'manual' | 'feishu_thread' | 'auto_im' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -77,6 +77,7 @@ export interface WebDeps {
     message: string,
     sourceImJid?: string,
   ) => Promise<string>;
+  applyAutoIsolateContext?: (userId: string, enable: boolean) => number;
 }
 
 export type Variables = {

--- a/src/web.ts
+++ b/src/web.ts
@@ -1627,6 +1627,14 @@ export function broadcastAgentStatus(
   safeBroadcast(msg, isHostGroupJid(chatJid), allowedUserIds);
 }
 
+export function broadcastAgentRemoved(
+  chatJid: string,
+  agentId: string,
+  name: string,
+): void {
+  broadcastAgentStatus(chatJid, agentId, 'error', name, '', '__removed__', 'conversation');
+}
+
 /**
  * Broadcast an `agent_status` message that only flips the `titleGenerating`
  * loading flag — reads `agent.status`/`name`/`prompt` fresh from DB. Used by

--- a/tests/im-context-isolation.test.ts
+++ b/tests/im-context-isolation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import {
   applyAutoIsolateContextForGroups,
+  clearTargetAgentBindingsForDeletedAgents,
   getUserContextIsolationConfig,
 } from '../src/im-context-isolation.js';
 import type { RegisteredGroup, SubAgent } from '../src/types.js';
@@ -114,5 +115,31 @@ describe('applyAutoIsolateContextForGroups', () => {
 
     expect(applyAutoIsolateContextForGroups('u1', false, deps)).toBe(0);
     expect(deleteAgent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('clearTargetAgentBindingsForDeletedAgents', () => {
+  test('clears only target_agent_id bindings for agents deleted by workspace rebuild', () => {
+    const groups: Record<string, RegisteredGroup> = {
+      'feishu:auto': makeGroup('Auto', { target_agent_id: 'old-auto' }),
+      'tg:manual': makeGroup('Manual', { target_agent_id: 'old-manual' }),
+      'qq:survivor': makeGroup('Survivor', { target_agent_id: 'still-alive' }),
+      'feishu:main': makeGroup('Main', { target_main_jid: 'web:home-u1' }),
+    };
+    const setGroup = vi.fn((jid: string, group: RegisteredGroup) => {
+      groups[jid] = group;
+    });
+
+    const count = clearTargetAgentBindingsForDeletedAgents(
+      groups,
+      new Set(['old-auto', 'old-manual']),
+      setGroup,
+    );
+
+    expect(count).toBe(2);
+    expect(groups['feishu:auto'].target_agent_id).toBeUndefined();
+    expect(groups['tg:manual'].target_agent_id).toBeUndefined();
+    expect(groups['qq:survivor'].target_agent_id).toBe('still-alive');
+    expect(groups['feishu:main'].target_main_jid).toBe('web:home-u1');
   });
 });

--- a/tests/im-context-isolation.test.ts
+++ b/tests/im-context-isolation.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  applyAutoIsolateContextForGroups,
+  getUserContextIsolationConfig,
+} from '../src/im-context-isolation.js';
+import type { RegisteredGroup, SubAgent } from '../src/types.js';
+
+function makeGroup(
+  name: string,
+  overrides: Partial<RegisteredGroup> = {},
+): RegisteredGroup {
+  return {
+    name,
+    folder: 'home-u1',
+    added_at: '2026-04-26T00:00:00.000Z',
+    created_by: 'u1',
+    ...overrides,
+  };
+}
+
+function makeAgent(id: string, overrides: Partial<SubAgent> = {}): SubAgent {
+  return {
+    id,
+    group_folder: 'home-u1',
+    chat_jid: 'web:home-u1',
+    name: `Agent ${id}`,
+    prompt: '',
+    status: 'idle',
+    kind: 'conversation',
+    created_by: 'u1',
+    created_at: '2026-04-26T00:00:00.000Z',
+    completed_at: null,
+    result_summary: null,
+    last_im_jid: null,
+    spawned_from_jid: null,
+    source_kind: 'auto_im',
+    ...overrides,
+  };
+}
+
+describe('getUserContextIsolationConfig', () => {
+  test('only enables the current auto isolation toggle for Feishu', () => {
+    const deps = {
+      getUserFeishuConfig: vi.fn(() => ({ autoIsolateContext: true })),
+    };
+
+    expect(getUserContextIsolationConfig('u1', 'feishu', deps)).toEqual({
+      enabled: true,
+      sourceKind: 'auto_im',
+    });
+    expect(getUserContextIsolationConfig('u1', 'telegram', deps)).toEqual({
+      enabled: false,
+      sourceKind: 'auto_im',
+    });
+  });
+});
+
+describe('applyAutoIsolateContextForGroups', () => {
+  test('enable and disable are idempotent, and disable deletes only auto_im agents', () => {
+    const groups: Record<string, RegisteredGroup> = {
+      'feishu:p2p-1': makeGroup('飞书私聊'),
+      'feishu:manual': makeGroup('Manual', { target_agent_id: 'manual-agent' }),
+      'telegram:p2p-1': makeGroup('Telegram'),
+    };
+    const agents = new Map<string, SubAgent>([
+      ['manual-agent', makeAgent('manual-agent', { source_kind: 'manual' })],
+    ]);
+    let nextAgent = 1;
+
+    const ensureBinding = vi.fn((jid: string, group: RegisteredGroup) => {
+      const agentId = `auto-${nextAgent++}`;
+      group.target_agent_id = agentId;
+      agents.set(agentId, makeAgent(agentId, { last_im_jid: jid }));
+      groups[jid] = group;
+      return true;
+    });
+    const setGroup = vi.fn((jid: string, group: RegisteredGroup) => {
+      groups[jid] = group;
+    });
+    const deleteAgent = vi.fn((agentId: string) => {
+      agents.delete(agentId);
+    });
+    const broadcastAgentRemoved = vi.fn();
+    const deps = {
+      groups,
+      channelType: 'feishu',
+      getChannelType: (jid: string) =>
+        jid.startsWith('feishu:') ? 'feishu' : 'telegram',
+      getAgent: (agentId: string) => agents.get(agentId),
+      ensureBinding,
+      setGroup,
+      deleteAgent,
+      broadcastAgentRemoved,
+    };
+
+    expect(applyAutoIsolateContextForGroups('u1', true, deps)).toBe(1);
+    expect(applyAutoIsolateContextForGroups('u1', true, deps)).toBe(0);
+    expect(ensureBinding).toHaveBeenCalledTimes(1);
+
+    const autoAgentId = groups['feishu:p2p-1'].target_agent_id!;
+    expect(autoAgentId).toBe('auto-1');
+
+    expect(applyAutoIsolateContextForGroups('u1', false, deps)).toBe(1);
+    expect(deleteAgent).toHaveBeenCalledWith(autoAgentId);
+    expect(deleteAgent).not.toHaveBeenCalledWith('manual-agent');
+    expect(broadcastAgentRemoved).toHaveBeenCalledWith(
+      'web:home-u1',
+      autoAgentId,
+      'Agent auto-1',
+    );
+    expect(groups['feishu:p2p-1'].target_agent_id).toBeUndefined();
+    expect(groups['feishu:manual'].target_agent_id).toBe('manual-agent');
+
+    expect(applyAutoIsolateContextForGroups('u1', false, deps)).toBe(0);
+    expect(deleteAgent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/settings/FeishuChannelCard.tsx
+++ b/web/src/components/settings/FeishuChannelCard.tsx
@@ -16,6 +16,7 @@ interface UserFeishuConfig {
   enabled: boolean;
   connected: boolean;
   updatedAt: string | null;
+  autoIsolateContext?: boolean;
 }
 
 export function FeishuChannelCard() {
@@ -54,6 +55,19 @@ export function FeishuChannelCard() {
       toast.success(`飞书渠道已${newEnabled ? '启用' : '停用'}`);
     } catch (err) {
       toast.error(getErrorMessage(err, '切换飞书渠道状态失败'));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleAutoIsolateToggle = async (newValue: boolean) => {
+    setToggling(true);
+    try {
+      const data = await api.put<UserFeishuConfig>('/api/config/user-im/feishu', { autoIsolateContext: newValue });
+      setConfig(data);
+      toast.success(`自动隔离上下文已${newValue ? '开启' : '关闭'}`);
+    } catch (err) {
+      toast.error(getErrorMessage(err, '切换自动隔离上下文失败'));
     } finally {
       setToggling(false);
     }
@@ -144,6 +158,17 @@ export function FeishuChannelCard() {
                 {saving && <Loader2 className="size-4 animate-spin" />}
                 保存飞书配置
               </Button>
+            </div>
+            <div className="border-t border-border pt-3 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-foreground">自动隔离上下文</p>
+                <p className="text-xs text-muted-foreground">不同私聊和群聊自动绑定独立对话，上下文互不干扰</p>
+              </div>
+              <Switch
+                checked={config?.autoIsolateContext ?? false}
+                disabled={toggling}
+                onCheckedChange={handleAutoIsolateToggle}
+              />
             </div>
           </>
         )}

--- a/web/src/components/settings/FeishuChannelCard.tsx
+++ b/web/src/components/settings/FeishuChannelCard.tsx
@@ -162,7 +162,7 @@ export function FeishuChannelCard() {
             <div className="border-t border-border pt-3 flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-foreground">自动隔离上下文</p>
-                <p className="text-xs text-muted-foreground">不同私聊和群聊自动绑定独立对话，上下文互不干扰</p>
+                <p className="text-xs text-muted-foreground">飞书不同私聊和群聊会自动绑定独立对话，上下文互不干扰</p>
               </div>
               <Switch
                 checked={config?.autoIsolateContext ?? false}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -31,7 +31,7 @@ export interface AgentInfo {
   completed_at?: string;
   result_summary?: string;
   linked_im_groups?: Array<{ jid: string; name: string }>;
-  source_kind?: 'manual' | 'feishu_thread' | null;
+  source_kind?: 'manual' | 'feishu_thread' | 'auto_im' | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?: 'manual' | 'feishu_root' | 'auto' | 'auto_pending' | null;


### PR DESCRIPTION
> 已参照  #470 review 意见重新修改
## 背景

飞书 IM 之前默认把同一个 bot 下的不同私聊和群聊路由到用户主工作区，共享同一个上下文。这个默认能力需要保留，但在开启飞书按聊天隔离后，不同私聊、不同群聊应该自动绑定到各自独立的 conversation agent，避免上下文污染，并在重启、关闭开关、重建工作区等场景下保持一致行为。

## 改动

- 新增飞书 IM 按聊天隔离模式：默认仍为共享上下文，开启后每个飞书私聊/群聊自动绑定独立 conversation agent。
- 通过统一的 IM 上下文隔离配置入口判断渠道能力，目前仅飞书生效，为后续 Telegram/QQ/钉钉扩展预留接口。
- 自动创建并持久化 `auto_im` conversation agent，写入 `last_im_jid`，确保重启后能继续复用原对话。
- 修复同 workspace 下多个 IM 聊天共存时的回复路由问题，agent 回复媒体/文件时使用 agent 级 IM 路由，避免串到其他聊天。
- 关闭隔离开关时不只解绑，还会删除对应 `auto_im` agent，避免开关反复切换导致 DB 中 agent 无限累积。
- UI 文案限定为“飞书”，避免让其他渠道用户误以为 Telegram/QQ/钉钉也已支持该能力。
- 修复重建工作区兼容性：重建后删除旧 conversation agent，并清理指向已删除 agent 的 IM 绑定；下次飞书消息会自动重新绑定到新 conversation agent。
- 封装 `broadcastAgentRemoved`，替代直接透传 magic string 的 agent 删除广播。

