### PR TITLE
修复: 监控页版本检测因 SDK 0.2.113 移除 cli.js 失效

### DIFF
--- a/src/routes/monitor.ts
+++ b/src/routes/monitor.ts
@@ -68,18 +68,10 @@ async function getLatestClaudeCodeVersion(): Promise<string | null> {
   }
 }
 
-/** Get host Claude Code version by running SDK's built-in cli.js --version */
+/** Get host Claude Code version via global `claude --version` CLI */
 async function getHostClaudeCodeVersion(): Promise<string | null> {
   try {
-    const cliPath = path.resolve(
-      process.cwd(),
-      'container/agent-runner/node_modules/@anthropic-ai/claude-agent-sdk/cli.js',
-    );
-    const { stdout } = await execFileAsync(
-      'node',
-      ['-e', `process.argv = ['node', 'claude', '--version']; require('${cliPath}')`],
-      { timeout: 10000 },
-    );
+    const { stdout } = await execFileAsync('claude', ['--version'], { timeout: 10000 });
     return stdout.trim() || null;
   } catch {
     return null;
@@ -99,15 +91,14 @@ async function getDockerImageId(): Promise<string | null> {
   }
 }
 
-/** Get container Claude Code version from SDK's cli.js inside Docker image */
+/** Get container Claude Code version from Docker image */
 async function getContainerClaudeCodeVersion(): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync(
       'docker',
       [
-        'run', '--rm', '--entrypoint', 'node',
-        CONTAINER_IMAGE, '-e',
-        `process.argv = ['node', 'claude', '--version']; require('/app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js')`,
+        'run', '--rm', '--entrypoint', '/app/node_modules/.bin/claude',
+        CONTAINER_IMAGE, '--version',
       ],
       { timeout: 30000 },
     );


### PR DESCRIPTION
## 问题描述

关闭 #463（重新提交干净版本）。

`@anthropic-ai/claude-agent-sdk` 从 0.2.113 起移除了 `cli.js` 入口文件（`npm pack` 验证：0.2.110 有 cli.js，0.2.113 已无）。监控页的宿主机和容器版本检测通过 `require('cli.js')` 获取版本号，更新 SDK 后返回 null，页面显示"未知"/"未构建"。

## 修复方案

### `src/routes/monitor.ts`
- **宿主机版本检测**：从 `node -e "require('cli.js')"` 改为 `execFile('claude', ['--version'])`，调用全局 CLI
- **容器版本检测**：从 `docker run --entrypoint node ... require('cli.js')` 改为 `docker run --entrypoint /app/node_modules/.bin/claude ... --version`，使用容器内 npm 安装的 CLI 完整路径（不在默认 PATH 中）

仅修改 `src/routes/monitor.ts`，无其他改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)