### PR TITLE
修复: script-runner 错误地把 HOME 指向群组工作目录

### DIFF
--- a/src/routes/workspace-config.ts
+++ b/src/routes/workspace-config.ts
@@ -185,6 +185,7 @@ function resolveGroup(
   c: Context<{ Variables: Variables }>,
 ): (RegisteredGroup & { jid: string }) | null {
   const jid = c.req.param('jid');
+  if (!jid) return null;
   const authUser = c.get('user') as AuthUser;
 
   const group = getRegisteredGroup(jid!);

--- a/src/script-runner.ts
+++ b/src/script-runner.ts
@@ -51,7 +51,7 @@ export async function runScript(
               process.env.TZ ||
               Intl.DateTimeFormat().resolvedOptions().timeZone,
             GROUP_FOLDER: groupFolder,
-            HOME: cwd,
+            HOME: process.env.HOME || cwd,
           },
           shell: '/bin/sh',
         },


### PR DESCRIPTION
## 问题描述

`runScript()` 在为脚本任务子进程注入环境变量时，把 `HOME` 错误地设成了 cwd（即 `data/groups/{folder}/`），导致脚本里所有依赖 `$HOME` / `~` 的命令读错位置：

- `~/.npmrc` / `~/.bnpm` 找不到 → 私有 registry 装包失败
- `~/.gitconfig` / `~/.ssh` 读不到 → git 操作认证失败
- `~/.claude/` 读不到 → host 模式调起的 `claude` CLI 子进程（如 `/recall` 命令）找不到 OAuth 凭据，认证失败
- `~/.cache` / `~/.config` 等通用工具配置目录全部错位

触发场景：定时任务里的 `script` 类型命令；`/recall` 等通过 `script-runner` 跑外部命令的路径。

## 修复方案

### `src/script-runner.ts`

把 `HOME: cwd` 改为 `HOME: process.env.HOME || cwd`，优先使用主进程的真实 `HOME`，cwd 仅作兜底。

### `src/routes/workspace-config.ts`

顺手补 `resolveGroup()` 中 `c.req.param('jid')` 的非空检查（`if (!jid) return null;`），消除下方 `getRegisteredGroup(jid!)` 强制断言带来的潜在 undefined 流入。属于纯防御性整洁，路由层面实际触发不到。