### PR TITLE
修复: IM 群失效后 registered_groups 记录未清理

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2922,6 +2922,29 @@ export function deleteChatHistory(chatJid: string): void {
   tx(chatJid);
 }
 
+/**
+ * Delete an IM group's registered_groups entry and all jid-scoped data
+ * (messages, chat record, pinned references). Does NOT touch folder-scoped
+ * data (sessions, scheduled_tasks, group_members) because IM groups typically
+ * share their folder with the owner's home workspace.
+ *
+ * Used when an IM group is detected as dead (bot removed, group disbanded,
+ * health-check unreachable, or repeated send failures) and for the manual
+ * "delete this IM binding" UI button.
+ */
+export function deleteImGroupRecord(jid: string): void {
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM registered_groups WHERE jid = ?').run(jid);
+    db.prepare('DELETE FROM messages WHERE chat_jid = ?').run(jid);
+    db.prepare('DELETE FROM chats WHERE jid = ?').run(jid);
+    db.prepare('DELETE FROM user_pinned_groups WHERE jid = ?').run(jid);
+    db.prepare(
+      'UPDATE scheduled_tasks SET workspace_jid = NULL, workspace_folder = NULL WHERE workspace_jid = ?',
+    ).run(jid);
+  });
+  tx();
+}
+
 export function deleteGroupData(jid: string, folder: string): void {
   const tx = db.transaction(() => {
     // 1. 删除定时任务运行日志 + 定时任务

--- a/src/db.ts
+++ b/src/db.ts
@@ -2938,6 +2938,10 @@ export function deleteImGroupRecord(jid: string): void {
     db.prepare('DELETE FROM messages WHERE chat_jid = ?').run(jid);
     db.prepare('DELETE FROM chats WHERE jid = ?').run(jid);
     db.prepare('DELETE FROM user_pinned_groups WHERE jid = ?').run(jid);
+    // Feishu thread agents (source_kind='feishu_thread') and other chat-scoped
+    // agents reference this jid via agents.chat_jid — without this, deleting
+    // an IM group leaves orphan agent rows visible in the agents list.
+    db.prepare('DELETE FROM agents WHERE chat_jid = ?').run(jid);
     db.prepare(
       'UPDATE scheduled_tasks SET workspace_jid = NULL, workspace_folder = NULL WHERE workspace_jid = ?',
     ).run(jid);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import {
   updateAgentInfo,
   deleteAgent,
   deleteCompletedAgents,
+  deleteImGroupRecord,
   getRunningTaskAgentsByChat,
   markRunningTaskAgentsAsError,
   markAllRunningTaskAgentsAsError,
@@ -635,6 +636,31 @@ function unbindImGroup(jid: string, reason: string): void {
 }
 
 /**
+ * Remove an IM group entirely (jid record + chat history + pinned refs + send/health counters).
+ * Use this when the group is detected as dead — bot kicked, group disbanded,
+ * health-check repeatedly unreachable, or consecutive send failures.
+ *
+ * Differs from unbindImGroup() which only clears target_* fields (used for
+ * user-initiated soft unbind where the IM group itself is still alive).
+ */
+function removeImGroupRecord(jid: string, reason: string): void {
+  const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
+  if (!group) return;
+  deleteImGroupRecord(jid);
+  delete registeredGroups[jid];
+  imSendFailCounts.delete(jid);
+  imHealthCheckFailCounts.delete(jid);
+  logger.info(
+    {
+      jid,
+      hadTargetAgent: !!group.target_agent_id,
+      hadTargetMain: !!group.target_main_jid,
+    },
+    reason,
+  );
+}
+
+/**
  * Resolve the workspace folder an IM chat should use for file downloads and
  * execution context. Bound targets take precedence over the source IM folder.
  */
@@ -963,12 +989,12 @@ async function sendImWithRetry(
   imSendFailCounts.set(imJid, count);
   if (count >= IM_SEND_FAIL_THRESHOLD) {
     try {
-      unbindImGroup(
+      removeImGroupRecord(
         imJid,
-        'Auto-unbound IM group after consecutive send failures',
+        'Auto-removed IM group after consecutive send failures',
       );
     } catch (unbindErr) {
-      logger.error({ imJid, unbindErr }, 'Failed to auto-unbind IM group');
+      logger.error({ imJid, unbindErr }, 'Failed to auto-remove IM group');
     }
   }
   return false;
@@ -7497,9 +7523,9 @@ function learnFeishuOwner(
  */
 function buildOnBotRemovedFromGroup(): (chatJid: string) => void {
   return (chatJid: string) => {
-    unbindImGroup(
+    removeImGroupRecord(
       chatJid,
-      'Auto-unbound IM group: bot removed or group disbanded',
+      'Auto-removed IM group: bot removed or group disbanded',
     );
   };
 }
@@ -9442,9 +9468,9 @@ async function checkImBindingsHealth(): Promise<void> {
         const count = (imHealthCheckFailCounts.get(jid) ?? 0) + 1;
         imHealthCheckFailCounts.set(jid, count);
         if (count >= IM_HEALTH_CHECK_FAIL_THRESHOLD) {
-          unbindImGroup(
+          removeImGroupRecord(
             jid,
-            'IM group not reachable after multiple checks, auto-unbinding',
+            'IM group not reachable after multiple checks, auto-removing',
           );
         } else {
           logger.debug(

--- a/src/index.ts
+++ b/src/index.ts
@@ -643,7 +643,7 @@ function unbindImGroup(jid: string, reason: string): void {
  * Differs from unbindImGroup() which only clears target_* fields (used for
  * user-initiated soft unbind where the IM group itself is still alive).
  */
-function removeImGroupRecord(jid: string, reason: string): void {
+export function removeImGroupRecord(jid: string, reason: string): void {
   const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
   if (!group) return;
   deleteImGroupRecord(jid);
@@ -8898,6 +8898,7 @@ async function main(): Promise<void> {
     clearImFailCounts: (jid: string) => {
       imHealthCheckFailCounts.delete(jid);
     },
+    removeImGroupRecord,
     updateReplyRoute: (folder: string, sourceJid: string | null) => {
       activeRouteUpdaters.get(folder)?.(sourceJid);
     },

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -805,8 +805,15 @@ groupRoutes.delete('/:jid', authMiddleware, async (c) => {
     if (!getChannelType(jid)) {
       return c.json({ error: 'This group cannot be deleted' }, 403);
     }
-    deleteImGroupRecord(jid);
-    delete deps.getRegisteredGroups()[jid];
+    // Reuse the shared helper so the manual delete path also resets
+    // imSendFailCounts / imHealthCheckFailCounts, matching the auto-cleanup
+    // paths (bot removed / health check / send fail).
+    if (deps.removeImGroupRecord) {
+      deps.removeImGroupRecord(jid, 'Manually deleted via API');
+    } else {
+      deleteImGroupRecord(jid);
+      delete deps.getRegisteredGroups()[jid];
+    }
     deps.setLastAgentTimestamp(jid, { timestamp: '', id: '' });
     return c.json({ success: true });
   }

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -31,6 +31,7 @@ import {
   deleteSession,
   deleteChatHistory,
   deleteGroupData,
+  deleteImGroupRecord,
   ensureChatExists,
   storeMessageDirect,
   getMessagesPage,
@@ -62,6 +63,7 @@ import {
   toPublicContainerEnvConfig,
 } from '../runtime-config.js';
 import { clearTargetAgentBindingsForDeletedAgents } from '../im-context-isolation.js';
+import { getChannelType } from '../im-channel.js';
 import {
   loadMountAllowlist,
   findAllowedRoot,
@@ -795,8 +797,18 @@ groupRoutes.delete('/:jid', authMiddleware, async (c) => {
     return c.json({ error: 'Group not found' }, 404);
   }
 
+  // IM-prefixed groups (feishu:, telegram:, qq:, etc.) follow a separate
+  // cleanup path. They share their folder with the owner's home workspace,
+  // so we must NOT touch folder-scoped data (sessions, scheduled_tasks,
+  // group_members) or the workspace directory.
   if (!jid.startsWith('web:')) {
-    return c.json({ error: 'This group cannot be deleted' }, 403);
+    if (!getChannelType(jid)) {
+      return c.json({ error: 'This group cannot be deleted' }, 403);
+    }
+    deleteImGroupRecord(jid);
+    delete deps.getRegisteredGroups()[jid];
+    deps.setLastAgentTimestamp(jid, { timestamp: '', id: '' });
+    return c.json({ success: true });
   }
 
   if (isHostExecutionGroup(existing) && !hasHostExecutionPermission(authUser)) {

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -110,6 +110,14 @@ export interface WebDeps {
     group_message_type?: string;
   } | null>;
   clearImFailCounts?: (jid: string) => void;
+  /**
+   * Fully remove an IM group's registered_groups entry (plus jid-scoped data
+   * and fail counters). Used by DELETE /api/groups/:jid for IM-prefixed JIDs
+   * — shared with the auto-cleanup paths (bot removed / health check / send
+   * fail) so the manual delete path also resets imSendFailCounts /
+   * imHealthCheckFailCounts.
+   */
+  removeImGroupRecord?: (jid: string, reason: string) => void;
   updateReplyRoute?: (folder: string, sourceJid: string | null) => void;
   triggerTaskRun?: (taskId: string) => { success: boolean; error?: string };
   handleSpawnCommand?: (

--- a/web/src/components/settings/BindingsSection.tsx
+++ b/web/src/components/settings/BindingsSection.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { useImBindings } from './hooks/useImBindings';
 import { ImBindingRow } from './ImBindingRow';
 import { BindingTargetDialog } from './BindingTargetDialog';
+import { api } from '../../api/client';
 import type { AvailableImGroup } from '../../types';
 import type { BindingTarget } from './hooks/useImBindings';
 
@@ -25,6 +26,7 @@ export function BindingsSection() {
   const [rebindGroup, setRebindGroup] = useState<AvailableImGroup | null>(null);
   const [unbindGroup, setUnbindGroup] = useState<AvailableImGroup | null>(null);
   const [resetAllowlistGroup, setResetAllowlistGroup] = useState<AvailableImGroup | null>(null);
+  const [deleteGroup, setDeleteGroup] = useState<AvailableImGroup | null>(null);
 
   const channels: { key: ChannelFilter; label: string }[] = useMemo(() => {
     const types = new Set(bindings.map((b) => b.channel_type));
@@ -66,6 +68,26 @@ export function BindingsSection() {
   const handleResetAllowlist = useCallback((group: AvailableImGroup) => {
     setResetAllowlistGroup(group);
   }, []);
+
+  const handleDelete = useCallback((group: AvailableImGroup) => {
+    setDeleteGroup(group);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteGroup) return;
+    const jid = deleteGroup.jid;
+    setDeleteGroup(null);
+    setActioningJid(jid);
+    setLocalError(null);
+    try {
+      await api.delete(`/api/groups/${encodeURIComponent(jid)}`);
+      reload();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : '删除失败');
+    } finally {
+      setActioningJid(null);
+    }
+  }, [deleteGroup, reload]);
 
   const confirmResetAllowlist = useCallback(async () => {
     if (!resetAllowlistGroup) return;
@@ -237,6 +259,7 @@ export function BindingsSection() {
                 onUnbind={handleUnbind}
                 onResetAllowlist={handleResetAllowlist}
                 onActivationModeChange={handleActivationModeChange}
+                onDelete={handleDelete}
               />
             ))}
           </div>
@@ -287,6 +310,20 @@ export function BindingsSection() {
             : ''
         }
         confirmText="重置白名单"
+      />
+
+      {/* Delete IM group confirm dialog */}
+      <ConfirmDialog
+        open={!!deleteGroup}
+        onClose={() => setDeleteGroup(null)}
+        onConfirm={confirmDelete}
+        title="删除 IM 渠道"
+        message={
+          deleteGroup
+            ? `确认从 HappyClaw 中删除「${deleteGroup.name}」的注册记录？此操作仅清理本机绑定，不会影响该 IM 群本身。如果 bot 之后再次收到该群消息，会自动重新注册。`
+            : ''
+        }
+        confirmText="删除"
       />
     </div>
   );

--- a/web/src/components/settings/ImBindingRow.tsx
+++ b/web/src/components/settings/ImBindingRow.tsx
@@ -1,4 +1,4 @@
-import { Loader2, MessageSquare, Users, ArrowRightLeft, Unlink, AlertTriangle } from 'lucide-react';
+import { Loader2, MessageSquare, Users, ArrowRightLeft, Unlink, AlertTriangle, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { AvailableImGroup } from '../../types';
 import { ChannelBadge } from './channel-meta';
@@ -11,9 +11,10 @@ interface ImBindingRowProps {
   onUnbind: (group: AvailableImGroup) => void;
   onResetAllowlist: (group: AvailableImGroup) => void;
   onActivationModeChange: (jid: string, mode: string) => void;
+  onDelete: (group: AvailableImGroup) => void;
 }
 
-export function ImBindingRow({ group, isActioning, onRebind, onUnbind, onResetAllowlist, onActivationModeChange }: ImBindingRowProps) {
+export function ImBindingRow({ group, isActioning, onRebind, onUnbind, onResetAllowlist, onActivationModeChange, onDelete }: ImBindingRowProps) {
   const hasBound = !!group.bound_agent_id || !!group.bound_main_jid;
   // Empty array = "owner-locked trap": bot was added before Feishu owner DM'd it,
   // so nobody (not even the owner) can trigger the bot until allowlist is reset
@@ -139,6 +140,20 @@ export function ImBindingRow({ group, isActioning, onRebind, onUnbind, onResetAl
             <ArrowRightLeft className="w-3 h-3 mr-1" />
           )}
           换绑
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => onDelete(group)}
+          disabled={isActioning}
+          className="text-muted-foreground hover:text-error"
+          title="删除（群已不存在/bot 已被踢时使用）"
+        >
+          {isActioning ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Trash2 className="w-3.5 h-3.5" />
+          )}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## 问题描述

飞书群被解散 / bot 被踢之后，HappyClaw 的「IM 绑定」页面仍然显示这些幽灵群。即使飞书事件正常推送（`im.chat.member.bot.deleted_v1` / `im.chat.disbanded_v1`），bot 被踢事件触发的 `unbindImGroup()` 也只是清空 `target_agent_id` / `target_main_jid` 字段，并不删除 `registered_groups` 表里的记录本身，所以 UI 列表（`GET /api/groups/:jid/im-groups` 直接遍历 `getAllRegisteredGroups()`）仍然能看到这些已死的 IM 群。

## 修复方案

### `src/db.ts`
- 新增 `deleteImGroupRecord(jid)` —— jid 范围内的轻量级清理（registered_groups + messages + chats + user_pinned_groups + 断开 scheduled_tasks 的 workspace 关联）
- **不动 folder 范围数据**：IM 群的 folder 通常和 owner 的 home workspace 共享，不能误删 sessions / scheduled_tasks / group_members

### `src/index.ts`
- 新增 `removeImGroupRecord(jid, reason)`：在 db 删除基础上同步内存 `registeredGroups` + 清 `imSendFailCounts` / `imHealthCheckFailCounts` 计数器
- 三处「群已死」的 auto-cleanup 路径升级为 `removeImGroupRecord`：
  - 飞书 bot 被踢 / 群解散事件（`buildOnBotRemovedFromGroup`）
  - 健康检查 N 次不可达（`checkImBindingsHealth` unreachable 分支）
  - 连续 N 次发送失败（`sendImWithRetry` threshold）
- 保留 `unbindImGroup`（只清 target_*）用于「IM 群还活着但目标对象失效」的场景：用户主动 `/unbind` 命令、UI 解绑按钮、`target_main_jid` 指向的 web 工作区已删、`target_agent_id` 指向的 agent 已删

### `src/routes/groups.ts`
- `DELETE /api/groups/:jid` 放开 IM JID 前缀（原本只允许 `web:`），走轻量级 `deleteImGroupRecord` 路径

### `web/src/components/settings/ImBindingRow.tsx` + `BindingsSection.tsx`
- 加 Trash2 删除按钮 + ConfirmDialog 兜底：对于已经存在的孤儿群（事件可能没推送过、健康检查 API 可能返回 stale data 导致自动清理失效），给用户一个确定性的手动出口

## Test plan

- [x] `make typecheck` 通过
- [x] `make test` 通过（621/621）
- [ ] 实测：进 IM 绑定页面，对已失效的 feishu 群点垃圾桶图标，确认从列表消失
- [ ] 实测：bot 重新被加入已删除的群后能正常 auto-register（验证幂等）
- [ ] 实测：unbindImGroup 路径（`/unbind` 命令 / UI 解绑按钮）仍然只清 target_* 不删记录