### PR TITLE
修复: CLAUDE_CONFIG_DIR 绝对路径硬编码导致路径中毒后无法恢复 (#526)

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1507,7 +1507,18 @@ export async function runHostAgent(
     // 禁用记忆层且配置了 customCwd 时不覆盖 CLAUDE_CONFIG_DIR，让 SDK 使用用户真实 $HOME/.claude/
     // 未配 customCwd 时保留 override，避免 HappyClaw 的 cwd 污染 ~/.claude/projects/
     if (!disableMemoryLayer || !group.customCwd) {
-      hostEnv['CLAUDE_CONFIG_DIR'] = groupSessionsDir;
+      // Resolve symlinks so CLAUDE_CONFIG_DIR ends up as the real on-disk path.
+      // Some external layer (suspected backend rate-limiter) has been observed to
+      // pin failure state to specific CLAUDE_CONFIG_DIR path strings; allowing
+      // operators to redirect the literal path via a symlink (e.g. mv main main-v2
+      // && ln -s main-v2 main) is a cheap escape hatch when a path gets "tainted".
+      let resolvedSessionsDir = groupSessionsDir;
+      try {
+        resolvedSessionsDir = fs.realpathSync(groupSessionsDir);
+      } catch {
+        // Path may not exist yet on first spawn; fall back to the literal path.
+      }
+      hostEnv['CLAUDE_CONFIG_DIR'] = resolvedSessionsDir;
     }
 
     if (disableMemoryLayer) {


### PR DESCRIPTION
## 问题描述
关闭 #526。

`src/container-runner.ts` 的 host 模式 spawn agent-runner 时，把 `groupSessionsDir`（一个完全确定性的字面绝对路径，例如 `…/data/sessions/main/.claude`）直接赋给 `hostEnv['CLAUDE_CONFIG_DIR']`。

issue 报告人观察到某层（推测是 backend 限流器，但未完全证实）会按路径串记忆失败状态，一旦该路径累积过若干次失败请求（典型场景：provider 切换、OAuth 过期、网络抖动导致连串 403），后续所有从该路径发起的请求都会以 synthetic disable 消息 hard-fail，与凭据是否有效无关。100% 稳定可复现的对照实验：同凭据 + 同机 + 同 SDK 版本，仅 `CLAUDE_CONFIG_DIR` 字面路径不同 → 一通一不通。

由于 admin 主会话 folder 硬编码为 `main`，路径完全确定，运维无法在不丢失原工作目录里 `CLAUDE.md` 记忆、对话归档、IM 通道配置等的前提下绕开污染路径。已知的唯一 workaround 是 fresh-clone 到新路径。

## 修复方案

### `src/container-runner.ts`
- 在赋值前对 `groupSessionsDir` 调用 `fs.realpathSync()`，让 `CLAUDE_CONFIG_DIR` 落到真实磁盘路径
- 路径不存在时（首次 spawn）try/catch 回退到字面路径，与原实现一致
- 改动只发生在已有的 `if (!disableMemoryLayer || !group.customCwd)` 分支内，不影响 disableMemoryLayer + customCwd 走 `~/.claude/` 的既有路径

中毒后的运维恢复方法：
```
cd data/sessions
mv main main-tainted-YYYYMMDD
mkdir main-fresh
mv main-tainted-YYYYMMDD/.claude main-fresh/.claude
ln -s main-fresh main
```

## 测试
- `make build` 通过（backend + web + agent-runner）
- `make test` 全过（41 files / 598 tests）

## 备注
issue 报告人未完全证实"backend 按路径串限流"是唯一根因，也可能是某层本地缓存。但 realpath 这条最小化 fix 实测能修，且即便根因不同也提供了一条便宜的运维逃生通道，无副作用。