### PR TITLE
修复: 思考过程结束后默认折叠并展示思考时长 (#493)

### DIFF
--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -10,6 +10,7 @@ import { MessageContextMenu } from './MessageContextMenu';
 import { ImageLightbox } from './ImageLightbox';
 import { mediumTap } from '../../hooks/useHaptic';
 import { useDisplayMode } from '../../hooks/useDisplayMode';
+import { formatThinkingDuration } from '../../utils/thinking-duration';
 
 const ShareImageDialog = lazy(() => import('./ShareImageDialog').then(m => ({ default: m.ShareImageDialog })));
 
@@ -17,6 +18,7 @@ interface MessageBubbleProps {
   message: Message;
   showTime: boolean;
   thinkingContent?: string;
+  thinkingDurationMs?: number;
   isShared?: boolean;
 }
 
@@ -28,8 +30,9 @@ interface MessageAttachment {
 }
 
 /** Collapsible reasoning block for AI messages */
-function ReasoningBlock({ content }: { content: string }) {
+function ReasoningBlock({ content, durationMs }: { content: string; durationMs?: number }) {
   const [expanded, setExpanded] = useState(false);
+  const label = durationMs != null && durationMs > 0 ? formatThinkingDuration(durationMs) : 'Reasoning';
 
   return (
     <div className="mb-3 rounded-xl border border-amber-200/60 dark:border-amber-700/40 bg-amber-50/40 dark:bg-amber-950/30 overflow-hidden">
@@ -40,7 +43,7 @@ function ReasoningBlock({ content }: { content: string }) {
         <svg className="w-4 h-4 text-amber-500 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
         </svg>
-        <span className="text-xs font-medium text-amber-700 dark:text-amber-300">Reasoning</span>
+        <span className="text-xs font-medium text-amber-700 dark:text-amber-300">{label}</span>
         <span className="flex-1" />
         {expanded ? (
           <ChevronUp className="w-3.5 h-3.5 text-amber-400" />
@@ -133,7 +136,7 @@ function TokenUsageDisplay({ tokenUsageJson }: { tokenUsageJson: string }) {
   );
 }
 
-export const MessageBubble = memo(function MessageBubble({ message, showTime, thinkingContent, isShared }: MessageBubbleProps) {
+export const MessageBubble = memo(function MessageBubble({ message, showTime, thinkingContent, thinkingDurationMs, isShared }: MessageBubbleProps) {
   const [copied, setCopied] = useState(false);
   const [lightboxState, setLightboxState] = useState<{ images: string[]; index: number } | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
@@ -318,7 +321,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
         </div>
 
         {/* Reasoning */}
-        {thinkingContent && <ReasoningBlock content={thinkingContent} />}
+        {thinkingContent && <ReasoningBlock content={thinkingContent} durationMs={thinkingDurationMs} />}
 
         {/* Images */}
         {images.length > 0 && (
@@ -552,7 +555,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
           {/* Claude-style: no card container, direct content */}
           <div className="overflow-hidden font-serif">
             {/* Reasoning block — muted left border style */}
-            {thinkingContent && <ReasoningBlock content={thinkingContent} />}
+            {thinkingContent && <ReasoningBlock content={thinkingContent} durationMs={thinkingDurationMs} />}
 
             {/* Image attachments */}
             {images.length > 0 && (
@@ -645,5 +648,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showTime, th
   prev.message.token_usage === next.message.token_usage &&
   prev.showTime === next.showTime &&
   prev.thinkingContent === next.thinkingContent &&
+  prev.thinkingDurationMs === next.thinkingDurationMs &&
   prev.isShared === next.isShared
 );

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -44,6 +44,7 @@ const quickPrompts = [
 export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrigger, groupJid, isWaiting, onInterrupt, agentId, onSend }: MessageListProps) {
   const { mode: displayMode } = useDisplayMode();
   const thinkingCache = useChatStore(s => s.thinkingCache ?? {});
+  const thinkingDurationCache = useChatStore(s => s.thinkingDurationCache ?? {});
   const isShared = useChatStore(s => !!s.groups[groupJid ?? '']?.is_shared);
   // Spawn agents: selector returns stable reference (the agents array itself),
   // then useMemo filters for spawn kind. Direct .filter() in selector causes
@@ -498,7 +499,7 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
                 ref={virtualizer.measureElement}
                 data-index={virtualItem.index}
               >
-                <MessageBubble message={message} showTime={showTime} thinkingContent={thinkingCache[message.id]} isShared={isShared} />
+                <MessageBubble message={message} showTime={showTime} thinkingContent={thinkingCache[message.id]} thinkingDurationMs={thinkingDurationCache[message.id]} isShared={isShared} />
               </div>
             );
           })}

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -629,6 +629,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
                 thinkingExpanded={thinkingExpanded}
                 setThinkingExpanded={(v) => {
                   setThinkingExpanded(v);
+                  userToggledThinkingRef.current = true;
                   if (v) userScrolledRef.current = false;
                 }}
                 thinkingRef={thinkingRef}

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -8,6 +8,7 @@ import { MarkdownRenderer } from './MarkdownRenderer';
 import { TodoProgressPanel } from './TodoProgressPanel';
 import { ToolActivityCard } from './ToolActivityCard';
 import { useDisplayMode } from '../../hooks/useDisplayMode';
+import { formatThinkingDuration } from '../../utils/thinking-duration';
 
 /** Render AskUserQuestion options as a visual card (read-only). */
 function AskUserQuestionCard({ toolInput }: { toolInput: Record<string, unknown> }) {
@@ -221,7 +222,11 @@ function StreamingContent({
               <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
             </svg>
             <span className="text-xs font-medium text-amber-700 dark:text-amber-300">
-              {streaming.isThinking ? 'Reasoning...' : 'Reasoning'}
+              {streaming.isThinking
+                ? 'Reasoning...'
+                : (streaming.thinkingDurationMs != null && streaming.thinkingDurationMs > 0
+                    ? formatThinkingDuration(streaming.thinkingDurationMs)
+                    : 'Reasoning')}
             </span>
             {streaming.isThinking && (
               <span className="flex gap-0.5 ml-0.5">
@@ -354,6 +359,8 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
   const [thinkingExpanded, setThinkingExpanded] = useState(true);
   const thinkingRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
+  const prevIsThinkingRef = useRef(false);
+  const userToggledThinkingRef = useRef(false);
   const [localElapsed, setLocalElapsed] = useState<Record<string, number>>({});
 
   // Auto-clear stale waiting state to prevent UI getting stuck when agent
@@ -413,14 +420,37 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
   useEffect(() => {
     setThinkingExpanded(true);
     userScrolledRef.current = false;
+    userToggledThinkingRef.current = false;
+    prevIsThinkingRef.current = false;
   }, [groupJid]);
 
   useEffect(() => {
     if (!streaming) {
       setThinkingExpanded(true);
       userScrolledRef.current = false;
+      userToggledThinkingRef.current = false;
+      prevIsThinkingRef.current = false;
     }
   }, [streaming]);
+
+  // Auto-collapse the reasoning block on isThinking: true → false transition
+  // so the streaming card height matches the post-streaming MessageBubble's
+  // collapsed ReasoningBlock — eliminates the layout jump described in #493.
+  // We respect an explicit user toggle: if the user manually expanded/collapsed
+  // during this turn we don't override.
+  useEffect(() => {
+    const isThinking = streaming?.isThinking ?? false;
+    const hasThinking = !!streaming?.thinkingText;
+    if (
+      prevIsThinkingRef.current &&
+      !isThinking &&
+      hasThinking &&
+      !userToggledThinkingRef.current
+    ) {
+      setThinkingExpanded(false);
+    }
+    prevIsThinkingRef.current = isThinking;
+  }, [streaming?.isThinking, streaming?.thinkingText]);
 
   // Local elapsed time for tools
   useEffect(() => {
@@ -539,6 +569,7 @@ export function StreamingDisplay({ groupJid, isWaiting, senderName: senderNamePr
               thinkingExpanded={thinkingExpanded}
               setThinkingExpanded={(v) => {
                 setThinkingExpanded(v);
+                userToggledThinkingRef.current = true;
                 if (v) userScrolledRef.current = false;
               }}
               thinkingRef={thinkingRef}

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -152,9 +152,14 @@ function retainThinkingCacheForMessages<V>(
   return capThinkingCache(next);
 }
 
-/** Record the moment thinking starts; idempotent within a thinking burst. */
+/** Record the moment thinking starts; resets on transition non-thinking → thinking. */
 function markThinkingStarted(prev: StreamingState, next: StreamingState): void {
-  if (prev.thinkingStartedAt == null) next.thinkingStartedAt = Date.now();
+  if (!prev.isThinking) {
+    next.thinkingStartedAt = Date.now();
+    next.thinkingDurationMs = undefined;
+  } else if (prev.thinkingStartedAt == null) {
+    next.thinkingStartedAt = Date.now();
+  }
 }
 
 /** Record the elapsed thinking duration on the transition isThinking:true → false. */

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -64,6 +64,10 @@ export interface StreamingState {
   partialText: string;
   thinkingText: string;
   isThinking: boolean;
+  /** Wall-clock ms of the first thinking_delta in the current thinking burst. */
+  thinkingStartedAt?: number;
+  /** Captured at the transition isThinking: true → false. Used to render "已思考 Xs". */
+  thinkingDurationMs?: number;
   activeTools: Array<{
     toolName: string;
     toolUseId: string;
@@ -123,29 +127,41 @@ function mergeMessagesChronologically(
 const MAX_THINKING_CACHE_SIZE = 500;
 
 /** Evict oldest entries when cache exceeds capacity (relies on insertion order) */
-function capThinkingCache(cache: Record<string, string>): Record<string, string> {
+function capThinkingCache<V>(cache: Record<string, V>): Record<string, V> {
   const keys = Object.keys(cache);
   if (keys.length <= MAX_THINKING_CACHE_SIZE) return cache;
   const keep = keys.slice(keys.length - MAX_THINKING_CACHE_SIZE);
-  const next: Record<string, string> = {};
+  const next: Record<string, V> = {};
   for (const k of keep) next[k] = cache[k];
   return next;
 }
 
-function retainThinkingCacheForMessages(
+function retainThinkingCacheForMessages<V>(
   messagesByGroup: Record<string, Message[]>,
-  cache: Record<string, string>,
-): Record<string, string> {
+  cache: Record<string, V>,
+): Record<string, V> {
   const aliveMessageIds = new Set<string>();
   for (const messages of Object.values(messagesByGroup)) {
     for (const m of messages) aliveMessageIds.add(m.id);
   }
 
-  const next: Record<string, string> = {};
+  const next: Record<string, V> = {};
   for (const [messageId, content] of Object.entries(cache)) {
     if (aliveMessageIds.has(messageId)) next[messageId] = content;
   }
   return capThinkingCache(next);
+}
+
+/** Record the moment thinking starts; idempotent within a thinking burst. */
+function markThinkingStarted(prev: StreamingState, next: StreamingState): void {
+  if (prev.thinkingStartedAt == null) next.thinkingStartedAt = Date.now();
+}
+
+/** Record the elapsed thinking duration on the transition isThinking:true → false. */
+function markThinkingEnded(prev: StreamingState, next: StreamingState): void {
+  if (prev.isThinking && prev.thinkingStartedAt != null && next.thinkingDurationMs == null) {
+    next.thinkingDurationMs = Date.now() - prev.thinkingStartedAt;
+  }
 }
 
 interface ChatState {
@@ -158,7 +174,10 @@ interface ChatState {
   error: string | null;
   streaming: Record<string, StreamingState>;
   thinkingCache: Record<string, string>;
+  /** Per-message-id duration in ms; rendered as "已思考 Xs" inside ReasoningBlock. */
+  thinkingDurationCache: Record<string, number>;
   pendingThinking: Record<string, string>;
+  pendingThinkingDuration: Record<string, number>;
   /** Per-group lock: true while clearHistory is in-flight, prevents race re-injection */
   clearing: Record<string, boolean>;
   // Sub-agent state
@@ -266,6 +285,12 @@ function freezeStreamingState(state: StreamingState | undefined): StreamingState
     state.recentEvents.length > 0 ||
     (state.todos && state.todos.length > 0);
   if (!hasData) return null;
+  // Preserve any in-flight thinking duration so the interrupted card still shows "已思考 Xs".
+  const thinkingDurationMs = state.thinkingDurationMs ?? (
+    state.isThinking && state.thinkingStartedAt != null
+      ? Date.now() - state.thinkingStartedAt
+      : undefined
+  );
   return {
     ...state,
     isThinking: false,
@@ -273,6 +298,7 @@ function freezeStreamingState(state: StreamingState | undefined): StreamingState
     activeHook: null,
     systemStatus: null,
     interrupted: true,
+    thinkingDurationMs,
   };
 }
 
@@ -406,11 +432,13 @@ function flushPendingDelta(
         const combined = prev.partialText + mergedText;
         next.partialText = combined.length > MAX_STREAMING_TEXT ? combined.slice(-MAX_STREAMING_TEXT) : combined;
         next.isThinking = false;
+        markThinkingEnded(prev, next);
       }
       if (mergedThinking) {
         const combined = prev.thinkingText + mergedThinking;
         next.thinkingText = combined.length > MAX_STREAMING_TEXT ? combined.slice(-MAX_STREAMING_TEXT) : combined;
         next.isThinking = true;
+        markThinkingStarted(prev, next);
       }
       return { agentStreaming: { ...s.agentStreaming, [agentId]: next } };
     });
@@ -424,11 +452,13 @@ function flushPendingDelta(
         const combined = prev.partialText + mergedText;
         next.partialText = combined.length > MAX_STREAMING_TEXT ? combined.slice(-MAX_STREAMING_TEXT) : combined;
         next.isThinking = false;
+        markThinkingEnded(prev, next);
       }
       if (mergedThinking) {
         const combined = prev.thinkingText + mergedThinking;
         next.thinkingText = combined.length > MAX_STREAMING_TEXT ? combined.slice(-MAX_STREAMING_TEXT) : combined;
         next.isThinking = true;
+        markThinkingStarted(prev, next);
       }
       saveStreamingToSession(chatJid, next);
       return {
@@ -636,16 +666,19 @@ function applyStreamEvent(
       const combined = prev.partialText + (event.text || '');
       next.partialText = combined.length > maxText ? combined.slice(-maxText) : combined;
       next.isThinking = false;
+      markThinkingEnded(prev, next);
       break;
     }
     case 'thinking_delta': {
       const combined = prev.thinkingText + (event.text || '');
       next.thinkingText = combined.length > maxText ? combined.slice(-maxText) : combined;
       next.isThinking = true;
+      markThinkingStarted(prev, next);
       break;
     }
     case 'tool_use_start': {
       next.isThinking = false;
+      markThinkingEnded(prev, next);
       const toolUseId = event.toolUseId || '';
       const existing = prev.activeTools.find(t => t.toolUseId === toolUseId && toolUseId);
       const tool = {
@@ -772,7 +805,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   error: null,
   streaming: {},
   thinkingCache: {},
+  thinkingDurationCache: {},
   pendingThinking: {},
+  pendingThinkingDuration: {},
   clearing: {},
   agents: {},
   agentStreaming: {},
@@ -911,7 +946,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
           // Transfer pending thinking to thinkingCache
           let nextThinkingCache = s.thinkingCache;
+          let nextThinkingDurationCache = s.thinkingDurationCache;
           let nextPendingThinking = s.pendingThinking;
+          let nextPendingThinkingDuration = s.pendingThinkingDuration;
           if (agentReplied && s.pendingThinking[jid]) {
             const lastAiMsg = [...data.messages]
               .reverse()
@@ -923,8 +960,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
               );
             if (lastAiMsg) {
               nextThinkingCache = capThinkingCache({ ...s.thinkingCache, [lastAiMsg.id]: s.pendingThinking[jid] });
+              const pendingDur = s.pendingThinkingDuration[jid];
+              if (pendingDur != null) {
+                nextThinkingDurationCache = capThinkingCache({ ...s.thinkingDurationCache, [lastAiMsg.id]: pendingDur });
+              }
               const { [jid]: _, ...restPending } = s.pendingThinking;
               nextPendingThinking = restPending;
+              const { [jid]: __, ...restPendingDur } = s.pendingThinkingDuration;
+              nextPendingThinkingDuration = restPendingDur;
             }
           }
 
@@ -937,7 +980,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
               ? (() => { const next = { ...s.streaming }; delete next[jid]; return next; })()
               : s.streaming,
             thinkingCache: nextThinkingCache,
+            thinkingDurationCache: nextThinkingDurationCache,
             pendingThinking: nextPendingThinking,
+            pendingThinkingDuration: nextPendingThinkingDuration,
             error: null,
           };
         });
@@ -1183,6 +1228,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
             nextMessages,
             s.thinkingCache,
           ),
+          thinkingDurationCache: retainThinkingCacheForMessages(
+            nextMessages,
+            s.thinkingDurationCache,
+          ),
           agents: nextAgents,
           agentMessages: nextAgentMessages,
           agentStreaming: nextAgentStreaming,
@@ -1338,6 +1387,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
           thinkingCache: retainThinkingCacheForMessages(
             nextMessages,
             s.thinkingCache,
+          ),
+          thinkingDurationCache: retainThinkingCacheForMessages(
+            nextMessages,
+            s.thinkingDurationCache,
           ),
           currentGroup: nextCurrent,
           error: null,
@@ -1778,10 +1831,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
         const thinkingText = isAgentReply
           ? (streamState?.thinkingText || s.pendingThinking[chatJid])
           : undefined;
+        const thinkingDuration = isAgentReply
+          ? (streamState?.thinkingDurationMs ?? s.pendingThinkingDuration[chatJid])
+          : undefined;
         const nextStreaming = { ...s.streaming };
         delete nextStreaming[chatJid];
         const nextPending = { ...s.pendingThinking };
         delete nextPending[chatJid];
+        const nextPendingDur = { ...s.pendingThinkingDuration };
+        delete nextPendingDur[chatJid];
 
         // 未读计数：页面隐藏或不在当前对话时增加
         const isHidden = typeof document !== 'undefined' && document.hidden;
@@ -1795,8 +1853,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
           waiting: { ...s.waiting, [chatJid]: false },
           streaming: nextStreaming,
           pendingThinking: nextPending,
+          pendingThinkingDuration: nextPendingDur,
           unreadReplies: nextUnread,
           ...(thinkingText ? { thinkingCache: capThinkingCache({ ...s.thinkingCache, [msg.id]: thinkingText }) } : {}),
+          ...(thinkingDuration != null ? { thinkingDurationCache: capThinkingCache({ ...s.thinkingDurationCache, [msg.id]: thinkingDuration }) } : {}),
         };
       }
 
@@ -2446,13 +2506,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set((s) => {
       const next = { ...s.streaming };
       const thinkingText = next[chatJid]?.thinkingText;
+      const thinkingDur = next[chatJid]?.thinkingDurationMs;
       const preserveThinking = options?.preserveThinking !== false;
       const nextPendingThinking = { ...s.pendingThinking };
+      const nextPendingThinkingDuration = { ...s.pendingThinkingDuration };
       delete next[chatJid];
       if (preserveThinking && thinkingText) {
         nextPendingThinking[chatJid] = thinkingText;
+        if (thinkingDur != null) nextPendingThinkingDuration[chatJid] = thinkingDur;
+        else delete nextPendingThinkingDuration[chatJid];
       } else {
         delete nextPendingThinking[chatJid];
+        delete nextPendingThinkingDuration[chatJid];
       }
 
       // 收集该 chatJid 下仍在运行的 SDK Task
@@ -2484,6 +2549,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         waiting: { ...s.waiting, [chatJid]: false },
         streaming: next,
         pendingThinking: nextPendingThinking,
+        pendingThinkingDuration: nextPendingThinkingDuration,
         ...(agentStreamingChanged ? { agentStreaming: nextAgentStreaming } : {}),
       };
     });

--- a/web/src/utils/thinking-duration.ts
+++ b/web/src/utils/thinking-duration.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a thinking duration in milliseconds as a short human-readable label
+ * for the Reasoning header (e.g. "已思考 3.2 秒" or "已思考 1 分 12 秒").
+ */
+export function formatThinkingDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '已思考 0 秒';
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 10) {
+    const rounded = Math.round(totalSeconds * 10) / 10;
+    return `已思考 ${rounded} 秒`;
+  }
+  if (totalSeconds < 60) {
+    return `已思考 ${Math.round(totalSeconds)} 秒`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.round(totalSeconds - minutes * 60);
+  if (seconds === 0) return `已思考 ${minutes} 分`;
+  return `已思考 ${minutes} 分 ${seconds} 秒`;
+}


### PR DESCRIPTION
## 问题描述
关闭 #493。

Web 端 Agent 流式输出的「思考过程」区域在思考阶段结束后整块从 UI 中消失，最终回复抵达时下方内容向上跳动，并且用户失去回看 Agent 推理过程的入口。

## 修复方案
对齐主流 LLM 产品（ChatGPT / Claude）的折叠模式：

- 思考阶段进行中：保持当前行为（默认展开，实时流式）
- 思考阶段结束：Reasoning 块自动折叠为「已思考 X 秒」摘要条
- 折叠后用户仍可点击展开查看完整思考内容
- StreamingDisplay 和 MessageBubble 的 Reasoning 折叠态视觉对齐 → 流式收尾切换到最终回复时高度不变 → 不再跳动
- 用户在本轮已手动切换过状态时尊重用户选择，不再自动折叠

### `web/src/stores/chat.ts`
- `StreamingState` 增加 `thinkingStartedAt` / `thinkingDurationMs`
- 在 `thinking_delta` 首次到达时记录起始时间；在 `text_delta` / `tool_use_start` / rAF 批处理触发 `isThinking: true → false` 转换时计算并写入 `thinkingDurationMs`
- 新增 `thinkingDurationCache` 与 `pendingThinkingDuration`，与已有 `thinkingCache` / `pendingThinking` 对称跟踪 per-message 思考时长
- `clearStreaming`、`handleWsNewMessage`、消息轮询和 `clearHistory` / `deleteFlow` 路径都同步流转 duration
- `freezeStreamingState` 在中断冻结时保留思考时长

### `web/src/utils/thinking-duration.ts`
- 新增 `formatThinkingDuration` 工具函数（< 10s 显示一位小数，< 60s 整秒，更长走「X 分 Y 秒」），供 StreamingDisplay 和 MessageBubble 复用

### `web/src/components/chat/StreamingDisplay.tsx`
- 监听 `isThinking` 状态：true → false 转换时自动折叠 Reasoning 块（用户手动切换过就不再自动折叠）
- Reasoning 标题在思考结束后展示「已思考 X 秒」

### `web/src/components/chat/MessageBubble.tsx`
- `ReasoningBlock` 接受 `durationMs`，标题展示「已思考 X 秒」
- `MessageBubbleProps` 增加 `thinkingDurationMs`，并加入 memo 比较

### `web/src/components/chat/MessageList.tsx`
- 从 store 读取 `thinkingDurationCache` 并透传给每条 MessageBubble

## 测试

- `make typecheck` 通过
- `make test` 通过（225 / 225）
- `make build` 通过