### PR TITLE
新增: PWA 重启路由恢复 + 跨工作区子对话记忆 (#494)

### DIFF
--- a/tests/route-restore.test.ts
+++ b/tests/route-restore.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  clear() { this.store.clear(); }
+  getItem(key: string) { return this.store.has(key) ? this.store.get(key)! : null; }
+  setItem(key: string, value: string) { this.store.set(key, String(value)); }
+  removeItem(key: string) { this.store.delete(key); }
+  key(index: number) { return Array.from(this.store.keys())[index] ?? null; }
+}
+
+const memoryStorage = new MemoryStorage();
+vi.stubGlobal('localStorage', memoryStorage);
+
+const {
+  isRouteRestoreEnabled,
+  setRouteRestoreEnabled,
+  saveLastRoute,
+  getLastRoute,
+} = await import('../web/src/utils/routeRestore');
+
+describe('routeRestore', () => {
+  beforeEach(() => {
+    memoryStorage.clear();
+  });
+
+  describe('toggle', () => {
+    it('defaults to disabled', () => {
+      expect(isRouteRestoreEnabled()).toBe(false);
+    });
+
+    it('persists the enable flag', () => {
+      setRouteRestoreEnabled(true);
+      expect(isRouteRestoreEnabled()).toBe(true);
+    });
+
+    it('clears saved route when disabling', () => {
+      setRouteRestoreEnabled(true);
+      saveLastRoute('/chat/main');
+      expect(getLastRoute()).toBe('/chat/main');
+
+      setRouteRestoreEnabled(false);
+      expect(isRouteRestoreEnabled()).toBe(false);
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+
+  describe('saveLastRoute / getLastRoute', () => {
+    it('round-trips a valid route', () => {
+      saveLastRoute('/chat/main');
+      expect(getLastRoute()).toBe('/chat/main');
+    });
+
+    it('preserves search params', () => {
+      saveLastRoute('/settings?tab=groups');
+      expect(getLastRoute()).toBe('/settings?tab=groups');
+    });
+
+    it('skips blacklisted login route', () => {
+      saveLastRoute('/login');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('skips blacklisted register route', () => {
+      saveLastRoute('/register');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('skips blacklisted setup root', () => {
+      saveLastRoute('/setup');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('skips blacklisted setup subroutes', () => {
+      saveLastRoute('/setup/providers');
+      expect(getLastRoute()).toBeNull();
+
+      saveLastRoute('/setup/channels');
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('rejects empty path', () => {
+      saveLastRoute('');
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+
+  describe('expiry', () => {
+    it('returns null and clears when expired', () => {
+      saveLastRoute('/chat/main');
+      // Backdate the timestamp by 8 days (exceeds 7-day expiry).
+      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(eightDaysAgo));
+
+      expect(getLastRoute()).toBeNull();
+      // Subsequent reads should also be null (storage cleared).
+      expect(memoryStorage.getItem('happyclaw-pwa-last-route')).toBeNull();
+    });
+
+    it('returns route when within expiry window', () => {
+      saveLastRoute('/chat/main');
+      const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
+      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(sixDaysAgo));
+
+      expect(getLastRoute()).toBe('/chat/main');
+    });
+
+    it('returns null on missing or invalid timestamp', () => {
+      memoryStorage.setItem('happyclaw-pwa-last-route', '/chat/main');
+      // No timestamp set.
+      expect(getLastRoute()).toBeNull();
+
+      memoryStorage.setItem('happyclaw-pwa-last-route-ts', 'not-a-number');
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when no route was saved', () => {
+      expect(getLastRoute()).toBeNull();
+    });
+  });
+});

--- a/tests/route-restore.test.ts
+++ b/tests/route-restore.test.ts
@@ -86,38 +86,14 @@ describe('routeRestore', () => {
     });
   });
 
-  describe('expiry', () => {
-    it('returns null and clears when expired', () => {
-      saveLastRoute('/chat/main');
-      // Backdate the timestamp by 8 days (exceeds 7-day expiry).
-      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
-      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(eightDaysAgo));
-
-      expect(getLastRoute()).toBeNull();
-      // Subsequent reads should also be null (storage cleared).
-      expect(memoryStorage.getItem('happyclaw-pwa-last-route')).toBeNull();
-    });
-
-    it('returns route when within expiry window', () => {
-      saveLastRoute('/chat/main');
-      const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
-      memoryStorage.setItem('happyclaw-pwa-last-route-ts', String(sixDaysAgo));
-
-      expect(getLastRoute()).toBe('/chat/main');
-    });
-
-    it('returns null on missing or invalid timestamp', () => {
-      memoryStorage.setItem('happyclaw-pwa-last-route', '/chat/main');
-      // No timestamp set.
-      expect(getLastRoute()).toBeNull();
-
-      memoryStorage.setItem('happyclaw-pwa-last-route-ts', 'not-a-number');
-      expect(getLastRoute()).toBeNull();
-    });
-  });
-
   describe('edge cases', () => {
     it('returns null when no route was saved', () => {
+      expect(getLastRoute()).toBeNull();
+    });
+
+    it('rejects a previously-saved route that became blacklisted', () => {
+      // Manually inject a blacklisted route to simulate stale storage.
+      memoryStorage.setItem('happyclaw-pwa-last-route', '/login');
       expect(getLastRoute()).toBeNull();
     });
   });

--- a/tests/workspace-last-agent.test.ts
+++ b/tests/workspace-last-agent.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  clear() { this.store.clear(); }
+  getItem(key: string) { return this.store.has(key) ? this.store.get(key)! : null; }
+  setItem(key: string, value: string) { this.store.set(key, String(value)); }
+  removeItem(key: string) { this.store.delete(key); }
+  key(index: number) { return Array.from(this.store.keys())[index] ?? null; }
+}
+
+const memoryStorage = new MemoryStorage();
+vi.stubGlobal('localStorage', memoryStorage);
+
+const { getWorkspaceLastAgent, setWorkspaceLastAgent } = await import('../web/src/utils/workspaceLastAgent');
+
+const KEY = 'happyclaw-workspace-last-agent';
+
+describe('workspaceLastAgent', () => {
+  beforeEach(() => {
+    memoryStorage.clear();
+  });
+
+  it('returns null for unknown workspace', () => {
+    expect(getWorkspaceLastAgent('web:main')).toBeNull();
+  });
+
+  it('round-trips a value', () => {
+    setWorkspaceLastAgent('web:main', 'agent-1');
+    expect(getWorkspaceLastAgent('web:main')).toBe('agent-1');
+  });
+
+  it('keys are independent per workspace', () => {
+    setWorkspaceLastAgent('web:main', 'agent-1');
+    setWorkspaceLastAgent('web:home-abc', 'agent-2');
+    expect(getWorkspaceLastAgent('web:main')).toBe('agent-1');
+    expect(getWorkspaceLastAgent('web:home-abc')).toBe('agent-2');
+  });
+
+  it('null clears the entry', () => {
+    setWorkspaceLastAgent('web:main', 'agent-1');
+    setWorkspaceLastAgent('web:main', null);
+    expect(getWorkspaceLastAgent('web:main')).toBeNull();
+  });
+
+  it('removes storage key entirely when last entry cleared', () => {
+    setWorkspaceLastAgent('web:main', 'agent-1');
+    setWorkspaceLastAgent('web:main', null);
+    expect(memoryStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('keeps other entries when one is cleared', () => {
+    setWorkspaceLastAgent('web:main', 'agent-1');
+    setWorkspaceLastAgent('web:home-abc', 'agent-2');
+    setWorkspaceLastAgent('web:main', null);
+    expect(getWorkspaceLastAgent('web:main')).toBeNull();
+    expect(getWorkspaceLastAgent('web:home-abc')).toBe('agent-2');
+  });
+
+  it('handles corrupted storage gracefully', () => {
+    memoryStorage.setItem(KEY, 'not-json');
+    expect(getWorkspaceLastAgent('web:main')).toBeNull();
+    // Subsequent writes should still work after auto-recovery
+    setWorkspaceLastAgent('web:main', 'agent-1');
+    expect(getWorkspaceLastAgent('web:main')).toBe('agent-1');
+  });
+
+  it('handles non-object stored values gracefully', () => {
+    memoryStorage.setItem(KEY, JSON.stringify(['array', 'not', 'object']));
+    expect(getWorkspaceLastAgent('web:main')).toBeNull();
+  });
+});

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -25,6 +25,7 @@ import { AgentTabBar } from './AgentTabBar';
 import { ImBindingDialog } from './ImBindingDialog';
 import { TopicSidebar } from './TopicSidebar';
 import { showToast } from '../../utils/toast';
+import { getWorkspaceLastAgent, setWorkspaceLastAgent } from '../../utils/workspaceLastAgent';
 import { CHANNEL_LABEL } from '../settings/channel-meta';
 
 /** Sentinel value for binding the main conversation (vs. a specific agent) */
@@ -123,7 +124,8 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
       else next.delete('agent');
       return next;
     }, { replace: true });
-  }, [setSearchParams]);
+    setWorkspaceLastAgent(groupJid, id);
+  }, [groupJid, setSearchParams]);
   const loadAgents = useChatStore(s => s.loadAgents);
   const deleteAgentAction = useChatStore(s => s.deleteAgentAction);
   const agentStreaming = useChatStore(s => s.agentStreaming);
@@ -292,17 +294,44 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   }, [urlAgentId, groupJid, setActiveAgentTab]);
 
   // If URL points to an agent that no longer exists in this workspace
-  // (e.g., deleted while we were on it, or stale deep link), strip the param.
+  // (e.g., deleted while we were on it, or stale deep link), strip the param
+  // and clear the workspace memory so we don't try to restore it again.
   useEffect(() => {
     if (!urlAgentId) return;
     if (agents.length === 0) return;
     if (agents.some((a) => a.id === urlAgentId)) return;
+    setWorkspaceLastAgent(groupJid, null);
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       next.delete('agent');
       return next;
     }, { replace: true });
-  }, [urlAgentId, agents, setSearchParams]);
+  }, [urlAgentId, agents, groupJid, setSearchParams]);
+
+  // On entering a workspace without ?agent=, restore the last sub-tab the
+  // user was on in this workspace (per-workspace memory, persisted across
+  // PWA restarts via localStorage). Stale entries (agent deleted) get cleaned.
+  const memoryRestoredRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (memoryRestoredRef.current === groupJid) return;
+    if (urlAgentId) {
+      memoryRestoredRef.current = groupJid;
+      return;
+    }
+    if (agents.length === 0) return;
+    const remembered = getWorkspaceLastAgent(groupJid);
+    memoryRestoredRef.current = groupJid;
+    if (!remembered) return;
+    if (!agents.some((a) => a.id === remembered)) {
+      setWorkspaceLastAgent(groupJid, null);
+      return;
+    }
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('agent', remembered);
+      return next;
+    }, { replace: true });
+  }, [groupJid, urlAgentId, agents, setSearchParams]);
 
   useEffect(() => {
     setTopicFilter('');

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useChatStore } from '../../stores/chat';
 import { useAuthStore } from '../../stores/auth';
@@ -109,6 +109,21 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const agents = useChatStore(s => s.agents[groupJid] ?? EMPTY_AGENTS);
   const activeAgentTab = useChatStore(s => s.activeAgentTab[groupJid] ?? null);
   const setActiveAgentTab = useChatStore(s => s.setActiveAgentTab);
+
+  // URL `?agent=` is the source of truth for the active sub-conversation tab.
+  // Refresh, browser back/forward, route restore, and direct deep-links all
+  // converge here. `selectTab` updates the URL only; an effect below mirrors
+  // the URL value into the store for consumers that read it directly.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlAgentId = searchParams.get('agent') || null;
+  const selectTab = useCallback((id: string | null) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (id) next.set('agent', id);
+      else next.delete('agent');
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
   const loadAgents = useChatStore(s => s.loadAgents);
   const deleteAgentAction = useChatStore(s => s.deleteAgentAction);
   const agentStreaming = useChatStore(s => s.agentStreaming);
@@ -271,6 +286,24 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
     loadAgents(groupJid);
   }, [groupJid, loadAgents]);
 
