### PR TITLE
优化: 持久化子对话消息快照

### DIFF
--- a/tests/chat-agent-messages.test.ts
+++ b/tests/chat-agent-messages.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Message } from '../web/src/stores/chat';
+
+const {
+  apiGetMock,
+  apiPostMock,
+  apiPatchMock,
+  apiDeleteMock,
+  deleteAgentMessageSnapshotMock,
+  deleteGroupMessageSnapshotsMock,
+  loadAgentMessageSnapshotMock,
+  saveAgentMessageSnapshotMock,
+} = vi.hoisted(() => ({
+  apiGetMock: vi.fn(),
+  apiPostMock: vi.fn(),
+  apiPatchMock: vi.fn(),
+  apiDeleteMock: vi.fn(),
+  deleteAgentMessageSnapshotMock: vi.fn(),
+  deleteGroupMessageSnapshotsMock: vi.fn(),
+  loadAgentMessageSnapshotMock: vi.fn(),
+  saveAgentMessageSnapshotMock: vi.fn(),
+}));
+
+vi.mock('../web/src/api/client', () => ({
+  api: {
+    get: apiGetMock,
+    post: apiPostMock,
+    patch: apiPatchMock,
+    delete: apiDeleteMock,
+  },
+}));
+
+vi.mock('../web/src/api/ws', () => ({
+  wsManager: {
+    send: vi.fn(() => true),
+    on: vi.fn(() => vi.fn()),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: vi.fn(() => true),
+  },
+}));
+
+vi.mock('../web/src/stores/files', () => ({
+  useFileStore: {
+    getState: () => ({
+      loadFiles: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../web/src/stores/auth', () => ({
+  useAuthStore: {
+    getState: () => ({
+      user: null,
+    }),
+  },
+}));
+
+vi.mock('../web/src/utils/toast', () => ({
+  showToast: vi.fn(),
+  notifyIfHidden: vi.fn(),
+  shouldEmitBackgroundTaskNotice: vi.fn(() => false),
+  showNotificationPromptToast: vi.fn(),
+}));
+
+vi.mock('../web/src/utils/pwaCache', () => ({
+  invalidateGroupCache: vi.fn(),
+}));
+
+vi.mock('../web/src/utils/messageSnapshotCache', () => ({
+  deleteAgentMessageSnapshot: deleteAgentMessageSnapshotMock,
+  deleteGroupMessageSnapshots: deleteGroupMessageSnapshotsMock,
+  loadAgentMessageSnapshot: loadAgentMessageSnapshotMock,
+  saveAgentMessageSnapshot: saveAgentMessageSnapshotMock,
+}));
+
+const { useChatStore } = await import('../web/src/stores/chat');
+const initialState = useChatStore.getState();
+
+function message(id: string, timestamp: string): Message {
+  return {
+    id,
+    chat_jid: 'web:main#agent:agent-1',
+    sender: 'user',
+    sender_name: 'User',
+    content: id,
+    timestamp,
+    is_from_me: false,
+  };
+}
+
+function resetChatStore(): void {
+  useChatStore.setState({
+    ...initialState,
+    groups: {},
+    currentGroup: null,
+    messages: {},
+    waiting: {},
+    hasMore: {},
+    loading: false,
+    error: null,
+    streaming: {},
+    thinkingCache: {},
+    thinkingDurationCache: {},
+    pendingThinking: {},
+    pendingThinkingDuration: {},
+    clearing: {},
+    agents: {},
+    agentStreaming: {},
+    activeAgentTab: {},
+    sdkTasks: {},
+    sdkTaskAliases: {},
+    agentMessages: {},
+    agentWaiting: {},
+    agentHasMore: {},
+    drafts: {},
+    unreadReplies: {},
+  }, true);
+}
+
+describe('loadAgentMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGetMock.mockReset();
+    saveAgentMessageSnapshotMock.mockResolvedValue(undefined);
+    deleteAgentMessageSnapshotMock.mockResolvedValue(undefined);
+    loadAgentMessageSnapshotMock.mockResolvedValue(null);
+    resetChatStore();
+  });
+
+  it('replaces hydrated agent messages with the server latest page on first-page calibration', async () => {
+    const jid = 'web:main';
+    const agentId = 'agent-1';
+    const staleHydrated = message('stale-snapshot', '2026-01-02T09:30:00.000Z');
+    const serverOlder = message('server-older', '2026-01-02T10:00:00.000Z');
+    const serverLatest = message('server-latest', '2026-01-02T11:00:00.000Z');
+
+    useChatStore.setState({
+      agentMessages: { [agentId]: [staleHydrated] },
+      agentHasMore: { [agentId]: true },
+    });
+    apiGetMock.mockResolvedValueOnce({
+      messages: [serverLatest, serverOlder],
+      hasMore: false,
+    });
+
+    await useChatStore.getState().loadAgentMessages(jid, agentId);
+
+    expect(useChatStore.getState().agentMessages[agentId]).toEqual([
+      serverOlder,
+      serverLatest,
+    ]);
+    expect(saveAgentMessageSnapshotMock).toHaveBeenCalledWith(
+      jid,
+      agentId,
+      [serverOlder, serverLatest],
+      false,
+    );
+    expect(deleteAgentMessageSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it('merges older pages only when loading more', async () => {
+    const jid = 'web:main';
+    const agentId = 'agent-1';
+    const currentOlder = message('current-older', '2026-01-02T10:00:00.000Z');
+    const currentLatest = message('current-latest', '2026-01-02T11:00:00.000Z');
+    const oldOldest = message('old-oldest', '2026-01-02T08:00:00.000Z');
+    const oldNewest = message('old-newest', '2026-01-02T09:00:00.000Z');
+
+    useChatStore.setState({
+      agentMessages: { [agentId]: [currentOlder, currentLatest] },
+      agentHasMore: { [agentId]: true },
+    });
+    apiGetMock.mockResolvedValueOnce({
+      messages: [oldNewest, oldOldest],
+      hasMore: false,
+    });
+
+    await useChatStore.getState().loadAgentMessages(jid, agentId, true);
+
+    expect(useChatStore.getState().agentMessages[agentId]).toEqual([
+      oldOldest,
+      oldNewest,
+      currentOlder,
+      currentLatest,
+    ]);
+    const calledPath = apiGetMock.mock.calls[0]?.[0] as string;
+    const calledUrl = new URL(calledPath, 'http://localhost');
+    expect(calledUrl.searchParams.get('before')).toBe(currentOlder.timestamp);
+    expect(calledUrl.searchParams.get('agentId')).toBe(agentId);
+    expect(saveAgentMessageSnapshotMock).toHaveBeenCalledWith(
+      jid,
+      agentId,
+      [oldOldest, oldNewest, currentOlder, currentLatest],
+      false,
+    );
+  });
+
+  it('clears hydrated messages and deletes the snapshot when the server latest page is empty', async () => {
+    const jid = 'web:main';
+    const agentId = 'agent-1';
+    const staleHydrated = message('deleted-stale-snapshot', '2026-01-02T09:30:00.000Z');
+
+    useChatStore.setState({
+      agentMessages: { [agentId]: [staleHydrated] },
+      agentHasMore: { [agentId]: true },
+    });
+    apiGetMock.mockResolvedValueOnce({
+      messages: [],
+      hasMore: false,
+    });
+
+    await useChatStore.getState().loadAgentMessages(jid, agentId);
+
+    expect(useChatStore.getState().agentMessages[agentId]).toEqual([]);
+    expect(useChatStore.getState().agentHasMore[agentId]).toBe(false);
+    expect(saveAgentMessageSnapshotMock).not.toHaveBeenCalled();
+    expect(deleteAgentMessageSnapshotMock).toHaveBeenCalledWith(jid, agentId);
+  });
+});

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -133,6 +133,7 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
   const renameConversation = useChatStore(s => s.renameConversation);
   const reorderConversations = useChatStore(s => s.reorderConversations);
   const loadAgentMessages = useChatStore(s => s.loadAgentMessages);
+  const hydrateAgentMessages = useChatStore(s => s.hydrateAgentMessages);
   const refreshAgentMessages = useChatStore(s => s.refreshAgentMessages);
   const sendAgentMessage = useChatStore(s => s.sendAgentMessage);
   const agentMessages = useChatStore(s => s.agentMessages);
@@ -358,13 +359,19 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
 
   // Load messages for conversation agent tabs
   useEffect(() => {
+    let cancelled = false;
     if (activeAgentTab && isConversationTab) {
       const existing = agentMessages[activeAgentTab];
       if (!existing) {
-        loadAgentMessages(groupJid, activeAgentTab);
+        const agentId = activeAgentTab;
+        void (async () => {
+          await hydrateAgentMessages(groupJid, agentId);
+          if (!cancelled) await loadAgentMessages(groupJid, agentId);
+        })();
       }
     }
-  }, [activeAgentTab, isConversationTab, groupJid, loadAgentMessages, agentMessages]);
+    return () => { cancelled = true; };
+  }, [activeAgentTab, isConversationTab, groupJid, hydrateAgentMessages, loadAgentMessages, agentMessages]);
 
   // 监听 WebSocket 流式事件
   useEffect(() => {

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -357,20 +357,21 @@ export function ChatView({ groupJid, onBack, headerLeft }: ChatViewProps) {
     selectTab(isDesktop && topicAgents[0] ? topicAgents[0].id : null);
   }, [isTopicWorkspace, activeAgentTab, topicAgents, isDesktop, selectTab]);
 
-  // Load messages for conversation agent tabs
+  // Load messages for conversation agent tabs.
+  // hydrate-then-calibrate: 先把 IndexedDB 快照灌回 store（避免首屏回退），
+  // 再走网络以服务端为准。不要用 useEffect cleanup 的 cancelled flag —— hydrate
+  // 的 set() 会改 agentMessages 触发 effect 重跑，cleanup 会把上一轮的 cancelled
+  // 置 true，导致网络校准被自己取消。改成 hydrate 完成后直接读 store 判断
+  // 「用户是否仍停留在这个 conversation tab」。
   useEffect(() => {
-    let cancelled = false;
-    if (activeAgentTab && isConversationTab) {
-      const existing = agentMessages[activeAgentTab];
-      if (!existing) {
-        const agentId = activeAgentTab;
-        void (async () => {
-          await hydrateAgentMessages(groupJid, agentId);
-          if (!cancelled) await loadAgentMessages(groupJid, agentId);
-        })();
-      }
-    }
-    return () => { cancelled = true; };
+    if (!activeAgentTab || !isConversationTab) return;
+    if (agentMessages[activeAgentTab]) return;
+    const agentId = activeAgentTab;
+    void (async () => {
+      await hydrateAgentMessages(groupJid, agentId);
+      if (useChatStore.getState().activeAgentTab[groupJid] !== agentId) return;
+      await loadAgentMessages(groupJid, agentId);
+    })();
   }, [activeAgentTab, isConversationTab, groupJid, hydrateAgentMessages, loadAgentMessages, agentMessages]);
 
   // 监听 WebSocket 流式事件

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { api, apiFetch } from '../api/client';
 import { clearApiCaches } from '../utils/pwaCache';
+import { clearMessageSnapshotCache } from '../utils/messageSnapshotCache';
 
 export type Permission =
   | 'manage_system_config'
@@ -80,7 +81,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     // Clear API caches BEFORE login: previous user may have left data behind
     // (e.g. they closed the browser without logout). Without this, the new
     // user could see the previous user's data on first frame from SWR cache.
-    await clearApiCaches();
+    await Promise.allSettled([clearApiCaches(), clearMessageSnapshotCache()]);
     const data = await api.post<{ success: boolean; user: UserPublic; setupStatus?: SetupStatus; appearance?: AppearanceConfig }>(
       '/api/auth/login',
       { username, password },
@@ -90,7 +91,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   register: async (payload) => {
     // Same rationale as login: belt-and-suspenders cache clear on tenant switch.
-    await clearApiCaches();
+    await Promise.allSettled([clearApiCaches(), clearMessageSnapshotCache()]);
     const data = await api.post<{ success: boolean; user: UserPublic }>('/api/auth/register', payload);
     set({ authenticated: true, user: data.user, setupStatus: null, initialized: true });
   },
@@ -99,7 +100,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     await api.post('/api/auth/logout');
     // Clear AFTER server-side session is invalidated so subsequent users on
     // this device don't see this user's cached messages/agents/profile.
-    await clearApiCaches();
+    await Promise.allSettled([clearApiCaches(), clearMessageSnapshotCache()]);
     set({ authenticated: false, user: null, setupStatus: null, appearance: null, initialized: true });
   },
 

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -5,6 +5,12 @@ import { useFileStore } from './files';
 import { useAuthStore } from './auth';
 import { showToast, notifyIfHidden, shouldEmitBackgroundTaskNotice, showNotificationPromptToast } from '../utils/toast';
 import { invalidateGroupCache } from '../utils/pwaCache';
+import {
+  deleteAgentMessageSnapshot,
+  deleteGroupMessageSnapshots,
+  loadAgentMessageSnapshot,
+  saveAgentMessageSnapshot,
+} from '../utils/messageSnapshotCache';
 import type { GroupInfo, AgentInfo, AvailableImGroup } from '../types';
 
 export type { GroupInfo, AgentInfo };
@@ -237,6 +243,7 @@ interface ChatState {
   createConversation: (jid: string, name?: string, description?: string) => Promise<AgentInfo | null>;
   renameConversation: (jid: string, agentId: string, name: string) => Promise<boolean>;
   loadAgentMessages: (jid: string, agentId: string, loadMore?: boolean) => Promise<void>;
+  hydrateAgentMessages: (jid: string, agentId: string) => Promise<void>;
   sendAgentMessage: (jid: string, agentId: string, content: string, attachments?: Array<{ data: string; mimeType: string }>) => boolean;
   refreshAgentMessages: (jid: string, agentId: string) => Promise<void>;
   // Runner state sync
@@ -1195,6 +1202,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Invalidate SW cache for this group so the next page load doesn't
       // serve a stale messages/agents response from before the clear (#467).
       void invalidateGroupCache(jid);
+      void deleteGroupMessageSnapshots(jid);
 
       set((s) => {
         // Delete the key entirely (not []==[]) so selectGroup/ChatView effect
@@ -1785,9 +1793,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     // Route to agentMessages if this is a conversation agent message
     if (agentId) {
+      let snapshotMessages: Message[] | null = null;
+      let snapshotHasMore = false;
       set((s) => {
         const existing = s.agentMessages[agentId] || [];
         const updated = mergeMessagesChronologically(existing, [msg]);
+        snapshotMessages = updated;
+        snapshotHasMore = !!s.agentHasMore[agentId];
         const isAgentReply =
           msg.is_from_me &&
           msg.sender !== '__system__' &&
@@ -1818,6 +1830,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
           agentStreaming: nextAgentStreaming,
         };
       });
+      if (snapshotMessages) {
+        void saveAgentMessageSnapshot(
+          chatJid,
+          agentId,
+          snapshotMessages,
+          snapshotHasMore,
+        );
+      }
       return;
     }
 
@@ -2137,12 +2157,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
   deleteAgentAction: async (jid, agentId) => {
     try {
       await api.delete(`/api/groups/${encodeURIComponent(jid)}/agents/${agentId}`);
+      void deleteAgentMessageSnapshot(jid, agentId);
       clearSdkTaskCleanupTimer(agentId);
       clearSdkTaskStaleTimer(agentId);
       set((s) => {
         const updated = (s.agents[jid] || []).filter((a) => a.id !== agentId);
+        const nextAgentMessages = { ...s.agentMessages };
+        delete nextAgentMessages[agentId];
         const nextAgentStreaming = { ...s.agentStreaming };
         delete nextAgentStreaming[agentId];
+        const nextAgentWaiting = { ...s.agentWaiting };
+        delete nextAgentWaiting[agentId];
+        const nextAgentHasMore = { ...s.agentHasMore };
+        delete nextAgentHasMore[agentId];
         const nextActiveTab = { ...s.activeAgentTab };
         if (nextActiveTab[jid] === agentId) nextActiveTab[jid] = null;
         const nextSdkTasks = { ...s.sdkTasks };
@@ -2150,7 +2177,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
         const nextSdkTaskAliases = removeSdkTaskAliases(s.sdkTaskAliases, agentId);
         return {
           agents: { ...s.agents, [jid]: updated },
+          agentMessages: nextAgentMessages,
           agentStreaming: nextAgentStreaming,
+          agentWaiting: nextAgentWaiting,
+          agentHasMore: nextAgentHasMore,
           activeAgentTab: nextActiveTab,
           sdkTasks: nextSdkTasks,
           sdkTaskAliases: nextSdkTaskAliases,
@@ -2233,19 +2263,40 @@ export const useChatStore = create<ChatState>((set, get) => ({
         `/api/groups/${encodeURIComponent(jid)}/messages?${params}`,
       );
       const sorted = [...data.messages].reverse();
+      let snapshotMessages: Message[] | null = null;
       set((s) => {
         const merged = mergeMessagesChronologically(
           s.agentMessages[agentId] || [],
           sorted,
         );
+        snapshotMessages = merged;
         return {
           agentMessages: { ...s.agentMessages, [agentId]: merged },
           agentHasMore: { ...s.agentHasMore, [agentId]: data.hasMore },
         };
       });
+      if (snapshotMessages) {
+        void saveAgentMessageSnapshot(jid, agentId, snapshotMessages, data.hasMore);
+      }
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
     }
+  },
+
+  hydrateAgentMessages: async (jid, agentId) => {
+    const snapshot = await loadAgentMessageSnapshot(jid, agentId);
+    if (!snapshot || snapshot.messages.length === 0) return;
+    set((s) => {
+      const existing = s.agentMessages[agentId] || [];
+      const merged = mergeMessagesChronologically(existing, snapshot.messages);
+      return {
+        agentMessages: { ...s.agentMessages, [agentId]: merged },
+        agentHasMore: {
+          ...s.agentHasMore,
+          [agentId]: s.agentHasMore[agentId] ?? snapshot.hasMore,
+        },
+      };
+    });
   },
 
   sendAgentMessage: (jid, agentId, content, attachments?) => {
@@ -2284,11 +2335,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
       );
 
       if (data.messages.length > 0) {
+        let snapshotMessages: Message[] | null = null;
+        let snapshotHasMore = false;
         set((s) => {
           const merged = mergeMessagesChronologically(
             s.agentMessages[agentId] || [],
             data.messages,
           );
+          snapshotMessages = merged;
+          snapshotHasMore = !!s.agentHasMore[agentId];
           const agentReplied = data.messages.some(
             (m) =>
               m.is_from_me &&
@@ -2307,6 +2362,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
             agentStreaming: nextAgentStreaming,
           };
         });
+        if (snapshotMessages) {
+          void saveAgentMessageSnapshot(jid, agentId, snapshotMessages, snapshotHasMore);
+        }
       }
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -2266,19 +2266,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
         `/api/groups/${encodeURIComponent(jid)}/messages?${params}`,
       );
       const sorted = [...data.messages].reverse();
-      let snapshotMessages: Message[] | null = null;
+      let snapshotMessages = sorted;
       set((s) => {
-        const merged = mergeMessagesChronologically(
-          s.agentMessages[agentId] || [],
-          sorted,
-        );
-        snapshotMessages = merged;
+        const nextMessages = loadMore
+          ? mergeMessagesChronologically(s.agentMessages[agentId] || [], sorted)
+          : sorted;
+        snapshotMessages = nextMessages;
         return {
-          agentMessages: { ...s.agentMessages, [agentId]: merged },
+          agentMessages: { ...s.agentMessages, [agentId]: nextMessages },
           agentHasMore: { ...s.agentHasMore, [agentId]: data.hasMore },
         };
       });
-      if (snapshotMessages) {
+      if (!loadMore && snapshotMessages.length === 0) {
+        void deleteAgentMessageSnapshot(jid, agentId);
+      } else {
         void saveAgentMessageSnapshot(jid, agentId, snapshotMessages, data.hasMore);
       }
     } catch (err) {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1390,6 +1390,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   deleteFlow: async (jid: string) => {
     try {
       await api.delete<{ success: boolean }>(`/api/groups/${encodeURIComponent(jid)}`);
+      // Workspace 已删除，连带把该 jid 下所有 conversation agent 的 IDB 快照
+      // 也清掉，避免 IDB 长期堆积孤儿条目。
+      void deleteGroupMessageSnapshots(jid);
       set((s) => {
         const nextGroups = { ...s.groups };
         const nextMessages = { ...s.messages };
@@ -2284,8 +2287,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   hydrateAgentMessages: async (jid, agentId) => {
+    // Honor clearHistory's in-flight lock — same contract as loadMessages /
+    // refreshMessages / handleWsNewMessage. Without this, snapshot hydrate can
+    // race with clearHistory and resurrect just-deleted messages into the
+    // agentMessages map.
+    if (get().clearing[jid]) return;
     const snapshot = await loadAgentMessageSnapshot(jid, agentId);
     if (!snapshot || snapshot.messages.length === 0) return;
+    // Re-check after the async IDB read: clearHistory may have started while
+    // we were awaiting.
+    if (get().clearing[jid]) return;
     set((s) => {
       const existing = s.agentMessages[agentId] || [];
       const merged = mergeMessagesChronologically(existing, snapshot.messages);

--- a/web/src/utils/messageSnapshotCache.ts
+++ b/web/src/utils/messageSnapshotCache.ts
@@ -1,0 +1,164 @@
+import type { Message } from '../stores/chat';
+
+const DB_NAME = 'happyclaw-message-snapshots';
+const DB_VERSION = 1;
+const AGENT_MESSAGES_STORE = 'agentMessages';
+const MAX_MESSAGES_PER_AGENT = 100;
+
+interface AgentMessageSnapshot {
+  key: string;
+  jid: string;
+  agentId: string;
+  messages: Message[];
+  hasMore: boolean;
+  updatedAt: number;
+}
+
+function canUseIndexedDB(): boolean {
+  return typeof window !== 'undefined' && 'indexedDB' in window;
+}
+
+function agentSnapshotKey(jid: string, agentId: string): string {
+  return `${jid}#agent:${agentId}`;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openSnapshotDb(): Promise<IDBDatabase> {
+  if (!canUseIndexedDB()) return Promise.reject(new Error('IndexedDB unavailable'));
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(AGENT_MESSAGES_STORE)) {
+        const store = db.createObjectStore(AGENT_MESSAGES_STORE, { keyPath: 'key' });
+        store.createIndex('jid', 'jid', { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error('IndexedDB upgrade blocked'));
+  });
+
+  return dbPromise;
+}
+
+function runAgentStore<T>(
+  mode: IDBTransactionMode,
+  action: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openSnapshotDb().then((db) => new Promise<T>((resolve, reject) => {
+    const tx = db.transaction(AGENT_MESSAGES_STORE, mode);
+    const request = action(tx.objectStore(AGENT_MESSAGES_STORE));
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    tx.onerror = () => reject(tx.error);
+  }));
+}
+
+function normalizeSnapshotMessages(messages: Message[]): Message[] {
+  return [...messages]
+    .sort((a, b) => {
+      if (a.timestamp === b.timestamp) return a.id.localeCompare(b.id);
+      return a.timestamp.localeCompare(b.timestamp);
+    })
+    .slice(-MAX_MESSAGES_PER_AGENT);
+}
+
+/**
+ * Persist the latest known app-state snapshot for a conversation agent.
+ *
+ * This is intentionally an application cache (IndexedDB), not a Workbox HTTP
+ * response cache: WebSocket-delivered state is fresher than the last HTTP
+ * response but still needs to survive a page reload.
+ */
+export async function saveAgentMessageSnapshot(
+  jid: string,
+  agentId: string,
+  messages: Message[],
+  hasMore: boolean,
+): Promise<void> {
+  if (!canUseIndexedDB()) return;
+  const snapshot: AgentMessageSnapshot = {
+    key: agentSnapshotKey(jid, agentId),
+    jid,
+    agentId,
+    messages: normalizeSnapshotMessages(messages),
+    hasMore,
+    updatedAt: Date.now(),
+  };
+  try {
+    await runAgentStore('readwrite', (store) => store.put(snapshot));
+  } catch {
+    /* best effort */
+  }
+}
+
+export async function loadAgentMessageSnapshot(
+  jid: string,
+  agentId: string,
+): Promise<Pick<AgentMessageSnapshot, 'messages' | 'hasMore'> | null> {
+  if (!canUseIndexedDB()) return null;
+  try {
+    const snapshot = await runAgentStore<AgentMessageSnapshot | undefined>(
+      'readonly',
+      (store) => store.get(agentSnapshotKey(jid, agentId)),
+    );
+    if (!snapshot || snapshot.jid !== jid || snapshot.agentId !== agentId) {
+      return null;
+    }
+    return {
+      messages: normalizeSnapshotMessages(snapshot.messages || []),
+      hasMore: !!snapshot.hasMore,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteAgentMessageSnapshot(
+  jid: string,
+  agentId: string,
+): Promise<void> {
+  if (!canUseIndexedDB()) return;
+  try {
+    await runAgentStore('readwrite', (store) => store.delete(agentSnapshotKey(jid, agentId)));
+  } catch {
+    /* best effort */
+  }
+}
+
+export async function deleteGroupMessageSnapshots(jid: string): Promise<void> {
+  if (!canUseIndexedDB()) return;
+  try {
+    const db = await openSnapshotDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(AGENT_MESSAGES_STORE, 'readwrite');
+      const store = tx.objectStore(AGENT_MESSAGES_STORE);
+      const index = store.index('jid');
+      const request = index.openKeyCursor(IDBKeyRange.only(jid));
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) return;
+        store.delete(cursor.primaryKey);
+        cursor.continue();
+      };
+      request.onerror = () => reject(request.error);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch {
+    /* best effort */
+  }
+}
+
+export async function clearMessageSnapshotCache(): Promise<void> {
+  if (!canUseIndexedDB()) return;
+  try {
+    await runAgentStore('readwrite', (store) => store.clear());
+  } catch {
+    /* best effort */
+  }
+}

--- a/web/src/utils/messageSnapshotCache.ts
+++ b/web/src/utils/messageSnapshotCache.ts
@@ -38,8 +38,18 @@ function openSnapshotDb(): Promise<IDBDatabase> {
       }
     };
     request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-    request.onblocked = () => reject(new Error('IndexedDB upgrade blocked'));
+    // Reset the cached promise on failure so a later call can retry. Otherwise
+    // a single transient IDB error (Safari ITP eviction, private-mode quota
+    // refusal, ...) would poison every subsequent snapshot read/write until
+    // the page is reloaded.
+    request.onerror = () => {
+      dbPromise = null;
+      reject(request.error);
+    };
+    request.onblocked = () => {
+      dbPromise = null;
+      reject(new Error('IndexedDB upgrade blocked'));
+    };
   });
 
   return dbPromise;
@@ -55,6 +65,9 @@ function runAgentStore<T>(
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => reject(request.error);
     tx.onerror = () => reject(tx.error);
+    // Quota-exceeded triggers abort (not error). Without this, the
+    // returned promise hangs forever on storage pressure.
+    tx.onabort = () => reject(tx.error);
   }));
 }
 
@@ -148,6 +161,7 @@ export async function deleteGroupMessageSnapshots(jid: string): Promise<void> {
       request.onerror = () => reject(request.error);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
     });
   } catch {
     /* best effort */


### PR DESCRIPTION
## 问题描述

子对话运行中已经通过 WebSocket / store 进入最新状态（状态 2）后，刷新页面会清空 JS 内存。如果只依赖下一次 HTTP 首屏请求，弱网或 SW 旧缓存场景下用户会看到状态回退（状态 1），体验像消息丢失。

URL 形态：

```http
GET /chat/main?agent=<agentId>
```

## 设计原理（hydrate-then-calibrate）

核心是把「最新状态」从 HTTP cache 这一层分离出来，落到应用层 IndexedDB：

1. 运行时 WebSocket / store 进入状态 2 → 同步写入 IDB 快照
2. 刷新后子对话 tab 打开时，**先**从 IDB hydrate 状态 2 到 store（用户立刻看到熟悉的内容）
3. **再**走网络请求做后端校准（merge 而不是覆盖，因为快照可能比网络新）
4. 不把内存状态反写到 Workbox HTTP cache —— HTTP 缓存策略保持不变（仍由 PR #541 单独负责）

这样和 #541 是正交的：#541 让首屏网络请求绕过 SWR 拿到当时的服务端真值；#542 让首屏在网络回来之前就有一个比 SWR cache 更新的本地状态。两个 PR 互不依赖，可以独立 merge / revert。

## 实现要点

### 新增 `web/src/utils/messageSnapshotCache.ts`

IndexedDB 存储 `${jid}#agent:${agentId}` → 最近 100 条消息 + hasMore，纯 best-effort（IDB 不可用时全部静默 noop）。

### 写入快照的路径

| 触发点 | 时机 |
|---|---|
| `loadAgentMessages` | HTTP 拉取成功 merge 进 store 后 |
| `refreshAgentMessages` | 增量刷新 merge 后 |
| `handleWsNewMessage`（带 agentId） | WS 流式消息 merge 进 agentMessages 后 |

### 读取与校准

`hydrateAgentMessages(jid, agentId)`：从 IDB 读出快照，merge 到 store。不是「替换」而是「合并」—— 这样并发场景下网络旧状态先落地、hydrate 晚到也不会被错误跳过。

`ChatView.tsx` conversation tab 首次打开：

```ts
useEffect(() => {
  if (!activeAgentTab || !isConversationTab) return;
  if (agentMessages[activeAgentTab]) return;
  const agentId = activeAgentTab;
  void (async () => {
    await hydrateAgentMessages(groupJid, agentId);
    if (useChatStore.getState().activeAgentTab[groupJid] !== agentId) return;
    await loadAgentMessages(groupJid, agentId);
  })();
}, [...]);
```

### 清理路径

| 操作 | 清理内容 |
|---|---|
| `clearHistory(jid)` | `deleteGroupMessageSnapshots(jid)` —— 该 jid 下所有 agent |
| `deleteAgentAction(jid, agentId)` | `deleteAgentMessageSnapshot(jid, agentId)` |
| `deleteFlow(jid)` | `deleteGroupMessageSnapshots(jid)` —— 整个 workspace 删除 |
| login / register / logout | `clearMessageSnapshotCache()` —— 全表 clear，防跨用户复活 |

## 第二轮修复（responding to review）

第一版被 review 指出 4 处问题，本 PR 已合并修复：

### 1. ChatView 的 cancelled flag 把自己取消了（functional bug）

原写法：

```ts
let cancelled = false;
void (async () => {
  await hydrateAgentMessages(...);
  if (!cancelled) await loadAgentMessages(...);
})();
return () => { cancelled = true; };
```

`agentMessages` 在 deps 里。hydrate 的 `set()` 写 agentMessages → effect 重跑 → cleanup 把上一轮 `cancelled` 置 true → 上一轮的 `loadAgentMessages` 永远不调用。结果：首屏只看到 IDB 快照，没有走网络校准 —— 等于把 staleness 从 SW cache 搬到了 IDB。

修复：去掉 cleanup flag，hydrate 完成后直接读 store 校验 `activeAgentTab[groupJid] === agentId`（"用户是否还在这个 tab"）。

### 2. hydrate 不 honor clearing[jid] lock（stale resurrection）

`loadMessages` / `refreshMessages` / `handleStreamEvent` / `handleWsNewMessage` 都在 set 前检查 `get().clearing[jid]` 防 race，第一版 hydrate 没检查。

时序：
1. 用户切到 conversation tab → hydrate 开始读 IDB
2. 用户点 clear history → `clearing[jid] = true` + `deleteGroupMessageSnapshots(jid)` fire
3. hydrate 的 IDB get 比 cursor delete 早一点点返回旧数据 → set() 把 `agentMessages[agentId]` 又写回去 → 已被清掉的消息复活

修复：`await` 前后各检查一次 `get().clearing[jid]`。

### 3. `deleteFlow(jid)` 没清快照

workspace 删除后该 jid 下的所有 agent 快照在 IDB 永久留存。第一版只覆盖了 `clearHistory` / `deleteAgentAction` / 登入登出，遗漏 `deleteFlow`。补 `void deleteGroupMessageSnapshots(jid)`。

### 4. IDB 错误粘性 + 缺 tx.onabort（resilience）

- `openSnapshotDb` 失败一次后，缓存的 rejected `dbPromise` 让后续所有调用立刻失败，直到 reload。Safari ITP 7 天清理 IDB 或私密模式 quota 拒绝等场景特别明显。失败时 `dbPromise = null` 允许下次重试。
- `runAgentStore` 和 `deleteGroupMessageSnapshots` 的事务只监听 `onerror`，没监听 `onabort`。quota exceeded 触发的是 abort 而非 error，否则 promise 永远 hang。

## 覆盖场景

| 场景 | 行为 |
|---|---|
| 正常运行 → 刷新 | hydrate 灌 IDB 快照（状态 2）→ 网络校准 merge 出 superset，无回退 |
| 弱网 / SW 返回旧 cache | hydrate 已经填好状态 2，等网络回来后 merge，体感上看不到状态 1 |
| 刷新 + IDB 不可用（Safari 私密 / 配额满） | silent noop，回落到纯网络 + #541 的 SWR-bypass 路径（如果 #541 已合）或老的 SWR 体验 |
| clearHistory 期间用户切到 conversation tab | hydrate 被 clearing lock 拦住，不会复活已清消息 |
| 用户切 tab 早于 hydrate 完成 | 通过 `activeAgentTab` 再校验跳过 loadAgentMessages |
| deleteFlow 整个 workspace | 同步清 IDB 所有该 jid 的快照 |
| logout / 切用户 | 全表 clear，无跨用户复活 |

## 与 PR #541 的关系

- #541 改 `web/vite.config.ts`（Workbox runtime cache matcher）
- #542 改 `web/src/...`（应用层 IDB 快照）
- 文件不重合，**完全独立**，任意顺序 merge 都可以
- 两个都合后，刷新体验在「首屏立刻有状态 2」+「网络校准也直接走最新」两条路径上同时收敛

## 验证

- ✅ `cd web && npm run build`
- ✅ `cd web && npx tsc --noEmit`（仅 tsconfig.json 的 `baseUrl` deprecation 提示，非本 PR 引入）
- ⚠️ 根目录 `npm run typecheck` 在 `src/whatsapp.ts:893` 的 `Long` namespace 类型问题处失败，是 upstream/main 既有问题，本 PR 未改 `src/whatsapp.ts`
