### PR TITLE
修复: 流式输出时滚动到底部的 3-4 次跳动 (#489)

### DIFF
--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -60,11 +60,15 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   const aiColor = currentUser?.ai_avatar_color || appearance?.aiAvatarColor;
   const aiImageUrl = currentUser?.ai_avatar_url;
   const parentRef = useRef<HTMLDivElement>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
   const scrollStateRef = useRef({ autoScroll: true, atTop: false });
   const [autoScroll, setAutoScroll] = useState(true);
   const [atTop, setAtTop] = useState(false);
   const prevMessageCount = useRef(messages.length);
+  // Window during which the scroll handler ignores updates and the streaming
+  // RAF skips its catch-up scroll, so a user-initiated smooth scroll can run
+  // uninterrupted (≈500ms browser default + 100ms slack).
+  const smoothScrollUntilRef = useRef(0);
+  const SMOOTH_SCROLL_LOCK_MS = 600;
 
   // Compute flatMessages (with date headers) before virtualizer
   const flatMessages = useMemo<FlatItem[]>(() => {
@@ -148,39 +152,30 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
     overscan: window.innerWidth < 1024 ? 12 : 8,
   });
 
-  // IntersectionObserver detects when the sentinel element (at the very bottom of
-  // content) enters or leaves the viewport. This replaces the manual isAtBottom
-  // threshold and eliminates the race condition where setInterval fires before
-  // React state has propagated setAutoScroll(false).
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    const parent = parentRef.current;
-    if (!sentinel || !parent) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        const isVisible = entry.isIntersecting;
-        if (scrollStateRef.current.autoScroll !== isVisible) {
-          scrollStateRef.current.autoScroll = isVisible;
-          setAutoScroll(isVisible);
-        }
-      },
-      { root: parent, threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // 检测向上滚动触发 loadMore + 检测到顶
+  // Detect at-bottom (autoScroll) and at-top (loadMore) via the scroll event.
+  // Critically, this fires only on actual scroll events — not when scrollHeight
+  // grows during streaming with scrollTop unchanged. So content growth never
+  // spuriously flips autoScroll off (the failure mode of the IntersectionObserver
+  // approach in PR #455). The ref is updated synchronously to avoid races with
+  // the streaming RAF catch-up.
   useEffect(() => {
     const parent = parentRef.current;
     if (!parent) return;
 
     const handleScroll = () => {
-      const { scrollTop } = parent;
+      // While a programmatic smooth scroll is animating, ignore intermediate
+      // scroll events — they would briefly set autoScroll=false mid-animation
+      // and flicker the floating "scroll to bottom" button.
+      if (Date.now() < smoothScrollUntilRef.current) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = parent;
+      const isAtBottom = scrollHeight - scrollTop - clientHeight < 10;
       const isAtTop = scrollTop < 50;
 
+      if (scrollStateRef.current.autoScroll !== isAtBottom) {
+        scrollStateRef.current.autoScroll = isAtBottom;
+        setAutoScroll(isAtBottom);
+      }
       if (scrollStateRef.current.atTop !== isAtTop) {
         scrollStateRef.current.atTop = isAtTop;
         setAtTop(isAtTop);
@@ -199,7 +194,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   useEffect(() => {
     if (autoScroll && messages.length > prevMessageCount.current) {
       requestAnimationFrame(() => {
-        sentinelRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+        const parent = parentRef.current;
+        if (!parent) return;
+        smoothScrollUntilRef.current = Date.now() + SMOOTH_SCROLL_LOCK_MS;
+        parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
       });
     }
     prevMessageCount.current = messages.length;
@@ -211,7 +209,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
       scrollStateRef.current.autoScroll = true;
       setAutoScroll(true);
       requestAnimationFrame(() => {
-        sentinelRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+        const parent = parentRef.current;
+        if (!parent) return;
+        smoothScrollUntilRef.current = Date.now() + SMOOTH_SCROLL_LOCK_MS;
+        parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
       });
     }
   }, [scrollTrigger]);
@@ -264,23 +265,54 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flatMessages.length]);
 
-  // Auto-scroll when streaming content is active — poll-based to avoid
-  // re-rendering on every text_delta (the streaming object changes very frequently).
-  // Checks scrollStateRef (updated synchronously by IntersectionObserver) instead
-  // of the autoScroll state to eliminate the race condition where the interval
-  // fires before React has propagated setAutoScroll(false) after user scrolls up.
+  // Auto-scroll when streaming content is active. Subscribes directly to the
+  // chat store (no React re-render) and schedules a single rAF-coalesced
+  // scrollTo per animation frame, regardless of how many text_delta /
+  // thinking_delta updates land. This replaces the 100ms setInterval poll
+  // (PR #455 era) which competed with smooth scrolls and caused 3-4 visible
+  // jumps when the user scrolled to the bottom mid-stream.
   const hasStreaming = useChatStore(s =>
     agentId ? !!s.agentStreaming[agentId] : !!s.streaming[groupJid ?? '']
   );
   useEffect(() => {
     if (!hasStreaming) return;
-    const id = setInterval(() => {
-      if (scrollStateRef.current.autoScroll) {
-        sentinelRef.current?.scrollIntoView({ block: 'end' });
+
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        // Yield to any in-progress smooth scroll so we don't snap-interrupt it.
+        if (Date.now() < smoothScrollUntilRef.current) return;
+        if (!scrollStateRef.current.autoScroll) return;
+        const parent = parentRef.current;
+        if (!parent) return;
+        parent.scrollTo({ top: parent.scrollHeight });
+      });
+    };
+
+    const readStreaming = (state: ReturnType<typeof useChatStore.getState>) =>
+      agentId ? state.agentStreaming[agentId] : state.streaming[groupJid ?? ''];
+
+    let prevText = readStreaming(useChatStore.getState())?.partialText ?? '';
+    let prevThinking = readStreaming(useChatStore.getState())?.thinkingText ?? '';
+
+    const unsubscribe = useChatStore.subscribe((state) => {
+      const cur = readStreaming(state);
+      const curText = cur?.partialText ?? '';
+      const curThinking = cur?.thinkingText ?? '';
+      if (curText !== prevText || curThinking !== prevThinking) {
+        prevText = curText;
+        prevThinking = curThinking;
+        schedule();
       }
-    }, 100);
-    return () => clearInterval(id);
-  }, [hasStreaming]);
+    });
+
+    return () => {
+      unsubscribe();
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [hasStreaming, agentId, groupJid]);
 
   const scrollToTop = useCallback(() => {
     parentRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
@@ -289,7 +321,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   const scrollToBottom = useCallback(() => {
     scrollStateRef.current.autoScroll = true;
     setAutoScroll(true);
-    sentinelRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' });
+    smoothScrollUntilRef.current = Date.now() + SMOOTH_SCROLL_LOCK_MS;
+    const parent = parentRef.current;
+    if (!parent) return;
+    parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
   }, []);
 
   const showScrollButtons = messages.length > 0;
@@ -501,10 +536,6 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
         {groupJid && !agentId && spawnAgents.map(a => (
           <StreamingDisplay key={a.id} groupJid={groupJid} isWaiting={true} agentId={a.id} senderName={a.name} />
         ))}
-
-        {/* Sentinel element observed by IntersectionObserver to detect whether the
-            user is at the bottom. Visible → autoScroll=true; off-screen → false. */}
-        <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
 
         </div>
       </div>

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -68,7 +68,30 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
   // RAF skips its catch-up scroll, so a user-initiated smooth scroll can run
   // uninterrupted (≈500ms browser default + 100ms slack).
   const smoothScrollUntilRef = useRef(0);
+  const smoothCatchUpTimerRef = useRef<number | null>(null);
   const SMOOTH_SCROLL_LOCK_MS = 600;
+
+  const scheduleSmoothCatchUp = useCallback(() => {
+    if (smoothCatchUpTimerRef.current !== null) {
+      window.clearTimeout(smoothCatchUpTimerRef.current);
+    }
+    const delay = Math.max(0, smoothScrollUntilRef.current - Date.now()) + 16;
+    smoothCatchUpTimerRef.current = window.setTimeout(() => {
+      smoothCatchUpTimerRef.current = null;
+      if (!scrollStateRef.current.autoScroll) return;
+      const parent = parentRef.current;
+      if (!parent) return;
+      parent.scrollTo({ top: parent.scrollHeight });
+    }, delay);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (smoothCatchUpTimerRef.current !== null) {
+        window.clearTimeout(smoothCatchUpTimerRef.current);
+      }
+    };
+  }, []);
 
   // Compute flatMessages (with date headers) before virtualizer
   const flatMessages = useMemo<FlatItem[]>(() => {
@@ -198,10 +221,11 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
         if (!parent) return;
         smoothScrollUntilRef.current = Date.now() + SMOOTH_SCROLL_LOCK_MS;
         parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
+        scheduleSmoothCatchUp();
       });
     }
     prevMessageCount.current = messages.length;
