### PR TITLE
feat: 新增 支持从全局 settings 继承提供商配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Thumbs.db
 
 /log/
 nohup.out
+.codex/

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -17,6 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
 import { query, HookCallback, PreCompactHookInput, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { detectImageMimeTypeFromBase64Strict } from './image-detector.js';
 import { pruneProcessedHistoryImagesInTranscript as pruneProcessedHistoryImagesInTranscriptFile } from './history-image-prune.js';
@@ -52,6 +53,42 @@ const WORKSPACE_IPC = process.env.HAPPYCLAW_WORKSPACE_IPC || '/workspace/ipc';
 // 别名自动解析为最新版本，如 opus → Opus 4.6
 // [1m] 后缀启用 1M 上下文窗口（CLI 内部 jG() 识别后缀，sM() 返回 1M 窗口）
 const CLAUDE_MODEL = process.env.ANTHROPIC_MODEL || 'opus[1m]';
+const require = createRequire(import.meta.url);
+
+function resolveClaudeExecutable(): string | undefined {
+  const explicit = process.env.CLAUDE_CODE_EXECUTABLE?.trim();
+  if (explicit) return explicit;
+
+  if (process.platform !== 'linux' || process.arch !== 'x64') {
+    return undefined;
+  }
+
+  const report = process.report?.getReport?.() as {
+    header?: { glibcVersionRuntime?: string };
+  } | undefined;
+
+  const candidates = report?.header?.glibcVersionRuntime
+    ? [
+        '@anthropic-ai/claude-agent-sdk-linux-x64/claude',
+        '@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude',
+      ]
+    : [
+        '@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude',
+        '@anthropic-ai/claude-agent-sdk-linux-x64/claude',
+      ];
+
+  for (const candidate of candidates) {
+    try {
+      return require.resolve(candidate);
+    } catch {
+      // try next candidate
+    }
+  }
+
+  return undefined;
+}
+
+const CLAUDE_CODE_EXECUTABLE = resolveClaudeExecutable();
 
 const IPC_INPUT_DIR = path.join(WORKSPACE_IPC, 'input');
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
@@ -1180,7 +1217,7 @@ async function runQuery(
     const q = query({
     prompt: stream,
     options: {
-      ...(pathToClaudeCodeExecutable && { pathToClaudeCodeExecutable }),
+      ...(CLAUDE_CODE_EXECUTABLE ? { pathToClaudeCodeExecutable: CLAUDE_CODE_EXECUTABLE } : {}),
       model: CLAUDE_MODEL,
       cwd: WORKSPACE_GROUP,
       additionalDirectories: extraDirs,

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -36,6 +36,7 @@ import {
   getEnabledProviders,
   getFeishuProviderConfigWithSource,
   getAppearanceConfig,
+  providerToConfig,
 } from '../runtime-config.js';
 import {
   verifyPassword,
@@ -100,13 +101,14 @@ function buildSetupStatus() {
   // causing getClaudeProviderConfig() (first-match) to return an unconfigured provider.
   const providers = getEnabledProviders();
   const claudeConfigured = providers.some((p) => {
+    const resolved = providerToConfig(p);
     const hasOfficial =
-      !!p.claudeCodeOauthToken?.trim() ||
-      !!p.claudeOAuthCredentials ||
-      !!p.anthropicApiKey?.trim();
+      !!resolved.claudeCodeOauthToken?.trim() ||
+      !!resolved.claudeOAuthCredentials ||
+      !!resolved.anthropicApiKey?.trim();
     const hasThirdParty = !!(
-      p.anthropicBaseUrl?.trim() &&
-      p.anthropicAuthToken?.trim()
+      resolved.anthropicBaseUrl?.trim() &&
+      resolved.anthropicAuthToken?.trim()
     );
     return hasOfficial || hasThirdParty;
   });

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -313,6 +313,7 @@ interface StoredProviderV4 {
   id: string;
   name: string;
   type: 'official' | 'third_party';
+  useGlobalSettings?: boolean;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -334,6 +335,7 @@ export interface UnifiedProvider {
   id: string;
   name: string;
   type: 'official' | 'third_party';
+  useGlobalSettings: boolean;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -351,6 +353,7 @@ export interface UnifiedProviderPublic {
   id: string;
   name: string;
   type: 'official' | 'third_party';
+  useGlobalSettings: boolean;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -1001,6 +1004,7 @@ function toStoredProviderV4(provider: UnifiedProvider): StoredProviderV4 {
     id: provider.id,
     name: provider.name,
     type: provider.type,
+    useGlobalSettings: provider.useGlobalSettings,
     enabled: provider.enabled,
     weight: Math.max(1, Math.min(100, provider.weight || 1)),
     anthropicBaseUrl: provider.anthropicBaseUrl || '',
@@ -1019,6 +1023,7 @@ function fromStoredProviderV4(stored: StoredProviderV4): UnifiedProvider {
     id: stored.id,
     name: stored.name,
     type: stored.type,
+    useGlobalSettings: stored.useGlobalSettings === true,
     enabled: stored.enabled,
     weight: Math.max(1, Math.min(100, stored.weight || 1)),
     anthropicBaseUrl: stored.anthropicBaseUrl || '',
@@ -1052,6 +1057,7 @@ function migrateV3toV4(v3: ClaudeStoredStateV3Resolved): {
       id: OFFICIAL_CLAUDE_PROFILE_ID,
       name: '官方 Claude',
       type: 'official',
+      useGlobalSettings: false,
       enabled: isOfficialClaudeMode(v3.activeProfileId),
       weight: 1,
       anthropicBaseUrl: '',
@@ -1072,6 +1078,7 @@ function migrateV3toV4(v3: ClaudeStoredStateV3Resolved): {
       id: profile.id,
       name: profile.name,
       type: 'third_party',
+      useGlobalSettings: false,
       enabled: profile.id === v3.activeProfileId,
       weight: 1,
       anthropicBaseUrl: profile.anthropicBaseUrl,
@@ -1235,6 +1242,7 @@ export function saveBalancingConfig(
 export function createProvider(input: {
   name: string;
   type: 'official' | 'third_party';
+  useGlobalSettings?: boolean;
   anthropicBaseUrl?: string;
   anthropicAuthToken?: string;
   anthropicModel?: string;
@@ -1259,6 +1267,7 @@ export function createProvider(input: {
     id: crypto.randomBytes(8).toString('hex'),
     name: normalizeProfileName(input.name),
     type: input.type,
+    useGlobalSettings: input.useGlobalSettings === true,
     enabled: input.enabled ?? state.providers.length === 0,
     weight: Math.max(1, Math.min(100, input.weight ?? 1)),
     anthropicBaseUrl: input.anthropicBaseUrl
@@ -1292,6 +1301,7 @@ export function updateProvider(
   id: string,
   patch: {
     name?: string;
+    useGlobalSettings?: boolean;
     anthropicBaseUrl?: string;
     anthropicModel?: string;
     customEnv?: Record<string, string>;
@@ -1309,6 +1319,9 @@ export function updateProvider(
     ...current,
     ...(patch.name !== undefined
       ? { name: normalizeProfileName(patch.name) }
+      : {}),
+    ...(patch.useGlobalSettings !== undefined
+      ? { useGlobalSettings: patch.useGlobalSettings === true }
       : {}),
     ...(patch.anthropicBaseUrl !== undefined
       ? { anthropicBaseUrl: normalizeBaseUrl(patch.anthropicBaseUrl) }
@@ -1446,13 +1459,19 @@ export function deleteProvider(id: string): void {
 export function providerToConfig(
   provider: UnifiedProvider,
 ): ClaudeProviderConfig {
+  const global = provider.useGlobalSettings
+    ? getClaudeGlobalSettingsConfig()
+    : null;
   return {
-    anthropicBaseUrl: provider.anthropicBaseUrl,
-    anthropicAuthToken: provider.anthropicAuthToken,
-    anthropicApiKey: provider.anthropicApiKey,
-    claudeCodeOauthToken: provider.claudeCodeOauthToken,
-    claudeOAuthCredentials: provider.claudeOAuthCredentials,
-    anthropicModel: provider.anthropicModel,
+    anthropicBaseUrl: provider.anthropicBaseUrl || global?.anthropicBaseUrl || '',
+    anthropicAuthToken:
+      provider.anthropicAuthToken || global?.anthropicAuthToken || '',
+    anthropicApiKey: provider.anthropicApiKey || global?.anthropicApiKey || '',
+    claudeCodeOauthToken:
+      provider.claudeCodeOauthToken || global?.claudeCodeOauthToken || '',
+    claudeOAuthCredentials:
+      provider.claudeOAuthCredentials ?? global?.claudeOAuthCredentials ?? null,
+    anthropicModel: provider.anthropicModel || global?.anthropicModel || '',
     updatedAt: provider.updatedAt,
   };
 }
@@ -1465,6 +1484,7 @@ export function toPublicProvider(
     id: provider.id,
     name: provider.name,
     type: provider.type,
+    useGlobalSettings: provider.useGlobalSettings,
     enabled: provider.enabled,
     weight: provider.weight,
     anthropicBaseUrl: provider.anthropicBaseUrl,
@@ -1516,6 +1536,62 @@ export function resolveProviderById(providerId: string): {
     config: providerToConfig(provider),
     customEnv: provider.customEnv,
   };
+}
+
+function getClaudeGlobalSettingsConfig(): ClaudeProviderConfig | null {
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+  try {
+    if (!fs.existsSync(settingsPath)) return null;
+    const parsed = JSON.parse(
+      fs.readFileSync(settingsPath, 'utf-8'),
+    ) as Record<string, unknown>;
+    const env =
+      parsed.env && typeof parsed.env === 'object'
+        ? (parsed.env as Record<string, unknown>)
+        : {};
+
+    const anthropicBaseUrl =
+      typeof env.ANTHROPIC_BASE_URL === 'string'
+        ? env.ANTHROPIC_BASE_URL
+        : typeof env.ANTHROPIC_FOUNDRY_BASE_URL === 'string'
+          ? env.ANTHROPIC_FOUNDRY_BASE_URL
+          : '';
+    const anthropicApiKey =
+      typeof env.ANTHROPIC_API_KEY === 'string'
+        ? env.ANTHROPIC_API_KEY
+        : typeof env.ANTHROPIC_FOUNDRY_API_KEY === 'string'
+          ? env.ANTHROPIC_FOUNDRY_API_KEY
+          : typeof parsed.apiKeyHelper === 'string' && parsed.apiKeyHelper.trim()
+            ? '__GLOBAL_API_KEY_HELPER__'
+            : '';
+    const anthropicModel =
+      typeof parsed.model === 'string'
+        ? parsed.model
+        : typeof env.ANTHROPIC_MODEL === 'string'
+          ? env.ANTHROPIC_MODEL
+          : typeof env.ANTHROPIC_DEFAULT_SONNET_MODEL === 'string'
+            ? env.ANTHROPIC_DEFAULT_SONNET_MODEL
+            : '';
+
+    const raw = {
+      anthropicBaseUrl,
+      anthropicAuthToken:
+        typeof env.ANTHROPIC_AUTH_TOKEN === 'string'
+          ? env.ANTHROPIC_AUTH_TOKEN
+          : '',
+      anthropicApiKey,
+      claudeCodeOauthToken:
+        typeof env.CLAUDE_CODE_OAUTH_TOKEN === 'string'
+          ? env.CLAUDE_CODE_OAUTH_TOKEN
+          : '',
+      claudeOAuthCredentials: null,
+      anthropicModel,
+    };
+    return buildConfig(raw, null);
+  } catch (err) {
+    logger.warn({ err, settingsPath }, 'Failed to read global Claude settings');
+    return null;
+  }
 }
 
 // ─── V3 compat layer (used by remaining V3 code paths) ───────────
@@ -2119,6 +2195,7 @@ export function updateClaudeThirdPartyProfile(
   profileId: string,
   patch: {
     name?: string;
+    useGlobalSettings?: boolean;
     anthropicBaseUrl?: string;
     anthropicModel?: string;
     customEnv?: Record<string, string>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -164,6 +164,7 @@ export const ClaudeThirdPartyProfileCreateSchema = z.object({
 export const ClaudeThirdPartyProfilePatchSchema = z
   .object({
     name: z.string().min(1).max(64).optional(),
+    useGlobalSettings: z.boolean().optional(),
     anthropicBaseUrl: z.string().max(2000).optional(),
     anthropicModel: z.string().max(128).optional(),
     customEnv: z.record(z.string().max(256), z.string().max(4096)).optional(),
@@ -640,6 +641,7 @@ export const UnifiedProviderCreateSchema = z
   .object({
     name: z.string().min(1).max(64),
     type: z.enum(['official', 'third_party']),
+    useGlobalSettings: z.boolean().optional(),
     anthropicBaseUrl: z.string().max(2000).optional(),
     anthropicAuthToken: z.string().max(2000).optional(),
     anthropicModel: z.string().max(128).optional(),
@@ -653,6 +655,7 @@ export const UnifiedProviderCreateSchema = z
   .superRefine((data, ctx) => {
     if (
       data.type === 'third_party' &&
+      !data.useGlobalSettings &&
       !data.anthropicBaseUrl?.trim() &&
       !data.anthropicAuthToken?.trim()
     ) {
@@ -667,6 +670,7 @@ export const UnifiedProviderCreateSchema = z
 export const UnifiedProviderPatchSchema = z
   .object({
     name: z.string().min(1).max(64).optional(),
+    useGlobalSettings: z.boolean().optional(),
     anthropicBaseUrl: z.string().max(2000).optional(),
     anthropicModel: z.string().max(128).optional(),
     customEnv: z.record(z.string().max(256), z.string().max(4096)).optional(),
@@ -675,6 +679,7 @@ export const UnifiedProviderPatchSchema = z
   .refine(
     (data) =>
       data.name !== undefined ||
+      data.useGlobalSettings !== undefined ||
       data.anthropicBaseUrl !== undefined ||
       data.anthropicModel !== undefined ||
       data.customEnv !== undefined ||

--- a/web/src/components/settings/ProviderEditor.tsx
+++ b/web/src/components/settings/ProviderEditor.tsx
@@ -10,6 +10,7 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import { api } from '../../api/client';
 import type { ProviderWithHealth, EnvRow } from './types';
 import { getErrorMessage } from './types';
@@ -84,6 +85,8 @@ export function ProviderEditor({
   const [baseUrl, setBaseUrl] = useState('');
   const [model, setModel] = useState('');
   const [weight, setWeight] = useState(1);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [useGlobalSettings, setUseGlobalSettings] = useState(false);
 
   // 官方认证
   const [authTab, setAuthTab] = useState<OfficialAuthTab>('oauth');
@@ -117,6 +120,8 @@ export function ProviderEditor({
       setBaseUrl('');
       setModel('');
       setWeight(1);
+      setShowAdvanced(false);
+      setUseGlobalSettings(false);
       setAuthTab('oauth');
       setSetupToken('');
       setApiKey('');
@@ -132,6 +137,8 @@ export function ProviderEditor({
       setBaseUrl(provider.anthropicBaseUrl || '');
       setModel(provider.anthropicModel || '');
       setWeight(provider.weight);
+      setShowAdvanced(provider.weight !== 1);
+      setUseGlobalSettings(provider.useGlobalSettings);
       setAuthTab('oauth');
       setSetupToken('');
       setApiKey('');
@@ -223,6 +230,7 @@ export function ProviderEditor({
         const createBody: Record<string, unknown> = {
           name: trimmedName,
           type: providerType,
+          useGlobalSettings,
           customEnv: envResult.customEnv,
           weight,
         };
@@ -230,29 +238,31 @@ export function ProviderEditor({
         if (providerType === 'third_party') {
           const trimmedBaseUrl = baseUrl.trim();
           const trimmedToken = authToken.trim();
-          if (!trimmedBaseUrl) {
+          if (!useGlobalSettings && !trimmedBaseUrl) {
             setError('请填写 ANTHROPIC_BASE_URL');
             setSaving(false);
             return;
           }
-          if (!trimmedToken) {
+          if (!useGlobalSettings && !trimmedToken) {
             setError('新建第三方提供商时必须填写 ANTHROPIC_AUTH_TOKEN');
             setSaving(false);
             return;
           }
-          createBody.anthropicBaseUrl = trimmedBaseUrl;
-          createBody.anthropicAuthToken = trimmedToken;
+          if (trimmedBaseUrl) createBody.anthropicBaseUrl = trimmedBaseUrl;
+          if (trimmedToken) createBody.anthropicAuthToken = trimmedToken;
         } else {
           // 官方模式 — 根据认证方式设置凭据
           if (authTab === 'setup_token') {
             const trimmed = setupToken.trim();
-            if (!trimmed) {
+            if (!trimmed && !useGlobalSettings) {
               setError('请填写 setup-token 或粘贴 .credentials.json 内容');
               setSaving(false);
               return;
             }
-            // 检测是否为 .credentials.json
-            if (trimmed.startsWith('{')) {
+            if (!trimmed) {
+              // 留空时完全继承全局 settings
+            } else if (trimmed.startsWith('{')) {
+              // 检测是否为 .credentials.json
               try {
                 const parsed = JSON.parse(trimmed) as Record<string, unknown>;
                 const oauth = parsed.claudeAiOauth as Record<string, unknown> | undefined;
@@ -276,12 +286,12 @@ export function ProviderEditor({
             }
           } else if (authTab === 'api_key') {
             const trimmed = apiKey.trim();
-            if (!trimmed) {
+            if (!trimmed && !useGlobalSettings) {
               setError('请填写 Anthropic API Key');
               setSaving(false);
               return;
             }
-            createBody.anthropicApiKey = trimmed;
+            if (trimmed) createBody.anthropicApiKey = trimmed;
           } else {
             // OAuth 模式 — 不需要凭据，通过 OAuth 流程设置
             // 允许不带凭据创建，用户之后通过 OAuth 流程补充
@@ -296,6 +306,7 @@ export function ProviderEditor({
         // ── 编辑模式 ──
         const patchBody: Record<string, unknown> = {
           name: trimmedName,
+          useGlobalSettings,
           customEnv: envResult.customEnv,
           weight,
         };
@@ -303,9 +314,7 @@ export function ProviderEditor({
         if (providerType === 'third_party') {
           patchBody.anthropicBaseUrl = baseUrl.trim();
         }
-        if (model.trim()) {
-          patchBody.anthropicModel = model.trim();
-        }
+        patchBody.anthropicModel = model.trim();
 
         await api.patch(`/api/config/claude/providers/${provider!.id}`, patchBody);
 
@@ -435,6 +444,23 @@ export function ProviderEditor({
             />
           </div>
 
+          <div className="rounded-lg border border-border p-3 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-foreground">读取宿主机全局 settings</div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  从 ~/.claude/settings.json 读取基础配置；当前表单中非空字段会覆盖全局值，留空则继承全局值。
+                </p>
+              </div>
+              <Switch
+                checked={useGlobalSettings}
+                onCheckedChange={setUseGlobalSettings}
+                disabled={saving || oauthExchanging}
+                aria-label="读取宿主机全局 settings"
+              />
+            </div>
+          </div>
+
           {/* ─── 官方模式 ─── */}
           {providerType === 'official' && (
             <div className="space-y-4">
@@ -541,7 +567,9 @@ export function ProviderEditor({
                     placeholder={
                       !isCreate && (provider?.hasClaudeCodeOauthToken || provider?.hasClaudeOAuthCredentials)
                         ? '输入新值覆盖'
-                        : '粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出'
+                        : useGlobalSettings
+                          ? '留空继承全局 settings，或粘贴 setup-token / .credentials.json 覆盖'
+                          : '粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出'
                     }
                   />
                   <p className="text-xs text-muted-foreground">
@@ -571,7 +599,9 @@ export function ProviderEditor({
                     placeholder={
                       !isCreate && provider?.hasAnthropicApiKey
                         ? '输入新值覆盖'
-                        : 'sk-ant-api03-...'
+                        : useGlobalSettings
+                          ? '留空继承全局 settings'
+                          : 'sk-ant-api03-...'
                     }
                     className="font-mono"
                   />
@@ -602,7 +632,7 @@ export function ProviderEditor({
                   value={baseUrl}
                   onChange={(e) => setBaseUrl(e.target.value)}
                   disabled={saving}
-                  placeholder="https://your-relay.example.com/v1"
+                  placeholder={useGlobalSettings ? '留空继承全局 settings' : 'https://your-relay.example.com/v1'}
                 />
               </div>
 
@@ -624,10 +654,14 @@ export function ProviderEditor({
                   disabled={saving || clearTokenOnSave}
                   placeholder={
                     isCreate
-                      ? '输入 Token（必填）'
+                      ? useGlobalSettings
+                        ? '留空继承全局 settings；输入新值可覆盖'
+                        : '输入 Token（必填）'
                       : provider?.hasAnthropicAuthToken
                         ? '留空不变；输入新值覆盖'
-                        : '输入 Token（可选）'
+                        : useGlobalSettings
+                          ? '留空继承全局 settings'
+                          : '输入 Token（可选）'
                   }
                 />
                 {!isCreate && provider?.hasAnthropicAuthToken && (
@@ -679,7 +713,7 @@ export function ProviderEditor({
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
                   disabled={saving}
-                  placeholder="第三方 API 的模型名称"
+                  placeholder={useGlobalSettings ? '留空继承全局 settings' : '第三方 API 的模型名称'}
                   className="font-mono"
                 />
                 <p className="text-xs text-muted-foreground mt-1">

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -167,6 +167,11 @@ export function ProviderList({
                           权重 {provider.weight}
                         </span>
                       )}
+                      {provider.useGlobalSettings && (
+                        <span className="text-[11px] px-1.5 py-0.5 rounded shrink-0 bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300">
+                          全局 settings
+                        </span>
+                      )}
                     </div>
 
                     <div className="flex items-center gap-1.5 shrink-0">

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -4,6 +4,7 @@ export interface UnifiedProviderPublic {
   id: string;
   name: string;
   type: 'official' | 'third_party';
+  useGlobalSettings: boolean;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;

--- a/web/src/pages/SetupProvidersPage.tsx
+++ b/web/src/pages/SetupProvidersPage.tsx
@@ -26,16 +26,16 @@ function buildCustomEnv(rows: EnvRow[]): { customEnv: Record<string, string>; er
   const customEnv: Record<string, string> = {};
   for (const [idx, row] of rows.entries()) {
     const key = row.key.trim();
-    const value = row.value.trim();
-    if (!key && !value) continue;
-    if (!key || !value) {
-      return { customEnv: {}, error: `第 ${idx + 1} 行环境变量的 Key 和 Value 都要填写` };
+    const value = row.value;
+    if (!key && !value.trim()) continue;
+    if (!key) {
+      return { customEnv: {}, error: `第 ${idx + 1} 行环境变量 Key 不能为空` };
     }
-    if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
-      return { customEnv: {}, error: `环境变量 Key "${key}" 格式无效（仅允许大写字母/数字/下划线，且不能数字开头）` };
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      return { customEnv: {}, error: `环境变量 Key "${key}" 格式无效（需匹配 [A-Za-z_][A-Za-z0-9_]*）` };
     }
     if (RESERVED_ENV_KEYS.has(key)) {
-      return { customEnv: {}, error: `${key} 属于系统保留字段，请在必填区域填写` };
+      return { customEnv: {}, error: `${key} 属于系统保留字段，请在配置表单中填写` };
     }
     if (customEnv[key] !== undefined) {
       return { customEnv: {}, error: `环境变量 Key "${key}" 重复` };
@@ -76,6 +76,7 @@ export function SetupProvidersPage() {
   const [authToken, setAuthToken] = useState('');
   const [model, setModel] = useState('');
   const [customEnvRows, setCustomEnvRows] = useState<EnvRow[]>([]);
+  const [useGlobalSettings, setUseGlobalSettings] = useState(false);
 
   useEffect(() => {
     if (user === null && initialized === true) {
@@ -148,23 +149,24 @@ export function SetupProvidersPage() {
     }
 
     let customEnv: Record<string, string> = {};
+    const envResult = buildCustomEnv(customEnvRows);
+    if (envResult.error) {
+      setError(envResult.error);
+      return;
+    }
+    customEnv = envResult.customEnv;
+
     if (providerMode === 'third_party') {
-      if (!baseUrl.trim()) {
-        setError('第三方渠道必须填写 ANTHROPIC_BASE_URL');
+      if (!useGlobalSettings && !baseUrl.trim()) {
+        setError('第三方渠道必须填写 ANTHROPIC_BASE_URL，或开启“读取宿主机全局 settings”');
         return;
       }
-      if (!authToken.trim()) {
-        setError('第三方渠道必须填写 ANTHROPIC_AUTH_TOKEN');
+      if (!useGlobalSettings && !authToken.trim()) {
+        setError('第三方渠道必须填写 ANTHROPIC_AUTH_TOKEN，或开启“读取宿主机全局 settings”');
         return;
       }
-      const envResult = buildCustomEnv(customEnvRows);
-      if (envResult.error) {
-        setError(envResult.error);
-        return;
-      }
-      customEnv = envResult.customEnv;
-    } else if (!officialToken.trim() && !apiKey.trim() && !oauthDone) {
-      setError('官方渠道请通过一键登录、填写 API Key 或手动填写 setup-token / .credentials.json');
+    } else if (!useGlobalSettings && !officialToken.trim() && !apiKey.trim() && !oauthDone) {
+      setError('官方渠道请通过一键登录、填写 API Key / setup-token，或开启“读取宿主机全局 settings”');
       return;
     }
 
@@ -186,6 +188,14 @@ export function SetupProvidersPage() {
             name: '官方 Claude (API Key)',
             type: 'official',
             anthropicApiKey: apiKey.trim(),
+            useGlobalSettings,
+            enabled: true,
+          });
+        } else if (useGlobalSettings) {
+          await api.post('/api/config/claude/providers', {
+            name: '官方 Claude (继承全局 settings)',
+            type: 'official',
+            useGlobalSettings: true,
             enabled: true,
           });
         } else {
@@ -201,6 +211,7 @@ export function SetupProvidersPage() {
                 await api.post('/api/config/claude/providers', {
                   name: '官方 Claude (OAuth)',
                   type: 'official',
+                  useGlobalSettings,
                   claudeOAuthCredentials: {
                     accessToken: oauth.accessToken,
                     refreshToken: oauth.refreshToken,
@@ -222,6 +233,7 @@ export function SetupProvidersPage() {
               name: '官方 Claude (Setup Token)',
               type: 'official',
               claudeCodeOauthToken: trimmed,
+              useGlobalSettings,
               enabled: true,
             });
           }
@@ -235,6 +247,7 @@ export function SetupProvidersPage() {
             anthropicBaseUrl: baseUrl.trim(),
             anthropicAuthToken: authToken.trim(),
             anthropicModel: model.trim(),
+            useGlobalSettings,
             customEnv,
             enabled: true,
           },
@@ -304,6 +317,33 @@ export function SetupProvidersPage() {
           <div className="flex items-center gap-2 mb-3">
             <KeyRound className="w-4 h-4 text-primary" />
             <h2 className="text-base font-semibold text-foreground">Claude Code 配置（二选一）</h2>
+          </div>
+
+          <div className="rounded-lg border border-border p-3 space-y-2 mb-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-foreground">读取宿主机全局 settings</div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  从 ~/.claude/settings.json 读取基础配置；当前表单中非空字段会覆盖全局值，留空则继承全局值。
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={useGlobalSettings}
+                onClick={() => setUseGlobalSettings((prev) => !prev)}
+                disabled={saving || oauthExchanging}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  useGlobalSettings ? 'bg-primary' : 'bg-muted-foreground/30'
+                } ${(saving || oauthExchanging) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+              >
+                <span
+                  className={`inline-block h-5 w-5 transform rounded-full bg-background transition-transform ${
+                    useGlobalSettings ? 'translate-x-5' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
           </div>
 
           <div className="inline-flex rounded-lg border border-border p-1 bg-muted mb-4">
@@ -430,7 +470,7 @@ export function SetupProvidersPage() {
                       type="password"
                       value={officialToken}
                       onChange={(e) => setOfficialToken(e.target.value)}
-                      placeholder="粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出"
+                      placeholder={useGlobalSettings ? '留空继承全局 settings，或粘贴 setup-token / .credentials.json 覆盖' : '粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出'}
                     />
                     <p className="text-xs text-muted-foreground mt-1">
                       支持粘贴 <code className="bg-muted px-1 rounded">cat ~/.claude/.credentials.json</code> 的 JSON 内容
@@ -468,7 +508,7 @@ export function SetupProvidersPage() {
                       type="password"
                       value={apiKey}
                       onChange={(e) => setApiKey(e.target.value)}
-                      placeholder="sk-ant-api03-..."
+                      placeholder={useGlobalSettings ? '留空继承全局 settings' : 'sk-ant-api03-...'}
                       className="font-mono"
                     />
                     <p className="text-xs text-muted-foreground mt-1">
@@ -482,17 +522,17 @@ export function SetupProvidersPage() {
             <div className="space-y-4">
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Server className="w-4 h-4 text-primary" />
-                第三方渠道会写入系统全局默认环境变量。必填项为 ANTHROPIC_BASE_URL 和 ANTHROPIC_AUTH_TOKEN。
+                第三方渠道会写入系统全局默认环境变量。开启全局 settings 后，ANTHROPIC_BASE_URL 和 ANTHROPIC_AUTH_TOKEN 可留空。
               </div>
 
               <div className="grid grid-cols-1 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_BASE_URL（必填）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_BASE_URL{useGlobalSettings ? '' : '（必填）'}</label>
                   <Input
                     type="text"
                     value={baseUrl}
                     onChange={(e) => setBaseUrl(e.target.value)}
-                    placeholder="https://your-relay.example.com/v1"
+                    placeholder={useGlobalSettings ? '留空继承全局 settings' : 'https://your-relay.example.com/v1'}
                   />
                 </div>
 
@@ -502,18 +542,18 @@ export function SetupProvidersPage() {
                     type="text"
                     value={model}
                     onChange={(e) => setModel(e.target.value)}
-                    placeholder="opus[1m] / opus / sonnet[1m] / sonnet / haiku"
+                    placeholder={useGlobalSettings ? '留空继承全局 settings' : 'opus[1m] / opus / sonnet[1m] / sonnet / haiku'}
                     className="font-mono"
                   />
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_AUTH_TOKEN（必填）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_AUTH_TOKEN{useGlobalSettings ? '' : '（必填）'}</label>
                   <Input
                     type="password"
                     value={authToken}
                     onChange={(e) => setAuthToken(e.target.value)}
-                    placeholder="输入第三方网关 Token"
+                    placeholder={useGlobalSettings ? '留空继承全局 settings；输入新值可覆盖' : '输入第三方网关 Token'}
                   />
                 </div>
               </div>


### PR DESCRIPTION
添加 useGlobalSettings 选项，允许提供商从 ~/.claude/settings.json 继承基础配置 更新相关 UI 组件和表单验证逻辑
优化环境变量 key 的校验规则；并解决特定linux机器 找不到claude的问题；