### PR TITLE
新增: 用户级 default_require_mention，控制新群是否默认需要 @机器人

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -343,6 +343,7 @@ export function initDatabase(): void {
       ai_avatar_emoji TEXT,
       ai_avatar_color TEXT,
       ai_avatar_url TEXT,
+      default_require_mention INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
       last_login_at TEXT,
@@ -656,6 +657,11 @@ export function initDatabase(): void {
   ensureColumn('users', 'ai_avatar_emoji', 'TEXT');
   ensureColumn('users', 'ai_avatar_color', 'TEXT');
   ensureColumn('users', 'ai_avatar_url', 'TEXT');
+  ensureColumn(
+    'users',
+    'default_require_mention',
+    'INTEGER NOT NULL DEFAULT 0',
+  );
   ensureColumn('scheduled_tasks', 'created_by', 'TEXT');
   ensureColumn('scheduled_tasks', 'execution_type', "TEXT DEFAULT 'agent'");
   ensureColumn('scheduled_tasks', 'script_command', 'TEXT');
@@ -823,6 +829,7 @@ export function initDatabase(): void {
     'ai_avatar_emoji',
     'ai_avatar_color',
     'ai_avatar_url',
+    'default_require_mention',
     'created_at',
     'updated_at',
     'last_login_at',
@@ -1248,7 +1255,13 @@ export function initDatabase(): void {
     db.exec('ALTER TABLE sessions ADD COLUMN provider_id TEXT');
   }
 
-  const SCHEMA_VERSION = '37';
+  // v37 → v38: Added users.default_require_mention column (per-user default
+  // for require_mention on auto-registered IM group chats). The actual
+  // ensureColumn migration runs above with the other users.* additions —
+  // its position before assertSchema('users', …) matters because the
+  // schema check would otherwise reject pre-v38 databases on startup.
+
+  const SCHEMA_VERSION = '38';
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', SCHEMA_VERSION);
@@ -3251,6 +3264,7 @@ function mapUserRow(row: Record<string, unknown>): User {
       typeof row.ai_avatar_color === 'string' ? row.ai_avatar_color : null,
     ai_avatar_url:
       typeof row.ai_avatar_url === 'string' ? row.ai_avatar_url : null,
+    default_require_mention: !!row.default_require_mention,
     created_at: String(row.created_at),
     updated_at: String(row.updated_at),
     last_login_at:
@@ -3277,6 +3291,7 @@ function toUserPublic(user: User, lastActiveAt: string | null): UserPublic {
     ai_avatar_emoji: user.ai_avatar_emoji,
     ai_avatar_color: user.ai_avatar_color,
     ai_avatar_url: user.ai_avatar_url,
+    default_require_mention: user.default_require_mention,
     created_at: user.created_at,
     last_login_at: user.last_login_at,
     last_active_at: lastActiveAt,
@@ -3564,6 +3579,7 @@ export function updateUserFields(
       | 'ai_avatar_emoji'
       | 'ai_avatar_color'
       | 'ai_avatar_url'
+      | 'default_require_mention'
       | 'deleted_at'
     >
   >,
@@ -3638,6 +3654,10 @@ export function updateUserFields(
   if (updates.ai_avatar_url !== undefined) {
     fields.push('ai_avatar_url = ?');
     values.push(updates.ai_avatar_url);
+  }
+  if (updates.default_require_mention !== undefined) {
+    fields.push('default_require_mention = ?');
+    values.push(updates.default_require_mention ? 1 : 0);
   }
   if (updates.deleted_at !== undefined) {
     fields.push('deleted_at = ?');

--- a/src/im-group-defaults.ts
+++ b/src/im-group-defaults.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for computing default field values when auto-registering
+ * IM group chats. Extracted from src/index.ts so unit tests can lock the
+ * behavior without booting the full service.
+ *
+ * The single source of truth for "what defaults should a newly auto-
+ * registered Feishu/Telegram/etc group get" lives here. Both the
+ * `buildOnNewChat` flow in index.ts and unit tests call this.
+ */
+
+export interface ImGroupDefaultsInput {
+  /**
+   * The owner user's per-user preference for require_mention on newly
+   * auto-registered IM groups. Undefined when the user record cannot be
+   * resolved (defensive — auto-register can race with user deletion); in
+   * that case we treat as `false` to preserve the legacy default.
+   */
+  ownerDefaultRequireMention?: boolean | null;
+}
+
+export interface ImGroupDefaultsOutput {
+  /** Final require_mention value to stamp on the newly registered group. */
+  requireMention: boolean;
+}
+
+/**
+ * Compute the field values to apply when auto-registering a brand-new IM
+ * group chat (one that does NOT already exist in registered_groups).
+ *
+ * Locked by tests/im-group-defaults.test.ts. Adding new fields here
+ * should also extend the test file with a row.
+ */
+export function resolveImGroupDefaults(
+  input: ImGroupDefaultsInput,
+): ImGroupDefaultsOutput {
+  return {
+    requireMention: input.ownerDefaultRequireMention === true,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,7 @@ import {
   resolveBroadcastFolder,
   resolveTaskRoutingDecision,
 } from './task-routing.js';
+import { resolveImGroupDefaults } from './im-group-defaults.js';
 import {
   applyAutoIsolateContextForGroups,
   getUserContextIsolationConfig,
@@ -7327,6 +7328,10 @@ function buildOnNewChat(
       return;
     }
     const ownerOpenId = getOwnerOpenId?.();
+    const ownerUser = getUserById(userId);
+    const groupDefaults = resolveImGroupDefaults({
+      ownerDefaultRequireMention: ownerUser?.default_require_mention,
+    });
     registerGroup(chatJid, {
       name: chatName,
       folder: homeFolder,
@@ -7338,9 +7343,16 @@ function buildOnNewChat(
       sender_allowlist: getOwnerOpenId
         ? (ownerOpenId ? [ownerOpenId] : [])
         : undefined,
+      require_mention: groupDefaults.requireMention,
     });
     logger.info(
-      { chatJid, chatName, userId, homeFolder },
+      {
+        chatJid,
+        chatName,
+        userId,
+        homeFolder,
+        requireMention: groupDefaults.requireMention,
+      },
       'Auto-registered IM chat',
     );
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -87,6 +87,7 @@ export function toUserPublic(u: User): UserPublic {
     ai_avatar_emoji: u.ai_avatar_emoji ?? null,
     ai_avatar_color: u.ai_avatar_color ?? null,
     ai_avatar_url: u.ai_avatar_url ?? null,
+    default_require_mention: u.default_require_mention,
     created_at: u.created_at,
     last_login_at: u.last_login_at,
     last_active_at: null,
@@ -598,6 +599,9 @@ authRoutes.put('/profile', authMiddleware, async (c) => {
   }
   if (validation.data.ai_avatar_url !== undefined) {
     updates.ai_avatar_url = validation.data.ai_avatar_url;
+  }
+  if (validation.data.default_require_mention !== undefined) {
+    updates.default_require_mention = validation.data.default_require_mention;
   }
   if (Object.keys(updates).length === 0) {
     return c.json({ error: 'No fields to update' }, 400);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -296,6 +296,7 @@ export const ProfileUpdateSchema = z.object({
     .refine((v) => v.startsWith('/api/auth/avatars/'), 'Invalid avatar URL')
     .nullable()
     .optional(),
+  default_require_mention: z.boolean().optional(),
 });
 
 export const PermissionValueSchema = z

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,14 @@ export interface User {
   ai_avatar_emoji: string | null;
   ai_avatar_color: string | null;
   ai_avatar_url: string | null;
+  /**
+   * Per-user default for require_mention on auto-registered IM group chats.
+   * When true, newly auto-registered Feishu/Telegram/etc groups start with
+   * require_mention=1 (only @bot triggers a response). false preserves the
+   * legacy default of responding to every owner-sent message in the group.
+   * Existing groups are not retroactively changed.
+   */
+  default_require_mention: boolean;
   created_at: string;
   updated_at: string;
   last_login_at: string | null;
@@ -229,6 +237,7 @@ export interface UserPublic {
   ai_avatar_emoji: string | null;
   ai_avatar_color: string | null;
   ai_avatar_url: string | null;
+  default_require_mention: boolean;
   created_at: string;
   last_login_at: string | null;
   last_active_at: string | null;

--- a/tests/im-group-defaults.test.ts
+++ b/tests/im-group-defaults.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { resolveImGroupDefaults } from '../src/im-group-defaults.js';
+
+describe('resolveImGroupDefaults', () => {
+  test('owner 偏好 = true → 新群 require_mention = true', () => {
+    expect(
+      resolveImGroupDefaults({ ownerDefaultRequireMention: true }),
+    ).toEqual({ requireMention: true });
+  });
+
+  test('owner 偏好 = false → 新群 require_mention = false（保留 legacy 行为）', () => {
+    expect(
+      resolveImGroupDefaults({ ownerDefaultRequireMention: false }),
+    ).toEqual({ requireMention: false });
+  });
+
+  test('owner 偏好缺失（用户记录已删/未配置） → require_mention = false', () => {
+    // 防御性：getUserById 在 auto-register 和 user 删除之间存在竞态，
+    // 找不到 user 时不应默认开启 mention 门控（避免静默把所有新群锁死）
+    expect(resolveImGroupDefaults({})).toEqual({ requireMention: false });
+    expect(
+      resolveImGroupDefaults({ ownerDefaultRequireMention: null }),
+    ).toEqual({ requireMention: false });
+    expect(
+      resolveImGroupDefaults({ ownerDefaultRequireMention: undefined }),
+    ).toEqual({ requireMention: false });
+  });
+
+  test('truthy 但非 boolean 的值不应被当作 true（fail-safe）', () => {
+    // 防御性：DB 列若被外部脚本写入非 0/1 整数（如 2），mapUserRow 会
+    // 转成 boolean。这里只是再加一道防线，确保只有严格 === true 才生效。
+    expect(
+      resolveImGroupDefaults({
+        // @ts-expect-error: 模拟运行时被注入的脏数据
+        ownerDefaultRequireMention: 1,
+      }),
+    ).toEqual({ requireMention: false });
+  });
+});

--- a/web/src/components/settings/ProfileSection.tsx
+++ b/web/src/components/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Loader2, Upload, Trash2, User, Bot, Lock, Palette, Sun, Moon, Monitor, Bell, BellOff, CheckCircle2, RotateCcw } from 'lucide-react';
+import { Loader2, Upload, Trash2, User, Bot, Lock, Palette, Sun, Moon, Monitor, Bell, BellOff, CheckCircle2, RotateCcw, MessagesSquare } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useAuthStore } from '../../stores/auth';
@@ -154,6 +154,10 @@ export function ProfileSection() {
   const [avatarUploading, setAvatarUploading] = useState(false);
   const avatarInputRef = useRef<HTMLInputElement>(null);
 
+  // IM defaults — only affects NEW auto-registered IM groups
+  const [defaultRequireMention, setDefaultRequireMention] = useState(false);
+  const [imDefaultsSaving, setImDefaultsSaving] = useState(false);
+
   // Password
   const [currentPwd, setCurrentPwd] = useState('');
   const [newPwd, setNewPwd] = useState('');
@@ -169,7 +173,8 @@ export function ProfileSection() {
     setAiAvatarEmoji(currentUser?.ai_avatar_emoji ?? null);
     setAiAvatarColor(currentUser?.ai_avatar_color ?? null);
     setAiAvatarUrl(currentUser?.ai_avatar_url ?? null);
-  }, [currentUser?.username, currentUser?.display_name, currentUser?.avatar_emoji, currentUser?.avatar_color, currentUser?.avatar_url, currentUser?.ai_name, currentUser?.ai_avatar_emoji, currentUser?.ai_avatar_color, currentUser?.ai_avatar_url]);
+    setDefaultRequireMention(currentUser?.default_require_mention ?? false);
+  }, [currentUser?.username, currentUser?.display_name, currentUser?.avatar_emoji, currentUser?.avatar_color, currentUser?.avatar_url, currentUser?.ai_name, currentUser?.ai_avatar_emoji, currentUser?.ai_avatar_color, currentUser?.ai_avatar_url, currentUser?.default_require_mention]);
 
   const handleUpdateProfile = async () => {
     setProfileSaving(true);
@@ -275,6 +280,21 @@ export function ProfileSection() {
       toast.success('头像已移除');
     } catch (err) {
       toast.error(getErrorMessage(err, '移除头像失败'));
+    }
+  };
+
+  const handleToggleDefaultRequireMention = async (next: boolean) => {
+    const prev = defaultRequireMention;
+    setDefaultRequireMention(next);
+    setImDefaultsSaving(true);
+    try {
+      await updateProfile({ default_require_mention: next });
+      toast.success(next ? '新群默认需要 @机器人' : '新群默认响应所有消息');
+    } catch (err) {
+      setDefaultRequireMention(prev);
+      toast.error(getErrorMessage(err, '保存失败'));
+    } finally {
+      setImDefaultsSaving(false);
     }
   };
 
@@ -446,6 +466,28 @@ export function ProfileSection() {
           {aiAppearanceSaving && <Loader2 className="size-4 animate-spin" />}
           保存
         </Button>
+      </Section>
+
+      {/* ── 3.5 IM Group Defaults ── */}
+      <Section
+        icon={MessagesSquare}
+        title="IM 群聊默认行为"
+        desc="影响新自动注册的飞书 / Telegram 群聊。已有群聊保持原设置不变；可在每个群里用 /require_mention 命令单独切换。"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <Label className="text-sm text-foreground">新群默认需要 @机器人</Label>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              开启后，机器人加入新群后只对 @它的消息回复；关闭则响应群里你发送的所有消息。
+            </p>
+          </div>
+          <Switch
+            checked={defaultRequireMention}
+            disabled={imDefaultsSaving}
+            onCheckedChange={handleToggleDefaultRequireMention}
+            aria-label="新群默认需要 @机器人"
+          />
+        </div>
       </Section>
 
       {/* ── 4. Password ── */}

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -31,6 +31,7 @@ export interface UserPublic {
   ai_avatar_emoji: string | null;
   ai_avatar_color: string | null;
   ai_avatar_url: string | null;
+  default_require_mention: boolean;
 }
 
 export interface AppearanceConfig {
@@ -60,7 +61,7 @@ interface AuthState {
   checkStatus: () => Promise<void>;
   setupAdmin: (username: string, password: string) => Promise<void>;
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
-  updateProfile: (payload: { username?: string; display_name?: string; avatar_emoji?: string | null; avatar_color?: string | null; avatar_url?: string | null; ai_name?: string | null; ai_avatar_emoji?: string | null; ai_avatar_color?: string | null; ai_avatar_url?: string | null }) => Promise<void>;
+  updateProfile: (payload: { username?: string; display_name?: string; avatar_emoji?: string | null; avatar_color?: string | null; avatar_url?: string | null; ai_name?: string | null; ai_avatar_emoji?: string | null; ai_avatar_color?: string | null; ai_avatar_url?: string | null; default_require_mention?: boolean }) => Promise<void>;
   uploadAvatar: (file: File, target?: 'user' | 'ai') => Promise<string>;
   fetchAppearance: () => Promise<void>;
   hasPermission: (permission: Permission) => boolean;


### PR DESCRIPTION
## 问题描述

飞书 / Telegram / QQ / 钉钉群聊首次发消息时，由 `buildOnNewChat` 在
`src/index.ts` 自动注册到主容器。注册时 `require_mention` **从未被显式
设置**，落回 DB schema 默认值 `0`（=群聊里无需 @ 机器人即可触发回复）。

后果：

- 机器人加入新群后，会响应 owner 发出的**每一条**消息——包括用户本意
  只是和别人聊天、并不想触发 bot 的情况
- `sender_allowlist` 已经把"其他人"挡在外面，但 owner 自己被轰炸
- 实测在多个内部群出现误触发，需要用户事后手动 `/require_mention true`
  或走 SQL 改库收尾

历史背景：DB schema 里 `registered_groups.require_mention` 默认值是 `0`
是为了兼容老 DM 私聊场景；新加入的群聊本应跟随用户偏好而不是这个全局默认。

## 修复方案

引入**用户级**配置 `users.default_require_mention`（per-user，不是
per-group），auto-register 时按 owner 偏好初始化新群的 `require_mention`：

```mermaid
graph LR
  IM[飞书/Telegram 新群消息] --> Auto[buildOnNewChat]
  Auto --> Read[读 users.default_require_mention]
  Read --> Pure[resolveImGroupDefaults 纯函数]
  Pure --> Reg[registerGroup with require_mention]
```

老群完全不动（schema migration 不回填，buildOnNewChat 的 existing
分支也不改）。每个群仍可用 `/require_mention true|false` 命令单独切换。

### \`src/db.ts\`

- `CREATE TABLE users` 添加 `default_require_mention INTEGER NOT NULL DEFAULT 0`
- `ensureColumn('users', 'default_require_mention', …)` 与现有 `ai_*` 列
  同位置注入，**必须在 `assertSchema('users', …)` 之前**——否则 pre-v38
  数据库会在启动时被 schema 校验拒绝
- `mapUserRow` / `toUserPublic` / `updateUserFields` 各新增一行
- `SCHEMA_VERSION` 37 → 38

### \`src/im-group-defaults.ts\`（新文件）

抽出纯函数 `resolveImGroupDefaults({ ownerDefaultRequireMention })`，
把"owner 偏好 → 新群默认值"的派生逻辑独立出来。

- 通过单元测试锁定 4 个 case（true/false/undefined/脏数据 fail-safe）
- 后续如果再加新字段（例如新群默认 activation_mode），都从这里统一派生
- 避免下次重构再被改回 fail-open

### \`src/index.ts\` (buildOnNewChat)

```ts
const ownerUser = getUserById(userId);
const groupDefaults = resolveImGroupDefaults({
  ownerDefaultRequireMention: ownerUser?.default_require_mention,
});
registerGroup(chatJid, {
  ...,
  require_mention: groupDefaults.requireMention,
});
```

仅影响**新注册**的 IM 群组；existing 分支（已存在的群）完全不动。

### \`src/routes/auth.ts\` + \`src/schemas.ts\`

`PUT /api/auth/profile` 增加 `default_require_mention: boolean` 字段
（zod optional）。`toUserPublic` 把字段透出给前端。

### Web 前端

- `web/src/stores/auth.ts` UserPublic 接口和 updateProfile payload
  加上 `default_require_mention`
- `web/src/components/settings/ProfileSection.tsx` 在"我的机器人"
  section 后新增"IM 群聊默认行为" section，单开关 + 乐观更新 + 失败回滚

## 测试

- `tests/im-group-defaults.test.ts`（新增 4 case）锁住纯函数行为
- `make typecheck` 全绿
- `make test` 43 个测试文件 / 625 个测试全部通过

## 兼容性 / 升级

- 老用户：`default_require_mention=0`（不变），行为与今天一致
- 老群：不受影响（schema 不回填，buildOnNewChat existing 分支不动）
- 新群：跟随 owner 当前的 `default_require_mention` 设置
- 用户可随时在"设置 → 个人偏好"切换，也可在每个群里用
  `/require_mention true|false` 单独覆盖

## 不在本 PR 范围

- 不批量改写历史群的 `require_mention`（用户的预期是"以后的新群跟着
  偏好走，老群保持原状"）
- 不引入 group-level 的 "follow user default" 三态——目前每个群明确
  存 `0/1` 已能覆盖语义


Made with [Cursor](https://cursor.com)