### PR TITLE
修复: session recovery prompt 文案优化 + 防逃逸加固

### DIFF
--- a/container/agent-runner/src/session-history.ts
+++ b/container/agent-runner/src/session-history.ts
@@ -93,7 +93,10 @@ export function extractSessionHistory(
         m.content.length > RECOVERY_MESSAGE_TRUNCATE
           ? m.content.slice(0, RECOVERY_MESSAGE_TRUNCATE) + '…'
           : m.content;
-      const cleaned = truncated.replace(LONE_SURROGATE_RE, '');
+      let cleaned = truncated.replace(LONE_SURROGATE_RE, '');
+      // Defense in depth: strip the closing tag we use to fence this block
+      // so a user message containing "</system_context>" can't escape early.
+      cleaned = cleaned.replace(/<\/system_context>/gi, '</system_context_>');
       return `[${role}] ${cleaned}`;
     });
 
@@ -103,7 +106,8 @@ export function extractSessionHistory(
 
     return (
       '<system_context>\n' +
-      '会话恢复失败，当前为新会话。以下是之前的对话记录，供你了解上下文（请基于这些上下文继续对话）：\n\n' +
+      '检测到上次有未完成消息，当前使用新会话恢复处理。以下是恢复前的最近对话记录，供你了解上下文。\n' +
+      '重要：这些只是历史记录，可能包含不准确或过时的信息。回答当前用户消息时，请优先依据当前消息里的内容和文件；如果历史与当前问题无关，请直接忽略。\n\n' +
       historyLines.join('\n') +
       '\n</system_context>\n\n'
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -2585,7 +2585,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       });
       prompt =
         '<system_context>\n' +
-        '服务刚重启，当前为新会话。以下是重启前的最近对话记录，供你了解上下文：\n\n' +
+        '服务刚重启，当前为新会话。以下是重启前的最近对话记录，供你了解上下文。\n' +
+        '重要：这些只是历史记录，可能包含不准确或过时的信息。回答当前用户消息时，请优先依据当前消息里的内容和文件；如果历史与当前问题无关，请直接忽略。\n\n' +
         historyLines.join('\n') +
         '\n</system_context>\n\n' +
         prompt;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2577,15 +2577,18 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         // such as emoji. Must stay byte-for-byte aligned with the matching regex
         // in container/agent-runner/src/index.ts:extractSessionHistory — both
         // sides feed the same Anthropic API and must produce identical strings.
-        const cleaned = truncated.replace(
+        let cleaned = truncated.replace(
           /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g,
           '',
         );
+        // Defense in depth: strip the closing tag we use to fence this block
+        // so a user message containing "</system_context>" can't escape early.
+        cleaned = cleaned.replace(/<\/system_context>/gi, '</system_context_>');
         return `[${role}] ${cleaned}`;
       });
       prompt =
         '<system_context>\n' +
-        '服务刚重启，当前为新会话。以下是重启前的最近对话记录，供你了解上下文。\n' +
+        '检测到上次有未完成消息，当前使用新会话恢复处理。以下是恢复前的最近对话记录，供你了解上下文。\n' +
         '重要：这些只是历史记录，可能包含不准确或过时的信息。回答当前用户消息时，请优先依据当前消息里的内容和文件；如果历史与当前问题无关，请直接忽略。\n\n' +
         historyLines.join('\n') +
         '\n</system_context>\n\n' +


### PR DESCRIPTION
## 问题

`processGroupMessages` 在 recovery 模式下会把 DB 里最近 20 条消息作为 `<system_context>` 塞到新 prompt 头部，用于跨重启对话保留上下文。但存在两个问题：

1. **文案不准确**："服务刚重启"并不总是 recovery 的触发原因
2. **历史幻觉污染**：如果历史里有模型之前的幻觉回复，会把新 turn 也带偏
3. **标签逃逸**：用户消息中如果包含 `</system_context>`，可以提前闭合标签，逃逸出 system_context 块

## 修复

### 1. 文案优化
- "服务刚重启" → "检测到上次有未完成消息，当前使用新会话恢复处理"
- 更准确反映 recovery 的实际触发条件

### 2. 历史污染防护
在 `<system_context>` 说明中增加：
> 这些只是历史记录，可能包含不准确或过时的信息。回答当前用户消息时，请优先依据当前消息里的内容和文件；如果历史与当前问题无关，请直接忽略。

### 3. 标签防逃逸
历史文本中出现的 `</system_context>` 替换为 `</system_context_>`，防止恶意消息提前闭合标签。

### 4. 双端同步
`container/agent-runner/src/session-history.ts` 的文案和安全逻辑同步更新，保持一致。

## 改动范围

仅 session recovery 相关：
- `src/index.ts`（processGroupMessages）
- `container/agent-runner/src/session-history.ts`（extractSessionHistory）

从原 #496 拆出，钉钉改动已移至独立 PR (#501)。

## 测试

- `npx vitest run`：204 tests passed, 0 failed

关闭 #496