### PR TITLE
修复: ws 重连时 inferredWaiting 误判导致 UI 永久卡"正在思考..."

### DIFF
--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -2385,15 +2385,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
   restoreActiveState: async () => {
     try {
       const data = await api.get<{ groups: Array<{ jid: string; active: boolean; pendingMessages?: boolean }> }>('/api/status');
+      const knownJids = new Set(data.groups.map((g) => g.jid));
+
+      // 关键：对 active 群组先 refreshMessages 同步本地与后端真相，再做推断。
+      // 否则 ws 断开期间漏接 agent 完成的 new_message 时，本地最新仍是用户消息，
+      // 下面的 inferredWaiting 会错把 waiting 设回 true，UI 永久卡"正在思考..."。
+      // refreshMessages 内部在拉到 agent 回复时会主动清除 waiting/streaming。
+      // 仅刷新本地已加载过 messages 的群组，避免为侧边栏未点开的群组浪费请求。
+      const currentMessages = get().messages;
+      const activeJidsToRefresh = data.groups
+        .filter((g) => g.active && currentMessages[g.jid])
+        .map((g) => g.jid);
+      await Promise.all(
+        activeJidsToRefresh.map((jid) => get().refreshMessages(jid)),
+      );
+
       set((s) => {
         const nextWaiting = { ...s.waiting };
         const nextStreaming = { ...s.streaming };
 
-        // 构建后端已知的群组集合；不在集合中的 JID 说明后端无活跃进程
-        // （pm2 restart 后 queue 为空，所有 JID 都不在集合中）。
-        const knownJids = new Set(data.groups.map((g) => g.jid));
-
         // 清除后端不可见的 JID 的 waiting/streaming（进程已死）
+        // （pm2 restart 后 queue 为空，所有 JID 都不在集合中）。
         for (const jid of Object.keys(nextWaiting)) {
           if (!knownJids.has(jid)) {
             delete nextWaiting[jid];
@@ -2415,6 +2427,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             continue;
           }
           // active 可能仅表示 runner 空闲存活，这里回退到消息语义推断。
+          // 上面已 refreshMessages，s.messages 已与 DB 同步。
           const msgs = s.messages[g.jid] || [];
           const latest = msgs.length > 0 ? msgs[msgs.length - 1] : null;
           const inferredWaiting =


### PR DESCRIPTION
## 问题描述

WS 断线重连后，前端的对话区域永久显示"正在思考..."，但**在另一台未受影响的设备上打开同一对话显示正常**——说明后端、数据库、WS 推送都没问题，是本地 store 状态卡死。

## 复现

1. 在 Web 端发一条消息给 Agent
2. 在 Agent 即将完成回复的瞬间，制造 WS 断开（短暂网络抖动 / 切网 / 服务进程重启）
3. WS 重连后，本地浏览器的对话顶部一直显示"正在思考..."，输入框被锁死
4. 在另一台设备打开同一对话 → 正常显示 Agent 回复，无 waiting

## 根因

`web/src/stores/chat.ts` 的 `restoreActiveState` 在 WS 重连时对每个 `active=true` 的群组按以下逻辑推断 waiting：

```
latest = 本地 messages 最新一条
inferredWaiting = latest 是用户消息（is_from_me=false 或 sdk_send_message）
```

`new_message` WebSocket 推送是**一次性**的、没有补漏机制。如果 WS 在 Agent 完成那一瞬间断开，本地永远收不到那条 `new_message`，本地 messages 最新一条仍停留在用户的提问 → `inferredWaiting` 把 `waiting` 设回 `true` → UI 永久卡死。

另一台设备打开时是新会话，从 DB 拉到的最新消息已经包含 Agent 回复，所以 `inferredWaiting=false`，正常。

## 修复方案

在做 `inferredWaiting` 推断**之前**，先并行 `refreshMessages` 所有 `active=true` 的群组，让本地 messages 与 DB 真相同步。

`refreshMessages` 内部已有「拉到 Agent 回复时主动清除 waiting/streaming」的逻辑（`chat.ts:982-987`），所以 WS 漏接的回复会在此处被补回，后续的 `inferredWaiting` 基于真实最新消息计算，不再误判。

为避免无谓请求，**仅刷新本地已加载过 messages 的群组**（侧边栏未点开的群组保持懒加载）。

### \`web/src/stores/chat.ts\`

- \`restoreActiveState\`：把 \`knownJids\` 计算和 \`refreshMessages\` 调用提到 \`set\` 之前，对 active 且本地有 messages 的群组并行刷新一次。
- 注释说明这是修复 \`new_message\` 漏接导致 waiting 永久卡死的关键。

## 测试

- [x] `cd web && tsc --noEmit` 通过
- [ ] 手动复现：模拟 WS 断开漏接 `new_message`，重连后 waiting 自动清除