### PR TITLE
修复: 子对话首刷消息读取旧缓存

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -183,12 +183,15 @@ export default defineConfig(({ command }) => {
               //   4. login/logout 调 clearApiCaches() 阻止跨用户串号
               //   5. 服务端响应头 Cache-Control: private, no-store 兜底
               // `?after=` 增量轮询（每 2s）排除以免占用 maxEntries 配额。
+              // `?agentId=` 子对话首屏必须强一致；它没有主会话的 2s 轮询兜底，
+              // 若走 SWR 会出现"首次刷新旧消息，二次刷新才最新"。
               // agents 列表不在此处理：store 层已 memoize，SW 介入只会增加
               // 双层缓存失效协调的复杂度。
               {
                 urlPattern: ({ url, request }) => {
                   if (request.method !== 'GET') return false;
                   if (url.searchParams.has('after')) return false; // 排除轮询
+                  if (url.searchParams.has('agentId')) return false; // 子对话首屏走网络
                   return /^\/api\/groups\/[^/]+\/messages$/.test(url.pathname);
                 },
                 handler: 'StaleWhileRevalidate',


### PR DESCRIPTION
## 问题描述

子对话首屏消息接口 `GET /api/groups/:jid/messages?agentId=...` 会命中 PWA Workbox 的 `StaleWhileRevalidate` runtime cache。用户在页面内已经通过 WebSocket / store 看到最新消息后，刷新页面会丢失 JS 内存状态，并先展示旧的 SWR HTTP 缓存；后台 revalidate 完成后，第二次刷新才显示最新消息。

## 修复方案

- 在 `web/vite.config.ts` 中将带 `?agentId=` 的子对话首屏消息请求从消息接口的 SWR runtime cache 中排除，改为直接走网络。
- 保留主会话普通首屏消息的 SWR 缓存；`?after=` 增量轮询仍继续排除。

## 验证

- ✅ `npm run build:web`
- ⚠️ `npm run typecheck` 在当前 upstream/main 既有 `src/whatsapp.ts` 的 `Long` namespace 类型问题处失败，本 PR 未改动该文件。
