### PR TITLE
修复: 分享卡片导出图片漏图 + iOS PWA 白图与卡顿

### DIFF
--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -21,6 +21,8 @@ interface MarkdownRendererProps {
   variant?: 'chat' | 'docs';
   /** When true, skip expensive plugins (KaTeX, sanitize) for faster streaming render */
   streaming?: boolean;
+  /** When true, force images to load eagerly. Required for offscreen render contexts (e.g. share-image export) where lazy-loaded images would otherwise never start fetching. */
+  eagerImages?: boolean;
 }
 
 /** Resolve relative image paths to the file download API */
@@ -185,7 +187,7 @@ function CodeBlock({
   );
 }
 
-export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJid, variant = 'chat', streaming = false }: MarkdownRendererProps) {
+export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJid, variant = 'chat', streaming = false, eagerImages = false }: MarkdownRendererProps) {
   const textSizeClass = variant === 'chat'
     ? 'text-base leading-[1.65] text-foreground'
     : 'text-sm leading-6 text-foreground';
@@ -215,7 +217,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
         rehypePlugins={rehypePluginsList as any}
         components={{
           code: (props) => <CodeBlock {...props} variant={variant} />,
-          img: ({ src, alt }) => <MarkdownImage src={src ? resolveImageSrc(src, groupJid) : undefined} alt={alt} loading="lazy" />,
+          img: ({ src, alt }) => <MarkdownImage src={src ? resolveImageSrc(src, groupJid) : undefined} alt={alt} loading={eagerImages ? 'eager' : 'lazy'} />,
           a: ({ href, children }) => (
             <a
               href={href}

--- a/web/src/components/chat/ShareCardRenderer.tsx
+++ b/web/src/components/chat/ShareCardRenderer.tsx
@@ -157,7 +157,7 @@ export const ShareCardRenderer = forwardRef<HTMLDivElement, ShareCardRendererPro
           }}
         >
           <div className="share-card-content max-w-none">
-            <MarkdownRenderer content={content} groupJid={groupJid} variant="chat" />
+            <MarkdownRenderer content={content} groupJid={groupJid} variant="chat" eagerImages />
           </div>
           {/* Gradient fade for extremely long content */}
           {content.length > 30000 && (

--- a/web/src/components/chat/ShareImageDialog.tsx
+++ b/web/src/components/chat/ShareImageDialog.tsx
@@ -278,22 +278,29 @@ async function paintImageOverlays(canvas: HTMLCanvasElement, root: HTMLElement, 
   const scaleX = canvas.width / Math.max(rootRect.width, 1);
   const scaleY = canvas.height / Math.max(rootRect.height, 1);
 
-  await Promise.all(
-    overlays.map(async (overlay) => {
-      try {
-        const img = await loadOverlayImage(overlay.src);
-        ctx.drawImage(
-          img,
-          overlay.x * scaleX,
-          overlay.y * scaleY,
-          overlay.width * scaleX,
-          overlay.height * scaleY,
-        );
-      } catch {
-        // Best effort: the underlying html-to-image render remains in place.
-      }
-    }),
+  // Load concurrently for speed, but draw sequentially in overlays order so
+  // that any future case with positionally-overlapping images preserves DOM
+  // paint order (later in the list = drawn last = visually on top). Today's
+  // chat markdown is block flow with no overlaps; this is defence in depth.
+  const loaded = await Promise.all(
+    overlays.map((overlay) =>
+      loadOverlayImage(overlay.src).then(
+        (img) => ({ overlay, img }) as const,
+        () => null,
+      ),
+    ),
   );
+  for (const entry of loaded) {
+    if (!entry) continue; // load failed — leave the html-to-image render in place
+    const { overlay, img } = entry;
+    ctx.drawImage(
+      img,
+      overlay.x * scaleX,
+      overlay.y * scaleY,
+      overlay.width * scaleX,
+      overlay.height * scaleY,
+    );
+  }
 }
 
 export function ShareImageDialog({ onClose, message }: ShareImageDialogProps) {

--- a/web/src/components/chat/ShareImageDialog.tsx
+++ b/web/src/components/chat/ShareImageDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { X, Download, RefreshCw, Copy, Check } from 'lucide-react';
-import { toPng } from 'html-to-image';
+import { toCanvas } from 'html-to-image';
 import { Message } from '../../stores/chat';
 import { useAuthStore } from '../../stores/auth';
 import { downloadFromDataUrl } from '../../utils/download';
@@ -19,6 +19,49 @@ interface ShareImageDialogProps {
 }
 
 type GenerateState = 'generating' | 'preview' | 'error';
+
+interface ImageOverlay {
+  src: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_EXPORT_PIXEL_RATIO = 2;
+const DESKTOP_CANVAS_MAX_PIXELS = 48_000_000;
+const IOS_CANVAS_MAX_PIXELS = 14_000_000;
+const IOS_CANVAS_MAX_SIDE = 14_000;
+const MIN_EXPORT_PIXEL_RATIO = 0.6;
+
+function isIOSLike(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const iOSDevice = /iPad|iPhone|iPod/.test(ua);
+  const iPadDesktopMode =
+    navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+  return iOSDevice || iPadDesktopMode;
+}
+
+function computeExportPixelRatio(el: HTMLElement): number {
+  const rect = el.getBoundingClientRect();
+  const width = Math.ceil(rect.width || el.scrollWidth || SHARE_CARD_DEFAULT_WIDTH);
+  const height = Math.ceil(rect.height || el.scrollHeight || 1);
+  const ios = isIOSLike();
+  const maxPixels = ios ? IOS_CANVAS_MAX_PIXELS : DESKTOP_CANVAS_MAX_PIXELS;
+  let ratio = DEFAULT_EXPORT_PIXEL_RATIO;
+
+  const areaAtDefault = width * height * ratio * ratio;
+  if (areaAtDefault > maxPixels) {
+    ratio = Math.sqrt(maxPixels / Math.max(width * height, 1));
+  }
+
+  if (ios) {
+    ratio = Math.min(ratio, IOS_CANVAS_MAX_SIDE / Math.max(width, height, 1));
+  }
+
+  return Math.max(MIN_EXPORT_PIXEL_RATIO, Math.min(DEFAULT_EXPORT_PIXEL_RATIO, ratio));
+}
 
 /**
  * Wait for Mermaid diagrams and images inside the container to finish rendering.
@@ -54,9 +97,11 @@ function waitForRenderComplete(container: HTMLElement): Promise<void> {
       const loading = container.querySelectorAll('.animate-pulse');
       const images = container.querySelectorAll('img');
       images.forEach(watchImage);
-      const allImagesLoaded = Array.from(images).every(
-        (img) => img.complete && (img.naturalWidth > 0 || img.src === ''),
-      );
+      // `complete` is true once the image has either successfully loaded OR
+      // errored out (settled state). Don't gate on `naturalWidth > 0` here —
+      // a 404 image would otherwise stall the export until the 5s timeout
+      // even though its load already finished.
+      const allImagesLoaded = Array.from(images).every((img) => img.complete);
       if (loading.length === 0 && allImagesLoaded) {
         finish();
       }
@@ -65,6 +110,190 @@ function waitForRenderComplete(container: HTMLElement): Promise<void> {
     observer.observe(container, { childList: true, subtree: true });
     check();
   });
+}
+
+function decodeBase64Url(value: string): string | null {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    return decodeURIComponent(
+      Array.from(atob(padded))
+        .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
+        .join(''),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function inferImageMimeType(src: string, fallback?: string): string {
+  if (fallback?.startsWith('image/')) return fallback;
+
+  const pathSegment = (() => {
+    try {
+      const url = new URL(src, window.location.href);
+      const last = url.pathname.split('/').filter(Boolean).pop();
+      return last ? decodeBase64Url(last) || last : '';
+    } catch {
+      const last = src.split('?')[0].split('/').filter(Boolean).pop();
+      return last ? decodeBase64Url(last) || last : '';
+    }
+  })().toLowerCase();
+
+  if (pathSegment.endsWith('.jpg') || pathSegment.endsWith('.jpeg')) return 'image/jpeg';
+  if (pathSegment.endsWith('.webp')) return 'image/webp';
+  if (pathSegment.endsWith('.gif')) return 'image/gif';
+  if (pathSegment.endsWith('.svg')) return 'image/svg+xml';
+  if (pathSegment.endsWith('.png')) return 'image/png';
+  return 'image/png';
+}
+
+function blobToDataUrl(blob: Blob, src: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onloadend = () => resolve(String(reader.result || ''));
+    const imageBlob = blob.type.startsWith('image/')
+      ? blob
+      : new Blob([blob], { type: inferImageMimeType(src, blob.type) });
+    reader.readAsDataURL(imageBlob);
+  });
+}
+
+const IMAGE_READY_TIMEOUT_MS = 4000;
+
+async function waitForImageReady(img: HTMLImageElement): Promise<void> {
+  if (img.complete && img.naturalWidth > 0) return;
+  // Settled-but-broken (e.g. malformed data URL): don't block the dialog
+  // waiting for events that will never come.
+  if (img.complete) return;
+  if (img.decode) {
+    try {
+      await img.decode();
+      return;
+    } catch {
+      // Fall through to load/error listeners. Safari can reject decode() while
+      // still completing the image normally.
+    }
+  }
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    img.addEventListener('load', done, { once: true });
+    img.addEventListener('error', done, { once: true });
+    // Safety net: a corrupt data URL can leave the image in a state where
+    // neither `load` nor `error` ever fires. Cap the wait so the share
+    // dialog doesn't stall on a single bad inline.
+    setTimeout(done, IMAGE_READY_TIMEOUT_MS);
+  });
+}
+
+async function setImageSrcAndWait(img: HTMLImageElement, src: string): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const done = () => resolve();
+    img.addEventListener('load', done, { once: true });
+    img.addEventListener('error', done, { once: true });
+    img.src = src;
+    if (img.complete) resolve();
+  });
+  await waitForImageReady(img);
+}
+
+/**
+ * html-to-image re-fetches <img> resources while cloning the card. In iOS PWA,
+ * authenticated same-origin image URLs can render fine in the page but turn
+ * into white boxes during that second pass. Inline them explicitly first.
+ * Download endpoints return application/octet-stream, so force an image MIME
+ * from the original filename before assigning data URLs.
+ */
+async function inlineImagesAsDataUrls(container: HTMLElement): Promise<void> {
+  const images = Array.from(container.querySelectorAll('img'));
+  await Promise.all(
+    images.map(async (img) => {
+      const src = img.currentSrc || img.src;
+      if (!src || src.startsWith('data:') || src.startsWith('blob:')) return;
+
+      try {
+        const res = await fetch(src, { credentials: 'include' });
+        if (!res.ok) return;
+        const blob = await res.blob();
+        img.srcset = '';
+        await setImageSrcAndWait(img, await blobToDataUrl(blob, src));
+      } catch {
+        // Best effort: keep the original src so html-to-image can still try.
+      }
+    }),
+  );
+}
+
+function getImageContentRect(img: HTMLImageElement, rootRect: DOMRect): ImageOverlay | null {
+  const rect = img.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+
+  const style = getComputedStyle(img);
+  const borderLeft = parseFloat(style.borderLeftWidth || '0') || 0;
+  const borderTop = parseFloat(style.borderTopWidth || '0') || 0;
+  const borderRight = parseFloat(style.borderRightWidth || '0') || 0;
+  const borderBottom = parseFloat(style.borderBottomWidth || '0') || 0;
+  const width = Math.max(0, rect.width - borderLeft - borderRight);
+  const height = Math.max(0, rect.height - borderTop - borderBottom);
+  const src = img.currentSrc || img.src;
+  if (!src || width <= 0 || height <= 0) return null;
+
+  return {
+    src,
+    x: rect.left - rootRect.left + borderLeft,
+    y: rect.top - rootRect.top + borderTop,
+    width,
+    height,
+  };
+}
+
+function collectImageOverlays(container: HTMLElement): ImageOverlay[] {
+  const rootRect = container.getBoundingClientRect();
+  return Array.from(container.querySelectorAll('img'))
+    .map((img) => getImageContentRect(img, rootRect))
+    .filter((overlay): overlay is ImageOverlay => Boolean(overlay));
+}
+
+function loadOverlayImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load overlay image'));
+    img.src = src;
+  });
+}
+
+async function paintImageOverlays(canvas: HTMLCanvasElement, root: HTMLElement, overlays: ImageOverlay[]): Promise<void> {
+  if (overlays.length === 0) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const rootRect = root.getBoundingClientRect();
+  const scaleX = canvas.width / Math.max(rootRect.width, 1);
+  const scaleY = canvas.height / Math.max(rootRect.height, 1);
+
+  await Promise.all(
+    overlays.map(async (overlay) => {
+      try {
+        const img = await loadOverlayImage(overlay.src);
+        ctx.drawImage(
+          img,
+          overlay.x * scaleX,
+          overlay.y * scaleY,
+          overlay.width * scaleX,
+          overlay.height * scaleY,
+        );
+      } catch {
+        // Best effort: the underlying html-to-image render remains in place.
+      }
+    }),
+  );
 }
 
 export function ShareImageDialog({ onClose, message }: ShareImageDialogProps) {
@@ -112,6 +341,8 @@ export function ShareImageDialog({ onClose, message }: ShareImageDialogProps) {
       await new Promise((r) => requestAnimationFrame(r));
 
       await waitForRenderComplete(el);
+      await inlineImagesAsDataUrls(el);
+      await waitForRenderComplete(el);
 
       // Measure widest table to determine optimal card width
       const tables = el.querySelectorAll('table');
@@ -128,11 +359,17 @@ export function ShareImageDialog({ onClose, message }: ShareImageDialogProps) {
       el.style.width = `${cardWidth}px`;
       await new Promise((r) => requestAnimationFrame(r));
 
-      const url = await toPng(el, {
-        pixelRatio: 2,
+      await waitForRenderComplete(el);
+      const imageOverlays = collectImageOverlays(el);
+      const canvas = await toCanvas(el, {
+        pixelRatio: computeExportPixelRatio(el),
         cacheBust: true,
+        includeQueryParams: true,
+        fetchRequestInit: { credentials: 'include' },
         backgroundColor: '#ffffff',
       });
+      await paintImageOverlays(canvas, el, imageOverlays);
+      const url = canvas.toDataURL('image/png');
       setDataUrl(url);
       setState('preview');
     } catch (err) {
@@ -243,8 +480,8 @@ export function ShareImageDialog({ onClose, message }: ShareImageDialogProps) {
         )}
       </div>
 
-      {/* Offscreen rendering area — NOT display:none so Mermaid SVGs get proper dimensions */}
-      <div style={{ position: 'fixed', left: -9999, top: 0, opacity: 0, pointerEvents: 'none' }}>
+      {/* Hidden render area — keep it paintable for iOS PWA image rasterization. */}
+      <div style={{ position: 'fixed', left: 0, top: 0, zIndex: -1, pointerEvents: 'none' }}>
         <ShareCardRenderer
           ref={cardRef}
           content={message.content}

--- a/web/src/components/chat/ShareImageDialog.tsx
+++ b/web/src/components/chat/ShareImageDialog.tsx
@@ -253,11 +253,24 @@ function getImageContentRect(img: HTMLImageElement, rootRect: DOMRect): ImageOve
   };
 }
 
+function isSafeOverlayImageSrc(src: string): boolean {
+  if (src.startsWith('data:') || src.startsWith('blob:')) return true;
+  try {
+    return new URL(src, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeImageOverlay(overlay: ImageOverlay | null): overlay is ImageOverlay {
+  return overlay !== null && isSafeOverlayImageSrc(overlay.src);
+}
+
 function collectImageOverlays(container: HTMLElement): ImageOverlay[] {
   const rootRect = container.getBoundingClientRect();
   return Array.from(container.querySelectorAll('img'))
     .map((img) => getImageContentRect(img, rootRect))
-    .filter((overlay): overlay is ImageOverlay => Boolean(overlay));
+    .filter(isSafeImageOverlay);
 }
 
 function loadOverlayImage(src: string): Promise<HTMLImageElement> {

--- a/web/src/components/chat/ShareImageDialog.tsx
+++ b/web/src/components/chat/ShareImageDialog.tsx
@@ -22,25 +22,43 @@ type GenerateState = 'generating' | 'preview' | 'error';
 
 /**
  * Wait for Mermaid diagrams and images inside the container to finish rendering.
+ * Uses MutationObserver for DOM-based loaders (Mermaid placeholders) and explicit
+ * load/error event listeners for images (since image loading does not produce DOM mutations).
  */
 function waitForRenderComplete(container: HTMLElement): Promise<void> {
   return new Promise((resolve) => {
-    const observer = new MutationObserver(check);
-    const timeout = setTimeout(() => {
+    let resolved = false;
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
       observer.disconnect();
-      resolve();
-    }, 5000);
+      clearTimeout(timeout);
+      // Small extra delay to let SVG painting settle
+      setTimeout(resolve, 300);
+    };
+
+    const observer = new MutationObserver(check);
+    const timeout = setTimeout(finish, 5000);
+    const watched = new WeakSet<HTMLImageElement>();
+
+    function watchImage(img: HTMLImageElement) {
+      if (watched.has(img) || img.complete) return;
+      watched.add(img);
+      const handler = () => check();
+      img.addEventListener('load', handler, { once: true });
+      img.addEventListener('error', handler, { once: true });
+    }
 
     function check() {
       // Mermaid loading placeholders use animate-pulse
       const loading = container.querySelectorAll('.animate-pulse');
       const images = container.querySelectorAll('img');
-      const allImagesLoaded = Array.from(images).every((img) => img.complete);
+      images.forEach(watchImage);
+      const allImagesLoaded = Array.from(images).every(
+        (img) => img.complete && (img.naturalWidth > 0 || img.src === ''),
+      );
       if (loading.length === 0 && allImagesLoaded) {
-        clearTimeout(timeout);
-        observer.disconnect();
-        // Small extra delay to let SVG painting settle
-        setTimeout(resolve, 300);
+        finish();
       }
     }
 


### PR DESCRIPTION
## 用户现象

在 Web/PWA 用"分享为图片"导出对话卡片时，遇到三类问题：

1. **图片漏掉**：消息里有内嵌图片（聊天图、md 图等），生成出来的卡片图片位置全是空白盒。
2. **iOS 白图**：iOS PWA 上偶尔整张图片渲染成白色 placeholder，但页面里图片是好的。
3. **卡死/超时**：偶发"正在渲染图片"转圈 5 秒以上才出图，或长截图直接抛 canvas size 异常。

## 问题描述

挖根因后发现是几个独立问题叠加：

### 1. 屏外 lazy load 永不发起

\`ShareCardRenderer\` 在 \`position:fixed; left:-9999\` 屏外渲染分享卡。\`MarkdownRenderer\` 给 \`<img>\` 默认挂 \`loading=\"lazy\"\`，浏览器对屏外的 lazy 图片永不发起 fetch，\`naturalWidth=0\`。html-to-image 把 0×0 的 img 渲染成空白 → 导出图丢图。

\`waitForRenderComplete\` 仅靠 \`MutationObserver\` 等待，但**图片加载完成不触发 DOM mutation**，且 \`img.complete\` 对从未发起请求的 lazy 图片返回 \`true\`，导致过早 resolve。

### 2. iOS PWA html-to-image 二次 fetch 白图

iOS PWA 上 html-to-image 在 clone DOM 时会**重新 fetch** 每张 \`<img>\` 资源。同源 + Cookie 鉴权的图片 URL 在主页面渲染没问题，但二次 fetch 路径会被 WebView 当作非图片处理（部分场景下返回 \`application/octet-stream\`），结果整张渲成白盒。

### 3. canvas 上限

\`pixelRatio: 2\` 是硬编码。长截图（多 9-14 张图叠加）在 iOS 上会撞 canvas 14M pixels / 14000 边长上限，html-to-image 直接抛错。

### 4. 边界 case 卡顿

- \`waitForImageReady\` 遇到坏的 data URL（极端情况），\`load\`/\`error\` 都不会触发，对话框转圈不返回。
- 后续 review 中我把 \`waitForRenderComplete\` 的 readiness 收得过严（\`naturalWidth > 0 || src === ''\`），导致 404 图片要等 5s 超时兜底才能继续。

## 修复方案

两个 commit：

### Commit 1: \`修复: 分享卡片导出图片时漏掉对话内嵌图片\` (985b169)

针对屏外 lazy 与 observer 唤醒问题：

#### \`web/src/components/chat/MarkdownRenderer.tsx\`

新增 \`eagerImages?: boolean\` prop，true 时 \`<img loading=\"eager\">\`，避免屏外渲染场景图片永不发起 fetch。默认仍然 lazy，正常聊天界面行为不变。

#### \`web/src/components/chat/ShareCardRenderer.tsx\`

启用 \`eagerImages\`。

#### \`web/src/components/chat/ShareImageDialog.tsx\`

\`waitForRenderComplete\` 在 MutationObserver 之外，对每张 \`<img>\` 显式挂 \`load\`/\`error\` 事件监听器（用 WeakSet 去重），每次事件触发都重新 \`check()\`。MutationObserver 不会因为图片加载完成而唤醒，必须显式监听。

### Commit 2: \`修复: iOS PWA 分享卡片导出图片白图与卡顿问题\` (31b3648)

针对 iOS 白图、canvas 上限、边界卡死：

#### \`toPng → toCanvas + 后置 drawImage 兜底\`

分享卡先走 html-to-image 拿到 canvas，再 \`drawImage\` 把每张原始 \`<img>\` 按位置/尺寸贴回去。即使 html-to-image 那一遍把图渲染成白图，最终输出仍能拿到正确像素。

\`paintImageOverlays\`：按 \`getBoundingClientRect\` 收集每张 img 的位置 + currentSrc，扣掉 border 后等比例缩放贴到 canvas。

#### \`inlineImagesAsDataUrls\`

导出前先把每张 \`<img src>\` 主动 fetch + 转 data URL 并写回。\`/files/download/\` 返回 \`application/octet-stream\`，FileReader 直接读会让浏览器当非图片；通过文件名后缀（含 base64url 编码反查 \`/files/download/{encoded}\` 拿原始名）兜底推断 MIME。

#### \`computeExportPixelRatio\` adaptive ratio

按容器面积 + iOS canvas 上限（14M pixels / 14000 边长）动态算 ratio，长图自动降采样到 \`[0.6, 2]\` 区间。桌面端 48M pixels 上限。

#### 隐藏渲染区从 \`left:-9999 + opacity:0\` 改成 \`left:0 + zIndex:-1 + pointerEvents:none\`

iOS 对完全离屏 / 不可见的节点做光栅化时不稳定，留在视口内但 z-index 压到背后是更可靠的"隐藏"姿态。

#### \`waitForRenderComplete\` 收紧 readiness

\`img.complete\` 已经覆盖 load 与 error 两种 settled 状态——加 \`naturalWidth>0\` 校验会让 404 图片要等 5s 超时才出图。回滚到 \`every(img => img.complete)\`。

#### \`waitForImageReady\` 加 4s 超时与 settled 短路

- \`img.complete && naturalWidth === 0\` → 已 settled-but-broken，直接 return（不等永远不来的事件）
- 否则进 \`decode() / load / error\` 监听 + 4s \`setTimeout\` 兜底

## 影响范围

- 仅影响"分享为图片"功能；正常聊天界面 lazy loading 行为不变
- 桌面 + iOS PWA 双端兼顾
- 无后端 API 改动

## 测试

- macOS Safari：含图片消息导出图正常带图
- iOS PWA：长内容（含 9-14 张图）导出不再触发 canvas 上限报错
- 失败图片（404）：不再卡 5s
- 内嵌坏 data URL：不再永久转圈

## 关联 review

PR 内修复经过两轮 review：

1. 第一轮：发现 \`waitForRenderComplete\` 的 \`naturalWidth>0\` 收紧导致 404 图片回归到 5s 卡顿
2. 第二轮（codex）：识别 \`MarkdownRenderer.imageEndpoint\` prop 是与该 PR 无关的死代码（已清理）；\`waitForImageReady\` 缺超时兜底（已加）

最终 diff vs main：3 文件 +277/-20 行。