### PR TITLE
修复: 容器内 feishu-cli OAuth 状态持久化（per-user 挂载） (#477)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ StreamEvent 类型以 `shared/stream-event.ts` 为单一真相源，构建时通
 | IPC 通道 `data/ipc/{folder}/` | `/workspace/ipc` | 读写 | 读写（仅自己） |
 | 项目级 Skills `container/skills/` | `/workspace/project-skills` | 只读 | 只读 |
 | 用户级 Skills `~/.claude/skills/` | `/workspace/user-skills` | 只读 | admin 创建的会话可读 |
+| feishu-cli OAuth 状态 `data/config/user-cli/{userId}/feishu-cli/` | `/home/node/.feishu-cli` | 读写 | 读写（仅自己） |
 | 环境变量 `data/env/{folder}/env` | `/workspace/env-dir/env` | 只读 | 只读 |
 | 持久 extra 目录 `data/extra/{folder}/` | `/workspace/extra` | 读写 | 读写（仅自己） |
 | 额外挂载（白名单内） | `/workspace/extra/{name}` | 按白名单 | 按白名单（`nonMainReadOnly` 时强制只读） |
@@ -366,6 +367,7 @@ data/
   config/user-im/{userId}/telegram.json    # 用户级 Telegram IM 配置（AES-256-GCM 加密）
   config/user-im/{userId}/qq.json          # 用户级 QQ IM 配置（AES-256-GCM 加密）
   config/user-im/{userId}/dingtalk.json   # 用户级钉钉 IM 配置（AES-256-GCM 加密）
+  config/user-cli/{userId}/feishu-cli/     # 用户级 feishu-cli OAuth 状态（token.json + config.yaml，bind-mount 到容器 /home/node/.feishu-cli）
   config/registration.json                 # 注册设置（开关、邀请码要求）
   config/session-secret.key                # 会话签名密钥（0600 权限）
   config/system-settings.json              # 系统运行参数（容器超时、并发限制等）

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -11,6 +11,7 @@ umask 0000
 # rootless podman where uid remapping causes EACCES on bind mounts.
 # Running as root here so chown works regardless of host uid.
 chown -R node:node /home/node/.claude 2>/dev/null || true
+chown -R node:node /home/node/.feishu-cli 2>/dev/null || true
 chown -R node:node /workspace/group /workspace/global /workspace/memory /workspace/ipc 2>/dev/null || true
 
 # Mark mounted directories as safe for git (CVE-2022-24765 ownership check).

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -507,6 +507,25 @@ function buildVolumeMounts(
     });
   }
 
+  // Per-user feishu-cli OAuth state (token.json + config.yaml).
+  // Without this mount, every container restart loses the user's feishu OAuth
+  // authorization, forcing re-auth every IDLE_TIMEOUT (#477).
+  if (ownerId) {
+    const userFeishuCliDir = path.join(
+      DATA_DIR,
+      'config',
+      'user-cli',
+      ownerId,
+      'feishu-cli',
+    );
+    mkdirForContainer(userFeishuCliDir);
+    mounts.push({
+      hostPath: userFeishuCliDir,
+      containerPath: '/home/node/.feishu-cli',
+      readonly: false,
+    });
+  }
+
   // Per-group IPC namespace: each group gets its own IPC directory
   // Sub-agents get their own IPC subdirectory under agents/{agentId}/
   // Isolated tasks get their own IPC subdirectory under tasks-run/{taskRunId}/


### PR DESCRIPTION
## 问题描述

关闭 #477。本 PR 是 #478 的**拆分版本**——按 maintainer 在 [#478 review](https://github.com/riba2534/happyclaw/pull/478#issuecomment-3013015232) 中的要求，仅保留 OAuth 持久化相关的最小改动，资源限制 / NODE_OPTIONS / AGENT_BROWSER_ARGS 等议题各自单独讨论。

容器模式下 feishu-cli 的 OAuth token 写在 \`~/.feishu-cli/token.json\`，但 \`container-runner.ts\` 没把宿主机目录挂载到该路径，导致每次容器回收后授权状态丢失，agent 反复 fallback 到 docx 文件下发。海外用户反馈"环境每次都会重置"。

## 修复方案

按 HappyClaw 已有的 per-user 配置模式（\`data/config/user-im/{userId}/\`）扩展，新增持久化目录 \`data/config/user-cli/{userId}/feishu-cli/\`，挂到容器 \`/home/node/.feishu-cli\`。

### \`src/container-runner.ts\`（+19 行）

在 \`buildVolumeMounts()\` Skills 挂载之后新增 feishu-cli 配置卷：
- 仅在 \`ownerId\` 已知时挂载（per-user 隔离）
- 路径用 \`mkdirForContainer\` 幂等创建
- 路径与现有 \`data/config/user-im/{userId}/\` 同级，命名一致

### \`container/entrypoint.sh\`（+1 行）

新增 \`chown -R node:node /home/node/.feishu-cli\`，让容器 node 用户（uid 1000）可写。与既有 \`/home/node/.claude\` 的 chown 模式一致。

### \`CLAUDE.md\`（+2 行）

- §3.4 容器挂载策略表新增 feishu-cli 行
- §6 目录约定章节新增 \`config/user-cli/{userId}/feishu-cli/\` 条目

## 边界与风险

- **Per-user 隔离**：每个用户独立目录，OAuth token 不会跨用户泄露 ✅
- **不影响 admin host 模式**：host 模式不走容器，feishu-cli 本来就持久 ✅
- **新挂载点**：\`data/config/user-cli/\` 是新顶层目录，启动时自动创建（与 \`config/user-im/\` 同级处理） ✅
- **现有用户**：第一次重启容器后会丢一次 OAuth（旧 token 在镜像内层），重新 \`oauth login\` 即写入持久目录 ⚠️

## Test plan

- [x] \`bash -n container/entrypoint.sh\` 语法校验通过
- [x] \`make typecheck\` 通过（后端 + 前端 + agent-runner）
- [x] \`make test\` 通过（15 测试文件 / 225 测试）
- [ ] 端到端验证（待 maintainer 镜像重建）：
  - [ ] member 用户在容器内跑 \`feishu-cli oauth login\` → 完成授权
  - [ ] 容器空闲超时被回收
  - [ ] 新容器启动 → \`feishu-cli auth status\` 仍显示已登录
  - [ ] \`ls data/config/user-cli/{userId}/feishu-cli/\` 看到 \`token.json\`
  - [ ] 用户 A 装的 token 不出现在用户 B 的目录里

## 与 #478 的差异

| 项目 | #478（已关闭） | 本 PR |
|------|---------------|-------|
| feishu-cli OAuth mount | ✅ | ✅ |
| entrypoint.sh chown | ✅ | ✅ |
| CLAUDE.md §3.4 | ✅ | ✅ |
| CLAUDE.md §6 | ❌ | ✅（按要求补充）|
| \`--init\` / \`--memory\` / \`--cpus\` / \`--shm-size\` | ❌ 夹带 | 移除（另开 Issue）|
| \`NODE_OPTIONS\` 注入 | ❌ 夹带（绕过 DANGEROUS_ENV_VARS）| 移除（另开 Issue 讨论安全边界）|
| \`AGENT_BROWSER_ARGS\` | ❌ 夹带 | 移除（另开 PR）|
| 总改动行数 | 多个文件 / 数百行 | **3 文件 / +22 行** |