### PR TITLE
修复: provider 配置变更时收窄 session 清理粒度 (#476)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2289,19 +2289,22 @@ export function deleteSessionsByProviderId(providerId: string): {
   deletedCount: number;
   affectedFolders: string[];
 } {
-  const rows = db
-    .prepare(
-      'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?',
-    )
-    .all(providerId) as Array<{ group_folder: string }>;
-  const affectedFolders = rows.map((r) => r.group_folder);
-  const result = db
-    .prepare('DELETE FROM sessions WHERE provider_id = ?')
-    .run(providerId);
-  return {
-    deletedCount: Number(result.changes ?? 0),
-    affectedFolders,
-  };
+  const tx = db.transaction((id: string) => {
+    const rows = db
+      .prepare(
+        'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?',
+      )
+      .all(id) as Array<{ group_folder: string }>;
+    const affectedFolders = rows.map((r) => r.group_folder);
+    const result = db
+      .prepare('DELETE FROM sessions WHERE provider_id = ?')
+      .run(id);
+    return {
+      deletedCount: result.changes,
+      affectedFolders,
+    };
+  });
+  return tx(providerId);
 }
 
 export function getAllSessions(): Record<string, string> {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2271,6 +2271,39 @@ export function deleteAllSessionsForFolder(groupFolder: string): void {
   db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);
 }
 
