### PR TITLE
新增: 容器内 npm 全局包持久化到 per-user extra 目录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,9 @@ StreamEvent 类型以 `shared/stream-event.ts` 为单一真相源，构建时通
 | 环境变量 `data/env/{folder}/env` | `/workspace/env-dir/env` | 只读 | 只读 |
 | 持久 extra 目录 `data/extra/{folder}/` | `/workspace/extra` | 读写 | 读写（仅自己） |
 | 额外挂载（白名单内） | `/workspace/extra/{name}` | 按白名单 | 按白名单（`nonMainReadOnly` 时强制只读） |
+| 持久化 npm 全局包 `data/extra/{folder}/.npm-global/` | `/workspace/extra/.npm-global` | 读写 | 读写（仅自己） |
+
+> **npm 全局包持久化**：容器内 npm prefix 由 entrypoint.sh 指向 `/workspace/extra/.npm-global/`，PATH 也包含该目录的 `bin/`。Agent 在容器内执行 `npm install -g <pkg>`（如 `lark-cli`、`@fanfanv5/feishu-cli`、各类 npx 风格的 MCP server 包）会自动持久化到 host 端 `data/extra/{folder}/.npm-global/`，下次新容器启动直接可用，不会因 `docker run --rm` 销毁而丢失。Per-user 隔离（每个 home folder 有独立 extra 目录）。注意：跨 CPU 架构迁移时（如 ARM64 ↔ x86_64）带 native module 的包会失效，纯 JS 包不影响。
 
 ### 3.5 配置优先级
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ StreamEvent 类型以 `shared/stream-event.ts` 为单一真相源，构建时通
 | 持久化 npm 全局包 `data/extra/{folder}/.npm-global/` | `/workspace/extra/.npm-global` | 读写 | 读写（仅自己） |
 
 > **npm 全局包持久化**：容器内 npm prefix 由 entrypoint.sh 指向 `/workspace/extra/.npm-global/`，PATH 也包含该目录的 `bin/`。Agent 在容器内执行 `npm install -g <pkg>`（如 `lark-cli`、`@fanfanv5/feishu-cli`、各类 npx 风格的 MCP server 包）会自动持久化到 host 端 `data/extra/{folder}/.npm-global/`，下次新容器启动直接可用，不会因 `docker run --rm` 销毁而丢失。Per-user 隔离（每个 home folder 有独立 extra 目录）。注意：跨 CPU 架构迁移时（如 ARM64 ↔ x86_64）带 native module 的包会失效，纯 JS 包不影响。
+>
+> 注意：本机制依赖 `container/entrypoint.sh`，更新后需通过 `./container/build.sh` 重建镜像才能生效。
 
 ### 3.5 配置优先级
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -43,6 +43,24 @@ export CLAUDE_CONFIG_DIR=/home/node/.claude
 # IS_SANDBOX: Claude Code 2.1.114+ 要求 IS_SANDBOX=1 才允许 --dangerously-skip-permissions。
 # 与宿主机模式的 hostEnv['IS_SANDBOX'] = '1' 保持一致。
 export IS_SANDBOX=1
+
+# Persist Agent's `npm install -g <pkg>` to per-user mounted extra dir.
+# 容器是 docker run --rm 模式，每次结束销毁。如果 Agent 在容器里跑
+# `npm install -g lark-cli`、`@fanfanv5/feishu-cli`、各类 MCP server 包等，
+# 默认会装到镜像内层 /usr/local/lib/node_modules，下次新容器又得重装。
+# 把 npm prefix 指向已挂载的 /workspace/extra/.npm-global（host 端
+# data/extra/{folder}/.npm-global/，per-user 隔离）即可让全局包持久化。
+NPM_GLOBAL_DIR=/workspace/extra/.npm-global
+mkdir -p "$NPM_GLOBAL_DIR/bin" "$NPM_GLOBAL_DIR/lib"
+chown -R node:node "$NPM_GLOBAL_DIR" 2>/dev/null || true
+# 写到 node user 的 ~/.npmrc 让 npm 全局命令默认走该 prefix。
+# 镜像每次启动重置 /home/node，所以 entrypoint 每次都重写一遍是稳妥做法。
+cat > /home/node/.npmrc <<EOF
+prefix=$NPM_GLOBAL_DIR
+EOF
+chown node:node /home/node/.npmrc 2>/dev/null || true
+export PATH="$NPM_GLOBAL_DIR/bin:$PATH"
+
 # Discover and link skills (builtin → project → user, higher priority overwrites)
 # Only remove entries that conflict with mounted skills (non-symlink with same name),
 # preserving any skills the agent created directly in .claude/skills/.

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -59,7 +59,8 @@ cat > /home/node/.npmrc <<EOF
 prefix=$NPM_GLOBAL_DIR
 EOF
 chown node:node /home/node/.npmrc 2>/dev/null || true
