### PR TITLE
修复: 飞书群聊 mention 守卫在 bot open_id 缺失时静默 fail-open

### DIFF
--- a/src/feishu-mention-gate.ts
+++ b/src/feishu-mention-gate.ts
@@ -1,0 +1,106 @@
+/**
+ * 飞书群聊 mention 守卫 — 纯函数实现。
+ *
+ * 决定一条**群聊**消息是否应当继续被 agent 处理。p2p 私聊不走这条路径
+ * （由调用方上游判断），传入时直接放行。
+ *
+ * 之所以单独抽成纯函数：
+ *   - 历史 bug：`botOpenId` 为空时旧实现"安全降级 = 默认放行"，
+ *     导致 `require_mention=true` 在所有群静默失效（fail-open）。
+ *   - 新行为：`botOpenId` 未知时 fail-closed（拒绝），由调用方决定如何提示运维。
+ *   - 抽成纯函数是为了能用单测把 fail-closed 这条语义锁住，避免下次重构再被改回。
+ *
+ * 与调用方的边界：
+ *   - 这里只输出一个三态决定（allow / 拒绝 + 原因），不做任何日志、副作用、配置回写。
+ *   - warn 节流、lazy refetch 等观察 / 自愈策略由调用方实现。
+ */
+
+export interface MentionGateMention {
+  id?: { open_id?: string };
+}
+
+export interface MentionGateInput {
+  /** 飞书消息的会话类型，仅 'group' 会进入 mention 检查；其它（含 undefined）一律放行 */
+  chatType: string | undefined;
+  /** bot 的 open_id；空串 / undefined 视为"启动期拉取失败、当前未知" */
+  botOpenId: string;
+  /** 消息附带的 @mention 列表 */
+  mentions: MentionGateMention[] | undefined;
+  /** 群 jid（仅用于把上下文透传给两个回调） */
+  chatJid: string;
+  /** 发送者 open_id（用于 owner 判断） */
+  senderOpenId?: string;
+  /**
+   * 来自 happyclaw 主进程：根据该群 activation_mode / require_mention
+   * 决定"是否允许免 @"。
+   *   - 返回 true → always 模式，放行；
+   *   - 返回 false → when_mentioned / owner_mentioned，必须确认 bot 被 @。
+   */
+  shouldProcessGroupMessage?: (chatJid: string, senderOpenId?: string) => boolean;
+  /**
+   * owner_mentioned 模式专用：判断 sender 是否为该群登记的 owner。
+   * 仅在 bot 真的被 @ 的前提下才会被调用。
+   */
+  isGroupOwnerMessage?: (chatJid: string, senderOpenId?: string) => boolean;
+}
+
+export type MentionGateRejectReason =
+  /** botOpenId 未知，fail-closed 拒绝（区别于 not_mentioned，调用方应做不同的告警 / 自愈） */
+  | 'bot_open_id_missing'
+  /** 该群配置要求 @bot 但本条消息没 @ */
+  | 'not_mentioned'
+  /** owner_mentioned 模式下 bot 被 @ 了但 sender 不是 owner */
+  | 'not_owner';
+
+export type MentionGateDecision =
+  | { allow: true }
+  | { allow: false; reason: MentionGateRejectReason };
+
+const ALLOW: MentionGateDecision = { allow: true };
+
+/**
+ * 评估单条群聊消息是否通过 mention 门控。
+ *
+ * 行为表（仅当 chatType==='group' 且传入了 shouldProcessGroupMessage 时启用门控；
+ * 其它情况直接放行）：
+ *
+ * | shouldProcessGroupMessage | botOpenId | bot 被 @ | sender 是 owner | 决定 |
+ * |--------------------------|-----------|---------|---------------|------|
+ * | true (always)            | -         | -       | -             | allow |
+ * | false                    | ''        | -       | -             | reject:bot_open_id_missing |
+ * | false                    | 有        | 否      | -             | reject:not_mentioned |
+ * | false                    | 有        | 是      | 是 / 无 owner 检查 | allow |
+ * | false                    | 有        | 是      | 否            | reject:not_owner |
+ */
+export function evaluateMentionGate(input: MentionGateInput): MentionGateDecision {
+  if (input.chatType !== 'group' || !input.shouldProcessGroupMessage) {
+    return ALLOW;
+  }
+
+  const mentionNotRequired = input.shouldProcessGroupMessage(
+    input.chatJid,
+    input.senderOpenId,
+  );
+  if (mentionNotRequired) {
+    return ALLOW;
+  }
+
+  if (!input.botOpenId) {
+    return { allow: false, reason: 'bot_open_id_missing' };
+  }
+
+  const isBotMentioned =
+    input.mentions?.some((m) => m.id?.open_id === input.botOpenId) ?? false;
+  if (!isBotMentioned) {
+    return { allow: false, reason: 'not_mentioned' };
+  }
+
+  if (
+    input.isGroupOwnerMessage &&
+    !input.isGroupOwnerMessage(input.chatJid, input.senderOpenId)
+  ) {
+    return { allow: false, reason: 'not_owner' };
+  }
+
+  return ALLOW;
+}

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -23,6 +23,10 @@ import {
 } from './feishu-streaming-card.js';
 import { optimizeMarkdownStyle } from './feishu-markdown-style.js';
 import { buildAgentReplyCard } from './feishu-cards/builder.js';
