### PR TITLE
修复: PATH 中的 claude 包装器导致宿主机 agent 报 Not logged in

### DIFF
--- a/src/agent-capabilities.ts
+++ b/src/agent-capabilities.ts
@@ -9,7 +9,9 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import { logger } from './logger.js';
 
 const execFileAsync = promisify(execFile);
@@ -68,6 +70,7 @@ export const AGENT_CAPABILITIES: AgentCapability[] = [
 ];
 
 async function isBinaryAvailable(binary: string): Promise<boolean> {
+  if (binary === 'claude' && resolveSdkBundledClaude()) return true;
   try {
     await execFileAsync('which', [binary], { timeout: 5_000 });
     return true;
@@ -77,11 +80,62 @@ async function isBinaryAvailable(binary: string): Promise<boolean> {
 }
 
 /**
- * Resolve the actual path of a binary using `which`.
- * This is needed because `node_modules/.bin/` may contain stubs that shadow
- * the actual working binary.
+ * Locate the platform-specific Claude CLI binary shipped inside the SDK package
+ * at `container/agent-runner/node_modules/@anthropic-ai/claude-agent-sdk-<plat>-<arch>/claude`.
+ *
+ * Prefer this over `which claude` because:
+ *   1. PATH may be polluted by third-party wrappers (e.g. cmux ships its own
+ *      `claude` wrapper that hijacks the command and outputs "Not logged in"
+ *      when run outside its own terminal session).
+ *   2. The SDK binary is the upstream Anthropic build, version-pinned with the
+ *      SDK we actually use.
+ */
+function resolveSdkBundledClaude(): string | null {
+  const platMap: Record<string, string> = {
+    darwin: 'darwin',
+    linux: 'linux',
+    win32: 'win32',
+  };
+  const archMap: Record<string, string> = {
+    arm64: 'arm64',
+    x64: 'x64',
+  };
+  const plat = platMap[process.platform];
+  const arch = archMap[process.arch];
+  if (!plat || !arch) return null;
+  const binName = process.platform === 'win32' ? 'claude.exe' : 'claude';
+  const candidate = path.join(
+    process.cwd(),
+    'container',
+    'agent-runner',
+    'node_modules',
+    '@anthropic-ai',
+    `claude-agent-sdk-${plat}-${arch}`,
+    binName,
+  );
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the actual path of a binary.
+ *
+ * For `claude`, the SDK-bundled binary takes precedence over PATH lookup —
+ * this avoids cmux-style wrappers that shadow `claude` in PATH and break
+ * subprocess invocation.
+ *
+ * Fallback uses `which` because `node_modules/.bin/` may contain stubs that
+ * shadow the actual working binary.
  */
 async function resolveBinaryPath(binary: string): Promise<string | null> {
+  if (binary === 'claude') {
+    const bundled = resolveSdkBundledClaude();
+    if (bundled) return bundled;
+  }
   try {
     const { stdout } = await execFileAsync('which', [binary], {
       timeout: 5_000,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1455,17 +1455,17 @@ export async function runHostAgent(
       if (!hostEnv[key]) hostEnv[key] = value;
     }
 
-    // Ensure the resolved claude binary path takes precedence over any stub in node_modules/.bin/
-    // 新版本 SDK (0.2.114+) 内部使用 which 查找 claude CLI，但 node_modules/.bin/claude
-    // 可能是 stub。通过 which 找到的实际路径应该优先被找到。
+    // Prepend the resolved claude binary directory to PATH so SDK subprocesses
+    // (which look up `claude` via PATH) hit the correct binary first. agent-capabilities
+    // prefers the SDK-bundled binary over `which` to avoid third-party wrappers
+    // (e.g. cmux) that hijack `claude` in PATH and break subprocess invocation.
     if (capResult.resolvedPaths['claude']) {
       const resolvedClaudeDir = path.dirname(capResult.resolvedPaths['claude']);
-      // 将 resolved claude 所在目录放到 PATH 最前面，确保优先找到
       const currentPath = hostEnv['PATH'] || process.env.PATH || '';
       hostEnv['PATH'] = `${resolvedClaudeDir}:${currentPath}`;
       logger.info(
         { group: group.name, resolvedClaudeDir, resolvedPath: capResult.resolvedPaths['claude'] },
-        'Host preflight: using resolved claude from which',
+        'Host preflight: claude binary resolved',
       );
     }
 


### PR DESCRIPTION
## 用户现象

主对话发消息后 Agent 立刻返回 `Not logged in · Please run /login`，0 tokens、0.1s 内退出，不消耗任何 API 用量。第三方 provider（如 mimo）和官方 OAuth provider 都受影响。**典型触发条件是宿主机 PATH 中存在某个第三方工具往同名 `claude` 命令做的包装器** —— 当前已知案例是 [cmux](https://cmux.sh) 终端 app，它把自己的 `claude` bash wrapper 注入到 shell PATH 最前；同样思路的 wrapper（CodeWhisperer、Warp、自定义 dotfiles 等）也会触发。

## 问题描述

`Not logged in · Please run /login` 不是 Provider 鉴权失败，而是来自被劫持后的 `claude` 命令本身。happyclaw 的 `agent-capabilities.ts:resolveBinaryPath` 通过 `which claude` 找命令，命中了 PATH 中第一个名为 `claude` 的可执行文件——如果那是个第三方 wrapper（典型如 cmux），它会在脱离自己上下文（happyclaw 子进程没有相应 socket / session token）时直接 print 该消息退出。happyclaw 把这个 wrapper 路径 prepend 到子进程 PATH，agent-runner 进而把 wrapper 当成执行引擎。

## 复现路径（cmux 为例）

1. macOS 上安装 cmux（它会把 `/Applications/cmux.app/Contents/Resources/bin` 注入 shell PATH 最前，里面有同名 `claude` 包装脚本）
2. 在任意 cmux 启动的终端里跑 `pm2 start dist/index.js`，或者直接 `node dist/index.js`
3. 配置任一 host 模式 provider（实测 mimo / 官方 OAuth 都能复现）
4. 主对话发消息
5. **期望**：Agent 正常回复
6. **实际**：Agent 输出 `Not logged in · Please run /login` + 0 tokens + 0.1s 退出

> 任何"在 PATH 早段塞同名 `claude` 命令"的工具都会触发同一问题，cmux 只是当前已知最广泛的案例。

## 根因

`src/agent-capabilities.ts:84` 的 `resolveBinaryPath()` 仅依赖 `which claude`：

```ts
async function resolveBinaryPath(binary: string): Promise<string | null> {
  try {
    const { stdout } = await execFileAsync('which', [binary], { timeout: 5_000 });
    return stdout.trim() || null;
  } catch {
    return null;
  }
}
```

只要 PATH 里有第三方 wrapper 排在真实 claude 二进制前面，返回的就是 wrapper 路径而非真正的 claude binary。container-runner.ts 把这个路径 prepend 到 hostEnv['PATH']，agent-runner 进而把 wrapper 当成执行引擎。

可以通过 happyclaw 的 pm2-out.log 确认是否中招——找这行：
```
Host preflight: claude binary resolved
  resolvedPath: "/Applications/cmux.app/Contents/Resources/bin/claude"
```
路径不是 `node_modules/@anthropic-ai/claude-agent-sdk-*` 即为本 issue。

## 影响

- 装了任何会注入 `claude` 命令包装器工具的用户，host 模式（admin 主容器）完全不可用
- 错误信息误导：看起来像 provider auth 问题，实际是本地 wrapper 劫持。我自己排查时被引导去查了 mimo provider key、OAuth credentials、session 目录残留 OAuth 凭据等多个无关方向
- provider key 完全合法、curl 直接 200，仍然 \"Not logged in\"，排查成本高

## 修复方案

让 `resolveBinaryPath('claude')` 优先返回 SDK 自带的 claude 二进制（`container/agent-runner/node_modules/@anthropic-ai/claude-agent-sdk-<plat>-<arch>/claude`），仅在 SDK 未铺该平台/架构时回退到 `which`。

SDK 的二进制是 Anthropic 上游构建的真 claude，跟着 SDK 版本走，不被 PATH 污染影响。

### `src/agent-capabilities.ts`

- 新增 `resolveSdkBundledClaude()`：根据 `process.platform`/`process.arch` 拼出 SDK 包内的 claude binary 路径，存在且可执行才返回
- `resolveBinaryPath('claude')`：先调 `resolveSdkBundledClaude()`，命中即返回；否则走原 `which` 路径
- `isBinaryAvailable('claude')`：同样先 short-circuit SDK bundled，避免 SDK 包齐备但宿主无 PATH 中 claude 时被误判为 missing

### `src/container-runner.ts`

log 文案 `using resolved claude from which` 改为 `claude binary resolved`，避免在已经从 SDK bundle 拿路径时仍然说 \"from which\" 误导。注释同步更新。

## 验证

```bash
# 即使 PATH 第一位是 cmux wrapper，新逻辑依然返回 SDK bundled binary
PATH=\"/Applications/cmux.app/Contents/Resources/bin:\$PATH\" node -e \"
import('./dist/agent-capabilities.js').then(async (m) => {
  const r = await m.checkHostCapabilities();
  console.log(r.resolvedPaths.claude);
});
\"
# 输出: /<repo>/container/agent-runner/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude
```

实机验证：装了 cmux 的 macOS + mimo provider，修复前每次报 Not logged in，应用本 commit 后主对话正常返回模型回复。