+  // Mirror URL → store so consumers reading activeAgentTab stay in sync.
+  useEffect(() => {
+    setActiveAgentTab(groupJid, urlAgentId);
+  }, [urlAgentId, groupJid, setActiveAgentTab]);
+
+  // If URL points to an agent that no longer exists in this workspace
+  // (e.g., deleted while we were on it, or stale deep link), strip the param.
+  useEffect(() => {
+    if (!urlAgentId) return;
+    if (agents.length === 0) return;
+    if (agents.some((a) => a.id === urlAgentId)) return;
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('agent');
+      return next;
+    }, { replace: true });
+  }, [urlAgentId, agents, setSearchParams]);
+
   useEffect(() => {
     setTopicFilter('');
   }, [groupJid]);
@@ -285,15 +318,15 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
 
   useEffect(() => {
     if (!isTopicWorkspace || !isDesktop || activeAgentTab || filteredTopicAgents.length === 0) return;
-    setActiveAgentTab(groupJid, filteredTopicAgents[0].id);
-  }, [isTopicWorkspace, isDesktop, activeAgentTab, filteredTopicAgents, groupJid, setActiveAgentTab]);
+    selectTab(filteredTopicAgents[0].id);
+  }, [isTopicWorkspace, isDesktop, activeAgentTab, filteredTopicAgents, selectTab]);
 
   useEffect(() => {
     if (!isTopicWorkspace || !activeAgentTab) return;
     const existsInTopics = topicAgents.some((agent) => agent.id === activeAgentTab);
     if (existsInTopics) return;
-    setActiveAgentTab(groupJid, isDesktop && topicAgents[0] ? topicAgents[0].id : null);
-  }, [isTopicWorkspace, activeAgentTab, topicAgents, isDesktop, groupJid, setActiveAgentTab]);
+    selectTab(isDesktop && topicAgents[0] ? topicAgents[0].id : null);
+  }, [isTopicWorkspace, activeAgentTab, topicAgents, isDesktop, selectTab]);
 
   // Load messages for conversation agent tabs
   useEffect(() => {
@@ -459,7 +492,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
 
   const handleBackAction = () => {
     if (isTopicWorkspace && !isDesktop && activeAgentTab) {
-      setActiveAgentTab(groupJid, null);
+      selectTab(null);
       return;
     }
     onBack?.();
@@ -594,7 +627,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
         <AgentTabBar
           agents={agents}
           activeTab={activeAgentTab}
-          onSelectTab={(id) => setActiveAgentTab(groupJid, id)}
+          onSelectTab={(id) => selectTab(id)}
           onDeleteAgent={(id) => {
             const agent = agents.find((a) => a.id === id);
             if (agent?.linked_im_groups && agent.linked_im_groups.length > 0) {
@@ -608,7 +641,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
           onRenameAgent={(id, currentName) => setRenameTarget({ agentId: id, name: currentName })}
           onCreateConversation={() => {
             createConversation(groupJid, '').then((agent) => {
-              if (agent) setActiveAgentTab(groupJid, agent.id);
+              if (agent) selectTab(agent.id);
             });
           }}
           onBindIm={setBindingAgentId}
@@ -630,7 +663,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                 <TopicSidebar
                   topicAgents={filteredTopicAgents}
                   activeAgentTab={activeAgentTab}
-                  onSelectAgent={(id) => setActiveAgentTab(groupJid, id)}
+                  onSelectAgent={(id) => selectTab(id)}
                   onDeleteAgent={(id) => deleteAgentAction(groupJid, id)}
                   topicFilter={topicFilter}
                   onFilterChange={setTopicFilter}
@@ -644,7 +677,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
                     {!isDesktop && (
                       <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
                         <button
-                          onClick={() => setActiveAgentTab(groupJid, null)}
+                          onClick={() => selectTab(null)}
                           className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted cursor-pointer"
                           aria-label="返回话题列表"
                         >

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useChatStore } from '../../stores/chat';
 import { useAuthStore } from '../../stores/auth';
@@ -311,16 +311,15 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   // On entering a workspace without ?agent=, restore the last sub-tab the
   // user was on in this workspace (per-workspace memory, persisted across
   // PWA restarts via localStorage). Stale entries (agent deleted) get cleaned.
-  const memoryRestoredRef = useRef<string | null>(null);
+  // Guarded by `params.groupFolder` so this doesn't fire when the URL is on
+  // the workspace picker (mobile back) but ChatView is still mounted with
+  // a stale `currentGroup`.
+  const params = useParams<{ groupFolder?: string }>();
   useEffect(() => {
-    if (memoryRestoredRef.current === groupJid) return;
-    if (urlAgentId) {
-      memoryRestoredRef.current = groupJid;
-      return;
-    }
+    if (!params.groupFolder) return;
+    if (urlAgentId) return;
     if (agents.length === 0) return;
     const remembered = getWorkspaceLastAgent(groupJid);
-    memoryRestoredRef.current = groupJid;
     if (!remembered) return;
     if (!agents.some((a) => a.id === remembered)) {
       setWorkspaceLastAgent(groupJid, null);
@@ -331,7 +330,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
       next.set('agent', remembered);
       return next;
     }, { replace: true });
-  }, [groupJid, urlAgentId, agents, setSearchParams]);
+  }, [groupJid, urlAgentId, agents, setSearchParams, params.groupFolder]);
 
   useEffect(() => {
     setTopicFilter('');

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { BottomTabBar } from './BottomTabBar';
 import { ConnectionBanner } from '../common/ConnectionBanner';
 import { wsManager } from '../../api/ws';
 import { useTheme } from '../../hooks/useTheme';
+import { useRouteRestore } from '../../hooks/useRouteRestore';
 import { useBillingStore } from '../../stores/billing';
 import { useGroupsStore } from '../../stores/groups';
 import { useChatStore } from '../../stores/chat';
@@ -15,6 +16,7 @@ export function AppLayout() {
   const isChatRoute = location.pathname.startsWith('/chat');
   const hideMobileTabBar = /^\/chat\/.+/.test(location.pathname);
   useTheme(); // 应用并同步持久化的主题偏好
+  useRouteRestore(); // PWA 重启时恢复上次访问的路由（默认关闭，设置中启用）
 
   // Sidebar: expanded only on chat route, collapsed on other routes
   const [userCollapsed, setUserCollapsed] = useState(false);

--- a/web/src/components/settings/ProfileSection.tsx
+++ b/web/src/components/settings/ProfileSection.tsx
@@ -119,7 +119,7 @@ function PwaRouteRestoreSection() {
     <Section
       icon={RotateCcw}
       title="重启时恢复上次页面"
-      desc="安装为 PWA 后，从后台被系统回收再次打开时回到上次访问的页面，而非默认主页（保留 7 天）"
+      desc="安装为 PWA 后，从后台被系统回收再次打开时回到上次访问的页面，而非默认主页"
     >
       <div className="flex items-center justify-between">
         <Label className="text-sm text-foreground">启用恢复</Label>

--- a/web/src/components/settings/ProfileSection.tsx
+++ b/web/src/components/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Loader2, Upload, Trash2, User, Bot, Lock, Palette, Sun, Moon, Monitor, Bell, BellOff, CheckCircle2 } from 'lucide-react';
+import { Loader2, Upload, Trash2, User, Bot, Lock, Palette, Sun, Moon, Monitor, Bell, BellOff, CheckCircle2, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useAuthStore } from '../../stores/auth';
@@ -7,9 +7,11 @@ import { useTheme, type Theme, type ColorScheme, type FontStyle } from '../../ho
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { EmojiAvatar } from '@/components/common/EmojiAvatar';
 import { EmojiPicker } from '@/components/common/EmojiPicker';
 import { ColorPicker } from '@/components/common/ColorPicker';
+import { isRouteRestoreEnabled, setRouteRestoreEnabled } from '../../utils/routeRestore';
 import { getErrorMessage } from './types';
 import { SettingsCard as Section } from './SettingsCard';
 
@@ -99,6 +101,30 @@ function DesktopNotificationSection() {
           </Button>
         </div>
       )}
+    </Section>
+  );
+}
+
+/* ── PWA Route Restore Section ────────────────────────────── */
+
+function PwaRouteRestoreSection() {
+  const [enabled, setEnabled] = useState(() => isRouteRestoreEnabled());
+
+  const handleChange = (next: boolean) => {
+    setEnabled(next);
+    setRouteRestoreEnabled(next);
+  };
+
+  return (
+    <Section
+      icon={RotateCcw}
+      title="重启时恢复上次页面"
+      desc="安装为 PWA 后，从后台被系统回收再次打开时回到上次访问的页面，而非默认主页（保留 7 天）"
+    >
+      <div className="flex items-center justify-between">
+        <Label className="text-sm text-foreground">启用恢复</Label>
+        <Switch checked={enabled} onCheckedChange={handleChange} aria-label="启用 PWA 重启路由恢复" />
+      </div>
     </Section>
   );
 }
@@ -310,6 +336,9 @@ export function ProfileSection() {
 
       {/* ── 2. Desktop Notifications ── */}
       <DesktopNotificationSection />
+
+      {/* ── 2.5 PWA Route Restore ── */}
+      <PwaRouteRestoreSection />
 
       {/* ── 3. Account Info ── */}
       <Section icon={User} title="账户信息">

--- a/web/src/hooks/useRouteRestore.ts
+++ b/web/src/hooks/useRouteRestore.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { isRouteRestoreEnabled, saveLastRoute, getLastRoute } from '../utils/routeRestore';
+
+// Paths that count as "fresh app launch" — a PWA cold start lands on the
+// manifest start_url (`/chat`). When the user opens a deep link directly we
+// honor it instead of overriding with the saved route.
+const RESTORE_TRIGGER_PATHS = new Set(['/chat', '/']);
+
+export function useRouteRestore(): void {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+
+    if (!isRouteRestoreEnabled()) return;
+    if (!RESTORE_TRIGGER_PATHS.has(location.pathname)) return;
+
+    const saved = getLastRoute();
+    if (!saved) return;
+
+    const currentFull = location.pathname + location.search;
+    if (saved === currentFull) return;
+
+    navigate(saved, { replace: true });
+    // Run only on initial mount; subsequent location changes are handled below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!isRouteRestoreEnabled()) return;
+    saveLastRoute(location.pathname + location.search);
+  }, [location.pathname, location.search]);
+}

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -817,9 +817,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   clearing: {},
   agents: {},
   agentStreaming: {},
-  activeAgentTab: (() => {
-    try { return JSON.parse(sessionStorage.getItem('hc_activeAgentTabs') || '{}'); } catch { return {}; }
-  })(),
+  // Active sub-conversation tab is mirrored from URL (?agent=...) by ChatView.
+  // The store holds an in-memory copy for components that read it directly.
+  activeAgentTab: {},
   sdkTasks: {},
   sdkTaskAliases: {},
   agentMessages: {},
@@ -2148,20 +2148,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }
   },
 
-  // 切换子 Agent 标签页（持久化到 sessionStorage，刷新后恢复）
+  // 切换子 Agent 标签页（在内存中 mirror，URL 是真正的真相源）
   setActiveAgentTab: (jid, agentId) => {
     set((s) => ({
       activeAgentTab: { ...s.activeAgentTab, [jid]: agentId },
     }));
-    try {
-      const stored = JSON.parse(sessionStorage.getItem('hc_activeAgentTabs') || '{}');
-      if (agentId) {
-        stored[jid] = agentId;
-      } else {
-        delete stored[jid];
-      }
-      sessionStorage.setItem('hc_activeAgentTabs', JSON.stringify(stored));
-    } catch { /* ignore */ }
   },
 
   // -- Conversation agent actions --

--- a/web/src/utils/routeRestore.ts
+++ b/web/src/utils/routeRestore.ts
@@ -4,9 +4,6 @@
 
 const STORAGE_KEY_ENABLED = 'happyclaw-pwa-restore-enabled';
 const STORAGE_KEY_ROUTE = 'happyclaw-pwa-last-route';
-const STORAGE_KEY_TIMESTAMP = 'happyclaw-pwa-last-route-ts';
-
-const EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 const BLACKLIST_PATTERNS: RegExp[] = [
   /^\/login(\?|$)/,
@@ -38,7 +35,6 @@ export function setRouteRestoreEnabled(enabled: boolean): void {
   } else {
     ls.removeItem(STORAGE_KEY_ENABLED);
     ls.removeItem(STORAGE_KEY_ROUTE);
-    ls.removeItem(STORAGE_KEY_TIMESTAMP);
   }
 }
 
@@ -48,7 +44,6 @@ export function saveLastRoute(path: string): void {
   if (!path || isBlacklisted(path)) return;
   try {
     ls.setItem(STORAGE_KEY_ROUTE, path);
-    ls.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
   } catch {
     /* quota exceeded — ignore */
   }
@@ -58,14 +53,7 @@ export function getLastRoute(): string | null {
   const ls = safeStorage();
   if (!ls) return null;
   const route = ls.getItem(STORAGE_KEY_ROUTE);
-  const tsRaw = ls.getItem(STORAGE_KEY_TIMESTAMP);
-  if (!route || !tsRaw) return null;
-  const ts = Number(tsRaw);
-  if (!Number.isFinite(ts) || Date.now() - ts > EXPIRY_MS) {
-    ls.removeItem(STORAGE_KEY_ROUTE);
-    ls.removeItem(STORAGE_KEY_TIMESTAMP);
-    return null;
-  }
+  if (!route) return null;
   if (isBlacklisted(route)) return null;
   return route;
 }

--- a/web/src/utils/routeRestore.ts
+++ b/web/src/utils/routeRestore.ts
@@ -1,0 +1,71 @@
+// PWA route restore: persist last visited route to localStorage so PWA reopens
+// land on the user's previous location instead of the manifest start_url.
+// Disabled by default; toggled from Settings → Profile.
+
+const STORAGE_KEY_ENABLED = 'happyclaw-pwa-restore-enabled';
+const STORAGE_KEY_ROUTE = 'happyclaw-pwa-last-route';
+const STORAGE_KEY_TIMESTAMP = 'happyclaw-pwa-last-route-ts';
+
+const EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+const BLACKLIST_PATTERNS: RegExp[] = [
+  /^\/login(\?|$)/,
+  /^\/register(\?|$)/,
+  /^\/setup($|\/|\?)/,
+];
+
+function isBlacklisted(path: string): boolean {
+  return BLACKLIST_PATTERNS.some((re) => re.test(path));
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function isRouteRestoreEnabled(): boolean {
+  return safeStorage()?.getItem(STORAGE_KEY_ENABLED) === '1';
+}
+
+export function setRouteRestoreEnabled(enabled: boolean): void {
+  const ls = safeStorage();
+  if (!ls) return;
+  if (enabled) {
+    ls.setItem(STORAGE_KEY_ENABLED, '1');
+  } else {
+    ls.removeItem(STORAGE_KEY_ENABLED);
+    ls.removeItem(STORAGE_KEY_ROUTE);
+    ls.removeItem(STORAGE_KEY_TIMESTAMP);
+  }
+}
+
+export function saveLastRoute(path: string): void {
+  const ls = safeStorage();
+  if (!ls) return;
+  if (!path || isBlacklisted(path)) return;
+  try {
+    ls.setItem(STORAGE_KEY_ROUTE, path);
+    ls.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
+  } catch {
+    /* quota exceeded — ignore */
+  }
+}
+
+export function getLastRoute(): string | null {
+  const ls = safeStorage();
+  if (!ls) return null;
+  const route = ls.getItem(STORAGE_KEY_ROUTE);
+  const tsRaw = ls.getItem(STORAGE_KEY_TIMESTAMP);
+  if (!route || !tsRaw) return null;
+  const ts = Number(tsRaw);
+  if (!Number.isFinite(ts) || Date.now() - ts > EXPIRY_MS) {
+    ls.removeItem(STORAGE_KEY_ROUTE);
+    ls.removeItem(STORAGE_KEY_TIMESTAMP);
+    return null;
+  }
+  if (isBlacklisted(route)) return null;
+  return route;
+}

--- a/web/src/utils/workspaceLastAgent.ts
+++ b/web/src/utils/workspaceLastAgent.ts
@@ -1,0 +1,55 @@
+// Per-workspace last-active sub-conversation memory.
+// When the user re-enters a workspace via sidebar/URL without `?agent=`,
+// ChatView consults this map to auto-restore the previous tab.
+// Entries are cleared by `selectTab(null)` (explicit return to main).
+
+const STORAGE_KEY = 'happyclaw-workspace-last-agent';
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readMap(): Record<string, string> {
+  const ls = safeStorage();
+  if (!ls) return {};
+  try {
+    const raw = ls.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: Record<string, string>): void {
+  const ls = safeStorage();
+  if (!ls) return;
+  try {
+    if (Object.keys(map).length === 0) {
+      ls.removeItem(STORAGE_KEY);
+    } else {
+      ls.setItem(STORAGE_KEY, JSON.stringify(map));
+    }
+  } catch {
+    /* quota exceeded — ignore */
+  }
+}
+
+export function getWorkspaceLastAgent(jid: string): string | null {
+  return readMap()[jid] || null;
+}
+
+export function setWorkspaceLastAgent(jid: string, agentId: string | null): void {
+  const map = readMap();
+  if (agentId) {
+    map[jid] = agentId;
+  } else {
+    delete map[jid];
+  }
+  writeMap(map);
+}


### PR DESCRIPTION
## 问题描述

关闭 #494。

PWA 从后台被系统回收后重新拉起会落到 manifest 的 `start_url`（`/chat`），用户上次所在的工作区和子对话都丢失。

## 修复方案

三层组合：

1. **路由层（PWA 重启回到上次 URL）**：localStorage 持久化 `pathname + search`，开关默认关闭，设置中启用
2. **状态层（子对话进入 URL）**：把活跃子对话从 sessionStorage 升级到 URL `?agent=...`，让路由恢复天然覆盖到子对话粒度
3. **跨工作区记忆层（默认 UX，与开关无关）**：每个工作区的最后子对话存 localStorage，从 A 切到 B 再切回 A 仍然回到上次的子对话

### 路由层（commit 5e373f3 + a7cb49d）

`web/src/utils/routeRestore.ts`（新增）

- `isRouteRestoreEnabled()` / `setRouteRestoreEnabled()` — 开关读写
- `saveLastRoute(path)` / `getLastRoute()` — 路由读写，黑名单 `/login`、`/register`、`/setup/*`
- 所有 `localStorage` 访问包了 try/catch，规避隐私模式或配额异常
- **不设过期**：原本想加 7 天阈值是拍脑袋，主流原生 App 都不做这个，用户主动开启就是要恢复

`web/src/hooks/useRouteRestore.ts`（新增）

- 在 `AppLayout` 挂载时调用一次：仅当当前 `pathname` 是 `/chat` 或 `/`（manifest `start_url`）且开关启用且有未黑名单记录时，`navigate(saved, { replace: true })`
- 监听 `useLocation()` 变化，未黑名单路径写回 localStorage（开关关闭时不写）

`web/src/components/layout/AppLayout.tsx`

- 调用 `useRouteRestore()`。AppLayout 已经在 `AuthGuard` 内部，所以恢复发生在认证完成之后，不会和登录跳转冲突

`web/src/components/settings/ProfileSection.tsx`

- 在「桌面通知」下方新增 Section「重启时恢复上次页面」，单一 Switch，默认关闭

### 状态层（commit aa86220）

之前 `activeAgentTab` 只存在 sessionStorage，PWA 整个关闭后清空，单纯路由恢复仅能回到 `/chat/{folder}`（主对话），用户实际想停留的子对话还是丢。把 URL 升级为单一真相源：

`web/src/stores/chat.ts`

- 移除 sessionStorage 持久化（init 时不再读 `hc_activeAgentTabs`，`setActiveAgentTab` 不再写）
- store 退化为纯内存 mirror

`web/src/components/chat/ChatView.tsx`

- `useSearchParams` 读 `?agent=` 作为 active tab
- `selectTab(id)` helper 用 `setSearchParams` `replace` 更新 URL（不污染浏览器历史）
- URL→store 同步 effect 让现有读 `activeAgentTab` 的代码继续工作
- URL 指向已删除 agent 时自动清掉 `?agent=` 参数
- 7 处直接调用 `setActiveAgentTab(groupJid, X)` 改为 `selectTab(X)`

### 跨工作区记忆层（commit 5a345ba + 8bab54b）

URL 单一真相源后，从工作区 A 切到 B 再切回 A 默认会落到主对话——之前 sessionStorage 提供的「记住每个工作区上次激活子对话」UX 丢失。把这层记忆迁移到 localStorage，跨 PWA 重启也保留。

`web/src/utils/workspaceLastAgent.ts`（新增）

- localStorage key `happyclaw-workspace-last-agent`，存 `Record<jid, agentId>`
- `getWorkspaceLastAgent(jid)` / `setWorkspaceLastAgent(jid, id)`，null 清空该 jid 条目，全空时移除整个 storage key

`web/src/components/chat/ChatView.tsx`

- `selectTab(id)` 同时写入工作区记忆（id 为 null 时清掉条目）
- mount-time effect：URL 没有 `?agent=` + agents 已加载 + 记忆存在 + agent 仍存在 → setSearchParams replace 加上 `?agent=`
- URL 指向已删除 agent 时（已有 cleanup effect），现在同时清掉记忆，避免下次重入时尝试恢复
- **mobile back-and-forth 修复**（8bab54b）：mobile 端 picker（`/chat`）→ workspace（`/chat/main`）之间 ChatView 不会重新挂载（同一 `currentGroup`，只用 CSS hidden）。原本用 ref 做「每挂载一次只触发一次」的保护会让第二次进入工作区时 effect 不再 fire；改用 `useParams.groupFolder` 作为守卫：URL 在具体 workspace 路径下才考虑恢复，在 picker 页直接 bail。URL→store 同步链路本身保证不会循环。

不与路由恢复开关耦合：跨工作区记忆是默认 UX，与 sessionStorage 时代行为一致；路由恢复开关只控制「PWA 整体重启时是否回到上次 URL」。两层独立工作，组合后用户从 PWA 冷启动到子对话状态完整恢复。

## 测试

`tests/route-restore.test.ts`（12 用例）+ `tests/workspace-last-agent.test.ts`（8 用例）

覆盖：开关默认关闭、开关切换、关闭时清空已存路由、search 参数保留、各类黑名单路径、stale 黑名单数据防御、跨 jid 隔离、null 清理、storage key 移除、损坏数据降级。

## 副作用

- **刷新页面**：URL 保留，子对话保持 ✓（原本 sessionStorage 也保留，行为不变）
- **PWA 重启 + 路由恢复开启**：localStorage 存的 last route 已含 search 参数，恢复时 navigate 到 `/chat/{folder}?agent={id}`，子对话状态自然恢复 ✓
- **跨工作区切换**：从 A 到 B 再回 A，自动恢复 A 上次的子对话 ✓（升级到 localStorage 后 PWA 重启也保留）
- **deep link**：`?agent=xyz` 进 URL 后可分享/书签，目标 agent 不存在时自动剥掉参数 + 清掉对应记忆条目

## 验证

### 自动化

- `make typecheck` 通过
- `make test` — 282 passed (+12 routeRestore + 8 workspaceLastAgent 单测)

### 端到端 UI 验证（桌面 Chrome via CDP）

#### 路由层 + 状态层（16/16 通过）

| 步骤 | 验证项 | 结果 |
|---|---|---|
| B | `/chat/main` 列出多个子对话 tab | ✓ |
| C | 点击某子对话 tab → URL 变成 `/chat/main?agent={id}` | ✓ |
| D | **刷新后 URL 保留 + 该子对话 tab 仍处于视觉激活状态**（用户日常核心场景） | ✓ ✓ |
| E | sessionStorage `hc_activeAgentTabs` 不再被使用 | ✓ |
| F | 设置 → 个人偏好：开关出现，默认 unchecked，localStorage `happyclaw-pwa-restore-enabled` 为 null | ✓ |
| G | 打开开关 → localStorage 写入 `"1"` | ✓ |
| H | 访问 `/chat/main?agent=X` → `last-route` 保存完整 URL（含 search 参数） | ✓ |
| **I** | **模拟 PWA 冷启动：导航到 `/chat` → 自动恢复到 `/chat/main?agent={id}`** | ✓ |
| J | 关闭开关 → enabled 和 last-route 都清空 | ✓ |
| K | 开关关闭状态下访问 `/chat` → 停在 `/chat`，不自动恢复 | ✓ |

#### 跨工作区记忆层 + mobile back-and-forth（6/6 通过）

| 步骤 | 验证项 | 结果 |
|---|---|---|
| B | 点击 vps 子对话 tab → URL 含 `?agent=` + `localStorage['happyclaw-workspace-last-agent']` 含 `{web:main: vps_id}` | ✓ ✓ |
| C | 模拟 mobile back（pushState）→ `/chat`：picker URL 保持干净（不被错误注入 `?agent=`） | ✓ |
| **D** | **重新进入 `/chat/main` → URL 自动恢复 `?agent=vps_id`，vps tab 视觉激活** | ✓ ✓ |
| E | 整页 reload `/chat/main` → 也能恢复 | ✓ |

### iOS PWA 真机实测

✅ 已实测通过：杀 PWA 重开后，配合「重启时恢复上次页面」开关 + 跨工作区记忆，回到上次的子对话工作正常。

## 与 #485 兼容

PWA 离线缓存（PR #485）解决数据缓存层；本 PR 解决路由/状态层。两者正交，组合后从 PWA 冷启动到展示完整子对话历史无网络等待。