### PR TITLE
修复: 任务工作区单条 BLOB 消息导致 Web 页面黑屏

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1342,6 +1342,58 @@ export function setLastGroupSync(): void {
 }
 
 /**
+ * Coerce a value bound to a TEXT column into a real JS string.
+ *
+ * SQLite has dynamic typing: a TEXT-affinity column will silently accept a
+ * Buffer/Uint8Array binding and store it as BLOB. better-sqlite3 then reads
+ * that cell back as a Buffer, which propagates through JSON.stringify as
+ * `{type:"Buffer",data:[…]}` and breaks any consumer expecting a string.
+ *
+ * Caller contracts are typed `string`, but TypeScript is erased at runtime —
+ * so wrap every text-column binding with this guard. Buffers are decoded as
+ * UTF-8 (the only encoding the codebase ever stores); other shapes are
+ * coerced via String() and a warn-level log surfaces the offending caller.
+ */
+function coerceTextField(
+  value: unknown,
+  field: string,
+): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    const decoded = Buffer.from(value as Uint8Array).toString('utf8');
+    logger.warn(
+      { field, byteLen: (value as Uint8Array).byteLength, sample: decoded.slice(0, 80), stack: new Error().stack },
+      'coerceTextField: received Buffer/Uint8Array, decoded as UTF-8',
+    );
+    return decoded;
+  }
+  const coerced = String(value);
+  logger.warn(
+    { field, jsType: typeof value, sample: coerced.slice(0, 80), stack: new Error().stack },
+    'coerceTextField: received non-string, coerced via String()',
+  );
+  return coerced;
+}
+
+/**
+ * Read-side companion to coerceTextField: SQLite cells with BLOB affinity
+ * (legacy bad data written before the write-side guard existed) are read
+ * back by better-sqlite3 as Buffer. Decode them to UTF-8 so downstream
+ * JSON serialization and React rendering do not choke.
+ *
+ * Fast path returns the input unchanged when it is already a string.
+ */
+function normalizeTextCell(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    return Buffer.from(value as Uint8Array).toString('utf8');
+  }
+  return String(value);
+}
+
+/**
  * Ensure a chat row exists in the chats table (avoids FK violation on messages insert).
  */
 export function ensureChatExists(chatJid: string): void {
@@ -1381,7 +1433,7 @@ export function storeMessageDirect(
     sourceJid ?? chatJid,
     sender,
     senderName,
-    content,
+    coerceTextField(content, 'messages.content'),
     timestamp,
     isFromMe ? 1 : 0,
     attachments ?? null,
@@ -1882,12 +1934,13 @@ export function getNewMessages(
 ): { messages: NewMessage[]; newCursor: MessageCursor } {
   if (jids.length === 0) return { messages: [], newCursor: cursor };
 
-  const rows = getNewMessagesStmt(jids.length).all(
+  const rawRows = getNewMessagesStmt(jids.length).all(
     cursor.timestamp,
     cursor.timestamp,
     cursor.id,
     ...jids,
   ) as NewMessage[];
+  const rows = rawRows.map((r) => ({ ...r, content: normalizeTextCell(r.content) ?? '' }));
   const last = rows[rows.length - 1];
   return {
     messages: rows,
@@ -1899,12 +1952,13 @@ export function getMessagesSince(
   chatJid: string,
   cursor: MessageCursor,
 ): NewMessage[] {
-  return stmts().getMessagesSince.all(
+  const rows = stmts().getMessagesSince.all(
     chatJid,
     cursor.timestamp,
     cursor.timestamp,
     cursor.id,
   ) as NewMessage[];
+  return rows.map((r) => ({ ...r, content: normalizeTextCell(r.content) ?? '' }));
 }
 
 export function createTask(
@@ -1919,12 +1973,14 @@ export function createTask(
     task.id,
     task.group_folder,
     task.chat_jid,
-    task.prompt,
+    coerceTextField(task.prompt, 'scheduled_tasks.prompt'),
     task.schedule_type,
     task.schedule_value,
     task.context_mode || 'group',
     task.execution_type || 'agent',
-    task.script_command ?? null,
+    task.script_command == null
+      ? null
+      : coerceTextField(task.script_command, 'scheduled_tasks.script_command'),
     task.execution_mode ?? null,
     task.next_run,
     task.status,
@@ -1950,6 +2006,9 @@ function mapTaskRow(row: unknown): ScheduledTask {
   if (r.execution_mode === undefined) r.execution_mode = null;
   if (r.workspace_jid === undefined) r.workspace_jid = null;
   if (r.workspace_folder === undefined) r.workspace_folder = null;
+  // Defensive: legacy BLOB cells in TEXT-affinity columns come back as Buffer.
+  r.prompt = normalizeTextCell(r.prompt) ?? '';
+  if (r.script_command !== undefined) r.script_command = normalizeTextCell(r.script_command);
   return r as ScheduledTask;
 }
 
@@ -1999,7 +2058,7 @@ export function updateTask(
 
   if (updates.prompt !== undefined) {
     fields.push('prompt = ?');
-    values.push(updates.prompt);
+    values.push(coerceTextField(updates.prompt, 'scheduled_tasks.prompt'));
   }
   if (updates.schedule_type !== undefined) {
     fields.push('schedule_type = ?');
@@ -2023,7 +2082,11 @@ export function updateTask(
   }
   if (updates.script_command !== undefined) {
     fields.push('script_command = ?');
-    values.push(updates.script_command);
+    values.push(
+      updates.script_command == null
+        ? null
+        : coerceTextField(updates.script_command, 'scheduled_tasks.script_command'),
+    );
   }
   if (updates.next_run !== undefined) {
     fields.push('next_run = ?');
@@ -2928,6 +2991,7 @@ export function getMessagesPage(
 
   return rows.map((row) => ({
     ...row,
+    content: normalizeTextCell(row.content) ?? '',
     is_from_me: row.is_from_me === 1,
   }));
 }
@@ -2954,6 +3018,7 @@ export function getMessagesAfter(
 
   return rows.map((row) => ({
     ...row,
+    content: normalizeTextCell(row.content) ?? '',
     is_from_me: row.is_from_me === 1,
   }));
 }
@@ -2991,6 +3056,7 @@ export function getMessagesPageMulti(
 
   return rows.map((row) => ({
     ...row,
+    content: normalizeTextCell(row.content) ?? '',
     is_from_me: row.is_from_me === 1,
   }));
 }
@@ -3022,6 +3088,7 @@ export function getMessagesAfterMulti(
 
   return rows.map((row) => ({
     ...row,
+    content: normalizeTextCell(row.content) ?? '',
     is_from_me: row.is_from_me === 1,
   }));
 }
@@ -3071,6 +3138,7 @@ export function getMessagesByTimeRange(
 
   return rows.map((row) => ({
     ...row,
+    content: normalizeTextCell(row.content) ?? '',
     is_from_me: row.is_from_me === 1,
   }));
 }

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../../stores/auth';
 import { MessageBubble } from './MessageBubble';
 import { StreamingDisplay } from './StreamingDisplay';
 import { EmojiAvatar } from '../common/EmojiAvatar';
+import { ErrorBoundary } from '../common';
 import { Loader2, ChevronUp, ChevronDown, AlertTriangle, Square, Code2, Zap, BookOpen, Wrench } from 'lucide-react';
 import { useDisplayMode } from '../../hooks/useDisplayMode';
 
@@ -505,7 +506,9 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
                 ref={virtualizer.measureElement}
                 data-index={virtualItem.index}
               >
-                <MessageBubble message={message} showTime={showTime} thinkingContent={thinkingCache[message.id]} thinkingDurationMs={thinkingDurationCache[message.id]} isShared={isShared} />
+                <ErrorBoundary>
+                  <MessageBubble message={message} showTime={showTime} thinkingContent={thinkingCache[message.id]} thinkingDurationMs={thinkingDurationCache[message.id]} isShared={isShared} />
+                </ErrorBoundary>
               </div>
             );
           })}

--- a/web/src/components/common/ErrorBoundary.tsx
+++ b/web/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary] caught render error:', error, info.componentStack);
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback(error, this.reset);
+    return (
+      <div className="px-3 py-2 my-1 rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-xs">
+        渲染失败: {error.message}
+      </div>
+    );
+  }
+}

--- a/web/src/components/common/index.ts
+++ b/web/src/components/common/index.ts
@@ -3,3 +3,4 @@ export { EmptyState, type EmptyStateProps } from './EmptyState';
 export { PageHeader, type PageHeaderProps } from './PageHeader';
 export { LoadingSpinner, type LoadingSpinnerProps } from './LoadingSpinner';
 export { ConfirmDialog, type ConfirmDialogProps } from './ConfirmDialog';
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## 用户现象

打开 \`/chat/<某些 task 工作区>\` 时整页黑屏，DOM 里 \`#root\` 完全为空，没有任何错误提示。看起来像页面没加载，实际上是 React 把整棵树卸载了。

## 问题描述

某些 task 工作区里有一条 \`messages.content\` 单元格被存成了 BLOB（不是 TEXT）。better-sqlite3 读 BLOB 单元格返回 Buffer，经 \`JSON.stringify\` 序列化后变成 \`{type:\"Buffer\",data:[…]}\` 对象，前端 \`MessageBubble\` 调 \`message.content.trim()\` 抛 \`TypeError\`。MessageBubble 上方一路到 ChatPage 都没有 ErrorBoundary，未捕获的渲染异常 → React 卸载整个 root → 黑屏。

进一步追溯发现写入侧守卫缺失：\`storeMessageDirect\` / \`createTask\` / \`updateTask\` 都只靠 TS 编译期约束，任何 caller 把 Buffer 当 string 传进来就会无声落 BLOB。生产 DB 里已经看到一条 \`scheduled_tasks.prompt\` 是 BLOB（约 3669 字节，2026-03-15 创建），定时任务每天 03:00 触发就把这条 BLOB 复制成新的 message 行，直到用户打开这个 workspace 才被引爆。

## 复现路径

1. 让 \`messages.content\` 任意一行被存为 BLOB（DB 直接 \`UPDATE messages SET content=? WHERE id=?\` 绑 \`Buffer.from(s,'utf8')\`）
2. 浏览器打开该 workspace 的 \`/chat/<folder>\`
3. 期望：消息正常渲染；实际：整页空白，控制台 \`TypeError: t.content.trim is not a function\` 之后是 React 默认 root 卸载

## 修复方案

### \`src/db.ts\`（写入 + 读取双侧守卫）
- 新增 \`coerceTextField(value, field)\`：写入 TEXT 列前强制转 string，Buffer 按 UTF-8 解码，其他用 \`String()\`，并 \`logger.warn\` 带 caller stack 帮助定位真正的写入源
- 应用到：\`storeMessageDirect.content\`、\`createTask.{prompt,script_command}\`、\`updateTask.{prompt,script_command}\`
- 新增 \`normalizeTextCell(value)\`：读侧透明解码，fast-path 透传 string，遇 Buffer 解码为 UTF-8
- 应用到所有 message 读路径（\`getMessagesPage\` / \`getMessagesAfter\` / \`*Multi\` / \`getNewMessages\` / \`getMessagesSince\`）和 \`mapTaskRow\`

### \`web/src/components/common/ErrorBoundary.tsx\` + \`MessageList.tsx\`
- 新增通用 ErrorBoundary（\`getDerivedStateFromError\` + 默认占位渲染）
- \`MessageList\` 里以单条消息为粒度包裹 \`<MessageBubble>\`，单条渲染失败时只显示 \`渲染失败: <reason>\` 占位，其他消息和侧边栏照常工作

## Test plan

- [x] \`make typecheck\` 全绿
- [x] \`make test\`：204 passed
- [x] 端到端：手动把一行 \`messages.content\` 写成 Buffer，刷新页面后 API 返回 string（read-side decode 生效）、页面正常渲染、ErrorBoundary 不需触发
- [x] 历史脏数据 \`messages.content\` / \`scheduled_tasks.prompt\` 各 1 行已 \`CAST AS TEXT\` 清理