### PR TITLE
修复: WhatsApp normalizeTimestamp 误用 Long.Long 命名空间

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -890,7 +890,7 @@ export function extractMessageText(content: proto.IMessage): string | null {
  * Returns 0 if not a usable value (caller falls back to Date.now()).
  */
 export function normalizeTimestamp(
-  ts: number | Long.Long | null | undefined,
+  ts: number | { toNumber(): number } | null | undefined,
 ): number {
   if (ts === null || ts === undefined) return 0;
   if (typeof ts === 'number') return ts * 1000;


### PR DESCRIPTION
## 问题描述

合到 main 的 #513（WhatsApp 通道）在 `src/whatsapp.ts:893` 把 `Long.Long` 当 namespace 使用，但 baileys 仅以 type 形式导出 `Long`，触发 TS2702 后端 typecheck/`make build` 失败。

```
src/whatsapp.ts(893,16): error TS2702: 'Long' only refers to a type, but is being used as a namespace here.
```

## 修复方案

`normalizeTimestamp()` 函数体内只 duck-type 用 `toNumber()`（第 898 行），从未真正依赖 `Long` 的具体类型。把参数注解改成结构类型 `{ toNumber(): number }`，避开 `Long` 命名空间使用，运行时行为完全不变。

### `src/whatsapp.ts`

- `normalizeTimestamp()` 参数注解 `Long.Long` → `{ toNumber(): number }`