### PR TITLE
修复: 宿主机 Agent 启动时解析 Node 可执行文件

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -188,6 +188,64 @@ function ensureSettingsJson(
   fs.writeFileSync(settingsFile, newContent, { mode: 0o644 });
 }
 
+function isExecutableFile(
+  filePath: string | undefined | null,
+): filePath is string {
+  if (!filePath) return false;
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveBinaryOnPath(
+  binary: string,
+  envPath: string | undefined,
+): string | null {
+  if (!envPath) return null;
+  for (const dir of envPath.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, binary);
+    if (isExecutableFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+function resolveHostNodeBinary(env: Record<string, string>): string {
+  const homeDir = env.HOME || os.homedir();
+  const candidates = [
+    process.execPath,
+    process.argv[0],
+    env.npm_node_execpath,
+    env.NVM_BIN ? path.join(env.NVM_BIN, 'node') : null,
+    env.FNM_MULTISHELL_PATH ? path.join(env.FNM_MULTISHELL_PATH, 'node') : null,
+    env.VOLTA_HOME ? path.join(env.VOLTA_HOME, 'bin', 'node') : null,
+    resolveBinaryOnPath('node', env.PATH),
+    path.join(
+      homeDir,
+      '.local',
+      'share',
+      'fnm',
+      'aliases',
+      'default',
+      'bin',
+      'node',
+    ),
+    path.join(homeDir, '.nvm', 'versions', 'node', 'current', 'bin', 'node'),
+    '/opt/homebrew/bin/node',
+    '/usr/local/bin/node',
+    '/usr/bin/node',
+  ];
+
+  for (const candidate of candidates) {
+    if (isExecutableFile(candidate)) return candidate;
+  }
+
+  return 'node';
+}
+
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
@@ -1641,6 +1699,7 @@ export async function runHostAgent(
     );
 
     const logsDir = logsBaseDir;
+    const hostNodeBinary = resolveHostNodeBinary(hostEnv);
 
     const hostResult = await new Promise<ContainerOutput>((resolve) => {
       let settled = false;
@@ -1651,7 +1710,7 @@ export async function runHostAgent(
       };
 
       // 7. 启动进程
-      const proc = spawn('node', [agentRunnerDist], {
+      const proc = spawn(hostNodeBinary, [agentRunnerDist], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: hostEnv,
         cwd: groupDir,

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -890,7 +890,7 @@ export function extractMessageText(content: proto.IMessage): string | null {
  * Returns 0 if not a usable value (caller falls back to Date.now()).
  */
 export function normalizeTimestamp(
-  ts: number | Long.Long | null | undefined,
+  ts: number | { toNumber(): number } | null | undefined,
 ): number {
   if (ts === null || ts === undefined) return 0;
   if (typeof ts === 'number') return ts * 1000;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -183,12 +183,15 @@ export default defineConfig(({ command }) => {
               //   4. login/logout 调 clearApiCaches() 阻止跨用户串号
               //   5. 服务端响应头 Cache-Control: private, no-store 兜底
               // `?after=` 增量轮询（每 2s）排除以免占用 maxEntries 配额。
+              // `?agentId=` 子对话首屏必须强一致；它没有主会话的 2s 轮询兜底，
+              // 若走 SWR 会出现"首次刷新旧消息，二次刷新才最新"。
               // agents 列表不在此处理：store 层已 memoize，SW 介入只会增加
               // 双层缓存失效协调的复杂度。
               {
                 urlPattern: ({ url, request }) => {
                   if (request.method !== 'GET') return false;
                   if (url.searchParams.has('after')) return false; // 排除轮询
+                  if (url.searchParams.has('agentId')) return false; // 子对话首屏走网络
                   return /^\/api\/groups\/[^/]+\/messages$/.test(url.pathname);
                 },
                 handler: 'StaleWhileRevalidate',

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -183,15 +183,12 @@ export default defineConfig(({ command }) => {
               //   4. login/logout 调 clearApiCaches() 阻止跨用户串号
               //   5. 服务端响应头 Cache-Control: private, no-store 兜底
               // `?after=` 增量轮询（每 2s）排除以免占用 maxEntries 配额。
-              // `?agentId=` 子对话首屏必须强一致；它没有主会话的 2s 轮询兜底，
-              // 若走 SWR 会出现"首次刷新旧消息，二次刷新才最新"。
               // agents 列表不在此处理：store 层已 memoize，SW 介入只会增加
               // 双层缓存失效协调的复杂度。
               {
                 urlPattern: ({ url, request }) => {
                   if (request.method !== 'GET') return false;
                   if (url.searchParams.has('after')) return false; // 排除轮询
-                  if (url.searchParams.has('agentId')) return false; // 子对话首屏走网络
                   return /^\/api\/groups\/[^/]+\/messages$/.test(url.pathname);
                 },
                 handler: 'StaleWhileRevalidate',


### PR DESCRIPTION
## 问题描述

Host 模式启动 agent-runner 时直接执行 `spawn('node', ...)`。当 HappyClaw 由 PM2 / launchd / GUI 环境启动时，运行时 `PATH` 可能缺失或保留了已经不存在的 Node 版本路径，导致 Host Agent 启动失败：

```text
Host agent spawn error: spawn node ENOENT
```

用户侧表现为 Web 服务和 WebSocket 正常，但发送消息后 Agent 没有响应。



此外，当前 `upstream/main` 的 WhatsApp 通道存在一个 typecheck 问题：`Long` 只作为 type 导入时不能再写成 `Long.Long` namespace 类型，导致 `make typecheck` 卡在 `src/whatsapp.ts`。

## 修复方案 / 实现方案

### `src/container-runner.ts`

- 新增 `resolveHostNodeBinary()`，在启动 Host Agent 前解析可执行的 Node 路径。
- 优先使用当前 HappyClaw 进程自身的 `process.execPath`，再依次检查 npm / NVM / FNM / Volta / PATH / 常见系统路径。
- 将 Host Agent 启动从 `spawn('node', ...)` 改为 `spawn(hostNodeBinary, ...)`，避免依赖不可靠的裸 `node` PATH 查找。

### `src/whatsapp.ts`

- 顺手修复 upstream/main 既有 typecheck 错误：将 `Long.Long` namespace 类型改成实际使用所需的结构类型 `{ toNumber(): number }`。
- 运行逻辑不变，仍只依赖 Long-like 对象暴露的 `toNumber()`。



## 验证

- ✅ 本地重启 PM2 HappyClaw 后，`/api/health` 返回 healthy。
- ✅ 确认 Host Agent 可通过绝对 fnm Node 路径启动，不再出现 `spawn node ENOENT`。
- ✅ `make typecheck`