-  }, [messages.length, autoScroll]);
+  }, [messages.length, autoScroll, scheduleSmoothCatchUp]);
 
   // 外部触发滚到底部（发送消息后）
   useEffect(() => {
@@ -213,9 +237,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
         if (!parent) return;
         smoothScrollUntilRef.current = Date.now() + SMOOTH_SCROLL_LOCK_MS;
         parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
+        scheduleSmoothCatchUp();
       });
     }
-  }, [scrollTrigger]);
+  }, [scrollTrigger, scheduleSmoothCatchUp]);
 
   // Fallback: 消息在挂载后加载（首次页面加载时 store 为空）
   // initialOffset 只在挂载时生效，消息后加载需要手动定位
@@ -283,7 +308,10 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
       raf = requestAnimationFrame(() => {
         raf = 0;
         // Yield to any in-progress smooth scroll so we don't snap-interrupt it.
-        if (Date.now() < smoothScrollUntilRef.current) return;
+        if (Date.now() < smoothScrollUntilRef.current) {
+          scheduleSmoothCatchUp();
+          return;
+        }
         if (!scrollStateRef.current.autoScroll) return;
         const parent = parentRef.current;
         if (!parent) return;
@@ -312,7 +340,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
       unsubscribe();
       if (raf) cancelAnimationFrame(raf);
     };
-  }, [hasStreaming, agentId, groupJid]);
+  }, [hasStreaming, agentId, groupJid, scheduleSmoothCatchUp]);
 
   const scrollToTop = useCallback(() => {
     parentRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
@@ -325,7 +353,8 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
     const parent = parentRef.current;
     if (!parent) return;
     parent.scrollTo({ top: parent.scrollHeight, behavior: 'smooth' });
-  }, []);
+    scheduleSmoothCatchUp();
+  }, [scheduleSmoothCatchUp]);
 
   const showScrollButtons = messages.length > 0;
 