-export PATH="$NPM_GLOBAL_DIR/bin:$PATH"
+# 注意：append 而非 prepend，避免持久化的 npm shim 屏蔽 /app/node_modules/.bin 中 SDK 自带的 claude CLI（见上方第 28-33 行注释）
+export PATH="$PATH:$NPM_GLOBAL_DIR/bin"
 
 # Discover and link skills (builtin → project → user, higher priority overwrites)
 # Only remove entries that conflict with mounted skills (non-symlink with same name),


### PR DESCRIPTION
## 问题描述

容器是 \`docker run --rm\` 模式，每次结束销毁。Agent 在容器内执行 \`npm install -g <pkg>\`（如 \`lark-cli\`、\`@fanfanv5/feishu-cli\`、各类 npx 风格的 MCP server 包等）默认装在镜像内层 \`/usr/local/lib/node_modules\`，下次新容器又得重装。

**用户现象**：海外用户反馈"环境每次都会重置，lark-cli 配置无法持久化"，每次新对话都看到 Agent 在重装 cli，浪费时间和带宽。这是普适问题——影响所有依赖 \`npm install -g\` 的工具，不止 lark-cli。

## 根因

容器内 npm 默认 prefix 是 \`/usr/local\`（镜像层），容器销毁就丢。

## 修复方案

\`entrypoint.sh\` 把 npm prefix 指向已挂载的 \`/workspace/extra/.npm-global\`（host 端 \`data/extra/{folder}/.npm-global/\`，per-user 隔离的持久目录），并将其 \`bin/\` 加入 PATH。

\`/workspace/extra/\` 已经是 happyclaw 现有的 per-user 持久挂载点（CLAUDE.md §3.4 容器挂载策略表里的"持久 extra 目录"），不需要新增挂载或改动 \`container-runner.ts\`。

### 改动清单

- \`container/entrypoint.sh\`：在 \`IS_SANDBOX\` 设置之后加 6 行（创建目录 + chown + 写 \`.npmrc\` + 加 PATH）
- \`CLAUDE.md\` §3.4：表格新增一行 npm-global 持久化说明 + 一段 blockquote 解释机制和 per-user 隔离边界

## 边界与风险

- **Per-user 隔离**：每个 home folder 有独立 extra 目录，全局包不会跨用户共享 ✅
- **跨 CPU 架构迁移**（ARM64 ↔ x86_64）时带 native module 的包会失效，纯 JS 包不影响。这是普适风险，与本方案无关。
- **不影响 admin host 模式**：host 模式不走容器，npm 全局包本来就持久 ✅
- **现有用户**：旧装在镜像内层的全局包不会"消失"（路径独立），但下次新容器启动后 PATH 优先级是 \`/workspace/extra/.npm-global/bin\` > \`/usr/local/bin\`，同名 cli 优先用持久化版本

## Test plan

- [x] \`bash -n container/entrypoint.sh\` 语法校验通过
- [x] \`make typecheck\` 通过（后端 + 前端 + agent-runner）
- [x] \`make test\` 通过（13 测试文件 / 204 测试）
- [ ] 重建镜像后端到端验证：
  - [ ] 容器启动日志显示 \`/home/node/.npmrc\` 写入成功
  - [ ] Agent 跑 \`npm root -g\` 输出 \`/workspace/extra/.npm-global/lib/node_modules\`
  - [ ] Agent 跑 \`npm install -g lark-cli\`，安装目录持久到 \`data/extra/{folder}/.npm-global/\`
  - [ ] 杀掉容器后再启新容器，\`which lark-cli\` 仍能找到
  - [ ] 不同用户的 home folder 互相隔离（A 用户装的看不到 B 用户的）