### PR TITLE
修复: 重启后逾期定时任务集体 backfill 导致刷屏 (#520)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,6 +546,7 @@ WebSocket：`/ws`（协议详见 §3.6）。
 | `MAX_LOGIN_ATTEMPTS` | `5` | 登录失败锁定阈值（可通过设置页覆盖） |
 | `LOGIN_LOCKOUT_MINUTES` | `15` | 锁定持续时间（分钟）（可通过设置页覆盖） |
 | `AUTO_COMPACT_WINDOW` | `0`（禁用，使用 SDK 默认 ~1M） | Claude Agent SDK 自动对话压缩触发点（tokens），0 = 关闭，>0 范围 [10000, 2000000]（可通过设置页覆盖） |
+| `TASK_BACKFILL_GRACE_MS` | `300000`（5min） | 定时任务逾期容忍窗口（毫秒）。停机重启后 `next_run` 距今超过该窗口的任务直接跳过本次（推到下一次触发），避免跨天积压任务集体 fire 刷屏。0 = 关闭旧行为（可通过设置页覆盖） |
 | `TRUST_PROXY` | `false` | 信任反向代理的 `X-Forwarded-For` 头（启用后从代理头获取客户端 IP） |
 | `TZ` | 系统时区 | 定时任务时区 |
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -2116,6 +2116,19 @@ export function updateTaskAfterRun(
   ).run(nextRun, now, lastResult, nextRun, id);
 }
 
