### PR TITLE
文档: 在 PR 规范中补充分支干净性要求

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,6 +616,13 @@ WebSocket：`/ws`（协议详见 §3.6）。
 
 **Issue 正文**（Feature）：自由格式，说清需求背景和预期行为即可。
 
+**PR 分支干净性**：目标是 PR 只含本次要提的 commit，不夹带其它本地 commit。
+
+提 PR 前先 `git fetch upstream`，再用 `git log upstream/main..HEAD` 自查——输出应只含本次要提的 commit。
+
+- 若本地 `main` 与 `upstream/main` 对齐，从本地 `main` 切分支没问题；
+- 若本地 `main` 有未合并到上游的 commit（之前提的 PR 未 merge / 被关闭等），从它切会把这些 commit 一并带进新 PR。这种情况要么直接从 `upstream/main` 切（`git fetch upstream && git checkout -b fix/xxx upstream/main`），要么修正：`git checkout -B <branch> upstream/main && git cherry-pick <你的 commit>` 后 `git push --force-with-lease fork <branch>`（force push 自己的功能分支需用户确认，但属于必要清理）。
+
 **PR 标题**：与 commit message 一致，`类型: 简要描述`（如 `修复: 定时任务运行时用户消息被吞掉的问题 (#151)`）。关联 Issue 时在末尾加 `(#issue号)`。
 
 **PR 正文**：


### PR DESCRIPTION
重新提交 PR #510，已按评审意见修复分支干净性问题。

## 问题描述

CLAUDE.md §10.1 PR 规范没有提到分支干净性要求。从本地 `main` 切分支时，如果本地 `main` 落后于 `upstream/main` 或保留了未合并到上游的 commit（之前提的 PR 未 merge / 被关闭等），新 PR 会被串入无关 commit，需要事后修正。

## 实现方案

### `CLAUDE.md` §10.1

在「Issue 正文（Feature）」与「PR 标题」之间补充「PR 分支干净性」段落：

- 强调目的：PR 只含本次要提的 commit
- 给出自查命令：`git log upstream/main..HEAD`
- 区分两种情况：本地 main 已对齐上游 vs 有未合并 commit
- 给出修正方法：`reset --hard upstream/main + cherry-pick + force-with-lease`，并保留「force push 自己的功能分支需用户确认」的边界

## 与 #510 的差异

#510 因从 stale local main 切出，被串入了 PR #509 的代码改动（43 文件 / +2580 行）。本 PR 已 reset 到 `upstream/main` 后 cherry-pick CLAUDE.md commit，diff 只剩 1 commit / 1 文件 / +7 行，本身即是新规范的可验证范例。