### PR TITLE
修复: QQ 渠道短暂网络抖动后永久离线

### DIFF
--- a/src/qq-reconnect.ts
+++ b/src/qq-reconnect.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for QQ WebSocket reconnect strategy.
+ *
+ * Extracted to a separate module so they can be unit-tested without
+ * spinning up a real WebSocket. The factory in `qq.ts` composes these
+ * with closure-held state (attempt counter, keepalive mode, etc.).
+ */
+
+// Transient network errors that shouldn't burn our reconnect budget.
+// Source: openclaw-qqbot/src/image-server.ts (same canonical list).
+const TRANSIENT_ERROR_CODES: ReadonlySet<string> = new Set([
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'UND_ERR_CONNECT_TIMEOUT',
+]);
+
+export function isTransientError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string' && TRANSIENT_ERROR_CODES.has(code)) {
+    return true;
+  }
+
+  // Some libraries wrap the underlying errno into the message string only
+  // (e.g. `getaddrinfo EAI_AGAIN api.sgroup.qq.com`).
+  const msg = (err as { message?: unknown }).message;
+  if (typeof msg === 'string') {
+    for (const transientCode of TRANSIENT_ERROR_CODES) {
+      if (msg.includes(transientCode)) return true;
+    }
+  }
+
+  return false;
+}
+
+export const RECONNECT_DELAYS: readonly number[] = [
+  1_000,
+  2_000,
+  5_000,
+  10_000,
+  30_000,
+  60_000,
+];
+
+export function getReconnectDelay(
+  attempt: number,
+  delays: readonly number[] = RECONNECT_DELAYS,
+): number {
+  const idx = Math.min(Math.max(attempt, 0), delays.length - 1);
+  return delays[idx]!;
+}
+
+export type CloseCodeAction =
+  | { kind: 'normal' }
+  | { kind: 'refresh-token' }
+  | { kind: 'rate-limit' }
+  | { kind: 'reset-session' };
+
+/**
+ * Map a WebSocket close code to a reconnect strategy.
+ *
+ * - 4004: invalid token → drop cached token, IDENTIFY fresh
+ * - 4008: rate limited → wait `RATE_LIMIT_DELAY_MS` before retry
+ * - 4900-4913: server internal error → drop session, IDENTIFY fresh
+ * - anything else: normal reconnect (RESUME if session is still valid)
+ */
+export function classifyCloseCode(
+  code: number | undefined | null,
+): CloseCodeAction {
+  if (code === 4004) return { kind: 'refresh-token' };
+  if (code === 4008) return { kind: 'rate-limit' };
+  if (typeof code === 'number' && code >= 4900 && code <= 4913) {
+    return { kind: 'reset-session' };
+  }
+  return { kind: 'normal' };
+}

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -27,6 +27,11 @@ import { saveDownloadedFile, MAX_FILE_SIZE } from './im-downloader.js';
 import { detectImageMimeTypeStrict } from './image-detector.js';
 import path from 'node:path';
 import { markdownToPlainText, splitTextChunks } from './im-utils.js';
+import {
+  isTransientError,
+  getReconnectDelay,
+  classifyCloseCode,
+} from './qq-reconnect.js';
 // ─── Constants ──────────────────────────────────────────────────
 
 const QQ_TOKEN_URL = 'https://bots.qq.com/app/getAppAccessToken';
@@ -35,8 +40,16 @@ const TOKEN_REFRESH_BUFFER_MS = 300_000; // refresh 5min before expiry
 const MSG_DEDUP_MAX = 1000;
 const MSG_DEDUP_TTL = 30 * 60 * 1000; // 30min
 const MSG_SPLIT_LIMIT = 5000;