+// Advance next_run for a task we deliberately did NOT execute (e.g. overdue
+// beyond the backfill grace window). Does not touch last_run, so the task
+// detail view continues to reflect the last *actual* run.
+export function advanceSkippedTask(id: string, nextRun: string | null): void {
+  db.prepare(
+    `
+    UPDATE scheduled_tasks
+    SET next_run = ?, status = CASE WHEN ? IS NULL THEN 'completed' ELSE status END
+    WHERE id = ?
+  `,
+  ).run(nextRun, nextRun, id);
+}
+
 export function logTaskRun(log: TaskRunLog): void {
   db.prepare(
     `

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3539,6 +3539,11 @@ export interface SystemSettings {
   // false = 关闭定时扫描，admin 仍可手点 POST /api/plugins/catalog/scan。
   // 适用于不希望本机私有 plugin 自动入共享 catalog 的环境。
   pluginAutoScan: boolean;
+  // 定时任务逾期容忍窗口（毫秒）。任何 next_run 落在过去且距今超过该窗口的任务
+  // 在 scheduler 轮询时直接跳过本次（next_run 推到下一次），避免停机/重启后多个
+  // 跨天积压任务集体在重启那一秒并发 fire 刷屏。
+  // 0 = 关闭（保留旧行为：无视逾期时长全部 backfill）。默认 300000 (5 分钟)。
+  taskBackfillGraceMs: number;
 }
 
 const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
@@ -3560,6 +3565,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   autoCompactWindow: 0,
   disableMemoryLayerForAdminHost: false,
   pluginAutoScan: true,
+  taskBackfillGraceMs: 300000,
 };
 
 function parseIntEnv(envVar: string | undefined, fallback: number): number {
@@ -3658,6 +3664,11 @@ function readSystemSettingsFromFile(): SystemSettings | null {
       typeof raw.pluginAutoScan === 'boolean'
         ? raw.pluginAutoScan
         : DEFAULT_SYSTEM_SETTINGS.pluginAutoScan,
+    taskBackfillGraceMs:
+      typeof raw.taskBackfillGraceMs === 'number' &&
+      raw.taskBackfillGraceMs >= 0
+        ? raw.taskBackfillGraceMs
+        : DEFAULT_SYSTEM_SETTINGS.taskBackfillGraceMs,
   };
 }
 
@@ -3726,6 +3737,10 @@ function buildEnvFallbackSettings(): SystemSettings {
       process.env.PLUGIN_AUTO_SCAN === 'false'
         ? false
         : DEFAULT_SYSTEM_SETTINGS.pluginAutoScan,
+    taskBackfillGraceMs: parseIntEnv(
+      process.env.TASK_BACKFILL_GRACE_MS,
+      DEFAULT_SYSTEM_SETTINGS.taskBackfillGraceMs,
+    ),
   };
 }
 
@@ -3820,6 +3835,19 @@ export function saveSystemSettings(
   } else if (merged.autoCompactWindow > 0) {
     if (merged.autoCompactWindow < 10000) merged.autoCompactWindow = 10000;
     if (merged.autoCompactWindow > 2000000) merged.autoCompactWindow = 2000000;
+  }
+
+  // taskBackfillGraceMs: 0 = 关闭（旧行为：无视逾期全 backfill）；
+  // >0 限制在 [1s, 24h]，避免误配置成几毫秒导致正常任务也被跳过。
+  if (
+    merged.taskBackfillGraceMs < 0 ||
+    !Number.isFinite(merged.taskBackfillGraceMs)
+  ) {
+    merged.taskBackfillGraceMs = 0;
+  } else if (merged.taskBackfillGraceMs > 0) {
+    if (merged.taskBackfillGraceMs < 1000) merged.taskBackfillGraceMs = 1000;
+    if (merged.taskBackfillGraceMs > 86400000)
+      merged.taskBackfillGraceMs = 86400000;
   }
 
   // Validate externalClaudeDir: must be empty or an absolute directory path

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -246,6 +246,14 @@ export const SystemSettingsSchema = z.object({
     .optional(),
   disableMemoryLayerForAdminHost: z.boolean().optional(),
   pluginAutoScan: z.boolean().optional(),
+  taskBackfillGraceMs: z
+    .number()
+    .int()
+    .refine(
+      (v) => v === 0 || (v >= 1000 && v <= 86400000),
+      'taskBackfillGraceMs must be 0 (disabled) or between 1000 (1s) and 86400000 (24h)',
+    )
+    .optional(),
 });
 
 export const AppearanceConfigSchema = z.object({

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -19,6 +19,7 @@ import {
 } from './container-runner.js';
 import {
   addGroupMember,
+  advanceSkippedTask,
   getAllTasks,
   cleanupOldTaskRunLogs,
   cleanupStaleRunningLogs,
@@ -852,6 +853,8 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
         logger.info({ count: dueTasks.length }, 'Found due tasks');
       }
 
+      const graceMs = getSystemSettings().taskBackfillGraceMs;
+
       for (const task of dueTasks) {
         // Re-check task status in case it was paused/cancelled
         const currentTask = getTaskById(task.id);
@@ -861,6 +864,37 @@ export function startSchedulerLoop(deps: SchedulerDependencies): void {
 
         if (runningTaskIds.has(currentTask.id)) {
           continue;
+        }
+
+        // Backfill grace check: if the task is overdue beyond the configured
+        // window (e.g. machine was offline for days), skip this missed run and
+        // advance next_run to its next scheduled trigger. This prevents the
+        // "restart-storm" failure mode where multiple tasks on the same chat
+        // all fire concurrently in the same second after a long downtime.
+        if (graceMs > 0 && currentTask.next_run) {
+          const overdueMs = Date.now() - new Date(currentTask.next_run).getTime();
+          if (overdueMs > graceMs) {
+            const advancedNextRun = computeNextRun(currentTask);
+            advanceSkippedTask(currentTask.id, advancedNextRun);
+            logTaskRun({
+              task_id: currentTask.id,
+              run_at: new Date().toISOString(),
+              duration_ms: 0,
+              status: 'success',
+              result: `Skipped: overdue by ${Math.round(overdueMs / 1000)}s, exceeds backfill grace window (${Math.round(graceMs / 1000)}s)`,
+              error: null,
+            });
+            logger.info(
+              {
+                taskId: currentTask.id,
+                overdueMs,
+                graceMs,
+                nextRun: advancedNextRun,
+              },
+              'Skipping overdue task: exceeds backfill grace window',
+            );
+            continue;
+          }
         }
 
         const groups = deps.registeredGroups();

--- a/tests/task-backfill-grace.test.ts
+++ b/tests/task-backfill-grace.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Isolate DB to a temp dir — same pattern as task-meta.test.ts.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-backfill-grace-'));
+const tmpStoreDir = path.join(tmpDir, 'db');
+const tmpGroupsDir = path.join(tmpDir, 'groups');
+fs.mkdirSync(tmpStoreDir, { recursive: true });
+fs.mkdirSync(tmpGroupsDir, { recursive: true });
+
+vi.mock('../src/config.js', async () => ({
+  STORE_DIR: tmpStoreDir,
+  GROUPS_DIR: tmpGroupsDir,
+}));
+
+const {
+  initDatabase,
+  createTask,
+  getTaskById,
+  getDueTasks,
+  advanceSkippedTask,
+  updateTaskAfterRun,
+} = await import('../src/db.js');
+
+beforeAll(() => {
+  initDatabase();
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function makeTask(overrides: Partial<Parameters<typeof createTask>[0]> = {}) {
+  const id = `t-${Math.random().toString(36).slice(2, 10)}`;
+  createTask({
+    id,
+    group_folder: 'home-test',
+    chat_jid: 'web:home-test',
+    prompt: 'noop',
+    schedule_type: 'cron',
+    schedule_value: '0 9 * * *',
+    context_mode: 'isolated',
+    execution_type: 'agent',
+    script_command: null,
+    execution_mode: 'container',
+    next_run: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 24h overdue
+    status: 'active',
+    created_at: new Date().toISOString(),
+    notify_channels: null,
+    workspace_jid: null,
+    workspace_folder: null,
+    ...overrides,
+  });
+  return id;
+}
+
+describe('task backfill grace — db helpers', () => {
+  test('getDueTasks returns all tasks with next_run <= now (regardless of how overdue)', () => {
+    const id1 = makeTask({
+      next_run: new Date(Date.now() - 60_000).toISOString(), // 1 min overdue
+    });
+    const id2 = makeTask({
+      next_run: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days overdue
+    });
+    const due = getDueTasks();
+    const ids = due.map((t) => t.id);
+    expect(ids).toContain(id1);
+    expect(ids).toContain(id2);
+  });
+
+  test('advanceSkippedTask updates next_run and does NOT touch last_run', () => {
+    const id = makeTask({
+      next_run: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    });
+    const before = getTaskById(id)!;
+    expect(before.last_run).toBeFalsy(); // never ran
+
+    const newNext = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    advanceSkippedTask(id, newNext);
+
+    const after = getTaskById(id)!;
+    expect(after.next_run).toBe(newNext);
+    expect(after.last_run).toBeFalsy(); // still not set — skipping is not running
+    expect(after.status).toBe('active');
+  });
+
+  test('advanceSkippedTask with null nextRun marks once-task as completed', () => {
+    const id = makeTask({
+      schedule_type: 'once',
+      schedule_value: new Date(Date.now() - 60_000).toISOString(),
+      next_run: new Date(Date.now() - 60_000).toISOString(),
+    });
+    advanceSkippedTask(id, null);
+    const after = getTaskById(id)!;
+    expect(after.next_run).toBeNull();
+    expect(after.status).toBe('completed');
+  });
+
+  test('updateTaskAfterRun continues to set last_run (sanity check the helpers stay distinct)', () => {
+    const id = makeTask();
+    updateTaskAfterRun(id, new Date(Date.now() + 60_000).toISOString(), 'ran ok');
+    const after = getTaskById(id)!;
+    expect(after.last_run).toBeTruthy(); // contrast with advanceSkippedTask
+    expect(after.last_result).toBe('ran ok');
+  });
+});
+
+describe('task backfill grace — decision predicate', () => {
+  // Mirrors the inline check in src/task-scheduler.ts. Kept here so the policy
+  // is independently testable without spinning up the scheduler loop.
+  function shouldSkipBackfill(
+    nextRunIso: string | null,
+    nowMs: number,
+    graceMs: number,
+  ): boolean {
+    if (graceMs <= 0 || !nextRunIso) return false;
+    const overdueMs = nowMs - new Date(nextRunIso).getTime();
+    return overdueMs > graceMs;
+  }
+
+  test('graceMs=0 disables skipping (legacy behavior preserved)', () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    expect(shouldSkipBackfill(tenDaysAgo, Date.now(), 0)).toBe(false);
+  });
+
+  test('within grace window: do not skip', () => {
+    const now = Date.now();
+    const oneMinuteAgo = new Date(now - 60_000).toISOString();
+    // grace = 5 min; 1 min overdue is within window
+    expect(shouldSkipBackfill(oneMinuteAgo, now, 300_000)).toBe(false);
+  });
+
+  test('beyond grace window: skip', () => {
+    const now = Date.now();
+    const tenMinutesAgo = new Date(now - 10 * 60_000).toISOString();
+    // grace = 5 min; 10 min overdue exceeds window
+    expect(shouldSkipBackfill(tenMinutesAgo, now, 300_000)).toBe(true);
+  });
+
+  test('null next_run never triggers skip', () => {
+    expect(shouldSkipBackfill(null, Date.now(), 300_000)).toBe(false);
+  });
+
+  test('exactly at boundary: do not skip (overdue must be strictly greater)', () => {
+    const now = Date.now();
+    const exactlyFiveMinutesAgo = new Date(now - 300_000).toISOString();
+    expect(shouldSkipBackfill(exactlyFiveMinutesAgo, now, 300_000)).toBe(false);
+  });
+});

--- a/web/src/components/settings/SystemSettingsSection.tsx
+++ b/web/src/components/settings/SystemSettingsSection.tsx
@@ -140,6 +140,19 @@ const fields: FieldConfig[] = [
     max: 2000,
     step: 10,
   },
+  {
+    key: 'taskBackfillGraceMs',
+    label: '定时任务逾期容忍窗口',
+    description:
+      '停机/重启后，next_run 落在过去且距今超过该窗口的任务直接跳过本次（推到下一次触发），'
+      + '避免跨天积压的多个任务在重启那一秒集体并发刷屏。0 = 关闭（旧行为）。',
+    unit: '分钟',
+    toDisplay: (v) => Math.round(v / 60000),
+    toStored: (v) => v * 60000,
+    min: 0,
+    max: 1440,
+    step: 1,
+  },
 ];
 
 export function SystemSettingsSection() {

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -106,6 +106,7 @@ export interface SystemSettings {
   autoCompactWindow: number;
   disableMemoryLayerForAdminHost: boolean;
   pluginAutoScan: boolean;
+  taskBackfillGraceMs: number;
 }
 
 // ─── OAuth Usage ────────────────────────────────────────────


### PR DESCRIPTION
## 问题描述
关闭 #520。

机器停机数天后开机，多个 `next_run` 落在过去的 cron 任务在重启那一秒集体 fire——`isolated` 模式下每个 task 自带 `#task:{id}` 后缀的 queue jid 不会互相串行，N 个 agent 并发跑、多段 reply 全部冲到同一个 chat，看起来像机器人疯了。`getDueTasks()` 只判断 `next_run <= now`，没有逾期阈值，无视错过的是 2 小时还是 2 天，全部一次性拉出闸。

## 修复方案
采用 issue 作者推荐的 **Path A**（跳过逾期，等下次正常时间再跑，对齐 Linux cron / k8s `concurrencyPolicy=Forbid+startingDeadlineSeconds` 的心智模型）。

### `src/db.ts`
- 新增 `advanceSkippedTask(id, nextRun)`：只更新 `next_run`，不触碰 `last_run`，避免任务详情页把"被跳过"误显示成"刚刚跑过"。

### `src/task-scheduler.ts`
- scheduler 循环里增加 backfill grace check：任何 `next_run` 距今超过 `taskBackfillGraceMs` 的任务直接跳过本次，`next_run` 推到下一次触发，并写入 `task_run_logs` 标注 `Skipped: overdue by Xs, exceeds backfill grace window (Ys)`。
- `graceMs = 0` 保留旧行为（无视逾期全部 backfill），向后兼容。

### `src/runtime-config.ts` + `src/schemas.ts`
- `SystemSettings.taskBackfillGraceMs` 默认 `300000 ms (5 min)`。
- 三级 fallback：file → env (`TASK_BACKFILL_GRACE_MS`) → default。
- 范围校验：0（关闭）或 [1000, 86400000]（1s ~ 24h）。

### Web UI
- `SystemSettingsSection.tsx` 增加"定时任务逾期容忍窗口"字段（分钟单位，0 = 关闭）。
- `types.ts` `SystemSettings` 接口同步。

### `CLAUDE.md`
- §9 环境变量表新增 `TASK_BACKFILL_GRACE_MS`。

### 测试
- `tests/task-backfill-grace.test.ts`：覆盖
  - `advanceSkippedTask` 不触碰 `last_run`、与 `updateTaskAfterRun` 行为隔离
  - once-task 跳过时正确标记 `completed`
  - grace 决策边界：`graceMs=0` 禁用、窗口内不跳、超出窗口跳、`null` next_run 不触发、严格大于（边界值不跳）

## Test plan
- [x] `make typecheck` — backend / web / agent-runner 全过
- [x] `make test` — 40 test files / 586 tests 全过（含新增 9 个）
- [x] `make build` — backend dist + web bundle + agent-runner dist 编译成功
- [ ] 手工验证：将系统时钟调到未来 +24h 重启服务，观察 cron 任务跳过 backfill（reviewer 可选）