### PR TITLE
修复: 宿主机 Agent / PTY 启动时解析 Node 可执行文件 (替代 #539)

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -15,6 +15,7 @@ import path from 'path';
 
 import { CONTAINER_IMAGE, DATA_DIR, GROUPS_DIR, TIMEZONE } from './config.js';
 import { logger } from './logger.js';
+import { resolveHostNodeBinary } from './node-resolver.js';
 import {
   loadMountAllowlist,
   validateAdditionalMounts,
@@ -1651,7 +1652,10 @@ export async function runHostAgent(
       };
 
       // 7. 启动进程
-      const proc = spawn('node', [agentRunnerDist], {
+      // Resolve absolute node path: bare 'node' fails with ENOENT under
+      // PM2 / launchd / GUI launchers where PATH lacks nvm/fnm dirs.
+      const hostNodeBinary = resolveHostNodeBinary(hostEnv);
+      const proc = spawn(hostNodeBinary, [agentRunnerDist], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: hostEnv,
         cwd: groupDir,

--- a/src/node-resolver.ts
+++ b/src/node-resolver.ts
@@ -45,18 +45,25 @@ export function resolveBinaryOnPath(
   return null;
 }
 
+function hasNodeBasename(filePath: string | undefined): filePath is string {
+  if (!filePath) return false;
+  const basename = path.basename(filePath.replace(/\\/g, '/')).toLowerCase();
+  return (
+    basename === 'node' || basename === 'nodejs' || basename === 'node.exe'
+  );
+}
+
 export function buildNodeCandidates(ctx: NodeResolverContext): string[] {
   const home = ctx.homeDir ?? '';
   const raw: (string | null | undefined)[] = [
-    // process.execPath is the absolute path of the current Node binary —
-    // since the parent process is already running on it, it's guaranteed
-    // to be executable. This is the highest-confidence candidate.
-    ctx.execPath,
-    ctx.argv0,
+    // process.execPath / argv0 can point at non-Node runtimes such as Bun,
+    // so only trust them when the executable basename is a Node binary name.
+    hasNodeBasename(ctx.execPath) ? ctx.execPath : null,
+    hasNodeBasename(ctx.argv0) ? ctx.argv0 : null,
     ctx.env.npm_node_execpath,
     ctx.env.NVM_BIN ? path.join(ctx.env.NVM_BIN, 'node') : null,
     ctx.env.FNM_MULTISHELL_PATH
-      ? path.join(ctx.env.FNM_MULTISHELL_PATH, 'node')
+      ? path.join(ctx.env.FNM_MULTISHELL_PATH, 'bin', 'node')
       : null,
     ctx.env.VOLTA_HOME ? path.join(ctx.env.VOLTA_HOME, 'bin', 'node') : null,
     resolveBinaryOnPath('node', ctx.env.PATH, ctx.isExecutable),

--- a/src/node-resolver.ts
+++ b/src/node-resolver.ts
@@ -1,0 +1,99 @@
+/**
+ * Resolves an absolute path to the `node` binary for spawning host-side
+ * child processes (host-mode agent-runner, PTY worker, etc.).
+ *
+ * Host services launched by PM2 / launchd / GUI launchers may inherit a
+ * minimal PATH that does not include nvm / fnm / volta managed Node
+ * installations. A bare `spawn('node', ...)` then fails with ENOENT even
+ * though the parent process is itself running on Node. This module walks
+ * a prioritised candidate list and returns the first executable path,
+ * falling back to literal `'node'` if nothing matches.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export interface NodeResolverContext {
+  env: Record<string, string | undefined>;
+  execPath?: string;
+  argv0?: string;
+  homeDir?: string;
+  isExecutable: (filePath: string) => boolean;
+}
+
+export function isExecutableFile(filePath: string | undefined | null): boolean {
+  if (!filePath) return false;
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveBinaryOnPath(
+  binary: string,
+  envPath: string | undefined,
+  isExec: (filePath: string) => boolean = isExecutableFile,
+): string | null {
+  if (!envPath) return null;
+  for (const dir of envPath.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, binary);
+    if (isExec(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function buildNodeCandidates(ctx: NodeResolverContext): string[] {
+  const home = ctx.homeDir ?? '';
+  const raw: (string | null | undefined)[] = [
+    // process.execPath is the absolute path of the current Node binary —
+    // since the parent process is already running on it, it's guaranteed
+    // to be executable. This is the highest-confidence candidate.
+    ctx.execPath,
+    ctx.argv0,
+    ctx.env.npm_node_execpath,
+    ctx.env.NVM_BIN ? path.join(ctx.env.NVM_BIN, 'node') : null,
+    ctx.env.FNM_MULTISHELL_PATH
+      ? path.join(ctx.env.FNM_MULTISHELL_PATH, 'node')
+      : null,
+    ctx.env.VOLTA_HOME ? path.join(ctx.env.VOLTA_HOME, 'bin', 'node') : null,
+    resolveBinaryOnPath('node', ctx.env.PATH, ctx.isExecutable),
+    home
+      ? path.join(
+          home,
+          '.local',
+          'share',
+          'fnm',
+          'aliases',
+          'default',
+          'bin',
+          'node',
+        )
+      : null,
+    '/opt/homebrew/bin/node',
+    '/usr/local/bin/node',
+    '/usr/bin/node',
+  ];
+  return raw.filter((c): c is string => typeof c === 'string' && c.length > 0);
+}
+
+export function resolveNodeBinary(ctx: NodeResolverContext): string {
+  for (const candidate of buildNodeCandidates(ctx)) {
+    if (ctx.isExecutable(candidate)) return candidate;
+  }
+  return 'node';
+}
+
+export function resolveHostNodeBinary(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return resolveNodeBinary({
+    env,
+    execPath: process.execPath,
+    argv0: process.argv[0],
+    homeDir: os.homedir(),
+    isExecutable: isExecutableFile,
+  });
+}

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { logger } from './logger.js';
+import { resolveHostNodeBinary } from './node-resolver.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -75,7 +76,8 @@ export class TerminalManager {
           rows,
         });
 
-        const proc = spawn('node', [PTY_WORKER_PATH, workerArgs], {
+        const hostNodeBinary = resolveHostNodeBinary(process.env);
+        const proc = spawn(hostNodeBinary, [PTY_WORKER_PATH, workerArgs], {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: process.env as Record<string, string>,
         });

--- a/tests/node-resolver.test.ts
+++ b/tests/node-resolver.test.ts
@@ -1,0 +1,231 @@
+import path from 'path';
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildNodeCandidates,
+  resolveBinaryOnPath,
+  resolveNodeBinary,
+} from '../src/node-resolver.js';
+
+const HOME = '/home/test';
+
+function ctx(overrides: {
+  env?: Record<string, string | undefined>;
+  execPath?: string;
+  argv0?: string;
+  homeDir?: string;
+  isExecutable: (filePath: string) => boolean;
+}) {
+  return {
+    env: {},
+    execPath: undefined,
+    argv0: undefined,
+    homeDir: HOME,
+    ...overrides,
+  };
+}
+
+describe('buildNodeCandidates', () => {
+  test('process.execPath comes first when provided', () => {
+    const candidates = buildNodeCandidates(
+      ctx({
+        execPath: '/custom/node',
+        env: { NVM_BIN: '/nvm/bin', PATH: '/usr/bin' },
+        isExecutable: () => false,
+      }),
+    );
+    expect(candidates[0]).toBe('/custom/node');
+  });
+
+  test('NVM_BIN / FNM_MULTISHELL_PATH / VOLTA_HOME are joined with node', () => {
+    const candidates = buildNodeCandidates(
+      ctx({
+        env: {
+          NVM_BIN: '/nvm/bin',
+          FNM_MULTISHELL_PATH: '/fnm/shell',
+          VOLTA_HOME: '/volta',
+        },
+        isExecutable: () => false,
+      }),
+    );
+    expect(candidates).toContain('/nvm/bin/node');
+    expect(candidates).toContain('/fnm/shell/node');
+    expect(candidates).toContain(path.join('/volta', 'bin', 'node'));
+  });
+
+  test('skips env-derived candidates when env vars are missing', () => {
+    const candidates = buildNodeCandidates(
+      ctx({
+        env: {},
+        isExecutable: () => false,
+      }),
+    );
+    expect(candidates.every((c) => !c.includes('/nvm/'))).toBe(true);
+    expect(candidates.every((c) => !c.includes('/fnm/shell/'))).toBe(true);
+    expect(candidates.every((c) => !c.includes('/volta/'))).toBe(true);
+  });
+
+  test('includes hardcoded fallbacks regardless of env', () => {
+    const candidates = buildNodeCandidates(
+      ctx({
+        env: {},
+        isExecutable: () => false,
+      }),
+    );
+    expect(candidates).toContain('/opt/homebrew/bin/node');
+    expect(candidates).toContain('/usr/local/bin/node');
+    expect(candidates).toContain('/usr/bin/node');
+  });
+
+  test('includes fnm aliases default path under HOME', () => {
+    const candidates = buildNodeCandidates(
+      ctx({
+        env: {},
+        isExecutable: () => false,
+      }),
+    );
+    expect(candidates).toContain(
+      path.join(
+        HOME,
+        '.local',
+        'share',
+        'fnm',
+        'aliases',
+        'default',
+        'bin',
+        'node',
+      ),
+    );
+  });
+
+  test('does not include the non-existent NVM "current" symlink path', () => {
+    // NVM does not maintain a "current" symlink (unlike fnm). The original
+    // PR #539 had this entry but it would never match in practice.
+    const candidates = buildNodeCandidates(
+      ctx({
+        env: {},
+        isExecutable: () => false,
+      }),
+    );
+    expect(
+      candidates.every((c) => !c.endsWith('/.nvm/versions/node/current/bin/node')),
+    ).toBe(true);
+  });
+
+  test('filters out null and empty candidates', () => {
+    const candidates = buildNodeCandidates(
+      ctx({
+        env: { PATH: '' },
+        execPath: '',
+        isExecutable: () => false,
+      }),
+    );
+    expect(candidates.every((c) => typeof c === 'string' && c.length > 0)).toBe(true);
+  });
+});
+
+describe('resolveBinaryOnPath', () => {
+  test('returns first executable match in PATH order', () => {
+    const exec = new Set(['/opt/bin/node']);
+    const result = resolveBinaryOnPath(
+      'node',
+      '/no-here:/opt/bin:/usr/bin',
+      (p) => exec.has(p),
+    );
+    expect(result).toBe('/opt/bin/node');
+  });
+
+  test('returns null when nothing matches', () => {
+    const result = resolveBinaryOnPath(
+      'node',
+      '/a:/b:/c',
+      () => false,
+    );
+    expect(result).toBeNull();
+  });
+
+  test('returns null when PATH is undefined or empty', () => {
+    expect(resolveBinaryOnPath('node', undefined, () => true)).toBeNull();
+    expect(resolveBinaryOnPath('node', '', () => true)).toBeNull();
+  });
+
+  test('skips empty segments without crashing', () => {
+    const exec = new Set(['/usr/bin/node']);
+    const result = resolveBinaryOnPath(
+      'node',
+      '::/usr/bin::',
+      (p) => exec.has(p),
+    );
+    expect(result).toBe('/usr/bin/node');
+  });
+});
+
+describe('resolveNodeBinary', () => {
+  test('returns process.execPath when it is executable (highest priority)', () => {
+    const result = resolveNodeBinary(
+      ctx({
+        execPath: '/parent/node',
+        env: { NVM_BIN: '/nvm/bin', PATH: '/usr/bin' },
+        isExecutable: () => true, // everything executable, must pick first
+      }),
+    );
+    expect(result).toBe('/parent/node');
+  });
+
+  test('falls back to argv0 when execPath is missing', () => {
+    const exec = new Set(['/argv0/node']);
+    const result = resolveNodeBinary(
+      ctx({
+        argv0: '/argv0/node',
+        env: {},
+        isExecutable: (p) => exec.has(p),
+      }),
+    );
+    expect(result).toBe('/argv0/node');
+  });
+
+  test('falls back to NVM_BIN/node when execPath and argv0 are missing', () => {
+    const exec = new Set(['/nvm/bin/node']);
+    const result = resolveNodeBinary(
+      ctx({
+        env: { NVM_BIN: '/nvm/bin' },
+        isExecutable: (p) => exec.has(p),
+      }),
+    );
+    expect(result).toBe('/nvm/bin/node');
+  });
+
+  test('resolves via PATH when env-specific candidates miss', () => {
+    const exec = new Set(['/usr/local/bin/node']);
+    const result = resolveNodeBinary(
+      ctx({
+        env: { PATH: '/no-here:/usr/local/bin' },
+        isExecutable: (p) => exec.has(p),
+      }),
+    );
+    expect(result).toBe('/usr/local/bin/node');
+  });
+
+  test('falls back to hardcoded /opt/homebrew/bin/node', () => {
+    const exec = new Set(['/opt/homebrew/bin/node']);
+    const result = resolveNodeBinary(
+      ctx({
+        env: {},
+        isExecutable: (p) => exec.has(p),
+      }),
+    );
+    expect(result).toBe('/opt/homebrew/bin/node');
+  });
+
+  test('returns literal "node" when nothing matches (final fallback)', () => {
+    const result = resolveNodeBinary(
+      ctx({
+        env: { PATH: '/a:/b' },
+        execPath: '/no-here/node',
+        isExecutable: () => false,
+      }),
+    );
+    expect(result).toBe('node');
+  });
+});

--- a/tests/node-resolver.test.ts
+++ b/tests/node-resolver.test.ts
@@ -27,7 +27,7 @@ function ctx(overrides: {
 }
 
 describe('buildNodeCandidates', () => {
-  test('process.execPath comes first when provided', () => {
+  test('process.execPath comes first when it has a Node basename', () => {
     const candidates = buildNodeCandidates(
       ctx({
         execPath: '/custom/node',
@@ -36,6 +36,30 @@ describe('buildNodeCandidates', () => {
       }),
     );
     expect(candidates[0]).toBe('/custom/node');
+  });
+
+  test('filters process execPath and argv0 to Node binary basenames', () => {
+    const accepted = buildNodeCandidates(
+      ctx({
+        execPath: '/usr/bin/nodejs',
+        argv0: 'C:\\Program Files\\nodejs\\node.exe',
+        env: {},
+        isExecutable: () => false,
+      }),
+    );
+    expect(accepted[0]).toBe('/usr/bin/nodejs');
+    expect(accepted[1]).toBe('C:\\Program Files\\nodejs\\node.exe');
+
+    const rejected = buildNodeCandidates(
+      ctx({
+        execPath: '/opt/homebrew/bin/bun',
+        argv0: '/tmp/node-wrapper',
+        env: {},
+        isExecutable: () => false,
+      }),
+    );
+    expect(rejected).not.toContain('/opt/homebrew/bin/bun');
+    expect(rejected).not.toContain('/tmp/node-wrapper');
   });
 
   test('NVM_BIN / FNM_MULTISHELL_PATH / VOLTA_HOME are joined with node', () => {
@@ -50,7 +74,7 @@ describe('buildNodeCandidates', () => {
       }),
     );
     expect(candidates).toContain('/nvm/bin/node');
-    expect(candidates).toContain('/fnm/shell/node');
+    expect(candidates).toContain('/fnm/shell/bin/node');
     expect(candidates).toContain(path.join('/volta', 'bin', 'node'));
   });
 
@@ -183,6 +207,19 @@ describe('resolveNodeBinary', () => {
       }),
     );
     expect(result).toBe('/argv0/node');
+  });
+
+  test('does not choose Bun-like execPath or argv0 even when executable', () => {
+    const exec = new Set(['/opt/homebrew/bin/bun', '/nvm/bin/node']);
+    const result = resolveNodeBinary(
+      ctx({
+        execPath: '/opt/homebrew/bin/bun',
+        argv0: '/opt/homebrew/bin/bun',
+        env: { NVM_BIN: '/nvm/bin' },
+        isExecutable: (p) => exec.has(p),
+      }),
+    );
+    expect(result).toBe('/nvm/bin/node');
   });
 
   test('falls back to NVM_BIN/node when execPath and argv0 are missing', () => {


### PR DESCRIPTION
## 问题描述

关闭 #539（基于其思路接管完成）。

Host 模式下主进程 `spawn('node', ...)` 在 PM2 / launchd / GUI 启动场景会因 PATH 不含 nvm/fnm 目录而 ENOENT。两处受影响：

- `src/container-runner.ts:1654` — host 模式 admin 主容器启动 agent-runner
- `src/terminal-manager.ts:78` — Web 终端 PTY worker

用户侧表现：Web UI 健康，但发消息 Agent 无响应（或终端开不起来）。

## 修复方案

### `src/node-resolver.ts`（新增）

按优先级解析 node 绝对路径：

1. `process.execPath`（父进程自身的 node，必定可执行 — 最高确信度）
2. `process.argv[0]`
3. `env.npm_node_execpath`
4. `env.NVM_BIN/node`、`env.FNM_MULTISHELL_PATH/node`、`env.VOLTA_HOME/bin/node`
5. PATH 中的 node
6. `~/.local/share/fnm/aliases/default/bin/node`
7. `/opt/homebrew/bin/node`、`/usr/local/bin/node`、`/usr/bin/node`
8. fallback 字面 `'node'`

设计为纯函数 + 可注入 `isExecutable` 检查，便于单测。

### `src/container-runner.ts` / `src/terminal-manager.ts`

两处 `spawn('node', ...)` 改为 `spawn(resolveHostNodeBinary(env), ...)`，共享同一解析逻辑。

### `tests/node-resolver.test.ts`

17 个测试覆盖：

- `buildNodeCandidates`：execPath 优先、env 派生候选、硬编码 fallback、空字段过滤、确认移除不存在的 NVM `current` 候选
- `resolveBinaryOnPath`：PATH 顺序匹配、空 PATH、空段处理
- `resolveNodeBinary`：execPath / argv0 / NVM_BIN / PATH / 硬编码路径各档命中、全失败时返回字面 `'node'`

## 与 #539 的差异

| 项 | #539 | 本 PR |
|----|------|------|
| 核心思路 | resolveHostNodeBinary 按优先级解析 | 一致（致谢 Co-author） |
| 代码位置 | 函数嵌在 `container-runner.ts` | 抽到独立 `src/node-resolver.ts` |
| `terminal-manager.ts:78` 同问题 | 未覆盖 | 已统一修复 |
| 单测 | 无 | 17 个 |
| NVM `current` 候选 | 包含（实际不存在） | 已移除 |
| Draft 状态 | 仍 Draft | Ready |

## 验证

- ✅ `npx vitest run tests/node-resolver.test.ts` 17/17 通过
- ✅ 主项目 typecheck 与 main 持平（既有报错均与本 PR 无关，是本机 optional deps 未装）
- ✅ 主项目 test 与 main 持平（11 file 因 discord.js 未装无法 import，main 上同样）

## Co-author

Co-authored-by: flyinghanger（原 PR #539 提出问题与核心修复思路）