### PR TITLE
修复: 飞书卡片 header 与正文首行内容重复 (#488)

### DIFF
--- a/src/feishu-cards/builder.ts
+++ b/src/feishu-cards/builder.ts
@@ -56,7 +56,11 @@ export function buildAgentReplyCard(input: AgentCardInput): FeishuCardV2 {
 
   const header = buildHeader(normalizedInput);
   const elements: Array<Record<string, unknown>> = [];
-  elements.push(...buildBodyChunks(body || optimizedText.trim()));
+  // When the title was auto-extracted from the first line, body may be empty.
+  // Hiding the body area avoids the header/first-line duplication (issue #488).
+  if (body) {
+    elements.push(...buildBodyChunks(body));
+  }
 
   const metaRow = buildMetaRow(input.meta);
   const thinkingPanel = buildThinkingPanel(optimizedThinking);

--- a/src/feishu-cards/sections.ts
+++ b/src/feishu-cards/sections.ts
@@ -107,14 +107,14 @@ export function extractTitle(text: string): TitleExtractResult {
         bodyStartIndex: i + 1,
       };
     }
-    break;
+    const firstLine = lines[i].replace(/[*_`#\[\]]/g, '').trim();
+    const title =
+      firstLine.length > 40
+        ? firstLine.slice(0, 37) + '...'
+        : firstLine || 'Reply';
+    return { title, bodyStartIndex: i + 1 };
   }
-  const firstLine = (lines.find((l) => l.trim()) || '')
-    .replace(/[*_`#\[\]]/g, '')
-    .trim();
-  const title =
-    firstLine.length > 40 ? firstLine.slice(0, 37) + '...' : firstLine || 'Reply';
-  return { title, bodyStartIndex: 0 };
+  return { title: 'Reply', bodyStartIndex: 0 };
 }
 
 export function stripTitleFromBody(text: string, bodyStartIndex: number): string {

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -171,7 +171,10 @@ function splitCodeBlockSafe(text: string, maxLen: number): string[] {
 const CARD_MD_LIMIT = 4000;
 const CARD_SIZE_LIMIT = 25 * 1024; // Feishu limit ~30KB, 5KB safety margin
 
-function extractTitleAndBody(text: string): { title: string; body: string } {
+export function extractTitleAndBody(text: string): {
+  title: string;
+  body: string;
+} {
   const lines = text.split('\n');
   let title = '';
   let bodyStartIdx = 0;
@@ -180,22 +183,18 @@ function extractTitleAndBody(text: string): { title: string; body: string } {
     if (!lines[i].trim()) continue;
     if (/^#{1,3}\s+/.test(lines[i])) {
       title = lines[i].replace(/^#+\s*/, '').trim();
-      bodyStartIdx = i + 1;
+    } else {
+      const firstLine = lines[i].replace(/[*_`#\[\]]/g, '').trim();
+      title =
+        firstLine.length > 40 ? firstLine.slice(0, 37) + '...' : firstLine;
     }
+    bodyStartIdx = i + 1;
     break;
   }
 
   const body = lines.slice(bodyStartIdx).join('\n').trim();
 
-  if (!title) {
-    const firstLine = (lines.find((l) => l.trim()) || '')
-      .replace(/[*_`#\[\]]/g, '')
-      .trim();
-    title =
-      firstLine.length > 40
-        ? firstLine.slice(0, 37) + '...'
-        : firstLine || 'Reply';
-  }
+  if (!title) title = 'Reply';
 
   return { title, body };
 }
@@ -219,9 +218,9 @@ function buildCardContent(
 ): CardContentResult {
   const { title: extractedTitle, body } = extractTitleAndBody(text);
   const title = overrideTitle || extractedTitle;
-  // Apply Markdown optimization for Feishu card rendering
-  const rawContent = body || text.trim();
-  const contentToRender = optimizeMarkdownStyle(rawContent, 2);
+  // When the auto-extracted title is the first line, body excludes that line so
+  // we don't echo it back into the content area (issue #488).
+  const contentToRender = body ? optimizeMarkdownStyle(body, 2) : '';
   const elements: Array<Record<string, unknown>> = [];
 
   if (contentToRender.length > CARD_MD_LIMIT) {
@@ -232,10 +231,6 @@ function buildCardContent(
     // Keep --- as markdown content instead of using { tag: 'hr' }
     // because Schema 2.0 (CardKit) does not support the hr tag.
     elements.push({ tag: 'markdown', content: contentToRender });
-  }
-
-  if (elements.length === 0) {
-    elements.push({ tag: 'markdown', content: text.trim() || '...' });
   }
 
   return { title, contentElements: elements };
@@ -491,12 +486,15 @@ function buildStreamingCard(
 
   // Streaming state — flat v2 layout for cheap full-card patches.
   const optimized = optimizeMarkdownStyle(text || '...', 2);
-  const { title } = extractTitleAndBody(optimized);
+  const { title, body } = extractTitleAndBody(optimized);
   const displayTitle = title || '...';
+  // When the title was extracted from the first line, body is empty — keep the
+  // MAIN_CONTENT slot so streaming patches still target it, but avoid echoing
+  // the title back into the body (issue #488).
   const elements: Array<Record<string, unknown>> = [
     {
       tag: 'markdown',
-      content: optimized,
+      content: body,
       element_id: CARD_ELEMENT_IDS.MAIN_CONTENT,
     },
     { ...INTERRUPT_BUTTON_V2, element_id: CARD_ELEMENT_IDS.INTERRUPT_BTN },

--- a/tests/feishu-card.test.ts
+++ b/tests/feishu-card.test.ts
@@ -250,6 +250,44 @@ describe('formatters', () => {
     const text = 'Just some plain text that has no markdown heading at all';
     const { title, bodyStartIndex } = extractTitle(text);
     expect(title.length).toBeLessThanOrEqual(40);
+    // First line was consumed as the title — bodyStartIndex must skip past it
+    // so the body doesn't echo the same line back (issue #488).
+    expect(bodyStartIndex).toBe(1);
+  });
+
+  test('extractTitle: single-line input yields empty body to avoid duplication', () => {
+    const text = '~/.claude 同步完成：远端已是最新，无本地变更需要推送。';
+    const { title, bodyStartIndex } = extractTitle(text);
+    expect(title).toBe(text);
+    expect(bodyStartIndex).toBe(1);
+    // Stripping past line 1 of a single-line input gives empty body
+    expect(text.split('\n').slice(bodyStartIndex).join('\n').trim()).toBe('');
+  });
+
+  test('extractTitle: long single-line input gets truncated and body still empty', () => {
+    const text =
+      'a'.repeat(60) + ' end of long single line that exceeds the 40 char title cap';
+    const { title, bodyStartIndex } = extractTitle(text);
+    expect(title.length).toBeLessThanOrEqual(40);
+    expect(title.endsWith('...')).toBe(true);
+    expect(bodyStartIndex).toBe(1);
+    expect(text.split('\n').slice(bodyStartIndex).join('\n').trim()).toBe('');
+  });
+
+  test('extractTitle: multi-line fallback strips only the first non-empty line', () => {
+    const text = '\n\nFirst line summary\nSecond line detail\nThird line';
+    const { title, bodyStartIndex } = extractTitle(text);
+    expect(title).toBe('First line summary');
+    // Two leading blank lines + the first content line → bodyStartIndex = 3
+    expect(bodyStartIndex).toBe(3);
+    expect(text.split('\n').slice(bodyStartIndex).join('\n').trim()).toBe(
+      'Second line detail\nThird line',
+    );
+  });
+
+  test('extractTitle: empty input returns default title with no body', () => {
+    const { title, bodyStartIndex } = extractTitle('');
+    expect(title).toBe('Reply');
     expect(bodyStartIndex).toBe(0);
   });
 });
@@ -310,13 +348,38 @@ describe('buildAgentReplyCard', () => {
   });
 
   test('short body → single main_content element, no collapsible overflow', () => {
-    const card = buildAgentReplyCard({ status: 'done', text: 'short reply' });
+    // Multi-line input so body has content after the title is consumed
+    const card = buildAgentReplyCard({
+      status: 'done',
+      text: 'Summary line\nDetail body text',
+    });
     const body = card.body as { elements: Array<Record<string, unknown>> };
     const mainCount = body.elements.filter(
       (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
     ).length;
     expect(mainCount).toBe(1);
     expect(countTag(card, 'collapsible_panel')).toBe(0);
+  });
+
+  test('single-line reply → no body markdown to avoid header/body duplication (issue #488)', () => {
+    const card = buildAgentReplyCard({ status: 'done', text: 'short reply' });
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    // Header carries the title; body must not echo the same line back
+    const header = card.header as Record<string, unknown>;
+    const title = (header.title as Record<string, unknown>).content as string;
+    expect(title).toBe('short reply');
+    const mainCount = body.elements.filter(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    ).length;
+    expect(mainCount).toBe(0);
+    // No markdown element should contain the title text either
+    const markdownEchoesTitle = body.elements.some(
+      (e) =>
+        e.tag === 'markdown' &&
+        typeof e.content === 'string' &&
+        (e.content as string).includes('short reply'),
+    );
+    expect(markdownEchoesTitle).toBe(false);
   });
 
   test('long body → multiple flat markdown chunks, no "继续阅读" panels', () => {


### PR DESCRIPTION
## 问题描述

Fixes #488.

`extractTitle` / `extractTitleAndBody` 在 fallback 路径（文本不以 Markdown 标题 `#`/`##`/`###` 开头时）忘记把 `bodyStartIdx` 推进到首行之后，导致同一行既被截取为卡片 header，又留在 body 中渲染——视觉上是 header 和正文第一行完全重复。

由于绝大多数 Agent 回复都不是以 Markdown 标题开头，这个 bug 几乎在所有飞书卡片回复中都会触发。

## 修复方案

采用 issue 中建议的方案 A（保守），同时清理两处 `extractTitle` 副本以保持行为一致：

### `src/feishu-cards/sections.ts`
- `extractTitle` fallback 分支同步设置 `bodyStartIndex = i + 1`，让首行被消费后不再留在 body 里
- 输入完全为空白时返回 `{ title: 'Reply', bodyStartIndex: 0 }`，统一兜底分支

### `src/feishu-cards/builder.ts`
- `buildAgentReplyCard` 检测到 body 为空（单行输入被全部用作 title）时跳过 `buildBodyChunks`，让卡片只展示 header，避免「`body || optimizedText.trim()`」回退到完整原文导致重复

### `src/feishu-streaming-card.ts`
- `extractTitleAndBody` 同样的 fallback 推进修复，并导出便于测试
- `buildCardContent` 不再用 `body || text.trim()` 回退；body 为空就直接返回空 `contentElements`，由调用方决定是否显示
- `buildStreamingCard`（legacy 流式卡片 builder）的 `MAIN_CONTENT` 槽改用 `body` 而非完整 `optimized` 文本，元素 id 仍保留以便后续 streaming patches

### `tests/feishu-card.test.ts`
- 更新原 `extractTitle` fallback 用例：`bodyStartIndex` 从 `0` 改为 `1`
- 新增三个回归用例：单行截断输入、多行 fallback 入身、空输入兜底
- 新增 `buildAgentReplyCard` 单行场景断言：MAIN_CONTENT 元素数为 0、所有 markdown 元素都不再回显 title 文本

## 验证

- `make typecheck` 通过
- `make test` 通过（209/209）
- `make build` 通过