+/**
+ * Delete all session rows bound to the given provider_id.
+ *
+ * Used when a provider's protocol-level fields (anthropicBaseUrl /
+ * anthropicModel) change: any session whose history contains thinking blocks /
+ * model-specific framing produced by this provider must restart fresh,
+ * otherwise resuming under the new config can fail with "Invalid signature in
+ * thinking block" or "model mismatch" errors. Sessions bound to *other*
+ * providers are left intact so unrelated sticky bindings survive a partial
+ * config update — see issue #476.
+ *
+ * Returns the affected `group_folder` values so callers can also evict the
+ * in-memory sessions cache and the row count for telemetry.
+ */
+export function deleteSessionsByProviderId(providerId: string): {
+  deletedCount: number;
+  affectedFolders: string[];
+} {
+  const rows = db
+    .prepare(
+      'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?',
+    )
+    .all(providerId) as Array<{ group_folder: string }>;
+  const affectedFolders = rows.map((r) => r.group_folder);
+  const result = db
+    .prepare('DELETE FROM sessions WHERE provider_id = ?')
+    .run(providerId);
+  return {
+    deletedCount: Number(result.changes ?? 0),
+    affectedFolders,
+  };
+}
+
 export function getAllSessions(): Record<string, string> {
   const rows = db
     .prepare(

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -16,8 +16,8 @@ import {
   setRegisteredGroup,
   updateChatName,
   getAgent,
-  deleteAllSessionsForFolder,
   clearSenderAllowlist,
+  deleteSessionsByProviderId,
   VALID_ACTIVATION_MODES,
 } from '../db.js';
 import { authMiddleware, systemConfigMiddleware } from '../middleware/auth.js';
@@ -149,12 +149,23 @@ interface ClaudeApplyResultPayload {
   success: boolean;
   stoppedCount: number;
   failedCount: number;
+  clearedSessionsCount?: number;
   error?: string;
+}
+
+interface ApplyOptions {
+  /**
+   * If set, drop only sticky session bindings that point to this provider —
+   * preserves bindings to unrelated providers. Used when a provider's
+   * protocol-level fields (anthropicBaseUrl / anthropicModel) change.
+   */
+  clearSessionsForProviderId?: string;
 }
 
 async function applyClaudeConfigToAllGroups(
   actor: string,
   metadata?: Record<string, unknown>,
+  options?: ApplyOptions,
 ): Promise<ClaudeApplyResultPayload> {
   if (!deps) {
     throw new Error('Server not initialized');
@@ -167,18 +178,24 @@ async function applyClaudeConfigToAllGroups(
   const failedCount = results.filter((r) => r.status === 'rejected').length;
   const stoppedCount = groupJids.length - failedCount;
 
-  // 清除所有 session 记录，确保配置变更后下次启动创建全新 session
-  const registeredGroups = deps.getRegisteredGroups();
-  for (const [_, group] of Object.entries(registeredGroups) as [string, RegisteredGroup][]) {
-    if (group.folder) {
-      deleteAllSessionsForFolder(group.folder);
-      delete deps.sessions[group.folder];
+  // Narrowed session cleanup: only drop sticky bindings for the provider whose
+  // protocol-level fields actually changed. Bindings to other providers stay
+  // intact so a routine update doesn't reset the entire pool. See issue #476.
+  let clearedSessionsCount: number | undefined;
+  if (options?.clearSessionsForProviderId) {
+    const { deletedCount, affectedFolders } = deleteSessionsByProviderId(
+      options.clearSessionsForProviderId,
+    );
+    clearedSessionsCount = deletedCount;
+    for (const folder of affectedFolders) {
+      delete deps.sessions[folder];
     }
   }
 
   appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
     stoppedCount,
     failedCount,
+    ...(clearedSessionsCount !== undefined ? { clearedSessionsCount } : {}),
     ...(metadata || {}),
   });
 
@@ -187,6 +204,7 @@ async function applyClaudeConfigToAllGroups(
       success: false,
       stoppedCount,
       failedCount,
+      ...(clearedSessionsCount !== undefined ? { clearedSessionsCount } : {}),
       error: `${failedCount} container(s) failed to stop`,
     };
   }
@@ -195,6 +213,7 @@ async function applyClaudeConfigToAllGroups(
     success: true,
     stoppedCount,
     failedCount: 0,
+    ...(clearedSessionsCount !== undefined ? { clearedSessionsCount } : {}),
   };
 }
 
@@ -394,22 +413,43 @@ configRoutes.patch(
     const actor = (c.get('user') as AuthUser).username;
 
     try {
+      const previous = getProviders().find((p) => p.id === id);
       const updated = updateProvider(id, validation.data);
       const changedFields = Object.keys(validation.data).map(
         (k) => `${k}:updated`,
       );
+      // Protocol-level fields are the ones that, if changed, can break
+      // resumption of an existing Claude session (different model framing /
+      // different signing authority for thinking blocks). Other fields
+      // (name, weight, customEnv) only affect routing or environment and are
+      // safe to apply mid-session.
+      const protocolFieldChanged = !!(
+        previous &&
+        ((validation.data.anthropicBaseUrl !== undefined &&
+          validation.data.anthropicBaseUrl !== previous.anthropicBaseUrl) ||
+          (validation.data.anthropicModel !== undefined &&
+            validation.data.anthropicModel !== previous.anthropicModel))
+      );
       appendClaudeConfigAudit(actor, 'update_provider', [
         `id:${id}`,
         ...changedFields,
+        ...(protocolFieldChanged ? ['protocolFieldChanged'] : []),
       ]);
 
       // If this provider is enabled, apply to running containers
       let applied: ClaudeApplyResultPayload | null = null;
       if (updated.enabled) {
-        applied = await applyClaudeConfigToAllGroups(actor, {
-          trigger: 'provider_update',
-          providerId: id,
-        });
+        applied = await applyClaudeConfigToAllGroups(
+          actor,
+          {
+            trigger: 'provider_update',
+            providerId: id,
+            protocolFieldChanged,
+          },
+          protocolFieldChanged
+            ? { clearSessionsForProviderId: id }
+            : undefined,
+        );
       }
 
       return c.json({

--- a/tests/session-provider-binding.test.ts
+++ b/tests/session-provider-binding.test.ts
@@ -23,6 +23,7 @@ const {
   getSessionProviderId,
   setSessionProviderId,
   deleteSession,
+  deleteSessionsByProviderId,
 } = await import('../src/db.js');
 
 beforeAll(() => {
@@ -76,5 +77,58 @@ describe('session→provider sticky binding', () => {
     setSessionProviderId('folder-5', '', 'provider-E');
     deleteSession('folder-5', '');
     expect(getSessionProviderId('folder-5')).toBeUndefined();
+  });
+});
+
+describe('deleteSessionsByProviderId — narrowed cleanup (issue #476)', () => {
+  test('only removes rows bound to the target provider', () => {
+    setSession('folder-narrow-1', 'sess-1', '');
+    setSessionProviderId('folder-narrow-1', '', 'provider-target');
+    setSession('folder-narrow-2', 'sess-2', '');
+    setSessionProviderId('folder-narrow-2', '', 'provider-other');
+
+    const result = deleteSessionsByProviderId('provider-target');
+
+    expect(result.deletedCount).toBe(1);
+    expect(result.affectedFolders).toEqual(['folder-narrow-1']);
+    expect(getSessionProviderId('folder-narrow-1')).toBeUndefined();
+    // Unrelated provider's binding survives — this is the core fix.
+    expect(getSessionProviderId('folder-narrow-2')).toBe('provider-other');
+  });
+
+  test('removes per-agent bindings to the same provider in one folder', () => {
+    setSessionProviderId('folder-narrow-3', '', 'provider-shared');
+    setSessionProviderId('folder-narrow-3', 'agent-a', 'provider-shared');
+    setSessionProviderId('folder-narrow-3', 'agent-b', 'provider-other');
+
+    const result = deleteSessionsByProviderId('provider-shared');
+
+    expect(result.deletedCount).toBe(2);
+    expect(result.affectedFolders).toEqual(['folder-narrow-3']);
+    expect(getSessionProviderId('folder-narrow-3')).toBeUndefined();
+    expect(getSessionProviderId('folder-narrow-3', 'agent-a')).toBeUndefined();
+    expect(getSessionProviderId('folder-narrow-3', 'agent-b')).toBe(
+      'provider-other',
+    );
+  });
+
+  test('returns empty result when no sessions match', () => {
+    const result = deleteSessionsByProviderId('provider-does-not-exist');
+    expect(result.deletedCount).toBe(0);
+    expect(result.affectedFolders).toEqual([]);
+  });
+
+  test('deduplicates affected folders across multiple agent rows', () => {
+    setSessionProviderId('folder-narrow-4', '', 'provider-multi');
+    setSessionProviderId('folder-narrow-4', 'agent-x', 'provider-multi');
+    setSessionProviderId('folder-narrow-5', '', 'provider-multi');
+
+    const result = deleteSessionsByProviderId('provider-multi');
+
+    expect(result.deletedCount).toBe(3);
+    expect(result.affectedFolders.sort()).toEqual([
+      'folder-narrow-4',
+      'folder-narrow-5',
+    ]);
   });
 });


### PR DESCRIPTION
## 问题描述

关闭 #476。

#474 把 sticky 绑定写入 `sessions.provider_id` 之后，#461 引入的「provider 配置变更后清掉所有 sessions」的粗粒度清理（`applyClaudeConfigToAllGroups` 调用 `deleteAllSessionsForFolder` 扫所有 folder）会顺手把所有 provider 的 sticky 绑定一起清空。

后果：用户在 Web UI 修改任意 provider 的 name / weight / customEnv 都会触发 sticky 重置 → 下一轮调度走 round-robin → 在异构 pool（OAuth + 第三方代理混用）里命中不识别 Anthropic thinking-block 签名的第三方 → 400 `Invalid signature in thinking block`。audit log 显示一次普通的 `update_provider` 即触发 `apply_to_all_flows.stoppedCount: 73-74`，影响范围跨所有用户所有 folder。

## 修复方案

按 issue #476「方案 A」实现：把 session 清理收窄到「真正改了协议字段（`anthropicBaseUrl` / `anthropicModel`）的那个 provider」。

### `src/db.ts`

新增 `deleteSessionsByProviderId(providerId)`，返回删除条数和受影响的 `group_folder` 列表（去重），让调用方同步驱逐内存中的 `sessions` 缓存。

### `src/routes/config.ts`

- `applyClaudeConfigToAllGroups` 新增 `ApplyOptions.clearSessionsForProviderId`；不传时**不再执行任何 session 清理**，仅停容器。
- PATCH `/claude/providers/:id`：在调用 `updateProvider` 前 snapshot 当前 provider，若 `anthropicBaseUrl` / `anthropicModel` 字段实际值发生变化才传 `clearSessionsForProviderId`，并在 audit log 标记 `protocolFieldChanged`。
- PUT `/claude/providers/:id/secrets`：凭据变更不影响协议层语义（同 provider 的同一历史在新 token 下仍可恢复），不再触发 sticky 清理。
- POST `/claude/providers/:id/toggle`：disable 后 `selectProvider()` 已经通过 `enabledProviders.some(...)` 自动绕过失效 sticky，不必显式清理。
- POST `/claude/apply`：手动 apply 是「停容器让新配置生效」语义，不触发 sticky 清理。

### `tests/session-provider-binding.test.ts`

补 4 个用例覆盖核心不变量：

- 只删除目标 provider 的绑定，其他 provider 的绑定保留（核心修复）
- 同一 folder 下多个 agent 行各自绑定不同 provider 时正确按 provider_id 过滤
- provider 不存在时返回空结果
- 跨 folder 去重 `affectedFolders`

## Test plan

- [x] `make typecheck` 通过
- [x] `make build` 通过
- [x] `make test`：208/208 通过
- [ ] 手动验证：异构 pool 配置（Anthropic OAuth + 第三方代理）下，修改任一 provider 的 weight，原会话续聊不再 400
- [ ] 手动验证：修改 provider 的 `anthropicModel`，绑定到该 provider 的 session 被清空，绑定到其他 provider 的 session 不受影响