### PR TITLE
修复: 禁用单 $ 行内数学避免美元金额渲染错乱

### DIFF
--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -193,9 +193,18 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
     : 'text-sm leading-6 text-foreground';
   const tableTextClass = variant === 'chat' ? 'text-[0.95em]' : 'text-sm';
 
-  // Streaming mode: skip expensive KaTeX + sanitize for faster renders
+  // Streaming mode: skip expensive KaTeX + sanitize for faster renders.
+  // singleDollarTextMath: false — disables `$...$` inline math so dollar-sign
+  // amounts ($113, $5.51) in everyday text aren't parsed as LaTeX. Block math
+  // ($$...$$) still works for the rare case real formulas are needed.
   const remarkPluginsList = useMemo(() =>
-    streaming ? [remarkGfm, remarkBreaks] : [remarkGfm, remarkBreaks, remarkMath],
+    streaming
+      ? [remarkGfm, remarkBreaks]
+      : [
+          remarkGfm,
+          remarkBreaks,
+          [remarkMath, { singleDollarTextMath: false }] as const,
+        ],
     [streaming]
   );
   const rehypePluginsList = useMemo(() =>


### PR DESCRIPTION
## 问题描述

聊投资 / 股价时常用 `$113`、`$5.51` 这类美元金额。前端 `MarkdownRenderer` 加载了 `remark-math`，默认把 `$...$` 解析成 LaTeX 行内数学公式，导致两个 `$` 之间的文本（含汉字）被渲染成数学斜体，整段错乱。

例如 Agent 输出：

```
从 $113 跌到 $5.51，跌 95%
```

前端会把 `113 跌到 ` 当成行内公式中间部分，渲染结果完全不可读。

## 修复方案

### `web/src/components/chat/MarkdownRenderer.tsx`

- 给 `remark-math` 加 `singleDollarTextMath: false`，关闭单 `$` 触发的行内数学
- 块公式 `$$...$$` 仍保留，真要写数学公式不受影响
- 加注释说明动机

## Test plan

- [x] `web` 子项目 typecheck 通过
- [x] 全量 `make build` 通过
- [x] PWA 重新加载后，含 `$XX 跌到 $YY` 的历史回复正常渲染（不再变成 LaTeX 斜体）