### PR TITLE
修复: reloadFeishuConnection admin 热重载缺路由回调导致 IM 绑定失效

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8132,6 +8132,10 @@ async function main(): Promise<void> {
         {
           ignoreMessagesBefore: Date.now(),
           onCommand: handleCommand,
+          resolveGroupFolder: (chatJid: string) =>
+            resolveEffectiveFolder(chatJid),
+          resolveEffectiveChatJid: buildResolveEffectiveChatJid(),
+          onAgentMessage: buildOnAgentMessage(),
           onBotAddedToGroup: buildFeishuBotAddedHandler(adminUser.id, homeFolder, getAdminOwnerOpenId),
           onBotRemovedFromGroup: buildOnBotRemovedFromGroup(),
           shouldProcessGroupMessage,


### PR DESCRIPTION
## 问题描述

admin 用户通过系统级 API（legacy，对应 `/api/config/feishu`）保存飞书配置时，所有 IM 绑定关系立即失效，消息被强制路由到 home 工作区，必须重启服务才能恢复。

## 根因

`reloadFeishuConnection`（admin legacy 热重载路径）在调用 `imManager.connectUserFeishu` 重建连接时，缺少三个路由回调：

- `resolveGroupFolder` — 解析 IM 聊天对应的工作区 folder
- `resolveEffectiveChatJid` — 根据 IM 绑定关系解析目标工作区 JID
- `onAgentMessage` — 触发 Sub-Agent 消息处理

缺少 `resolveEffectiveChatJid` 后，`feishu.ts` 中 `agentRouting?.effectiveJid ?? chatJid` 始终回退到原始 `chatJid`（即 home 工作区），所有绑定关系形同虚设。

## 上下文（为何 #481 没覆盖到）

#481 已经修复了另外两条路径：

- `connectUserIMChannels`（启动路径）— 启动时读取已保存配置
- `reloadUserIMConfig`（per-user 热重载，对应 `/api/config/user-im/feishu`）

但 admin 走 legacy 系统级 API 保存时，走的是 `reloadFeishuConnection` 路径，这条路径上游仍遗漏三个回调。本 PR 补齐。

对比之下：
- `reloadTelegramConnection` 路径不需要这三个回调（Telegram 连接 API 的签名不同）
- `reloadUserIMConfig` 的飞书分支已有（#481 修复）
- `connectUserIMChannels` 启动路径已有（#481 修复）

实现上完全对齐 `reloadUserIMConfig` 飞书分支的写法。

## 修复方案

### `src/index.ts`

在 `reloadFeishuConnection` 的 `connectUserFeishu` options 里补齐三个回调（紧接 `onCommand` 后，与 `reloadUserIMConfig` 的飞书分支保持一致的顺序与风格）。

单文件 +4 行，无其他改动。

## 测试计划

- [x] `make typecheck` 通过
- [x] `make test`（262 tests）通过
- [x] 人工验证：admin 保存系统级飞书配置后，已绑定的 IM 群组消息仍正确路由到目标工作区（无需重启）
- [x] 人工验证：admin 保存后，重新绑定到不同工作区即时生效

## 为何这次拆成独立 PR

承接 #503 审查反馈。原 #503 混合了 5 个独立主题（飞书回调 + 钉钉引用 + 文件提取器 + prompt 加固 + session recovery），基线也过旧（fork 自 #481 合入前）。

其中：
- 钉钉引用/文件提取 → #501 已合并
- session recovery 文案 → #502 已合并
- prompt 注入加固（`sanitizeFileName` / nonce fence / `randomBytes`）→ 已在 main 的 `src/dingtalk.ts` 中
- 飞书回调 → **本 PR，基于最新 main 单独提交**