### PR TITLE
功能: Discord 添加频道历史与频道/服务器元信息工具

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -708,7 +708,12 @@ function shouldDrain(): boolean {
  * Returns messages found (with optional images), or empty array.
  */
 interface IpcDrainResult {
-  messages: Array<{ text: string; images?: Array<{ data: string; mimeType?: string }>; taskId?: string }>;
+  messages: Array<{
+    text: string;
+    images?: Array<{ data: string; mimeType?: string }>;
+    taskId?: string;
+    sourceJid?: string;
+  }>;
 }
 
 function drainIpcInput(): IpcDrainResult {
@@ -728,6 +733,7 @@ function drainIpcInput(): IpcDrainResult {
             text: data.text,
             images: data.images,
             taskId: typeof data.taskId === 'string' ? data.taskId : undefined,
+            sourceJid: typeof data.sourceJid === 'string' ? data.sourceJid : undefined,
           });
         }
       } catch (err) {
@@ -799,7 +805,7 @@ function createIpcWatcher(onFileDetected: () => void): { close: () => void } {
  * Wait for a new IPC message or _close sentinel.
  * Returns the messages (with optional images), or null if _close.
  */
-function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: string; mimeType?: string }>; taskId?: string } | null> {
+function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: string; mimeType?: string }>; taskId?: string; sourceJid?: string } | null> {
   return new Promise((resolve) => {
     let resolved = false;
     const tryDrain = () => {
@@ -836,12 +842,19 @@ function waitForIpcMessage(): Promise<{ text: string; images?: Array<{ data: str
         for (let i = messages.length - 1; i >= 0; i--) {
           if (messages[i].taskId) { combinedTaskId = messages[i].taskId; break; }
         }
+        // Same convention for sourceJid: per-channel MCP tools should see the
+        // chat the most recent message arrived from.
+        let combinedSourceJid: string | undefined;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].sourceJid) { combinedSourceJid = messages[i].sourceJid; break; }
+        }
         resolved = true;
         ipcWatcher?.close();
         resolve({
           text: combinedText,
           images: allImages.length > 0 ? allImages : undefined,
           taskId: combinedTaskId,
+          sourceJid: combinedSourceJid,
         });
         return;
       }
@@ -1555,11 +1568,16 @@ async function main(): Promise<void> {
   const disableMemoryLayer = process.env.HAPPYCLAW_DISABLE_MEMORY_LAYER === 'true';
 
   // Create in-process SDK MCP server (replaces the stdio subprocess)
-  // NOTE: currentTaskId is mutated in-place by the main loop below so that
-  // createMcpTools() closures observe updates via ctx reference. See the
-  // clear-before-next-turn logic at the bottom of the query loop.
+  // NOTE: chatJid and currentTaskId are mutated in-place by the main loop
+  // below so that createMcpTools() closures observe updates via ctx reference.
+  // See the per-turn updates at the bottom of the query loop.
+  //
+  // chatJid is initialized to the IM source of the message that triggered
+  // this run (when known) — falls back to the container's startup chatJid.
+  // This lets per-channel MCP tools (discord_*, etc.) see the actual incoming
+  // chat even when the home container is shared across channels.
   const mcpToolsConfig = {
-    chatJid: containerInput.chatJid,
+    chatJid: containerInput.currentSourceJid || containerInput.chatJid,
     groupFolder: containerInput.groupFolder,
     isHome,
     isAdminHome,
@@ -1610,6 +1628,12 @@ async function main(): Promise<void> {
     const pendingImages = pendingDrain.messages.flatMap((m) => m.images || []);
     if (pendingImages.length > 0) {
       promptImages = [...(promptImages || []), ...pendingImages];
+    }
+    // The latest drained message reflects the freshest incoming chat —
+    // override the startup chatJid so per-channel MCP tools see it correctly.
+    for (let i = pendingDrain.messages.length - 1; i >= 0; i--) {
+      const sj = pendingDrain.messages[i].sourceJid;
+      if (sj) { mcpToolsConfig.chatJid = sj; break; }
     }
   }
 
@@ -1791,6 +1815,8 @@ async function main(): Promise<void> {
         containerInput.turnId = generateTurnId();
         // See main-loop comment: reset task attribution for this new turn.
         mcpToolsConfig.currentTaskId = nextMessage.taskId ?? null;
+        // Update chatJid so per-channel MCP tools see the correct incoming chat.
+        if (nextMessage.sourceJid) mcpToolsConfig.chatJid = nextMessage.sourceJid;
         // Rebuild MCP server to avoid "Already connected to a transport" error
         // when the previous query was aborted mid-stream (#421).
         mcpServerConfig = buildMcpServerConfig();
@@ -1952,6 +1978,8 @@ async function main(): Promise<void> {
       // Forgetting to clear would cause regular user replies to be broadcast
       // to the task's notify channels, hijacking later conversation.
       mcpToolsConfig.currentTaskId = nextMessage.taskId ?? null;
+      // Update chatJid so per-channel MCP tools see the correct incoming chat.
+      if (nextMessage.sourceJid) mcpToolsConfig.chatJid = nextMessage.sourceJid;
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -836,6 +836,7 @@ Returns up to 100 messages per call (default 50), ordered oldest-first. Use "bef
           .describe('Number of messages to fetch (1-100, default 50)'),
         before: z
           .string()
+          .regex(/^\d{17,20}$/, 'must be a Discord snowflake')
           .optional()
           .describe(
             'Message ID (snowflake) — only return messages older than this. Use the "id" of the oldest message in your previous batch to paginate.',

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -332,7 +332,7 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
     // --- send_file ---
     tool(
       'send_file',
-      `Send a file to the current chat (the user you're talking to) via IM (Feishu/Telegram/DingTalk/QQ). The file path is relative to the workspace/group directory.
+      `Send a file to the current chat (the user you're talking to) via IM (Feishu/Telegram/DingTalk/QQ/Discord). The file path is relative to the workspace/group directory.
 Supports: PDF, DOC, XLS, PPT, MP4, ZIP, SO, etc. Max file size: 30MB.`,
       {
         filePath: z
@@ -818,6 +818,250 @@ You can optionally specify execution_mode: "container" (default, isolated Docker
             },
           ],
         };
+      },
+    ),
+
+    // --- discord_get_history ---
+    tool(
+      'discord_get_history',
+      `Fetch recent messages from the current Discord channel or DM. Only works when the current chat is a Discord channel.
+Returns up to 100 messages per call (default 50), ordered oldest-first. Use "before" with a message ID to paginate older messages.`,
+      {
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Number of messages to fetch (1-100, default 50)'),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            'Message ID (snowflake) — only return messages older than this. Use the "id" of the oldest message in your previous batch to paginate.',
+          ),
+      },
+      async (args) => {
+        if (!ctx.chatJid.startsWith('discord:')) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: discord_get_history only works in Discord channels. Current chat: ${ctx.chatJid}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        try {
+          const result = await pollIpcResult(
+            TASKS_DIR,
+            {
+              type: 'discord_get_history',
+              chatJid: ctx.chatJid,
+              limit: args.limit,
+              before: args.before,
+              requestId,
+              timestamp: new Date().toISOString(),
+            },
+            'discord_get_history_result',
+          );
+          if (!result.success) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Error fetching Discord history: ${result.error || 'Unknown error'}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          const messages = (result.messages || []) as Array<{
+            id: string;
+            authorName: string;
+            authorBot: boolean;
+            content: string;
+            timestamp: string;
+            attachments: Array<{ name: string; url: string }>;
+            replyToId?: string;
+            edited: boolean;
+          }>;
+          if (messages.length === 0) {
+            return {
+              content: [
+                { type: 'text' as const, text: 'No messages found in this channel.' },
+              ],
+            };
+          }
+          const formatted = messages
+            .map((m) => {
+              const tag = m.authorBot ? ' [bot]' : '';
+              const editFlag = m.edited ? ' (edited)' : '';
+              const replyFlag = m.replyToId ? ` ↪${m.replyToId}` : '';
+              const attachStr =
+                m.attachments.length > 0
+                  ? `\n  📎 ${m.attachments.map((a) => a.name).join(', ')}`
+                  : '';
+              return `[${m.timestamp}] ${m.authorName}${tag}${replyFlag}${editFlag} (id=${m.id})\n  ${m.content || '(empty)'}${attachStr}`;
+            })
+            .join('\n\n');
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Discord history (${messages.length} messages, oldest first):\n\n${formatted}`,
+              },
+            ],
+          };
+        } catch {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Timeout waiting for Discord history response.',
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    ),
+
+    // --- discord_get_channel_info ---
+    tool(
+      'discord_get_channel_info',
+      `Get metadata for the current Discord channel: name, type (guild_text/dm/etc), topic, NSFW flag, parent (category) ID, and guild ID.
+Only works when the current chat is a Discord channel.`,
+      {},
+      async () => {
+        if (!ctx.chatJid.startsWith('discord:')) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: discord_get_channel_info only works in Discord channels. Current chat: ${ctx.chatJid}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        try {
+          const result = await pollIpcResult(
+            TASKS_DIR,
+            {
+              type: 'discord_get_channel_info',
+              chatJid: ctx.chatJid,
+              requestId,
+              timestamp: new Date().toISOString(),
+            },
+            'discord_get_channel_info_result',
+          );
+          if (!result.success) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Error fetching Discord channel info: ${result.error || 'Unknown error'}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Discord channel info:\n${JSON.stringify(result.channel, null, 2)}`,
+              },
+            ],
+          };
+        } catch {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Timeout waiting for Discord channel info response.',
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    ),
+
+    // --- discord_get_server_info ---
+    tool(
+      'discord_get_server_info',
+      `Get metadata for the Discord server (guild) the current channel belongs to: name, description, owner ID, member count, icon URL.
+Returns null if the current chat is a DM (DMs do not belong to a server). Only works when the current chat is a Discord channel.`,
+      {},
+      async () => {
+        if (!ctx.chatJid.startsWith('discord:')) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: discord_get_server_info only works in Discord channels. Current chat: ${ctx.chatJid}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        try {
+          const result = await pollIpcResult(
+            TASKS_DIR,
+            {
+              type: 'discord_get_server_info',
+              chatJid: ctx.chatJid,
+              requestId,
+              timestamp: new Date().toISOString(),
+            },
+            'discord_get_server_info_result',
+          );
+          if (!result.success) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Error fetching Discord server info: ${result.error || 'Unknown error'}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          if (result.guild === null) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'This is a DM channel — no server (guild) information available.',
+                },
+              ],
+            };
+          }
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Discord server info:\n${JSON.stringify(result.guild, null, 2)}`,
+              },
+            ],
+          };
+        } catch {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Timeout waiting for Discord server info response.',
+              },
+            ],
+            isError: true,
+          };
+        }
       },
     ),
   ];

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -14,6 +14,10 @@ export interface ContainerInput {
   turnId?: string;
   groupFolder: string;
   chatJid: string;
+  /** Source JID of the latest message that triggered this run (e.g. `discord:123…`).
+   * Used by per-channel MCP tools (discord_*, etc.) to identify the current
+   * incoming chat. Undefined when chatJid already encodes the IM source. */
+  currentSourceJid?: string;
   /** @deprecated Use isHome + isAdminHome instead. Kept for backward compatibility with older host processes. */
   isMain?: boolean;
   /** Whether this is the user's home container (admin or member). */

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -185,6 +185,10 @@ export interface ContainerInput {
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
+  /** Source JID of the latest message that triggered this run (e.g. `discord:123…`).
+   * Used by per-channel MCP tools (discord_*, etc.) to identify the current
+   * incoming chat. Undefined when chatJid already encodes the IM source. */
+  currentSourceJid?: string;
   /** @deprecated Use isHome + isAdminHome instead */
   isMain: boolean;
   turnId?: string;

--- a/src/cross-group-acl.ts
+++ b/src/cross-group-acl.ts
@@ -1,0 +1,35 @@
+import type { RegisteredGroup } from './types.js';
+
+/**
+ * Check if a source group is authorized to send IPC messages to a target group.
+ * - Admin home can send to any group.
+ * - Non-home groups can only send to groups sharing the same folder.
+ * - Member home groups can send to groups created by the same user.
+ * - IM channels bound (target_main_jid) to the source workspace are reachable
+ *   from that workspace — without this, after agent-runner started rewriting
+ *   ctx.chatJid to the IM source, send_file/send_image/send_message from
+ *   non-home sub-workspaces got rejected.
+ */
+export function canSendCrossGroupMessage(
+  isAdminHome: boolean,
+  isHome: boolean,
+  sourceFolder: string,
+  sourceGroupEntry: RegisteredGroup | undefined,
+  targetGroup: RegisteredGroup | undefined,
+  lookupGroup: (jid: string) => RegisteredGroup | undefined,
+): boolean {
+  if (isAdminHome) return true;
+  if (targetGroup && targetGroup.folder === sourceFolder) return true;
+  if (
+    isHome &&
+    targetGroup &&
+    sourceGroupEntry?.created_by != null &&
+    targetGroup.created_by === sourceGroupEntry.created_by
+  )
+    return true;
+  if (targetGroup?.target_main_jid) {
+    const bound = lookupGroup(targetGroup.target_main_jid);
+    if (bound?.folder === sourceFolder) return true;
+  }
+  return false;
+}

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -79,6 +79,46 @@ export interface DiscordConnectOpts {
   isGroupOwnerMessage?: (chatJid: string, senderImId?: string) => boolean;
 }
 
+export interface DiscordHistoryMessage {
+  id: string;
+  authorId: string;
+  authorName: string;
+  authorBot: boolean;
+  content: string;
+  timestamp: string;
+  attachments: Array<{ name: string; url: string; size: number; contentType?: string }>;
+  replyToId?: string;
+  edited: boolean;
+}
+
+export interface DiscordChannelInfo {
+  id: string;
+  type: 'dm' | 'guild_text' | 'guild_voice' | 'guild_news' | 'guild_thread' | 'guild_other';
+  name: string;
+  topic?: string;
+  nsfw?: boolean;
+  guildId?: string;
+  parentId?: string;
+  recipientId?: string;
+  recipientName?: string;
+}
+
+export interface DiscordGuildInfo {
+  id: string;
+  name: string;
+  description?: string;
+  ownerId: string;
+  memberCount: number;
+  iconUrl?: string;
+  createdAt: string;
+}
+
+export interface DiscordHistoryOpts {
+  limit?: number;
+  before?: string;
+  after?: string;
+}
+
 export interface DiscordConnection {
   connect(opts: DiscordConnectOpts): Promise<boolean>;
   disconnect(): Promise<void>;
@@ -106,6 +146,12 @@ export interface DiscordConnection {
     | import('./discord-streaming-edit.js').DiscordStreamingEditController
     | undefined
   >;
+  getChannelHistory(
+    chatId: string,
+    opts?: DiscordHistoryOpts,
+  ): Promise<DiscordHistoryMessage[]>;
+  getChannelInfo(chatId: string): Promise<DiscordChannelInfo>;
+  getGuildInfo(chatId: string): Promise<DiscordGuildInfo | null>;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────
@@ -905,6 +951,119 @@ export function createDiscordConnection(
           fallbackSend: (text: string) => sendMessage(chatId, text),
         },
       );
+    },
+
+    async getChannelHistory(
+      chatId: string,
+      opts: DiscordHistoryOpts = {},
+    ): Promise<DiscordHistoryMessage[]> {
+      const channel = await resolveChannel(chatId);
+      if (!channel) {
+        throw new Error(`Discord getChannelHistory: unknown chat ${chatId}`);
+      }
+
+      // Discord API caps fetch at 100 messages per request.
+      const limit = Math.max(1, Math.min(opts.limit ?? 50, 100));
+      const fetchOpts: { limit: number; before?: string; after?: string } = {
+        limit,
+      };
+      if (opts.before) fetchOpts.before = opts.before;
+      if (opts.after) fetchOpts.after = opts.after;
+
+      const collection = await channel.messages.fetch(fetchOpts);
+      // Collection is keyed by snowflake; sort newest-first → oldest-first for readability.
+      const messages = Array.from(collection.values()).sort((a, b) =>
+        a.createdTimestamp - b.createdTimestamp,
+      );
+
+      return messages.map((m) => ({
+        id: m.id,
+        authorId: m.author.id,
+        authorName: m.author.username,
+        authorBot: m.author.bot,
+        content: m.content,
+        timestamp: m.createdAt.toISOString(),
+        attachments: Array.from(m.attachments.values()).map((a) => ({
+          name: a.name ?? 'attachment',
+          url: a.url,
+          size: a.size,
+          contentType: a.contentType ?? undefined,
+        })),
+        replyToId: m.reference?.messageId ?? undefined,
+        edited: m.editedTimestamp !== null,
+      }));
+    },
+
+    async getChannelInfo(chatId: string): Promise<DiscordChannelInfo> {
+      const channel = await resolveChannel(chatId);
+      if (!channel) {
+        throw new Error(`Discord getChannelInfo: unknown chat ${chatId}`);
+      }
+
+      // DM
+      if (channel.type === ChannelType.DM) {
+        const dm = channel as DMChannel;
+        return {
+          id: dm.id,
+          type: 'dm',
+          name: dm.recipient?.username
+            ? `DM: ${dm.recipient.username}`
+            : `DM: ${dm.recipientId ?? 'unknown'}`,
+          recipientId: dm.recipientId ?? undefined,
+          recipientName: dm.recipient?.username,
+        };
+      }
+
+      // Map ChannelType numeric enum to our friendlier labels.
+      const channelTypeNumber = channel.type as number;
+      let typeLabel: DiscordChannelInfo['type'] = 'guild_other';
+      if (channelTypeNumber === ChannelType.GuildText) typeLabel = 'guild_text';
+      else if (channelTypeNumber === ChannelType.GuildAnnouncement)
+        typeLabel = 'guild_news';
+      else if (channelTypeNumber === ChannelType.GuildVoice)
+        typeLabel = 'guild_voice';
+      else if (
+        channelTypeNumber === ChannelType.PublicThread ||
+        channelTypeNumber === ChannelType.PrivateThread ||
+        channelTypeNumber === ChannelType.AnnouncementThread
+      )
+        typeLabel = 'guild_thread';
+
+      const guildChannel = channel as TextChannel | NewsChannel;
+      return {
+        id: guildChannel.id,
+        type: typeLabel,
+        name: guildChannel.name,
+        topic: 'topic' in guildChannel ? guildChannel.topic ?? undefined : undefined,
+        nsfw: 'nsfw' in guildChannel ? guildChannel.nsfw : undefined,
+        guildId: guildChannel.guildId,
+        parentId: guildChannel.parentId ?? undefined,
+      };
+    },
+
+    async getGuildInfo(chatId: string): Promise<DiscordGuildInfo | null> {
+      const channel = await resolveChannel(chatId);
+      if (!channel) {
+        throw new Error(`Discord getGuildInfo: unknown chat ${chatId}`);
+      }
+
+      // DMs do not belong to a guild
+      if (channel.type === ChannelType.DM) return null;
+
+      const guild = (channel as TextChannel | NewsChannel).guild;
+      if (!guild) return null;
+
+      // Refresh guild data to get current memberCount where possible
+      const fresh = await guild.fetch();
+      return {
+        id: fresh.id,
+        name: fresh.name,
+        description: fresh.description ?? undefined,
+        ownerId: fresh.ownerId,
+        memberCount: fresh.memberCount,
+        iconUrl: fresh.iconURL({ size: 256 }) ?? undefined,
+        createdAt: fresh.createdAt.toISOString(),
+      };
     },
   };
 

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -495,6 +495,7 @@ export class GroupQueue {
     text: string,
     images?: Array<{ data: string; mimeType?: string }>,
     onInjected?: () => void,
+    sourceJid?: string,
   ): SendMessageResult {
     const state = this.resolveActiveState(groupJid);
     if (!state) return 'no_active';
@@ -532,7 +533,7 @@ export class GroupQueue {
       const tempPath = `${filepath}.tmp`;
       fs.writeFileSync(
         tempPath,
-        JSON.stringify({ type: 'message', text, images }),
+        JSON.stringify({ type: 'message', text, images, sourceJid }),
       );
       fs.renameSync(tempPath, filepath);
       state.queryInFlight = true;

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -33,6 +33,10 @@ import {
   createDiscordConnection,
   type DiscordConnection,
   type DiscordConnectionConfig,
+  type DiscordHistoryMessage,
+  type DiscordHistoryOpts,
+  type DiscordChannelInfo,
+  type DiscordGuildInfo,
 } from './discord.js';
 import { logger } from './logger.js';
 import type { FeishuMessageMeta } from './types.js';
@@ -758,15 +762,39 @@ export function createDingTalkChannel(
 
 // ─── Discord Adapter ────────────────────────────────────────────
 
+/**
+ * Discord-specific extensions on top of the unified IMChannel interface.
+ * Used by im-manager to route Discord-only capabilities (history, channel/guild metadata).
+ */
+export interface DiscordChannelExtensions {
+  getDiscordHistory(
+    chatId: string,
+    opts?: DiscordHistoryOpts,
+  ): Promise<DiscordHistoryMessage[]>;
+  getDiscordChannelInfo(chatId: string): Promise<DiscordChannelInfo>;
+  getDiscordGuildInfo(chatId: string): Promise<DiscordGuildInfo | null>;
+}
+
+/** Type guard: does this IMChannel expose Discord-specific extensions? */
+export function isDiscordChannel(
+  ch: IMChannel,
+): ch is IMChannel & DiscordChannelExtensions {
+  return (
+    ch.channelType === 'discord' &&
+    typeof (ch as Partial<DiscordChannelExtensions>).getDiscordHistory ===
+      'function'
+  );
+}
+
 export function createDiscordChannel(
   config: DiscordConnectionConfig,
   opts?: { streamingMode?: 'edit' | 'off' },
-): IMChannel {
+): IMChannel & DiscordChannelExtensions {
   const streamingEnabled = opts?.streamingMode === 'edit';
   let inner: DiscordConnection | null = null;
   let typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
-  const channel: IMChannel = {
+  const channel: IMChannel & DiscordChannelExtensions = {
     channelType: 'discord',
 
     async connect(opts: IMChannelConnectOpts): Promise<boolean> {
@@ -851,6 +879,27 @@ export function createDiscordChannel(
       if (!streamingEnabled) return undefined;
       if (!inner?.createStreamingSession) return undefined;
       return inner.createStreamingSession(chatId, onCardCreated);
+    },
+
+    async getDiscordHistory(chatId, historyOpts?) {
+      if (!inner) {
+        throw new Error('Discord channel not connected');
+      }
+      return inner.getChannelHistory(chatId, historyOpts);
+    },
+
+    async getDiscordChannelInfo(chatId) {
+      if (!inner) {
+        throw new Error('Discord channel not connected');
+      }
+      return inner.getChannelInfo(chatId);
+    },
+
+    async getDiscordGuildInfo(chatId) {
+      if (!inner) {
+        throw new Error('Discord channel not connected');
+      }
+      return inner.getGuildInfo(chatId);
     },
   };
   return channel;

--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -16,7 +16,14 @@ import {
   createWeChatChannel,
   createDingTalkChannel,
   createDiscordChannel,
+  isDiscordChannel,
 } from './im-channel.js';
+import type {
+  DiscordHistoryMessage,
+  DiscordHistoryOpts,
+  DiscordChannelInfo,
+  DiscordGuildInfo,
+} from './discord.js';
 import { parseFeishuRouteTarget, type FeishuConnectionConfig } from './feishu.js';
 import type { TelegramConnectionConfig } from './telegram.js';
 import type { QQConnectionConfig } from './qq.js';
@@ -222,6 +229,50 @@ class IMConnectionManager {
     } else {
       throw new Error(`通道 ${channelType} 不支持发送文件`);
     }
+  }
+
+  /**
+   * Fetch recent messages from a Discord channel/DM, auto-routing via JID prefix.
+   * Throws if the JID is not a Discord channel or no Discord connection is available.
+   */
+  async getDiscordHistory(
+    jid: string,
+    opts?: DiscordHistoryOpts,
+  ): Promise<DiscordHistoryMessage[]> {
+    const ch = this.requireDiscordChannel(jid, 'getDiscordHistory');
+    return ch.getDiscordHistory(extractChatId(jid), opts);
+  }
+
+  /**
+   * Get Discord channel/DM metadata.
+   */
+  async getDiscordChannelInfo(jid: string): Promise<DiscordChannelInfo> {
+    const ch = this.requireDiscordChannel(jid, 'getDiscordChannelInfo');
+    return ch.getDiscordChannelInfo(extractChatId(jid));
+  }
+
+  /**
+   * Get Discord guild (server) metadata for the channel's parent guild.
+   * Returns null if the JID points to a DM (no guild).
+   */
+  async getDiscordGuildInfo(jid: string): Promise<DiscordGuildInfo | null> {
+    const ch = this.requireDiscordChannel(jid, 'getDiscordGuildInfo');
+    return ch.getDiscordGuildInfo(extractChatId(jid));
+  }
+
+  /**
+   * Resolve the Discord channel adapter for a given JID, asserting type and connectivity.
+   */
+  private requireDiscordChannel(jid: string, op: string) {
+    const channelType = getChannelType(jid);
+    if (channelType !== 'discord') {
+      throw new Error(`${op}: JID is not a Discord channel: ${jid}`);
+    }
+    const ch = this.findChannelForJid(jid, 'discord');
+    if (!ch || !isDiscordChannel(ch)) {
+      throw new Error(`${op}: no connected Discord channel for ${jid}`);
+    }
+    return ch;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4223,6 +4223,10 @@ function stopStreamingBuffer(): void {
  * - Admin home can send to any group.
  * - Non-home groups can only send to groups sharing the same folder.
  * - Member home groups can send to groups created by the same user.
+ * - IM channels bound (target_main_jid) to the source workspace are reachable
+ *   from that workspace — without this, after agent-runner started rewriting
+ *   ctx.chatJid to the IM source, send_file/send_image/send_message from
+ *   non-home sub-workspaces got rejected.
  */
 export function canSendCrossGroupMessage(
   isAdminHome: boolean,
@@ -4240,6 +4244,12 @@ export function canSendCrossGroupMessage(
     targetGroup.created_by === sourceGroupEntry.created_by
   )
     return true;
+  if (targetGroup?.target_main_jid) {
+    const bound =
+      registeredGroups[targetGroup.target_main_jid] ??
+      getRegisteredGroup(targetGroup.target_main_jid);
+    if (bound?.folder === sourceFolder) return true;
+  }
   return false;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4680,13 +4680,22 @@ function startIpcWatcher(): void {
         });
 
         // 清理孤儿结果文件（容器崩溃或超时后残留，超过 10 分钟自动删除）
+        const RESULT_FILE_PREFIXES = [
+          'install_skill_result_',
+          'uninstall_skill_result_',
+          'list_tasks_result_',
+          'discord_get_history_result_',
+          'discord_get_channel_info_result_',
+          'discord_get_server_info_result_',
+        ];
+        const isResultFile = (name: string) =>
+          RESULT_FILE_PREFIXES.some((p) => name.startsWith(p));
+
         for (const entry of allEntries) {
           if (
             entry.isFile() &&
             entry.name.endsWith('.json') &&
-            (entry.name.startsWith('install_skill_result_') ||
-              entry.name.startsWith('uninstall_skill_result_') ||
-              entry.name.startsWith('list_tasks_result_'))
+            isResultFile(entry.name)
           ) {
             try {
               const filePath = path.join(tasksDir, entry.name);
@@ -4695,7 +4704,7 @@ function startIpcWatcher(): void {
                 await fsp.unlink(filePath);
                 logger.debug(
                   { sourceGroup, file: entry.name },
-                  'Cleaned up stale skill result file',
+                  'Cleaned up stale result file',
                 );
               }
             } catch {
@@ -4709,9 +4718,7 @@ function startIpcWatcher(): void {
             (entry) =>
               entry.isFile() &&
               entry.name.endsWith('.json') &&
-              !entry.name.startsWith('install_skill_result_') &&
-              !entry.name.startsWith('uninstall_skill_result_') &&
-              !entry.name.startsWith('list_tasks_result_'),
+              !isResultFile(entry.name),
           )
           .map((entry) => entry.name);
         for (const file of taskFiles) {
@@ -4828,6 +4835,9 @@ async function processTaskIpc(
     fileName?: string;
     // For list_tasks
     isAdminHome?: boolean;
+    // For discord_get_history
+    limit?: number;
+    before?: string;
   },
   sourceGroup: string, // Verified identity from IPC directory
   isAdminHome: boolean, // Whether source is admin home container
@@ -5093,6 +5103,18 @@ async function processTaskIpc(
           logger.error({ sourceGroup, err }, 'Failed to list tasks via IPC');
         }
       }
+      break;
+
+    case 'discord_get_history':
+    case 'discord_get_channel_info':
+    case 'discord_get_server_info':
+      await handleDiscordIpcRequest(
+        data,
+        sourceGroup,
+        sourceGroupEntry,
+        isAdminHome,
+        isHome,
+      );
       break;
 
     case 'refresh_groups':
@@ -5424,6 +5446,107 @@ async function processTaskIpc(
 
     default:
       logger.warn({ type: data.type }, 'Unknown IPC task type');
+  }
+}
+
+/**
+ * Handle Discord-specific IPC requests (history, channel info, server info).
+ * Writes a result file `{type}_result_{requestId}.json` back to the source group's tasks dir.
+ * Authorization: target chatJid must be owned by sourceGroup's user (or admin home for cross-group).
+ */
+async function handleDiscordIpcRequest(
+  data: {
+    type: string;
+    chatJid?: string;
+    requestId?: string;
+    limit?: number;
+    before?: string;
+  },
+  sourceGroup: string,
+  sourceGroupEntry: RegisteredGroup | undefined,
+  isAdminHome: boolean,
+  isHome: boolean,
+): Promise<void> {
+  const requestId = data.requestId;
+  if (!requestId || !SAFE_REQUEST_ID_RE.test(requestId)) {
+    logger.warn(
+      { sourceGroup, type: data.type, requestId },
+      'Rejected Discord IPC request with invalid requestId',
+    );
+    return;
+  }
+
+  const tasksDir = path.join(DATA_DIR, 'ipc', sourceGroup, 'tasks');
+  const tasksDirResolved = path.resolve(tasksDir);
+  const resultFileName = `${data.type}_result_${requestId}.json`;
+  const resultFilePath = path.resolve(tasksDir, resultFileName);
+  if (!resultFilePath.startsWith(`${tasksDirResolved}${path.sep}`)) {
+    logger.warn(
+      { sourceGroup, type: data.type, resultFilePath },
+      'Rejected Discord IPC request with unsafe result file path',
+    );
+    return;
+  }
+  fs.mkdirSync(path.dirname(resultFilePath), { recursive: true });
+
+  const writeResult = (payload: object): void => {
+    const tmpPath = `${resultFilePath}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(payload));
+    fs.renameSync(tmpPath, resultFilePath);
+  };
+
+  try {
+    const chatJid = data.chatJid;
+    if (!chatJid || !chatJid.startsWith('discord:')) {
+      writeResult({
+        success: false,
+        error: 'chatJid must be a Discord JID (discord:*)',
+      });
+      return;
+    }
+
+    // Authorization: target jid must be a registered group owned by the source user.
+    const targetGroup = registeredGroups[chatJid];
+    if (
+      !canSendCrossGroupMessage(
+        isAdminHome,
+        isHome,
+        sourceGroup,
+        sourceGroupEntry,
+        targetGroup,
+      )
+    ) {
+      writeResult({
+        success: false,
+        error: `Not authorized to access Discord chat ${chatJid}`,
+      });
+      return;
+    }
+
+    if (data.type === 'discord_get_history') {
+      const messages = await imManager.getDiscordHistory(chatJid, {
+        limit: data.limit,
+        before: data.before,
+      });
+      writeResult({ success: true, messages });
+    } else if (data.type === 'discord_get_channel_info') {
+      const channel = await imManager.getDiscordChannelInfo(chatJid);
+      writeResult({ success: true, channel });
+    } else if (data.type === 'discord_get_server_info') {
+      const guild = await imManager.getDiscordGuildInfo(chatJid);
+      writeResult({ success: true, guild });
+    } else {
+      writeResult({ success: false, error: `Unknown type: ${data.type}` });
+    }
+  } catch (err) {
+    logger.error(
+      { sourceGroup, type: data.type, err },
+      'Discord IPC request failed',
+    );
+    writeResult({
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2782,6 +2782,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     | { status: 'success' | 'error' | 'closed'; error?: string }
     | undefined;
   let activeSessionId = getSession(effectiveGroup.folder) || undefined;
+  // currentSourceJid: tells the agent-runner which IM chat the latest user
+  // message came from, so per-channel MCP tools (discord_*, etc.) can detect
+  // it correctly even when the home container was originally started by a
+  // different chat (e.g. web message before the Discord one arrived).
+  const currentSourceJid =
+    missedMessages[missedMessages.length - 1]?.source_jid || chatJid;
   try {
     output = await runAgent(
       effectiveGroup,
@@ -3336,6 +3342,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       },
       imagesForAgent,
       messageTaskId,
+      currentSourceJid,
     );
   } finally {
     await setTyping(chatJid, false);
@@ -3767,6 +3774,7 @@ async function runAgent(
   onOutput?: (output: ContainerOutput) => Promise<void>,
   images?: Array<{ data: string; mimeType?: string }>,
   messageTaskId?: string,
+  currentSourceJid?: string,
 ): Promise<{ status: 'success' | 'error' | 'closed'; error?: string }> {
   const isHome = !!group.is_home;
   // For the agent-runner: isMain means this is an admin home container (full privileges)
@@ -3852,6 +3860,7 @@ async function runAgent(
           turnId,
           groupFolder: group.folder,
           chatJid,
+          currentSourceJid,
           isMain: isAdminHome,
           isHome,
           isAdminHome,
@@ -3871,6 +3880,7 @@ async function runAgent(
           turnId,
           groupFolder: group.folder,
           chatJid,
+          currentSourceJid,
           isMain: isAdminHome,
           isHome,
           isAdminHome,
@@ -5505,17 +5515,18 @@ async function handleDiscordIpcRequest(
       return;
     }
 
-    // Authorization: target jid must be a registered group owned by the source user.
+    // Authorization: read-only Discord queries — admin home, same folder, or
+    // same owner is enough. We don't require sourceGroup to be `is_home` like
+    // cross-group sends do, because querying channel/history info doesn't
+    // write into another workspace.
     const targetGroup = registeredGroups[chatJid];
-    if (
-      !canSendCrossGroupMessage(
-        isAdminHome,
-        isHome,
-        sourceGroup,
-        sourceGroupEntry,
-        targetGroup,
-      )
-    ) {
+    const ownerOk =
+      isAdminHome ||
+      (targetGroup && targetGroup.folder === sourceGroup) ||
+      (targetGroup &&
+        sourceGroupEntry?.created_by != null &&
+        targetGroup.created_by === sourceGroupEntry.created_by);
+    if (!targetGroup || !ownerOk) {
       writeResult({
         success: false,
         error: `Not authorized to access Discord chat ${chatJid}`,
@@ -6522,6 +6533,7 @@ async function startMessageLoop(): Promise<void> {
               // IPC write succeeded — update reply route for the running agent
               activeRouteUpdaters.get(group.folder)?.(lastSourceJidForRoute);
             },
+            lastSourceJidForRoute,
           );
           if (sendResult === 'sent') {
             logger.debug(
@@ -7521,12 +7533,15 @@ function buildOnAgentMessage(): (baseChatJid: string, agentId: string) => void {
       const images = collectMessageImages(virtualChatJid, missedMessages);
       const imagesForAgent = images.length > 0 ? images : undefined;
 
+      const lastAgentSourceJid =
+        missedMessages[missedMessages.length - 1]?.source_jid || virtualChatJid;
       const sendResult = formatted
         ? queue.sendMessage(
             virtualChatJid,
             formatted,
             imagesForAgent,
             undefined,
+            lastAgentSourceJid,
           )
         : 'no_active';
       if (sendResult === 'no_active') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ import {
   applyAutoIsolateContextForGroups,
   getUserContextIsolationConfig,
 } from './im-context-isolation.js';
+import { canSendCrossGroupMessage as canSendCrossGroupMessagePure } from './cross-group-acl.js';
 import { invalidateSessionCache, getWebDeps } from './web-context.js';
 import {
   getFeishuProviderConfigWithSource,
@@ -4218,39 +4219,23 @@ function stopStreamingBuffer(): void {
   }
 }
 
-/**
- * Check if a source group is authorized to send IPC messages to a target group.
- * - Admin home can send to any group.
- * - Non-home groups can only send to groups sharing the same folder.
- * - Member home groups can send to groups created by the same user.
- * - IM channels bound (target_main_jid) to the source workspace are reachable
- *   from that workspace — without this, after agent-runner started rewriting
- *   ctx.chatJid to the IM source, send_file/send_image/send_message from
- *   non-home sub-workspaces got rejected.
- */
-export function canSendCrossGroupMessage(
+// Thin production wrapper around the pure helper in ./cross-group-acl.ts so
+// the helper can be unit-tested without booting all of index.ts.
+function canSendCrossGroupMessage(
   isAdminHome: boolean,
   isHome: boolean,
   sourceFolder: string,
   sourceGroupEntry: RegisteredGroup | undefined,
   targetGroup: RegisteredGroup | undefined,
 ): boolean {
-  if (isAdminHome) return true;
-  if (targetGroup && targetGroup.folder === sourceFolder) return true;
-  if (
-    isHome &&
-    targetGroup &&
-    sourceGroupEntry?.created_by != null &&
-    targetGroup.created_by === sourceGroupEntry.created_by
-  )
-    return true;
-  if (targetGroup?.target_main_jid) {
-    const bound =
-      registeredGroups[targetGroup.target_main_jid] ??
-      getRegisteredGroup(targetGroup.target_main_jid);
-    if (bound?.folder === sourceFolder) return true;
-  }
-  return false;
+  return canSendCrossGroupMessagePure(
+    isAdminHome,
+    isHome,
+    sourceFolder,
+    sourceGroupEntry,
+    targetGroup,
+    (jid) => registeredGroups[jid] ?? getRegisteredGroup(jid),
+  );
 }
 
 // Thin production wrapper around the pure helper in ./task-routing.ts so the
@@ -5549,7 +5534,12 @@ async function handleDiscordIpcRequest(
         limit: data.limit,
         before: data.before,
       });
-      writeResult({ success: true, messages });
+      // Strip authorId (Discord user Snowflake) before sending to agent.
+      // authorId + authorName uniquely identifies a user even after rename;
+      // letting it reach the agent risks cross-channel forwarding into 3rd-
+      // party LLM logs. Formatted output already only shows authorName.
+      const sanitized = messages.map(({ authorId: _id, ...rest }) => rest);
+      writeResult({ success: true, messages: sanitized });
     } else if (data.type === 'discord_get_channel_info') {
       const channel = await imManager.getDiscordChannelInfo(chatJid);
       writeResult({ success: true, channel });

--- a/src/web.ts
+++ b/src/web.ts
@@ -362,6 +362,7 @@ async function handleWebUserMessage(
       // Web messages have no IM source, so clear the IM route.
       updateRoute?.(group.folder, null);
     },
+    chatJid,
   );
   if (sendResult === 'sent') {
     pipedToActive = true;
@@ -504,6 +505,8 @@ async function handleAgentConversationMessage(
     virtualChatJid,
     formatted,
     agentImages,
+    undefined,
+    virtualChatJid,
   );
   if (agentSendResult === 'no_active') {
     // No running process — force close any stale state and start fresh.

--- a/tests/can-send-cross-group-message.test.ts
+++ b/tests/can-send-cross-group-message.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { canSendCrossGroupMessage } from '../src/cross-group-acl.js';
+import type { RegisteredGroup } from '../src/types.js';
+
+/**
+ * Regression tests for the cross-group ACL helper in src/cross-group-acl.ts.
+ *
+ * The 4 branches:
+ *  1. admin home → always allowed
+ *  2. target.folder === sourceFolder (same workspace)
+ *  3. member home + same created_by (cross-workspace, same user)
+ *  4. target.target_main_jid → bound workspace folder === sourceFolder
+ *     (added in f93d922 — without this, agent in non-home sub-workspaces
+ *      could not reply to its IM channel after agent-runner started
+ *      rewriting ctx.chatJid to the IM source jid)
+ *
+ * Mutation checks (run by QA): removing branch 4 should turn the
+ * "bound IM jid" cases red. Flipping `bound?.folder === sourceFolder`
+ * to `===` against anything else should also fail.
+ */
+
+function makeGroup(partial: Partial<RegisteredGroup>): RegisteredGroup {
+  return {
+    name: partial.name ?? 'g',
+    folder: partial.folder ?? 'f',
+    added_at: '2026-01-01T00:00:00Z',
+    ...partial,
+  };
+}
+
+describe('canSendCrossGroupMessage', () => {
+  test('admin home can send to any target', () => {
+    const target = makeGroup({ folder: 'other', created_by: 'someoneelse' });
+    expect(
+      canSendCrossGroupMessage(true, true, 'main', undefined, target, () =>
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  test('non-home group can send to a target sharing the same folder', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const target = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    expect(
+      canSendCrossGroupMessage(false, false, 'flow-x', source, target, () =>
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  test('member home can send to a target created by the same user', () => {
+    const source = makeGroup({ folder: 'home-u1', created_by: 'u1' });
+    const target = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    expect(
+      canSendCrossGroupMessage(false, true, 'home-u1', source, target, () =>
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  test('non-home + different folder + different owner → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const target = makeGroup({ folder: 'flow-y', created_by: 'u2' });
+    expect(
+      canSendCrossGroupMessage(false, false, 'flow-x', source, target, () =>
+        undefined,
+      ),
+    ).toBe(false);
+  });
+
+  // Branch 4: the f93d922 fix. Sub-workspace flow-x is bound to an IM
+  // chat (qq:c2c:xxx) via target_main_jid; replies must succeed.
+  test('IM chat bound to source workspace via target_main_jid → allowed', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    // The IM "group" entry has target_main_jid pointing at the workspace's
+    // web jid. The lookup resolves that jid to the bound workspace whose
+    // folder matches sourceFolder.
+    const imTarget = makeGroup({
+      folder: 'main', // home folder of admin (where IM messages land)
+      target_main_jid: 'web:flow-x',
+    });
+    const lookupGroup = vi.fn((jid: string) =>
+      jid === 'web:flow-x'
+        ? makeGroup({ folder: 'flow-x', created_by: 'u1' })
+        : undefined,
+    );
+    expect(
+      canSendCrossGroupMessage(false, false, 'flow-x', source, imTarget, lookupGroup),
+    ).toBe(true);
+    expect(lookupGroup).toHaveBeenCalledWith('web:flow-x');
+  });
+
+  test('IM chat bound to a DIFFERENT workspace → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_main_jid: 'web:flow-y',
+    });
+    const lookupGroup = vi.fn((jid: string) =>
+      jid === 'web:flow-y'
+        ? makeGroup({ folder: 'flow-y', created_by: 'u2' })
+        : undefined,
+    );
+    expect(
+      canSendCrossGroupMessage(false, false, 'flow-x', source, imTarget, lookupGroup),
+    ).toBe(false);
+  });
+
+  test('target_main_jid points to an unknown jid → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_main_jid: 'web:does-not-exist',
+    });
+    const lookupGroup = vi.fn(() => undefined);
+    expect(
+      canSendCrossGroupMessage(false, false, 'flow-x', source, imTarget, lookupGroup),
+    ).toBe(false);
+  });
+
+  test('undefined target → denied (regardless of source flags)', () => {
+    expect(
+      canSendCrossGroupMessage(false, false, 'flow-x', undefined, undefined, () =>
+        undefined,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

Agent 在 Discord 频道中没有上下文工具——既看不到频道最近消息，也拿不到频道/服务器元信息。本 PR 加三个 Discord 专属 MCP 工具，并修复了在共享 home 容器场景下工具识别错频道、子 workspace 调用被 ACL 拒绝的两个问题。

## 改动

### 1. 新增三个 Discord MCP 工具（5108a3b）

- `discord_get_history` —— 拉取频道/DM 最近消息（支持 limit + before 分页）
- `discord_get_channel_info` —— 频道元信息（名称、类型、topic、guildId 等）
- `discord_get_server_info` —— 所属 guild 元信息（名称、成员数、owner 等）

DM 场景下 channel_info 返回 `dm` 类型，server_info 返回 null。

涉及：
- `src/discord.ts` — DiscordConnection 加 `getChannelHistory` / `getChannelInfo` / `getGuildInfo`
- `src/im-channel.ts` — `DiscordChannelExtensions` 接口 + `isDiscordChannel` 类型守卫
- `src/im-manager.ts` — 路由方法 + `requireDiscordChannel` helper
- `src/index.ts` — 三个 IPC case 路由到 `handleDiscordIpcRequest`
- `container/agent-runner/src/mcp-tools.ts` — 注册三个新工具，复用 `pollIpcResult` 模式

### 2. 修复共享 home 容器中 ctx.chatJid 错位（d6e653a）

home 容器在 web 与 IM 共用时，`mcpToolsConfig.chatJid` 固定为容器启动时的 chatJid（如先到的 web 消息），后到的 Discord 消息无法让 `discord_*` 工具识别频道。

方案：让 IPC payload 携带 `sourceJid`，agent-runner drain 时取最新非空值更新 `mcpToolsConfig.chatJid`，让工具 ctx 引用同步刷新。

涉及：
- `src/group-queue.ts` — `sendMessage` 加 `sourceJid` 参数，写入 IPC JSON
- `src/index.ts` — 主消息循环 / agent-conv 路径传 `last.source_jid`
- `src/web.ts` — 两处 `sendMessage` 调用补 `chatJid` / `virtualChatJid`
- `src/container-runner.ts` — `ContainerInput` 加 `currentSourceJid`
- `container/agent-runner/src/index.ts` — drain + main loop 同步刷新 `mcpToolsConfig.chatJid`

### 3. 放宽 Discord IPC ACL 到同 owner（d6e653a）

`handleDiscordIpcRequest` 原本复用 `canSendCrossGroupMessage`，要求 `isHome=true` 才考虑跨 workspace；从子 workspace（非 home，如 conversation agent）调 `discord_*` 工具会被拒绝。

但 `discord_get_history` / `channel_info` / `server_info` 都是只读查询，不写入其它 workspace。改为：admin home / 同 folder / 同 owner 三者满足其一即放行。其他写入类 IPC（send_message / send_file）鉴权保持不变。

## 跨渠道影响审查

| 渠道 | 改动前后 ctx.chatJid 行为 | 影响 |
|---|---|---|
| Web 单聊 | `source_jid == chatJid`，无差别 | 无变化 |
| 飞书/Telegram/QQ/钉钉 DM | `source_jid == chatJid`，无差别 | 无变化 |
| home 容器跨渠道（web→discord 等） | 改前卡在启动 jid，改后跟随消息源 | bug fix |
| Conversation Agent | `source_jid` 走 messages.source_jid，fallback virtual JID | 无回归 |

`sendMessage()` 路由路径已校验：`broadcastNewMessage` 内的 `normalizeHomeJid` 会把 `discord:xxx` 映射回 `web:{folder}`，Web 客户端不丢消息；`getChannelType` 判断会跳过 `activeImReplyRoutes` 二次路由，IM 不会重复发。

## 测试

- `make typecheck` 通过
- `make test` —— 13 test files / 204 tests 全过
- 三个 `discord_*` 工具在 Discord 频道中实测通过（频道历史 + 频道信息 + 服务器信息）