-const RECONNECT_DELAY_MS = 5000;
-const MAX_RECONNECT_ATTEMPTS = 10;
+const MAX_RECONNECT_ATTEMPTS = 100;
+const RATE_LIMIT_DELAY_MS = 60_000;
+const QUICK_DISCONNECT_THRESHOLD_MS = 5_000;
+const MAX_QUICK_DISCONNECT_COUNT = 3;
+// After exhausting MAX_RECONNECT_ATTEMPTS we don't give up; we fall back to a
+// long-tail keepalive so a multi-hour outage eventually self-recovers.
+const KEEPALIVE_INTERVAL_MS = 5 * 60 * 1000;
+// Safety net: if we ever end up disconnected with no reconnect pending,
+// the watchdog kicks a fresh attempt instead of leaving the bot dead.
+const WATCHDOG_INTERVAL_MS = 60_000;
 
 const IMAGE_EXT_MAP: Record<string, string> = {
   'image/jpeg': '.jpg',
@@ -350,12 +363,20 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
   let ws: WebSocket | null = null;
   let heartbeatTimer: NodeJS.Timeout | null = null;
   let reconnectTimer: NodeJS.Timeout | null = null;
+  let watchdogTimer: NodeJS.Timeout | null = null;
   let reconnectAttempts = 0;
   let lastSequence: number | null = null;
   let sessionId: string | null = null;
   let resumeGatewayUrl: string | null = null;
   let stopping = false;
   let readyFired = false;
+
+  // Reconnect control state. Mutated by ws lifecycle handlers and the
+  // reconnect timer; read by scheduleReconnect to pick the next strategy.
+  let quickDisconnectCount = 0;
+  let lastConnectTime = 0;
+  let keepaliveMode = false;
+  let lastErrorIsTransient = false;
 
   // Message deduplication
   const msgCache = new Map<string, number>();
@@ -1132,6 +1153,34 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
     }
   }
 
