### PR TITLE
修复: assistant 消息中 tool_use 之前的文本被覆盖丢失

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1318,7 +1318,13 @@ async function runQuery(
               .join('')
           : '';
         if (topLevelText) {
-          canonicalAssistantText = topLevelText;
+          // Accumulate rather than overwrite. The SDK splits assistant output
+          // into multiple messages around each tool_use call (text → tool_use →
+          // text → tool_use → text...), so taking only the last message's text
+          // drops everything emitted before the first tool call. The canonical
+          // text must be the concatenation of all top-level text content blocks
+          // in this turn.
+          canonicalAssistantText = (canonicalAssistantText || '') + topLevelText;
           canonicalAssistantUuid = assistantMsg.uuid as string;
         }
       }


### PR DESCRIPTION
## 问题描述

当 agent 在回复中先输出文本再调用工具(Write/Edit/Bash),最终保存到 db 和发送给 IM 渠道的消息只包含工具调用之后的最后一段 text,工具调用之前的所有文本(可能数千字)被静默丢弃。

## 复现路径

1. agent 输出 3500 字深度调研报告
2. agent 调用 Write 工具保存报告
3. agent 输出 一句 已归档
4. 用户在 Web/飞书/微信只看到 已归档,**3500 字报告丢失**

用 a-stock-deep-dive skill 跑兆易/水晶光电/歌尔三次都复现。

## 根因

Anthropic Agent SDK 将 assistant 输出按 tool_use 拆成多个 message:

- message 1: content=[text 3500字, tool_use Write]
- message 2: content=[text 已归档]

`container/agent-runner/src/index.ts` 的 `canonicalAssistantText` 用赋值而非累加,每次新 message 覆盖旧的 → 只保留最后一条。

## 修复

改成累加(canonicalAssistantText = (canonicalAssistantText || ) + topLevelText)。canonicalAssistantText 是 query 局部变量,累加只在单次 query 内生效。

## 测试

- [x] tsc build 通过
- [x] 实测复现案例 3 次
- [ ] 修复后再测一次确认通过(本地已应用)