### PR TITLE
新增: PWA 重启路由恢复（默认关闭，设置中启用） (#494)

### DIFF
--- a/tests/route-restore.test.ts
+++ b/tests/route-restore.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  clear() { this.store.clear(); }
+  getItem(key: string) { return this.store.has(key) ? this.store.get(key)! : null; }
+  setItem(key: string, value: string) { this.store.set(key, String(value)); }
+  removeItem(key: string) { this.store.delete(key); }
+  key(index: number) { return Array.from(this.store.keys())[index] ?? null; }
+}
+
+const memoryStorage = new MemoryStorage();
+vi.stubGlobal('localStorage', memoryStorage);
+
+const {
+  isRouteRestoreEnabled,
+  setRouteRestoreEnabled,
+  saveLastRoute,
+  getLastRoute,
+} = await import('../web/src/utils/routeRestore');
+
+describe('routeRestore', () => {
+  beforeEach(() => {
+    memoryStorage.clear();
+  });
+
+  describe('toggle', () => {
+    it('defaults to disabled', () => {
+      expect(isRouteRestoreEnabled()).toBe(false);
+    });
+
+    it('persists the enable flag', () => {
+      setRouteRestoreEnabled(true);
+      expect(isRouteRestoreEnabled()).toBe(true);
+    });
+
+    it('clears saved route when disabling', () => {
+      setRouteRestoreEnabled(true);
+      saveLastRoute('/chat/main');
+      expect(getLastRoute()).toBe('/chat/main');
+
+      setRouteRestoreEnabled(false);
+      expect(isRouteRestoreEnabled()).toBe(false);
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+
+  describe('saveLastRoute / getLastRoute', () => {
+    it('round-trips a valid route', () => {
+      saveLastRoute('/chat/main');
+      expect(getLastRoute()).toBe('/chat/main');
+    });
+
+    it('preserves search params', () => {
+      saveLastRoute('/settings?tab=groups');
+      expect(getLastRoute()).toBe('/settings?tab=groups');
+    });
+
+    it('skips blacklisted login route', () => {
+      saveLastRoute('/login');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('skips blacklisted register route', () => {
+      saveLastRoute('/register');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('skips blacklisted setup root', () => {
+      saveLastRoute('/setup');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('skips blacklisted setup subroutes', () => {
+      saveLastRoute('/setup/providers');
+      expect(getLastRoute()).toBeNull();
+
+      saveLastRoute('/setup/channels');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('rejects empty path', () => {
+      saveLastRoute('');
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+
+  describe('expiry', () => {
+    it('returns null and clears when expired', () => {
+      saveLastRoute('/chat/main');
+      // Backdate the timestamp by 8 days (exceeds 7-day expiry).
+      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(eightDaysAgo));
+
+      expect(getLastRoute()).toBeNull();
+      // Subsequent reads should also be null (storage cleared).
+      expect(memoryStorage.getItem('happyclaw-pwa-last-route')).toBeNull();
+    });
+
+    it('returns route when within expiry window', () => {
+      saveLastRoute('/chat/main');
+      const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
+      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(sixDaysAgo));
+
+      expect(getLastRoute()).toBe('/chat/main');
+    });
+
+    it('returns null on missing or invalid timestamp', () => {
+      memoryStorage.setItem('happyclaw-pwa-last-route', '/chat/main');
+      // No timestamp set.
+      expect(getLastRoute()).toBeNull();
+
+      memoryStorage.setItem('happyclaw-pwa-last-route-ts', 'not-a-number');
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when no route was saved', () => {
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+});

--- a/tests/route-restore.test.ts
+++ b/tests/route-restore.test.ts
@@ -86,38 +86,14 @@ describe('routeRestore', () => {
     });
   });
 
-  describe('expiry', () => {
-    it('returns null and clears when expired', () => {
-      saveLastRoute('/chat/main');
-      // Backdate the timestamp by 8 days (exceeds 7-day expiry).
-      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
-      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(eightDaysAgo));
-
-      expect(getLastRoute()).toBeNull();
-      // Subsequent reads should also be null (storage cleared).
-      expect(memoryStorage.getItem('happyclaw-pwa-last-route')).toBeNull();
-    });
-
-    it('returns route when within expiry window', () => {
-      saveLastRoute('/chat/main');
-      const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
-      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(sixDaysAgo));
-
-      expect(getLastRoute()).toBe('/chat/main');
-    });
-
-    it('returns null on missing or invalid timestamp', () => {
-      memoryStorage.setItem('happyclaw-pwa-last-route', '/chat/main');
-      // No timestamp set.
-      expect(getLastRoute()).toBeNull();
-
-      memoryStorage.setItem('happyclaw-pwa-last-route-ts', 'not-a-number');
-      expect(getLastRoute()).toBeNull();
-    });
-  });
-
   describe('edge cases', () => {
     it('returns null when no route was saved', () => {
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('rejects a previously-saved route that became blacklisted', () => {
+      // Manually inject a blacklisted route to simulate stale storage.
+      memoryStorage.setItem('happyclaw-pwa-last-route', '/login');
       expect(getLastRoute()).toBeNull();
     });
   });

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { BottomTabBar } from './BottomTabBar';
 import { ConnectionBanner } from '../common/ConnectionBanner';
 import { wsManager } from '../../api/ws';
 import { useTheme } from '../../hooks/useTheme';
+import { useRouteRestore } from '../../hooks/useRouteRestore';
 import { useBillingStore } from '../../stores/billing';
 import { useGroupsStore } from '../../stores/groups';
 import { useChatStore } from '../../stores/chat';
@@ -15,6 +16,7 @@ export function AppLayout() {
   const isChatRoute = location.pathname.startsWith('/chat');
   const hideMobileTabBar = /^\/chat\/.+/.test(location.pathname);
   useTheme(); // 应用并同步持久化的主题偏好
+  useRouteRestore(); // PWA 重启时恢复上次访问的路由（默认关闭，设置中启用）
 
   // Sidebar: expanded only on chat route, collapsed on other routes
   const [userCollapsed, setUserCollapsed] = useState(false);

--- a/web/src/components/settings/ProfileSection.tsx
+++ b/web/src/components/settings/ProfileSection.tsx
@@ -119,7 +119,7 @@ function PwaRouteRestoreSection() {
     <Section
       icon={RotateCcw}
       title="重启时恢复上次页面"
-      desc="安装为 PWA 后，从后台被系统回收再次打开时回到上次访问的页面，而非默认主页（保留 7 天）"
+      desc="安装为 PWA 后，从后台被系统回收再次打开时回到上次访问的页面，而非默认主页"
     >
       <div className="flex items-center justify-between">
         <Label className="text-sm text-foreground">启用恢复</Label>

--- a/web/src/components/settings/ProfileSection.tsx
+++ b/web/src/components/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Loader2, Upload, Trash2, User, Bot, Lock, Palette, Sun, Moon, Monitor, Bell, BellOff, CheckCircle2 } from 'lucide-react';
+import { Loader2, Upload, Trash2, User, Bot, Lock, Palette, Sun, Moon, Monitor, Bell, BellOff, CheckCircle2, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useAuthStore } from '../../stores/auth';
@@ -7,9 +7,11 @@ import { useTheme, type Theme, type ColorScheme, type FontStyle } from '../../ho
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { EmojiAvatar } from '@/components/common/EmojiAvatar';
 import { EmojiPicker } from '@/components/common/EmojiPicker';
 import { ColorPicker } from '@/components/common/ColorPicker';
+import { isRouteRestoreEnabled, setRouteRestoreEnabled } from '../../utils/routeRestore';
 import { getErrorMessage } from './types';
 import { SettingsCard as Section } from './SettingsCard';
 
@@ -99,6 +101,30 @@ function DesktopNotificationSection() {
           </Button>
         </div>
       )}
+    </Section>
+  );
+}
+
+/* ── PWA Route Restore Section ────────────────────────────── */
+
+function PwaRouteRestoreSection() {
+  const [enabled, setEnabled] = useState(() => isRouteRestoreEnabled());
+
+  const handleChange = (next: boolean) => {
+    setEnabled(next);
+    setRouteRestoreEnabled(next);
+  };
+
+  return (
+    <Section
+      icon={RotateCcw}
+      title="重启时恢复上次页面"
+      desc="安装为 PWA 后，从后台被系统回收再次打开时回到上次访问的页面，而非默认主页（保留 7 天）"
+    >
+      <div className="flex items-center justify-between">
+        <Label className="text-sm text-foreground">启用恢复</Label>
+        <Switch checked={enabled} onCheckedChange={handleChange} aria-label="启用 PWA 重启路由恢复" />
+      </div>
     </Section>
   );
 }
@@ -310,6 +336,9 @@ export function ProfileSection() {
 
       {/* ── 2. Desktop Notifications ── */}
       <DesktopNotificationSection />
+
+      {/* ── 2.5 PWA Route Restore ── */}
+      <PwaRouteRestoreSection />
 
       {/* ── 3. Account Info ── */}
       <Section icon={User} title="账户信息">

--- a/web/src/hooks/useRouteRestore.ts
+++ b/web/src/hooks/useRouteRestore.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { isRouteRestoreEnabled, saveLastRoute, getLastRoute } from '../utils/routeRestore';
+
+// Paths that count as "fresh app launch" — a PWA cold start lands on the
+// manifest start_url (`/chat`). When the user opens a deep link directly we
+// honor it instead of overriding with the saved route.
+const RESTORE_TRIGGER_PATHS = new Set(['/chat', '/']);
+
+export function useRouteRestore(): void {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+
+    if (!isRouteRestoreEnabled()) return;
+    if (!RESTORE_TRIGGER_PATHS.has(location.pathname)) return;
+
+    const saved = getLastRoute();
+    if (!saved) return;
+
+    const currentFull = location.pathname + location.search;
+    if (saved === currentFull) return;
+
+    navigate(saved, { replace: true });
+    // Run only on initial mount; subsequent location changes are handled below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!isRouteRestoreEnabled()) return;
+    saveLastRoute(location.pathname + location.search);
+  }, [location.pathname, location.search]);
+}

--- a/web/src/utils/routeRestore.ts
+++ b/web/src/utils/routeRestore.ts
@@ -4,9 +4,6 @@
 
 const STORAGE_KEY_ENABLED = 'happyclaw-pwa-restore-enabled';
 const STORAGE_KEY_ROUTE = 'happyclaw-pwa-last-route';
-const STORAGE_KEY_TIMESTAMP = 'happyclaw-pwa-last-route-ts';
-
-const EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 const BLACKLIST_PATTERNS: RegExp[] = [
   /^\/login(\?|$)/,
@@ -38,7 +35,6 @@ export function setRouteRestoreEnabled(enabled: boolean): void {
   } else {
     ls.removeItem(STORAGE_KEY_ENABLED);
     ls.removeItem(STORAGE_KEY_ROUTE);
-    ls.removeItem(STORAGE_KEY_TIMESTAMP);
   }
 }
 
@@ -48,7 +44,6 @@ export function saveLastRoute(path: string): void {
   if (!path || isBlacklisted(path)) return;
   try {
     ls.setItem(STORAGE_KEY_ROUTE, path);
-    ls.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
   } catch {
     /* quota exceeded — ignore */
   }
@@ -58,14 +53,7 @@ export function getLastRoute(): string | null {
   const ls = safeStorage();
   if (!ls) return null;
   const route = ls.getItem(STORAGE_KEY_ROUTE);
-  const tsRaw = ls.getItem(STORAGE_KEY_TIMESTAMP);
-  if (!route || !tsRaw) return null;
-  const ts = Number(tsRaw);
-  if (!Number.isFinite(ts) || Date.now() - ts > EXPIRY_MS) {
-    ls.removeItem(STORAGE_KEY_ROUTE);
-    ls.removeItem(STORAGE_KEY_TIMESTAMP);
-    return null;
-  }
+  if (!route) return null;
   if (isBlacklisted(route)) return null;
   return route;
 }

--- a/web/src/utils/routeRestore.ts
+++ b/web/src/utils/routeRestore.ts
@@ -1,0 +1,71 @@
+// PWA route restore: persist last visited route to localStorage so PWA reopens
+// land on the user's previous location instead of the manifest start_url.
+// Disabled by default; toggled from Settings → Profile.
+
+const STORAGE_KEY_ENABLED = 'happyclaw-pwa-restore-enabled';
+const STORAGE_KEY_ROUTE = 'happyclaw-pwa-last-route';
+const STORAGE_KEY_TIMESTAMP = 'happyclaw-pwa-last-route-ts';
+
+const EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+const BLACKLIST_PATTERNS: RegExp[] = [
+  /^\/login(\?|$)/,
+  /^\/register(\?|$)/,
+  /^\/setup($|\/|\?)/,
+];
+
+function isBlacklisted(path: string): boolean {
+  return BLACKLIST_PATTERNS.some((re) => re.test(path));
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function isRouteRestoreEnabled(): boolean {
+  return safeStorage()?.getItem(STORAGE_KEY_ENABLED) === '1';
+}
+
+export function setRouteRestoreEnabled(enabled: boolean): void {
+  const ls = safeStorage();
+  if (!ls) return;
+  if (enabled) {
+    ls.setItem(STORAGE_KEY_ENABLED, '1');
+  } else {
+    ls.removeItem(STORAGE_KEY_ENABLED);
+    ls.removeItem(STORAGE_KEY_ROUTE);
+    ls.removeItem(STORAGE_KEY_TIMESTAMP);
+  }
+}
+
+export function saveLastRoute(path: string): void {
+  const ls = safeStorage();
+  if (!ls) return;
+  if (!path || isBlacklisted(path)) return;
+  try {
+    ls.setItem(STORAGE_KEY_ROUTE, path);
+    ls.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
+  } catch {
+    /* quota exceeded — ignore */
+  }
+}
+
+export function getLastRoute(): string | null {
+  const ls = safeStorage();
+  if (!ls) return null;
+  const route = ls.getItem(STORAGE_KEY_ROUTE);
+  const tsRaw = ls.getItem(STORAGE_KEY_TIMESTAMP);
+  if (!route || !tsRaw) return null;
+  const ts = Number(tsRaw);
+  if (!Number.isFinite(ts) || Date.now() - ts > EXPIRY_MS) {
+    ls.removeItem(STORAGE_KEY_ROUTE);
+    ls.removeItem(STORAGE_KEY_TIMESTAMP);
+    return null;
+  }
+  if (isBlacklisted(route)) return null;
+  return route;
+}


### PR DESCRIPTION
## 问题描述

关闭 #494。

PWA 从后台被系统回收后重新拉起会落到 manifest 的 `start_url`（`/chat`），用户上次所在的页面丢失，多会话场景尤其影响体验。

## 修复方案

新增**默认关闭**的可选路由恢复，用户可在「设置 → 个人资料」启用。整体客户端实现，不涉及后端：

- localStorage 持久化（key 前缀 `happyclaw-pwa-`）
- 黑名单跳过 `/login`、`/register`、`/setup/*`，避免在登录/初始化流程中污染
- 仅在「冷启动落到 `start_url`」时触发恢复（`/chat` 或 `/`），用户主动深链或外部分享的 URL 不会被覆盖
- 关闭开关时主动清空已存路由，防止下次启用时跳到过时位置
- 保留 `search` 参数（如 `/settings?tab=groups`）
- **不设过期**：原本想加 7 天阈值是拍脑袋的，主流原生 App 都不做这个，用户主动开启就是想要恢复；保存的群组被删除已由 ChatPage 自身错误兜底处理

### `web/src/utils/routeRestore.ts`（新增）

- `isRouteRestoreEnabled()` / `setRouteRestoreEnabled()` — 开关读写
- `saveLastRoute(path)` / `getLastRoute()` — 路由读写，含黑名单校验
- 所有 `localStorage` 访问都包了 try/catch，规避隐私模式或配额异常

### `web/src/hooks/useRouteRestore.ts`（新增）

- 在 `AppLayout` 挂载时调用一次：仅当当前 `pathname` 是 `/chat` 或 `/`（manifest `start_url`）且开关启用且有未黑名单记录时，`navigate(saved, { replace: true })`
- 监听 `useLocation()` 变化，未黑名单路径写回 localStorage（开关关闭时不写）

### `web/src/components/layout/AppLayout.tsx`

- 调用 `useRouteRestore()`。AppLayout 已经在 `AuthGuard` 内部，所以恢复发生在认证完成之后，不会和登录跳转冲突

### `web/src/components/settings/ProfileSection.tsx`

- 在「桌面通知」下方新增 Section「重启时恢复上次页面」，单一 Switch，默认关闭

### `tests/route-restore.test.ts`（新增）

12 个用例，覆盖：开关默认关闭、开关切换、关闭时清空已存路由、search 参数保留、各类黑名单路径、stale 黑名单数据防御。

## 测试

- `make typecheck` 通过
- `make test` — 274 passed (+12 新增用例)
- 仍需在真机/桌面装为 PWA 实测恢复行为（typecheck 验证不了 navigate 时序）
- 与 #485 PWA 离线缓存兼容：恢复路由后 SWR 缓存能立即读出历史消息，正是 v2 想要的效果

## 边界处理

- 用户清掉浏览器数据 → 下次启用后从零开始，不会指向不存在的路径
- 保存的路由对应的群组被删除 → 进入 `/chat/:groupFolder` 后由现有的 ChatPage 失败兜底处理（与用户手动点击进入已删除群组的行为一致）
- iOS PWA HashRouter 模式：`useLocation().pathname` 在 HashRouter 下也只返回 hash 内的路径，逻辑无需特殊处理