+  function stopWatchdog(): void {
+    if (watchdogTimer) {
+      clearInterval(watchdogTimer);
+      watchdogTimer = null;
+    }
+  }
+
+  function startWatchdog(opts: QQConnectOpts): void {
+    stopWatchdog();
+    watchdogTimer = setInterval(() => {
+      if (stopping) return;
+      if (connection.isConnected()) return;
+      // A reconnect is already in flight (including keepalive ticks).
+      if (reconnectTimer) return;
+      // Invariant violation: disconnected, not stopping, no retry pending.
+      // Reset the budget and kick a fresh attempt — this is the safety net
+      // that prevents the bot from staying permanently dead.
+      logger.warn(
+        { reconnectAttempts, keepaliveMode },
+        'QQ watchdog detected stale disconnected state, kicking fresh reconnect',
+      );
+      reconnectAttempts = 0;
+      keepaliveMode = false;
+      lastErrorIsTransient = false;
+      scheduleReconnect(opts);
+    }, WATCHDOG_INTERVAL_MS);
+  }
+
   function sendWs(payload: QQWsPayload): void {
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(payload));
@@ -1154,12 +1203,19 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
     return new Promise<void>((resolve, reject) => {
       let settled = false;
+      // True only once READY/RESUMED dispatched. Distinguishes a real
+      // mid-session disconnect from a connect-time error so the close handler
+      // doesn't double-schedule a reconnect that the rejection's catch path
+      // is already handling.
+      let connectionEstablished = false;
 
       ws = new WebSocket(gatewayUrl);
 
-      // Resolve once when session is ready (READY/RESUMED dispatched)
       const onSessionReady = (): void => {
+        connectionEstablished = true;
+        lastConnectTime = Date.now();
         reconnectAttempts = 0;
+        keepaliveMode = false;
         if (!settled) {
           settled = true;
           resolve();
@@ -1190,13 +1246,61 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         if (!settled) {
           settled = true;
           reject(new Error(`QQ WebSocket closed before ready: ${code}`));
-        } else if (!stopping) {
-          scheduleReconnect(opts);
+          return;
+        }
+        // settled but not established → ws.on('error') already rejected;
+        // let the rejection's catch path handle the reconnect (avoids the
+        // double-increment that drained the old budget in ~3 minutes).
+        if (!connectionEstablished) return;
+        if (stopping) return;
+
+        // Quick-disconnect detection: server flapping us right after READY
+        // usually signals a permission / auth issue. Back off harder.
+        if (
+          lastConnectTime > 0 &&
+          Date.now() - lastConnectTime < QUICK_DISCONNECT_THRESHOLD_MS
+        ) {
+          quickDisconnectCount++;
+          if (quickDisconnectCount >= MAX_QUICK_DISCONNECT_COUNT) {
+            logger.error(
+              { quickDisconnectCount, code },
+              'QQ too many quick disconnects, backing off (check appId/secret/permissions)',
+            );
+            quickDisconnectCount = 0;
+            scheduleReconnect(opts, RATE_LIMIT_DELAY_MS);
+            return;
+          }
+        } else {
+          quickDisconnectCount = 0;
+        }
+
+        const action = classifyCloseCode(code);
+        switch (action.kind) {
+          case 'refresh-token':
+            logger.info({ code }, 'QQ invalid token close, forcing token refresh');
+            tokenInfo = null;
+            sessionId = null;
+            lastSequence = null;
+            scheduleReconnect(opts);
+            break;
+          case 'rate-limit':
+            logger.warn({ code }, 'QQ rate limited, applying long delay');
+            scheduleReconnect(opts, RATE_LIMIT_DELAY_MS);
+            break;
+          case 'reset-session':
+            logger.info({ code }, 'QQ server internal error, dropping session');
+            sessionId = null;
+            lastSequence = null;
+            scheduleReconnect(opts);
+            break;
+          default:
+            scheduleReconnect(opts);
         }
       });
 
       ws.on('error', (err) => {
         logger.error({ err }, 'QQ WebSocket error');
+        lastErrorIsTransient = isTransientError(err);
         if (!settled) {
           settled = true;
           reject(err);
@@ -1294,21 +1398,45 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
     }
   }
 
-  function scheduleReconnect(opts: QQConnectOpts): void {
+  function scheduleReconnect(opts: QQConnectOpts, customDelay?: number): void {
     if (stopping) return;
-    if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-      logger.error('QQ max reconnect attempts reached, giving up');
-      return;
+    // Idempotent: if a reconnect is already pending, don't double-schedule
+    // (the close handler and the connect-failure catch can both fire for the
+    // same disconnect event).
+    if (reconnectTimer) return;
+
+    // Transition to keepalive mode once we exhaust the regular budget.
+    // We never hard-stop trying — a long network outage should self-recover.
+    if (
+      !keepaliveMode &&
+      !lastErrorIsTransient &&
+      reconnectAttempts >= MAX_RECONNECT_ATTEMPTS
+    ) {
+      keepaliveMode = true;
+      logger.error(
+        { attempts: reconnectAttempts },
+        'QQ max reconnect attempts reached, falling back to keepalive mode',
+      );
     }
 
-    const delay = Math.min(
-      RECONNECT_DELAY_MS * Math.pow(2, reconnectAttempts),
-      60000,
-    );
-    reconnectAttempts++;
+    let delay: number;
+    if (customDelay !== undefined) {
+      delay = customDelay;
+    } else if (keepaliveMode) {
+      delay = KEEPALIVE_INTERVAL_MS;
+    } else {
+      delay = getReconnectDelay(reconnectAttempts);
+      // Transient errors (DNS hiccups, brief TCP resets) shouldn't burn our
+      // attempt budget — otherwise a 3-minute network blip kills the bot.
+      if (!lastErrorIsTransient) {
+        reconnectAttempts++;
+      }
+    }
+    const wasTransient = lastErrorIsTransient;
+    lastErrorIsTransient = false;
 
     logger.info(
-      { delay, attempt: reconnectAttempts },
+      { delay, attempt: reconnectAttempts, keepaliveMode, wasTransient },
       'QQ scheduling reconnect',
     );
     reconnectTimer = setTimeout(async () => {
@@ -1326,6 +1454,7 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         }
       } catch (err) {
         logger.error({ err }, 'QQ reconnect failed');
+        lastErrorIsTransient = isTransientError(err);
         scheduleReconnect(opts);
       }
     }, delay);
@@ -1678,6 +1807,12 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       reconnectAttempts = 0;
       sessionId = null;
       lastSequence = null;
+      quickDisconnectCount = 0;
+      lastConnectTime = 0;
+      keepaliveMode = false;
+      lastErrorIsTransient = false;
+
+      startWatchdog(opts);
 
       try {
         // Validate token first
@@ -1688,12 +1823,14 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         await connectWs(opts, gatewayUrl, false);
       } catch (err) {
         logger.error({ err }, 'QQ initial connection failed');
+        lastErrorIsTransient = isTransientError(err);
         scheduleReconnect(opts);
       }
     },
 
     async disconnect(): Promise<void> {
       stopping = true;
+      stopWatchdog();
       clearTimers();
 
       if (ws) {
@@ -1709,6 +1846,11 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
       sessionId = null;
       lastSequence = null;
       resumeGatewayUrl = null;
+      reconnectAttempts = 0;
+      quickDisconnectCount = 0;
+      lastConnectTime = 0;
+      keepaliveMode = false;
+      lastErrorIsTransient = false;
       msgCache.clear();
       msgSeqCounters.clear();
       rejectTimestamps.clear();

--- a/tests/qq-reconnect.test.ts
+++ b/tests/qq-reconnect.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  isTransientError,
+  getReconnectDelay,
+  classifyCloseCode,
+  RECONNECT_DELAYS,
+} from '../src/qq-reconnect.js';
+
+describe('isTransientError', () => {
+  test('detects each known transient code via err.code', () => {
+    for (const code of [
+      'EAI_AGAIN',
+      'ENOTFOUND',
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'ECONNREFUSED',
+      'UND_ERR_CONNECT_TIMEOUT',
+    ]) {
+      expect(isTransientError({ code })).toBe(true);
+    }
+  });
+
+  test('detects transient code embedded in error message', () => {
+    expect(
+      isTransientError(new Error('getaddrinfo EAI_AGAIN api.sgroup.qq.com')),
+    ).toBe(true);
+    expect(
+      isTransientError(new Error('connect ECONNRESET 1.2.3.4:443')),
+    ).toBe(true);
+  });
+
+  test('returns false for application errors', () => {
+    expect(isTransientError(new Error('QQ API failed (401): bad token'))).toBe(
+      false,
+    );
+    expect(isTransientError({ code: 'ENOSPC' })).toBe(false);
+  });
+
+  test('returns false for non-error inputs', () => {
+    expect(isTransientError(null)).toBe(false);
+    expect(isTransientError(undefined)).toBe(false);
+    expect(isTransientError('EAI_AGAIN as string, not error')).toBe(false);
+    expect(isTransientError(42)).toBe(false);
+    expect(isTransientError({})).toBe(false);
+  });
+
+  test('ignores non-string code field', () => {
+    expect(isTransientError({ code: 1234 })).toBe(false);
+  });
+});
+
+describe('getReconnectDelay', () => {
+  test('default delay table is the openclaw-aligned step ladder', () => {
+    expect(RECONNECT_DELAYS).toEqual([
+      1_000, 2_000, 5_000, 10_000, 30_000, 60_000,
+    ]);
+  });
+
+  test('returns the matching step for early attempts', () => {
+    expect(getReconnectDelay(0)).toBe(1_000);
+    expect(getReconnectDelay(1)).toBe(2_000);
+    expect(getReconnectDelay(2)).toBe(5_000);
+    expect(getReconnectDelay(3)).toBe(10_000);
+    expect(getReconnectDelay(4)).toBe(30_000);
+    expect(getReconnectDelay(5)).toBe(60_000);
+  });
+
+  test('caps at the final step for high attempts', () => {
+    expect(getReconnectDelay(6)).toBe(60_000);
+    expect(getReconnectDelay(50)).toBe(60_000);
+    expect(getReconnectDelay(99)).toBe(60_000);
+  });
+
+  test('clamps negative attempts to the first step', () => {
+    expect(getReconnectDelay(-1)).toBe(1_000);
+    expect(getReconnectDelay(-100)).toBe(1_000);
+  });
+
+  test('honors a custom delay table', () => {
+    const custom = [500, 1500];
+    expect(getReconnectDelay(0, custom)).toBe(500);
+    expect(getReconnectDelay(1, custom)).toBe(1500);
+    expect(getReconnectDelay(2, custom)).toBe(1500);
+  });
+});
+
+describe('classifyCloseCode', () => {
+  test('4004 → refresh-token (invalid token)', () => {
+    expect(classifyCloseCode(4004)).toEqual({ kind: 'refresh-token' });
+  });
+
+  test('4008 → rate-limit', () => {
+    expect(classifyCloseCode(4008)).toEqual({ kind: 'rate-limit' });
+  });
+
+  test('4900–4913 inclusive → reset-session', () => {
+    expect(classifyCloseCode(4900)).toEqual({ kind: 'reset-session' });
+    expect(classifyCloseCode(4906)).toEqual({ kind: 'reset-session' });
+    expect(classifyCloseCode(4913)).toEqual({ kind: 'reset-session' });
+  });
+
+  test('boundaries around 4900–4913 fall back to normal', () => {
+    expect(classifyCloseCode(4899)).toEqual({ kind: 'normal' });
+    expect(classifyCloseCode(4914)).toEqual({ kind: 'normal' });
+  });
+
+  test('common WebSocket codes are normal', () => {
+    expect(classifyCloseCode(1000)).toEqual({ kind: 'normal' });
+    expect(classifyCloseCode(1001)).toEqual({ kind: 'normal' });
+    expect(classifyCloseCode(1006)).toEqual({ kind: 'normal' });
+    expect(classifyCloseCode(4000)).toEqual({ kind: 'normal' });
+  });
+
+  test('null / undefined → normal', () => {
+    expect(classifyCloseCode(null)).toEqual({ kind: 'normal' });
+    expect(classifyCloseCode(undefined)).toEqual({ kind: 'normal' });
+  });
+});
+
+/**
+ * Regression scenario for the production incident on 2026-05-15:
+ *
+ * Around 05:40 UTC the QQ gateway DNS started failing with EAI_AGAIN. The
+ * old reconnect loop used exponential backoff capped at 60s with a budget
+ * of only 10 attempts — meaning ~3 minutes of DNS trouble killed the bot
+ * permanently. The fix has two arms:
+ *   1. Transient errors don't burn the attempt budget.
+ *   2. Once the budget is exhausted, fall back to a long-tail keepalive
+ *      instead of a hard "give up".
+ *
+ * This is a documentation test that exercises the helpers with the actual
+ * error shape we'd see during the incident.
+ */
+describe('regression: 2026-05-15 DNS outage', () => {
+  test('the production EAI_AGAIN error is recognized as transient', () => {
+    const err: NodeJS.ErrnoException = Object.assign(
+      new Error('getaddrinfo EAI_AGAIN api.sgroup.qq.com'),
+      { code: 'EAI_AGAIN', syscall: 'getaddrinfo', hostname: 'api.sgroup.qq.com' },
+    );
+    expect(isTransientError(err)).toBe(true);
+  });
+
+  test('1006 abnormal closure that follows the EAI_AGAIN is normal', () => {
+    // The DNS failure shows up first as ws.on('error'); the close that
+    // follows usually carries 1006 (no close frame). We must not treat
+    // 1006 as a special case — the transient-error path drives the retry.
+    expect(classifyCloseCode(1006)).toEqual({ kind: 'normal' });
+  });
+});


### PR DESCRIPTION
## 问题描述

QQ 渠道的 WebSocket 重连机制在短暂网络故障（如 DNS 临时失败）时会**永久离线**，必须人工重启才能恢复。

**真实复现的故障序列**（生产实例日志摘录）：

```
05:40:47  QQ WebSocket closed                       ← 服务端 30min 滚动断开
05:41:12  QQ WebSocket error  EAI_AGAIN api.sgroup.qq.com   ← DNS 临时失败
05:41:12  QQ scheduling reconnect (attempt 1)
05:41:42  QQ WebSocket error  EAI_AGAIN
05:41:42  QQ scheduling reconnect (attempt 2)
... (重复)
05:43:16  QQ max reconnect attempts reached, giving up      ← ~2.5min 后死亡
```

故障约 2.5 分钟后 bot 永久离线，DNS 几分钟内即恢复正常但代码再无任何机制触发重连。前端表现为"该机器人的'灵魂'不在线，请检查它的主机服务部署环境"。

**根因**：`src/qq.ts` 重连预算只有 10 次（指数退避 `5s → 10s → 20s → 40s → 60s`），任何持续 ~3 分钟以上的网络故障都让 QQ 渠道永久死亡。其他通道（Telegram / 钉钉 / 飞书）没有这种"放弃即死亡"的硬上限。

**对比 openclaw-qqbot**：参考实现（`riba2534/openclaw-qqbot/src/gateway.ts`）的预算是 100 次 + 固定步长退避 `[1s, 2s, 5s, 10s, 30s, 60s]` + 框架级 health-monitor 兜底（plugin 长时间 disconnected 会被框架重启）。happyclaw 没有外层 health-monitor，所以单纯抄数字不够，需要在通道内自实现兜底。

## 实现方案

策略：**B + C 合并** —— B (永不硬放弃) 处理任何未知场景，C (transient 错误不计入预算) 直接命中本次故障类型。

### `src/qq-reconnect.ts`（new）

抽离纯函数便于单测：

- `isTransientError(err)` — 识别 DNS/TCP 瞬时错误（`EAI_AGAIN` / `ENOTFOUND` / `ECONNRESET` / `ETIMEDOUT` / `ECONNREFUSED` / `UND_ERR_CONNECT_TIMEOUT`），代码列表与 openclaw-qqbot 的 `image-server.ts:659` 一致
- `getReconnectDelay(attempt)` — 固定步长退避表 `[1s, 2s, 5s, 10s, 30s, 60s]`
- `classifyCloseCode(code)` — WebSocket close code 分类（4004 / 4008 / 4900–4913）

### `src/qq.ts`

- 重连预算 `10 → 100`，退避策略改为固定步长（对齐 openclaw-qqbot）
- **transient 网络错误不消耗重连预算** —— DNS 抖动不该让 bot 死亡（C）
- **预算耗尽后进入 5 分钟 keepalive 重试，永不硬放弃**（B）
- **watchdog 60s 兜底** —— 发现"已断开但无重连定时器"的不变量违反状态立即触发（B 的安全网）
- close code 分类处理：
  - `4004` (invalid token) → 强制刷 token + 清 session
  - `4008` (rate limited) → 触发 60s 速率限制延迟
  - `4900–4913` (server internal error) → 清 session 重新 IDENTIFY
- **5 秒内连断 3 次** → 长延迟退避（提示可能是 appId/secret/permissions 问题）
- 修复 `ws.on('error')` + `ws.on('close')` 双触发 `scheduleReconnect()` 导致预算被双倍消耗的隐藏 bug —— 通过新增 `connectionEstablished` 标志区分"已建立的连接被中途断开"和"建立前就出错"

### `tests/qq-reconnect.test.ts`（new）

18 个 vitest 单测覆盖 3 个纯函数，包含一个"DNS 故障复现"的回归用例（带本次事故的实际 error 形状）。

## 测试

- `npx vitest run tests/qq-reconnect.test.ts` → 18 passed
- `make typecheck` → clean（依赖 #537 合并以解锁 build）
- 本机生产实测：QQ 离线后部署本分支 + `pm2 restart` → bot 立即恢复在线

## 后续

如果未来出现类似"通道因可恢复故障永久死亡"，watchdog + keepalive 模式可以作为一个通用 pattern 推广到其他 IM 通道（飞书 / Telegram / 钉钉）的连接管理。但本 PR 只动 QQ，避免范围蔓延。