### PR TITLE
修复: Web /clear 走 HTTP 路径未被拦截

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@
 - `PATCH /api/groups/:jid`（重命名） · `DELETE /api/groups/:jid`
 - `POST /api/groups/:jid/reset-session`（重建工作区）
 - `GET /api/groups/:jid/messages`（分页 + 轮询，支持多 JID 查询）
+- `POST /api/messages`（向工作区发送消息；首字符 `/clear` 触发会话重置，返回 `{ success: true, cleared: true }`）
 - `GET|PUT /api/groups/:jid/env`（群组级容器环境变量）
 
 ## 文件

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,6 +22,15 @@ export interface CommandDeps {
   setLastAgentTimestamp: (jid: string, cursor: MessageCursor) => void;
 }
 
+// ─── Command parsing ────────────────────────────────────────────
+
+export function isClearCommand(content: string): boolean {
+  return content.trim().toLowerCase() === '/clear';
+}
+
+export const SESSION_RESET_FAILURE_MESSAGE =
+  'system_error:清除上下文失败，请稍后重试';
+
 // ─── Core reset ─────────────────────────────────────────────────
 
 export async function executeSessionReset(

--- a/src/web.ts
+++ b/src/web.ts
@@ -96,7 +96,11 @@ import {
   ASSISTANT_NAME,
 } from './config.js';
 import { logger } from './logger.js';
-import { executeSessionReset } from './commands.js';
+import {
+  executeSessionReset,
+  isClearCommand,
+  SESSION_RESET_FAILURE_MESSAGE,
+} from './commands.js';
 import {
   normalizeImageAttachments,
   toAgentImages,
@@ -214,6 +218,47 @@ app.post('/api/messages', authMiddleware, async (c) => {
       { error: 'Insufficient permissions for host execution mode' },
       403,
     );
+  }
+
+  // /clear: reset session without entering message pipeline.
+  // Permission: relies on the route-level canAccessGroup + host-mode checks above.
+  // Whether to tighten /clear to owner-only is left to the follow-up ACL audit
+  // (see PR description) — keeping it aligned with send-message for now.
+  if (isClearCommand(content)) {
+    if (!deps) return c.json({ error: 'Server not initialized' }, 500);
+    try {
+      await executeSessionReset(chatJid, group.folder, {
+        queue: deps.queue,
+        sessions: deps.getSessions(),
+        broadcast: broadcastNewMessage,
+        setLastAgentTimestamp: deps.setLastAgentTimestamp,
+      });
+      return c.json({ success: true, cleared: true });
+    } catch (err) {
+      logger.error({ chatJid, err }, '/clear command failed');
+      const errId = crypto.randomUUID();
+      const errTs = new Date().toISOString();
+      ensureChatExists(chatJid);
+      storeMessageDirect(
+        errId,
+        chatJid,
+        '__system__',
+        'system',
+        SESSION_RESET_FAILURE_MESSAGE,
+        errTs,
+        true,
+      );
+      broadcastNewMessage(chatJid, {
+        id: errId,
+        chat_jid: chatJid,
+        sender: '__system__',
+        sender_name: 'system',
+        content: SESSION_RESET_FAILURE_MESSAGE,
+        timestamp: errTs,
+        is_from_me: true,
+      });
+      return c.json({ error: '清除上下文失败' }, 500);
+    }
   }
 
   const result = await handleWebUserMessage(
@@ -829,6 +874,70 @@ function setupWebSocket(server: any): WebSocketServer {
             return;
           }
 
+          // ── /clear command: reset session without entering message pipeline ──
+          // Must run before the agentId early return so /clear in a sub-agent tab
+          // resets the agent session (passing agentId) instead of being delivered
+          // to the agent as plain text.
+          // Permission: relies on the canAccessGroup + host-mode checks above
+          // (kept aligned with send-message; ACL tightening tracked in follow-up).
+          // Success has no explicit ws_error/ack — the client sees the reset
+          // through the broadcastNewMessage(context_reset) push from executeSessionReset.
+          if (isClearCommand(content) && deps && targetGroup) {
+            // Validate agentId before passing to executeSessionReset →
+            // clearSessionFiles, which interpolates agentId into a filesystem
+            // path. Mirrors the reset-session route's check (routes/groups.ts).
+            if (agentId) {
+              const agent = getAgent(agentId);
+              if (!agent || agent.chat_jid !== chatJid) {
+                sendWsError('Agent not found', chatJid);
+                return;
+              }
+            }
+            const errorTargetJid = agentId
+              ? `${chatJid}#agent:${agentId}`
+              : chatJid;
+            try {
+              await executeSessionReset(
+                chatJid,
+                targetGroup.folder,
+                {
+                  queue: deps.queue,
+                  sessions: deps.getSessions(),
+                  broadcast: broadcastNewMessage,
+                  setLastAgentTimestamp: deps.setLastAgentTimestamp,
+                },
+                agentId,
+              );
+            } catch (err) {
+              logger.error(
+                { chatJid, agentId, err },
+                '/clear command failed',
+              );
+              const errId = crypto.randomUUID();
+              const errTs = new Date().toISOString();
+              ensureChatExists(errorTargetJid);
+              storeMessageDirect(
+                errId,
+                errorTargetJid,
+                '__system__',
+                'system',
+                SESSION_RESET_FAILURE_MESSAGE,
+                errTs,
+                true,
+              );
+              broadcastNewMessage(errorTargetJid, {
+                id: errId,
+                chat_jid: errorTargetJid,
+                sender: '__system__',
+                sender_name: 'system',
+                content: SESSION_RESET_FAILURE_MESSAGE,
+                timestamp: errTs,
+                is_from_me: true,
+              });
+            }
+            return;
+          }
+
           // Route to agent conversation handler if agentId is present
           if (agentId && deps) {
             await handleAgentConversationMessage(
@@ -839,45 +948,6 @@ function setupWebSocket(server: any): WebSocketServer {
               session.display_name || session.username,
               attachments,
             );
-            return;
-          }
-
-          // ── /clear command: reset session without entering message pipeline ──
-          if (content.trim().toLowerCase() === '/clear' && deps) {
-            const targetGroup = getRegisteredGroup(chatJid);
-            if (targetGroup) {
-              try {
-                await executeSessionReset(chatJid, targetGroup.folder, {
-                  queue: deps.queue,
-                  sessions: deps.getSessions(),
-                  broadcast: broadcastNewMessage,
-                  setLastAgentTimestamp: deps.setLastAgentTimestamp,
-                });
-              } catch (err) {
-                logger.error({ chatJid, err }, '/clear command failed');
-                const errId = crypto.randomUUID();
-                const errTs = new Date().toISOString();
-                ensureChatExists(chatJid);
-                storeMessageDirect(
-                  errId,
-                  chatJid,
-                  '__system__',
-                  'system',
-                  'system_error:清除上下文失败，请稍后重试',
-                  errTs,
-                  true,
-                );
-                broadcastNewMessage(chatJid, {
-                  id: errId,
-                  chat_jid: chatJid,
-                  sender: '__system__',
-                  sender_name: 'system',
-                  content: 'system_error:清除上下文失败，请稍后重试',
-                  timestamp: errTs,
-                  is_from_me: true,
-                });
-              }
-            }
             return;
           }
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { isClearCommand } from '../src/commands.js';
+
+// Hoisted so mock factories below can reference these before module evaluation.
+const {
+  deleteSessionMock,
+  getJidsByFolderMock,
+  storeMessageDirectMock,
+  ensureChatExistsMock,
+} = vi.hoisted(() => ({
+  deleteSessionMock: vi.fn(),
+  getJidsByFolderMock: vi.fn(),
+  storeMessageDirectMock: vi.fn(),
+  ensureChatExistsMock: vi.fn(),
+}));
+
+vi.mock('../src/db.js', () => ({
+  deleteSession: deleteSessionMock,
+  getJidsByFolder: getJidsByFolderMock,
+  storeMessageDirect: storeMessageDirectMock,
+  ensureChatExists: ensureChatExistsMock,
+}));
+
+vi.mock('../src/config.js', () => ({
+  DATA_DIR: '/tmp/happyclaw-test',
+}));
+
+describe('isClearCommand', () => {
+  test('exact match', () => {
+    expect(isClearCommand('/clear')).toBe(true);
+  });
+
+  test('case insensitive', () => {
+    expect(isClearCommand('/Clear')).toBe(true);
+  });
+
+  test('whitespace tolerant', () => {
+    expect(isClearCommand('  /clear  ')).toBe(true);
+  });
+
+  test('rejects trailing args', () => {
+    expect(isClearCommand('/clear hello')).toBe(false);
+  });
+
+  test('rejects embedded substring', () => {
+    expect(isClearCommand('hi /clear')).toBe(false);
+  });
+
+  // Pin behavior: full-width slash is a different codepoint, must not match.
+  test('rejects full-width slash', () => {
+    expect(isClearCommand('／clear')).toBe(false);
+  });
+});
+
+describe('executeSessionReset', () => {
+  beforeEach(() => {
+    deleteSessionMock.mockReset();
+    getJidsByFolderMock.mockReset();
+    storeMessageDirectMock.mockReset();
+    ensureChatExistsMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  test('resets a bound conversation agent under the real workspace jid', async () => {
+    const { executeSessionReset } = await import('../src/commands.js');
+    const stopGroup = vi.fn(async () => {});
+    const broadcast = vi.fn();
+    const setLastAgentTimestamp = vi.fn();
+    const sessions = { 'flow-graduation': 'session-1' } as Record<
+      string,
+      string
+    >;
+
+    await executeSessionReset(
+      'web:graduation-jid',
+      'flow-graduation',
+      {
+        queue: { stopGroup },
+        sessions,
+        broadcast,
+        setLastAgentTimestamp,
+      },
+      'agent-1234',
+    );
+
+    // Agent path: only the virtual JID is stopped (no sibling fan-out).
+    expect(stopGroup).toHaveBeenCalledTimes(1);
+    expect(stopGroup).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+      { force: true },
+    );
+    expect(ensureChatExistsMock).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+    );
+    expect(setLastAgentTimestamp).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      'web:graduation-jid#agent:agent-1234',
+      expect.objectContaining({
+        chat_jid: 'web:graduation-jid#agent:agent-1234',
+      }),
+    );
+    // Agent path must NOT delete the main session's cached session ID —
+    // sub-agent /clear should not corrupt the parent workspace's session.
+    expect(sessions).toHaveProperty('flow-graduation', 'session-1');
+  });
+
+  test('resets a main session by stopping all sibling JIDs and clearing the folder cache', async () => {
+    const { executeSessionReset } = await import('../src/commands.js');
+    const stopGroup = vi.fn(async () => {});
+    const broadcast = vi.fn();
+    const setLastAgentTimestamp = vi.fn();
+    const sessions = {
+      'home-u1': 'session-main',
+      'other-folder': 'session-other',
+    } as Record<string, string>;
+
+    getJidsByFolderMock.mockReturnValue(['web:foo', 'feishu:bar']);
+
+    await executeSessionReset(
+      'web:foo',
+      'home-u1',
+      {
+        queue: { stopGroup },
+        sessions,
+        broadcast,
+        setLastAgentTimestamp,
+      },
+      // agentId omitted (undefined) — main session branch
+    );
+
+    // stopGroup called once per sibling JID, all with { force: true }
+    expect(stopGroup).toHaveBeenCalledTimes(2);
+    expect(stopGroup).toHaveBeenCalledWith('web:foo', { force: true });
+    expect(stopGroup).toHaveBeenCalledWith('feishu:bar', { force: true });
+
+    // setLastAgentTimestamp called once per sibling JID
+    expect(setLastAgentTimestamp).toHaveBeenCalledTimes(2);
+    expect(setLastAgentTimestamp).toHaveBeenCalledWith(
+      'web:foo',
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+    expect(setLastAgentTimestamp).toHaveBeenCalledWith(
+      'feishu:bar',
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+
+    // sessions[folder] entry removed (in-memory cache)
+    expect(sessions).not.toHaveProperty('home-u1');
+    // unrelated entries preserved
+    expect(sessions).toHaveProperty('other-folder', 'session-other');
+
+    // ensureChatExists / broadcast use the baseChatJid (not a virtual agent JID)
+    expect(ensureChatExistsMock).toHaveBeenCalledWith('web:foo');
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith(
+      'web:foo',
+      expect.objectContaining({
+        chat_jid: 'web:foo',
+        content: 'context_reset',
+      }),
+    );
+  });
+});

--- a/tests/im-command-utils.test.ts
+++ b/tests/im-command-utils.test.ts
@@ -1,26 +1,10 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import {
   resolveBoundChatTarget,
   type RegisteredGroupLike,
   type AgentLike,
 } from '../src/im-command-utils.js';
-
-const deleteSessionMock = vi.fn();
-const getJidsByFolderMock = vi.fn();
-const storeMessageDirectMock = vi.fn();
-const ensureChatExistsMock = vi.fn();
-
-vi.mock('../src/db.js', () => ({
-  deleteSession: deleteSessionMock,
-  getJidsByFolder: getJidsByFolderMock,
-  storeMessageDirect: storeMessageDirectMock,
-  ensureChatExists: ensureChatExistsMock,
-}));
-
-vi.mock('../src/config.js', () => ({
-  DATA_DIR: '/tmp/happyclaw-test',
-}));
 
 describe('resolveBoundChatTarget', () => {
   const registeredGroups = new Map<string, RegisteredGroupLike>([
@@ -90,56 +74,5 @@ describe('resolveBoundChatTarget', () => {
       agentId: 'agent-1234',
       locationLine: 'graduation / Thesis Agent',
     });
-  });
-});
-
-describe('executeSessionReset', () => {
-  beforeEach(() => {
-    deleteSessionMock.mockReset();
-    getJidsByFolderMock.mockReset();
-    storeMessageDirectMock.mockReset();
-    ensureChatExistsMock.mockReset();
-    vi.useRealTimers();
-  });
-
-  test('resets a bound conversation agent under the real workspace jid', async () => {
-    const { executeSessionReset } = await import('../src/commands.js');
-    const stopGroup = vi.fn(async () => {});
-    const broadcast = vi.fn();
-    const setLastAgentTimestamp = vi.fn();
-    const sessions = { 'flow-graduation': 'session-1' } as Record<
-      string,
-      string
-    >;
-
-    await executeSessionReset(
-      'web:graduation-jid',
-      'flow-graduation',
-      {
-        queue: { stopGroup },
-        sessions,
-        broadcast,
-        setLastAgentTimestamp,
-      },
-      'agent-1234',
-    );
-
-    expect(stopGroup).toHaveBeenCalledWith(
-      'web:graduation-jid#agent:agent-1234',
-      { force: true },
-    );
-    expect(ensureChatExistsMock).toHaveBeenCalledWith(
-      'web:graduation-jid#agent:agent-1234',
-    );
-    expect(setLastAgentTimestamp).toHaveBeenCalledWith(
-      'web:graduation-jid#agent:agent-1234',
-      expect.objectContaining({ id: expect.any(String) }),
-    );
-    expect(broadcast).toHaveBeenCalledWith(
-      'web:graduation-jid#agent:agent-1234',
-      expect.objectContaining({
-        chat_jid: 'web:graduation-jid#agent:agent-1234',
-      }),
-    );
   });
 });

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -124,6 +124,8 @@ export function MessageList({ messages, loading, hasMore, onLoadMore, scrollTrig
             items.push({ type: 'error', content: msg.content.slice('agent_error:'.length) });
           } else if (msg.content.startsWith('agent_max_retries:')) {
             items.push({ type: 'error', content: msg.content.slice('agent_max_retries:'.length) });
+          } else if (msg.content.startsWith('system_error:')) {
+            items.push({ type: 'error', content: msg.content.slice('system_error:'.length) });
           } else if (msg.content.startsWith('system_info:')) {
             items.push({ type: 'divider', content: msg.content.slice('system_info:'.length) });
           }

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -549,6 +549,7 @@ function isTerminalSystemMessage(message: Pick<Message, 'sender' | 'content'>): 
   // query_interrupted 仅作为视觉分隔线，不参与流式状态清理。
   // 流式状态由 status:interrupted（冻结）→ interrupt_partial（转正）两阶段处理。
   return message.sender === '__system__' && (
+    message.content === 'context_reset' ||
     message.content.startsWith('agent_error:') ||
     message.content.startsWith('agent_max_retries:') ||
     message.content.startsWith('context_overflow:')
@@ -1010,7 +1011,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
         body.attachments = attachments.map(att => ({ type: 'image', ...att }));
       }
 
-      const data = await api.post<{ success: boolean; messageId: string; timestamp: string }>('/api/messages', body);
+      type ClearedResponse = { success: true; cleared: true };
+      type MessageCreateResponse =
+        | ClearedResponse
+        | { success: true; messageId: string; timestamp: string }
+        | { success: false };
+      const isClearedResponse = (
+        d: MessageCreateResponse,
+      ): d is ClearedResponse =>
+        d.success === true && 'cleared' in d && d.cleared === true;
+
+      const data = await api.post<MessageCreateResponse>('/api/messages', body);
       if (!data.success) {
         // Server returned non-success payload — surface as a send failure so caller can retain input.
         const msg = '服务器返回失败，请重试';
@@ -1018,6 +1029,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
         showToast('发送失败', msg);
         return false;
       }
+      // /clear was intercepted server-side: skip local user message merge.
+      // The context_reset divider arrives via WS new_message and triggers state cleanup.
+      if (isClearedResponse(data)) return true;
       // Add user message to local state immediately
       const authState = useAuthStore.getState();
       const sender = authState.user?.id || 'web-user';


### PR DESCRIPTION
## 问题描述

Web 端用户在主会话输入框发送 `/clear` 时，后端 HTTP 路由没有拦截，命令被当作普通消息送给 Agent，Agent 回复"`/clear` 是内置命令…"，体验上看像 `/clear` 不工作。同时 sub-agent tab 的 `/clear` 也无法工作。

## 根因

1. 前端主会话 `sendMessage` 走 HTTP `POST /api/messages`（`web/src/stores/chat.ts:1018`），但 `src/web.ts` 的 HTTP 路由**没有 `/clear` 拦截**。WS 分支虽有但前端从不走那条路径。
2. WS 分支 sub-agent `/clear` **顺序错误**：`if (agentId)` 早返回先于 `/clear` 检查，sub-agent tab 的 `/clear` 被当作普通消息送给 sub-agent。
3. 前端 `isTerminalSystemMessage` 不识别 `context_reset`（`web/src/stores/chat.ts:547`），流式中触发 `/clear` 时 streaming/waiting 残留（同时影响 IM `/clear` 与设置页 reset 按钮）。
4. `MessageList.tsx` 没有 `system_error:` 渲染分支，新引入的 `/clear` 失败 broadcast 在前端会被静默丢弃。

## 修复方案

### `src/commands.ts`
- 抽 `isClearCommand(content)` helper 消除字符串字面量重复。
- 新增 `SESSION_RESET_FAILURE_MESSAGE` 常量统一错误兜底文案。

### `src/web.ts`
- POST `/api/messages` 加 `/clear` 拦截块（host execution 权限校验之后、`handleWebUserMessage` 之前）。catch 持久化 `system_error:` 消息 + broadcast，HTTP 返 500。
- WS 分支 `/clear` 拦截前移到 `agentId` 早返回**之前**，把 `agentId` 传给 `executeSessionReset`，错误广播路由到 virtual JID（`chatJid#agent:agentId`）。
- 在 `executeSessionReset` 调用前加 `agentId` 验证（`getAgent` + `chat_jid` 比对，与 `routes/groups.ts:991-996` reset-session 路由一致），防止 attacker 利用 `agentId` 进入 `clearSessionFiles` 的 `path.join` 做 path traversal。

### `web/src/stores/chat.ts`
- `sendMessage` 响应类型改 discriminated union（`{cleared:true} | {messageId,timestamp} | {success:false}`）+ `isClearedResponse` 类型谓词，`cleared` 时早返回不本地插入用户消息。
- `isTerminalSystemMessage` 加 `message.content === 'context_reset'` 条件，让 WS new_message 与增量拉取两条路径都能在收到 `context_reset` 时清 streaming/waiting/pendingThinking。

### `web/src/components/chat/MessageList.tsx`
- 加 `system_error:` 渲染分支，复用 `agent_error:` 的红色错误气泡（去前缀只显示文案）。否则 `__system__` 消息无匹配前缀时会被无声丢弃。

### `tests/commands.test.ts`（新建）
- `isClearCommand` 6 case：精确匹配、大小写、首尾空白、拒绝带参数、拒绝嵌入子串、拒绝全角斜杠。
- `executeSessionReset` agent 路径（迁自 `im-command-utils.test.ts`），强化 "agent 路径不 fan-out 到 sibling JID" + "agent 路径不删 `sessions[folder]`" 两条断言（防 sub-agent `/clear` 误删 main session 缓存）。
- `executeSessionReset` main session 路径（新增）：覆盖原本未测试的 `getJidsByFolder` 多 JID stop + sibling cursor 推进。

### `tests/im-command-utils.test.ts`
- `executeSessionReset` describe 迁到 `commands.test.ts`，命名一致性。本文件保留 `resolveBoundChatTarget` 测试。

### `docs/API.md`
- 补 `POST /api/messages` 端点（pre-existing 漏列）。

## 不在本 PR

- `/clear` 权限**暂保持与 `send-message` 一致**（`canAccessGroup`）。是否收紧到 owner-only（`canModifyGroup`）留给独立 ACL 审计 follow-up issue 决定——共享工作区可能就是公共机器人场景，权限语义变更不应混在 bugfix 里。
- `/sw` `/spawn` 在 HTTP 路径同样未拦截（HTTP/WS 镜像问题）— follow-up。
- `MessageList.tsx` 之前 `__system__` 消息无匹配前缀时被静默丢弃是 pre-existing 问题，本 PR 仅补齐 `system_error:` 这一条。

## 测试

HTTP 路由无现成 hono test harness，用 `isClearCommand` helper 单测 + `executeSessionReset` core 测试兜底；POST `/api/messages` 拦截路径靠手测验证。

- [x] `make typecheck` 全绿
- [x] `make test` 269 测试全过（20 文件）

## 手动验证

- [x] Web 主会话 `/clear`（含大小写、空白）→ 后端日志 `Session reset via /clear command`，前端只多一条"上下文已清除"分割线，输入框清空，无 Agent 回复
- [x] sub-agent tab `/clear` → 同样触发 reset，不被当作普通消息
- [x] 流式中 `/clear` → 流式卡片消失，waiting 清除，divider 出现
- [x] 刷新页面 → divider 持久化，streaming 不重新出现
- [x] `/clear` 失败兜底 → 前端 toast"发送失败"+ 聊天历史出现红色错误气泡，HTTP 500，输入保留
- [x] 普通文本仍走 `handleWebUserMessage` 与 Agent

---

## 开发流程

本 PR 基于 #487 新增的能力，全程在 HappyClaw 网页端（而不是本地终端）完成开发——用网页 chat 驱动 Claude Code agent 写代码 / 跑测试 / 改 review 反馈。开发中还调用了 `/codex:review` 这个 Codex 插件功能（GPT-5.x review 当前 working tree diff），收到 P2 反馈后修了一轮 path traversal 安全问题与 sub-agent /clear 漏拦。所以这个 PR 也算变相对 #487 的网页端开发体验 + 插件功能做了一次实地试用。