### PR DESCRIPTION
## 问题描述

Fixes #489。

[PR #455](https://github.com/riba2534/happyclaw/pull/455) 在修复 #453 时引入新问题：流式输出过程中，用户向下滚动到底部（点击"回到底部"按钮、或新消息到达且用户已在底部）时，页面会明显"跳"3-4 下。

根因有两个相互放大的设计错误：

1. **IntersectionObserver 配 sentinel 嵌入内容尾部、threshold=0**：流式 `text_delta` 让 `scrollHeight` 增长、`scrollTop` 不变时，sentinel 被推出视口 → IO 触发 `isIntersecting=false` → `autoScroll` 被错误置 false。明明用户没动。
2. **100ms instant 轮询和 smooth scroll 共存**：用户点按钮或收到新消息触发 smooth 动画后，interval tick 用 instant `scrollIntoView` 抢断 smooth，每 100ms 一次，500ms 内累积 3-5 次视觉跳动。

详细分析见 issue #489。

## 实现方案

参照 [open-webui Chat.svelte](https://github.com/open-webui/open-webui/blob/main/src/lib/components/chat/Chat.svelte) 的成熟方案重写：

### `web/src/components/chat/MessageList.tsx`

- **扔掉 IntersectionObserver 和 sentinel `<div>`**：替换成 `onScroll` 事件 + 10px 阈值判定。`onScroll` 只在用户主动滚动时触发，内容增长（`scrollHeight` 变 `scrollTop` 不变）不触发，从根本上避免 `autoScroll` 被误翻
- **扔掉 `setInterval(100ms)`**：改成订阅 chat store 的 `partialText` / `thinkingText` 变化（`useChatStore.subscribe`，不引发 React 重渲染），每帧 `requestAnimationFrame` 合并一次 `scrollTo`。数据驱动而非定时器轮询，自然不会和用户的 smooth scroll 打架
- **新增 `smoothScrollUntilRef` 时间戳**：smooth scroll 启动后 600ms 内（≈500ms 浏览器默认动画 + 100ms 余量），`handleScroll` 和 RAF catch-up 都让位，确保 smooth 动画一气呵成
- **`scrollIntoView({block:'end'})` → `scrollTo({top: scrollHeight})`**：移除 sentinel 后用最直接的 API

四个 UX 场景都覆盖：

| 场景 | 行为 |
|---|---|
| 默认 | 自动跟随到底，看到全部输出 |
| 用户上滚 | 用户优先，停在用户位置 |
| 用户滚回底部 | 检测到 `gap < 10px`，自动恢复跟随 |
| 点"回到底部"按钮 | smooth 动画一次到底，不再被打断 |

## Test plan

- [x] `make typecheck` 通过
- [x] `make build` 通过
- [x] 流式输出过程中保持在底部 → 平滑跟随，无抖动
- [x] 流式输出过程中向上滚动 → 用户位置稳定不动
- [ ] 上滚后再滚回底部 → 自动接管跟随
- [ ] 上滚后点"回到底部"按钮 → smooth 动画一次到底，不跳 3-4 下
- [ ] #453 修复的"用户上滚被强制拉回底部"问题不复发