+import {
+  evaluateMentionGate,
+  type MentionGateMention,
+} from './feishu-mention-gate.js';
 import type { FeishuMessageMeta } from './types.js';
 
 // ─── FeishuConnection Interface ────────────────────────────────
@@ -119,6 +123,12 @@ const WS_RECONNECT_MIN_INTERVAL_MS = 30_000;
 const BACKFILL_LOOKBACK_MS = 5 * 60 * 1000;
 const BACKFILL_PAGE_SIZE = 50;
 const BACKFILL_MAX_PAGES_PER_CHAT = 5;
+// 启动期 bot info 拉取的最大重试次数（指数退避 1s/2s/4s）
+const BOT_INFO_FETCH_MAX_ATTEMPTS = 4;
+// botOpenId 缺失时 lazy refetch 的最小间隔，避免对 OAPI 高频骚扰
+const BOT_INFO_REFETCH_MIN_INTERVAL_MS = 60_000;
+// "因 botOpenId 缺失而丢消息" 的 warn 节流间隔，避免日志刷屏
+const BOT_INFO_MISSING_WARN_INTERVAL_MS = 5 * 60 * 1000;
 
 interface FeishuMentionLike {
   key?: string;
@@ -518,6 +528,13 @@ export function createFeishuConnection(
   let disconnectedChecks = 0;
   let disconnectedSince: number | null = null;
   let healthTimer: NodeJS.Timeout | null = null;
+  // botOpenId 自愈状态：lastBotInfoFetchAt 防止 lazy refetch 高频骚扰 OAPI；
+  // botInfoRefetchInFlight 防止并发拉取
+  let lastBotInfoFetchAt = 0;
+  let botInfoRefetchInFlight: Promise<void> | null = null;
+  // mention gate fail-closed 的 warn 节流：避免 botOpenId 长时间缺失时日志洪水
+  let lastBotInfoMissingWarnAt = 0;
+  let botInfoMissingDroppedSinceLastWarn = 0;
 
   function rememberChatProgress(chatId: string, createTimeMs: number, chatType?: string): void {
     knownChatIds.add(chatId);
@@ -569,8 +586,87 @@ export function createFeishuConnection(
     stopHealthMonitor();
     healthTimer = setInterval(() => {
       void checkConnectionHealth();
+      // 兜底：botOpenId 缺失时让健康检查顺手 lazy refetch；
+      // 启动期 retry 失败 / 飞书短暂抖动后能在几分钟内自动恢复 mention 守卫。
+      if (!botOpenId) {
+        void ensureBotOpenIdFresh('health-check');
+      }
     }, WS_HEALTH_CHECK_INTERVAL_MS);
     healthTimer.unref?.();
+  }
+
+  /**
+   * 拉取 bot open_id —— 启动期与自愈共用入口。
+   * 失败时返回空串，由调用方决定是否重试。
+   */
+  async function fetchBotOpenIdOnce(): Promise<string> {
+    if (!client) return '';
+    try {
+      const botInfoRes = await client.request({
+        method: 'GET',
+        url: '/open-apis/bot/v3/info/',
+      });
+      const info = botInfoRes as {
+        bot?: { open_id?: string };
+        data?: { bot?: { open_id?: string } };
+      };
+      return info?.bot?.open_id || info?.data?.bot?.open_id || '';
+    } catch (err) {
+      logger.debug({ err }, 'fetchBotOpenIdOnce failed');
+      return '';
+    }
+  }
+
+  /**
+   * 启动期带指数退避的 bot open_id 拉取。最多 4 次（间隔 0/1s/2s/4s）。
+   * 即使全部失败也不阻塞 connect()，由 ensureBotOpenIdFresh() 后续兜底。
+   */
+  async function fetchBotOpenIdWithRetry(): Promise<void> {
+    for (let attempt = 0; attempt < BOT_INFO_FETCH_MAX_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, 1000 * 2 ** (attempt - 1)));
+      }
+      const id = await fetchBotOpenIdOnce();
+      lastBotInfoFetchAt = Date.now();
+      if (id) {
+        botOpenId = id;
+        logger.info(
+          { botOpenId, attempt: attempt + 1 },
+          'Fetched bot open_id for mention detection',
+        );
+        return;
+      }
+    }
+    logger.warn(
+      { attempts: BOT_INFO_FETCH_MAX_ATTEMPTS },
+      'Could not fetch bot open_id after retries; mention gating will fail-closed until recovered',
+    );
+  }
+
+  /**
+   * 后台 lazy refetch：消息进入 mention 门控前若发现 botOpenId 仍空，触发一次。
+   * 用 lastBotInfoFetchAt 节流，避免每条消息都打 OAPI；并发安全（in-flight Promise 复用）。
+   */
+  function ensureBotOpenIdFresh(reason: string): Promise<void> {
+    if (botOpenId) return Promise.resolve();
+    if (botInfoRefetchInFlight) return botInfoRefetchInFlight;
+    const now = Date.now();
+    if (now - lastBotInfoFetchAt < BOT_INFO_REFETCH_MIN_INTERVAL_MS) {
+      return Promise.resolve();
+    }
+    botInfoRefetchInFlight = (async () => {
+      const id = await fetchBotOpenIdOnce();
+      lastBotInfoFetchAt = Date.now();
+      if (id) {
+        botOpenId = id;
+        logger.info({ botOpenId, reason }, 'Recovered bot open_id (lazy refetch)');
+      } else {
+        logger.debug({ reason }, 'Lazy refetch of bot open_id still failed');
+      }
+    })().finally(() => {
+      botInfoRefetchInFlight = null;
+    });
+    return botInfoRefetchInFlight;
   }
 
   function isDuplicate(msgId: string): boolean {
@@ -1049,6 +1145,9 @@ export function createFeishuConnection(
     if (chatType === 'group' && isSenderAllowedInGroup && !isSenderAllowedInGroup(chatJid, senderOpenId)) {
       // 被 @bot 时回 SILENT 表情表达「看到但故意不回复」，让发言者知道 bot 并非无响应而是被白名单挡掉；
       // 未 @bot 时静默丢弃，避免把群聊闲聊污染成一堆表情。
+      // 注意：botOpenId 缺失时退化为 false（不加 SILENT 反应）——消息已被 allowlist
+      // 决定丢弃，反应只是 courtesy；不能确认 @ 时宁可不加表情，避免对所有路过消息刷反应。
+      // 与下方 mention gate 的 fail-closed 方向相反：那里是业务正确性边界，必须确认。
       const isBotMentioned = !!botOpenId && (mentions?.some((m) => m.id?.open_id === botOpenId) ?? false);
       if (isBotMentioned) {
         addReaction(messageId, 'SILENT').catch(() => {});
@@ -1066,23 +1165,57 @@ export function createFeishuConnection(
     }
 
     // ── 群聊 Mention 过滤：require_mention / owner_mentioned 模式下过滤 ──
-    if (chatType === 'group' && shouldProcessGroupMessage) {
-      const isBotMentioned = botOpenId
-        ? (mentions?.some((m) => m.id?.open_id === botOpenId) ?? false)
-        : true; // 无 bot open_id 时默认放行（安全降级）
-      if (!isBotMentioned && !shouldProcessGroupMessage(chatJid, senderOpenId)) {
-        logger.debug(
-          { chatJid, messageId },
-          'Dropped group message: mention required but bot not mentioned',
-        );
-        return;
-      }
-      // owner_mentioned 模式：bot 被 @mention 但发送者不是 owner 时丢弃
-      if (isBotMentioned && isGroupOwnerMessage && !isGroupOwnerMessage(chatJid, senderOpenId)) {
-        logger.debug(
-          { chatJid, messageId, senderOpenId },
-          'Dropped group message: owner_mentioned mode, sender is not owner',
-        );
+    // 决策由 evaluateMentionGate（src/feishu-mention-gate.ts）以纯函数形式给出，
+    // 历史上这里曾因 botOpenId 缺失而 fail-open 静默失效；新版 fail-closed，
+    // 并通过 ensureBotOpenIdFresh() 触发后台 lazy refetch 自愈。
+    {
+      const decision = evaluateMentionGate({
+        chatType,
+        botOpenId,
+        mentions: mentions as MentionGateMention[] | undefined,
+        chatJid,
+        senderOpenId,
+        shouldProcessGroupMessage,
+        isGroupOwnerMessage,
+      });
+      if (!decision.allow) {
+        if (decision.reason === 'bot_open_id_missing') {
+          // 触发后台 lazy refetch（节流由函数内部保证），不阻塞当前消息
+          void ensureBotOpenIdFresh('mention-gate-fallback');
+          // warn 日志按 5 分钟节流，避免 botOpenId 长时间缺失时刷屏
+          const now = Date.now();
+          botInfoMissingDroppedSinceLastWarn++;
+          if (
+            now - lastBotInfoMissingWarnAt >=
+            BOT_INFO_MISSING_WARN_INTERVAL_MS
+          ) {
+            logger.warn(
+              {
+                chatJid,
+                messageId,
+                droppedSinceLastWarn: botInfoMissingDroppedSinceLastWarn,
+              },
+              'Dropping group messages: bot open_id unknown (fail-closed). Triggered lazy refetch.',
+            );
+            lastBotInfoMissingWarnAt = now;
+            botInfoMissingDroppedSinceLastWarn = 0;
+          } else {
+            logger.debug(
+              { chatJid, messageId },
+              'Dropped group message: bot open_id missing (warn throttled)',
+            );
+          }
+        } else if (decision.reason === 'not_mentioned') {
+          logger.debug(
+            { chatJid, messageId },
+            'Dropped group message: mention required but bot not mentioned',
+          );
+        } else {
+          logger.debug(
+            { chatJid, messageId, senderOpenId },
+            'Dropped group message: owner_mentioned mode, sender is not owner',
+          );
+        }
         return;
       }
     }
@@ -1401,31 +1534,12 @@ export function createFeishuConnection(
         appType: lark.AppType.SelfBuild,
       });
 
-      // Fetch bot open_id for mention detection (best-effort, non-blocking)
-      try {
-        const botInfoRes = await client.request({
-          method: 'GET',
-          url: '/open-apis/bot/v3/info/',
-        });
-        const info = botInfoRes as { bot?: { open_id?: string }; data?: { bot?: { open_id?: string } } };
-        botOpenId = info?.bot?.open_id || info?.data?.bot?.open_id || '';
-        if (botOpenId) {
-          logger.info(
-            { botOpenId },
-            'Fetched bot open_id for mention detection',
-          );
-        } else {
-          logger.warn(
-            'Could not fetch bot open_id, mention gating will be bypassed',
-          );
-        }
-      } catch (err) {
-        logger.warn(
-          { err },
-          'Failed to fetch bot info, mention gating will be bypassed',
-        );
-        botOpenId = '';
-      }
+      // Fetch bot open_id for mention detection — 带 retry 的 best-effort 拉取。
+      // 启动期失败后，健康检查 + 进入 mention 门控前的 lazy refetch 会兜底自愈，
+      // 期间 mention 守卫维持 fail-closed（拒绝群消息），不会回退到默认放行。
+      botOpenId = '';
+      lastBotInfoFetchAt = 0;
+      await fetchBotOpenIdWithRetry();
 
       // Create event dispatcher
       eventDispatcher = new lark.EventDispatcher({}).register({

--- a/tests/feishu-mention-gate.test.ts
+++ b/tests/feishu-mention-gate.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'vitest';
+import {
+  evaluateMentionGate,
+  type MentionGateInput,
+  type MentionGateMention,
+} from '../src/feishu-mention-gate.js';
+
+const BOT_OPEN_ID = 'ou_bot_xyz';
+const SENDER = 'ou_user_abc';
+const OWNER = 'ou_owner_def';
+const CHAT = 'feishu:oc_test';
+
+function mention(openId: string): MentionGateMention {
+  return { id: { open_id: openId } };
+}
+
+function input(overrides: Partial<MentionGateInput> = {}): MentionGateInput {
+  return {
+    chatType: 'group',
+    botOpenId: BOT_OPEN_ID,
+    mentions: undefined,
+    chatJid: CHAT,
+    senderOpenId: SENDER,
+    shouldProcessGroupMessage: () => false, // 默认 require_mention
+    isGroupOwnerMessage: undefined,
+    ...overrides,
+  };
+}
+
+describe('evaluateMentionGate', () => {
+  test('p2p 私聊一律放行（即便没有 botOpenId 也不进入 mention 检查）', () => {
+    const decision = evaluateMentionGate(
+      input({ chatType: 'p2p', botOpenId: '' }),
+    );
+    expect(decision).toEqual({ allow: true });
+  });
+
+  test('未传 shouldProcessGroupMessage 时直接放行（视作"无门控"）', () => {
+    const decision = evaluateMentionGate(
+      input({ shouldProcessGroupMessage: undefined, botOpenId: '' }),
+    );
+    expect(decision).toEqual({ allow: true });
+  });
+
+  test('always 模式（shouldProcessGroupMessage 返回 true）一律放行，连 mention 都不查', () => {
+    const decision = evaluateMentionGate(
+      input({
+        shouldProcessGroupMessage: () => true,
+        botOpenId: '', // 即便 botOpenId 缺失也不影响
+        mentions: undefined,
+      }),
+    );
+    expect(decision).toEqual({ allow: true });
+  });
+
+  test('require_mention 模式 + bot 被 @ → 放行', () => {
+    const decision = evaluateMentionGate(
+      input({ mentions: [mention('ou_other'), mention(BOT_OPEN_ID)] }),
+    );
+    expect(decision).toEqual({ allow: true });
+  });
+
+  test('require_mention 模式 + bot 没被 @ → reject:not_mentioned', () => {
+    const decision = evaluateMentionGate(
+      input({ mentions: [mention('ou_other')] }),
+    );
+    expect(decision).toEqual({ allow: false, reason: 'not_mentioned' });
+  });
+
+  test('require_mention 模式 + mentions 数组缺失 → reject:not_mentioned（不会 NPE）', () => {
+    const decision = evaluateMentionGate(input({ mentions: undefined }));
+    expect(decision).toEqual({ allow: false, reason: 'not_mentioned' });
+  });
+
+  // 这是核心回归 case：历史 bug 是这里 fail-open，现在必须 fail-closed。
+  test('require_mention 模式 + botOpenId 缺失 → reject:bot_open_id_missing（fail-closed，禁止再 fall back 到放行）', () => {
+    const decision = evaluateMentionGate(
+      input({
+        botOpenId: '',
+        mentions: [mention('ou_anyone')], // 即便有 mentions 也不能假装匹配
+      }),
+    );
+    expect(decision).toEqual({
+      allow: false,
+      reason: 'bot_open_id_missing',
+    });
+  });
+
+  test('botOpenId 缺失但 always 模式优先：always 短路，仍然放行', () => {
+    const decision = evaluateMentionGate(
+      input({
+        botOpenId: '',
+        shouldProcessGroupMessage: () => true,
+      }),
+    );
+    expect(decision).toEqual({ allow: true });
+  });
+
+  test('owner_mentioned 模式：bot 被 @ + sender 是 owner → 放行', () => {
+    const decision = evaluateMentionGate(
+      input({
+        senderOpenId: OWNER,
+        mentions: [mention(BOT_OPEN_ID)],
+        isGroupOwnerMessage: (_chat, sender) => sender === OWNER,
+      }),
+    );
+    expect(decision).toEqual({ allow: true });
+  });
+
+  test('owner_mentioned 模式：bot 被 @ 但 sender 不是 owner → reject:not_owner', () => {
+    const decision = evaluateMentionGate(
+      input({
+        senderOpenId: SENDER,
+        mentions: [mention(BOT_OPEN_ID)],
+        isGroupOwnerMessage: (_chat, sender) => sender === OWNER,
+      }),
+    );
+    expect(decision).toEqual({ allow: false, reason: 'not_owner' });
+  });
+
+  test('owner_mentioned 模式：bot 没被 @ → 优先返回 not_mentioned，不进 owner 判断', () => {
+    let ownerCalled = false;
+    const decision = evaluateMentionGate(
+      input({
+        mentions: [mention('ou_other')],
+        isGroupOwnerMessage: () => {
+          ownerCalled = true;
+          return true;
+        },
+      }),
+    );
+    expect(decision).toEqual({ allow: false, reason: 'not_mentioned' });
+    expect(ownerCalled).toBe(false);
+  });
+
+  test('shouldProcessGroupMessage 收到的 chatJid / senderOpenId 与输入一致', () => {
+    let seen: { chatJid?: string; sender?: string } = {};
+    evaluateMentionGate(
+      input({
+        senderOpenId: SENDER,
+        shouldProcessGroupMessage: (chatJid, sender) => {
+          seen = { chatJid, sender };
+          return true;
+        },
+      }),
+    );
+    expect(seen).toEqual({ chatJid: CHAT, sender: SENDER });
+  });
+});


### PR DESCRIPTION
## 问题描述

飞书群聊在配置 `require_mention=true`（不论是显式配置，还是 IM 自动注册的群组默认值）时，
应当只在被 @bot 时才响应。但当前实现在 `botOpenId` 缺失时会**fail-open 静默放行**，
等价于让所有 require_mention 群聊回退到 always 响应。

历史触发路径：

\`\`\`ts
const isBotMentioned = botOpenId
  ? (mentions?.some((m) => m.id?.open_id === botOpenId) ?? false)
  : true; // 无 bot open_id 时默认放行（安全降级）  ← 这一行
\`\`\`

\`botOpenId\` 在 \`connect()\` 里通过 \`/open-apis/bot/v3/info/\` 拉取，但是：

- 启动时只拉一次，没有 retry，飞书 OAPI 偶发 5xx 就直接吞掉
- 网络抖动 / 凭据切换后没有自愈，需要重启服务才能恢复
- 一旦失败，**所有群聊的 require_mention 全部静默失效**，影响面是全部群

实测在 oncall 群被 bot 误回复，根因就是这条路径。

## 修复方案

### 1. 把 mention 决策抽成纯函数（`src/feishu-mention-gate.ts`）

\`evaluateMentionGate(input): MentionGateDecision\`，返回三态：

| shouldProcessGroupMessage | botOpenId | bot 被 @ | sender 是 owner | 决定 |
|---|---|---|---|---|
| true (always) | - | - | - | allow |
| false | '' | - | - | **reject:bot_open_id_missing**（fail-closed）|
| false | 有 | 否 | - | reject:not_mentioned |
| false | 有 | 是 | 是 / 无 owner 检查 | allow |
| false | 有 | 是 | 否 | reject:not_owner |

抽成纯函数的目的是用单测**锁住 fail-closed 语义**，避免下次重构再被改回。

### 2. \`src/feishu.ts\` 调用纯函数 + 自愈策略

- 启动期 \`fetchBotOpenIdWithRetry()\` 指数退避 4 次（间隔 0/1s/2s/4s）
- 仍失败由两条兜底路径自愈：
  - \`startHealthMonitor\` 健康检查每轮顺手 lazy refetch
  - 消息进入 mention gate 发现 \`botOpenId\` 仍空时触发 \`ensureBotOpenIdFresh()\`
- \`ensureBotOpenIdFresh\` 节流 60s + in-flight Promise 复用，不会刷 OAPI
- \`bot_open_id_missing\` warn 日志按 5 分钟节流并附 \`droppedSinceLastWarn\` 计数，
  避免飞书短暂抖动期日志洪水

### 3. allowlist 软拒绝 (\`feishu.ts:1144\`) 补一句注释

那段代码的 \`isBotMentioned\` 在 \`botOpenId\` 缺失时退化为 \`false\`，方向跟下方
mention gate 相反——它只是 courtesy 反应（决定要不要回 SILENT 表情），不是业务正确性
边界，所以宁可不加表情也不能在所有路过消息上刷反应。

### 4. 单元测试 \`tests/feishu-mention-gate.test.ts\`（12 case）

覆盖：
- p2p / 无 shouldProcessGroupMessage 一律放行
- always 模式短路（\`botOpenId\` 缺失也放行）
- require_mention 正常路径（bot 被 @ / 没被 @ / mentions 缺失）
- **fail-closed 核心回归**：require_mention + botOpenId 缺失 → bot_open_id_missing
- owner_mentioned 三种组合 + 短路顺序（not_mentioned 优先于 not_owner）
- 透传 chatJid/senderOpenId 给回调

## 验证

\`\`\`
make typecheck   # ✅
make test        # ✅ 589/589
\`\`\`

新增 \`tests/feishu-mention-gate.test.ts\` 12/12 通过。

## 影响

- 行为变更：\`botOpenId\` 缺失时群聊消息会被丢弃（fail-closed），之前是放行
- 自愈期 ≤ \`max(60s 节流, 60s 健康检查间隔)\`，不需要手动重启服务
- 不影响 always 模式群组（\`require_mention=false\`）


Made with [Cursor](https://cursor.com)