### PR TITLE
修复: 飞书卡片正文不再自动提升为标题

### DIFF
--- a/src/feishu-cards/builder.ts
+++ b/src/feishu-cards/builder.ts
@@ -2,9 +2,12 @@
  * Top-level Feishu v2 Agent reply card builders.
  *
  *   buildAgentReplyCard(input)
- *       Terminal (static) card. Structured body with optional explicit header,
- *       body chunks + metadata row (2×2) + optional thinking/tool panels +
- *       footer. Suitable for finalized Agent replies and error cards.
+ *       Terminal (static) card. Header is status-driven: a successful `done`
+ *       reply drops the header (unless an explicit title is passed) so short
+ *       status messages aren't reduced to a truncated header, while
+ *       running/warning/error keep a status-coloured header. Followed by body
+ *       chunks + metadata row (2×2) + optional thinking/tool panels + footer.
+ *       Suitable for finalized Agent replies and error cards.
  *
  *   buildStreamingAgentCard(opts)
  *       Initial streaming skeleton. Preserves the 5 slot element_ids that
@@ -24,7 +27,7 @@ import {
   buildFooter,
   buildStreamingPanels,
   buildStatusBannerText,
-  extractTitle,
+  statusHeadline,
   CARD_ELEMENT_IDS,
   type StreamingPanelsInit,
 } from './sections.js';
@@ -45,10 +48,23 @@ export function buildAgentReplyCard(input: AgentCardInput): FeishuCardV2 {
 
   const explicitTitle = input.title?.trim();
   const body = optimizedText.trim();
-  const summaryTitle = explicitTitle
+
+  // Header policy is driven by status, not by whether a title was passed:
+  //   - done  → drop the header unless an explicit title is given, so short
+  //             status replies don't promote their first line into a truncated
+  //             header (issue #488).
+  //   - running / warning / error → always render a status-coloured header so
+  //             the orange/red/blue state semantics survive into the terminal
+  //             card and the streaming→terminal transition stays visually
+  //             consistent (no header that suddenly disappears).
+  // The header title text comes from the explicit title when present, otherwise
+  // a minimal status word — never the body's first line.
+  const renderHeader = input.status !== 'done' || !!explicitTitle;
+  const headlineTitle = explicitTitle ?? statusHeadline(input.status);
+  const summaryTitle = renderHeader
     ? input.titlePrefix
-      ? `${input.titlePrefix}${explicitTitle}`
-      : explicitTitle
+      ? `${input.titlePrefix}${headlineTitle}`
+      : headlineTitle
     : undefined;
 
   const normalizedInput: AgentCardInput = {
@@ -58,7 +74,7 @@ export function buildAgentReplyCard(input: AgentCardInput): FeishuCardV2 {
     thinking: optimizedThinking,
   };
 
-  const header = explicitTitle ? buildHeader(normalizedInput) : undefined;
+  const header = renderHeader ? buildHeader(normalizedInput) : undefined;
   const elements: Array<Record<string, unknown>> = [];
   if (body) {
     elements.push(...buildBodyChunks(body));
@@ -132,8 +148,11 @@ export function buildStreamingAgentCard(
   opts: StreamingCardBuildOptions = {},
 ): FeishuCardV2 {
   const initialText = opts.initialText ?? '';
-  const { title: autoTitle } = extractTitle(initialText);
-  const displayTitle = opts.title ?? autoTitle ?? '...';
+  // Header/summary title follows the same status-driven policy as the terminal
+  // card: an explicit title wins, otherwise a minimal status word ("生成中") —
+  // never the reply's first line. This keeps the streaming→terminal transition
+  // consistent instead of moving the first line between header and body.
+  const displayTitle = opts.title?.trim() || statusHeadline('running');
   const useRich = opts.rich !== false;
 
   const header = buildHeader({

--- a/src/feishu-cards/builder.ts
+++ b/src/feishu-cards/builder.ts
@@ -2,9 +2,9 @@
  * Top-level Feishu v2 Agent reply card builders.
  *
  *   buildAgentReplyCard(input)
- *       Terminal (static) card. Structured body: title + body with collapsible
- *       overflow sections + metadata row (2×2) + optional thinking/tool panels
- *       + footer. Suitable for finalized Agent replies and error cards.
+ *       Terminal (static) card. Structured body with optional explicit header,
+ *       body chunks + metadata row (2×2) + optional thinking/tool panels +
+ *       footer. Suitable for finalized Agent replies and error cards.
  *
  *   buildStreamingAgentCard(opts)
  *       Initial streaming skeleton. Preserves the 5 slot element_ids that
@@ -25,7 +25,6 @@ import {
   buildStreamingPanels,
   buildStatusBannerText,
   extractTitle,
-  stripTitleFromBody,
   CARD_ELEMENT_IDS,
   type StreamingPanelsInit,
 } from './sections.js';
@@ -44,20 +43,23 @@ export function buildAgentReplyCard(input: AgentCardInput): FeishuCardV2 {
     ? optimizeMarkdownStyle(input.thinking, 2)
     : undefined;
 
-  const { title: autoTitle, bodyStartIndex } = extractTitle(optimizedText);
-  const displayTitle = input.title ?? autoTitle;
-  const body = stripTitleFromBody(optimizedText, bodyStartIndex);
+  const explicitTitle = input.title?.trim();
+  const body = optimizedText.trim();
+  const summaryTitle = explicitTitle
+    ? input.titlePrefix
+      ? `${input.titlePrefix}${explicitTitle}`
+      : explicitTitle
+    : undefined;
 
   const normalizedInput: AgentCardInput = {
     ...input,
     text: optimizedText,
+    title: explicitTitle,
     thinking: optimizedThinking,
   };
 
-  const header = buildHeader(normalizedInput);
+  const header = explicitTitle ? buildHeader(normalizedInput) : undefined;
   const elements: Array<Record<string, unknown>> = [];
-  // When the title was auto-extracted from the first line, body may be empty.
-  // Hiding the body area avoids the header/first-line duplication (issue #488).
   if (body) {
     elements.push(...buildBodyChunks(body));
   }
@@ -81,21 +83,28 @@ export function buildAgentReplyCard(input: AgentCardInput): FeishuCardV2 {
   elements.push(...toolsPanel);
   elements.push(...footer);
 
-  return {
+  const config: Record<string, unknown> = {
+    update_multi: true,
+    enable_forward: true,
+    width_mode: 'fill',
+  };
+  if (summaryTitle) {
+    config.summary = { content: summaryTitle };
+  }
+
+  const card: FeishuCardV2 = {
     schema: '2.0',
-    config: {
-      update_multi: true,
-      enable_forward: true,
-      width_mode: 'fill',
-      summary: { content: displayTitle },
-    },
-    header,
+    config,
     body: {
       direction: 'vertical',
       vertical_spacing: 'medium',
       elements,
     },
   };
+  if (header) {
+    card.header = header;
+  }
+  return card;
 }
 
 export interface StreamingCardBuildOptions {

--- a/src/feishu-cards/sections.ts
+++ b/src/feishu-cards/sections.ts
@@ -119,15 +119,30 @@ export function extractTitle(text: string): TitleExtractResult {
   return { title: 'Reply', bodyStartIndex: 0 };
 }
 
-export function stripTitleFromBody(text: string, bodyStartIndex: number): string {
-  if (bodyStartIndex <= 0) return text.trim();
-  return text.split('\n').slice(bodyStartIndex).join('\n').trim();
+/**
+ * Minimal status word shown as the header title when no explicit title is
+ * provided. Never derive the title from the body's first line — that was the
+ * root cause of the header/first-line duplication (issue #488). For terminal
+ * states we want a short, unambiguous status word instead.
+ */
+export function statusHeadline(status: AgentCardInput['status']): string {
+  switch (status) {
+    case 'running':
+      return '生成中';
+    case 'warning':
+      return '已中断';
+    case 'error':
+      return '出错';
+    case 'done':
+    default:
+      return '已完成';
+  }
 }
 
 export function buildHeader(input: AgentCardInput): El {
   const theme = resolveStatusTheme(input.status);
-  const { title: autoTitle } = extractTitle(input.text);
-  const baseTitle = input.title ?? autoTitle;
+  const explicitTitle = input.title?.trim();
+  const baseTitle = explicitTitle || statusHeadline(input.status);
   const displayTitle = input.titlePrefix
     ? `${input.titlePrefix}${baseTitle}`
     : baseTitle;

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -26,6 +26,7 @@ import {
 import type { CardStatus, ToolCallStat } from './feishu-cards/types.js';
 import {
   CARD_ELEMENT_IDS,
+  statusHeadline,
   buildStatusBannerText,
   buildProgressListText,
   buildToolsTimelineText,
@@ -499,9 +500,11 @@ function buildStreamingCard(
   state: 'streaming' | 'completed' | 'aborted',
   footerNote?: string,
 ): object {
-  // Terminal states delegate to the structured v2 builder so the final card
-  // matches every other reply (themed header + metadata slot + collapsible
-  // continuation sections + grey-notation footer).
+  // Terminal states delegate to the structured v2 builder, which drives the
+  // header off status: `done` drops the header so short replies aren't reduced
+  // to a truncated title (issue #488), while `aborted`→warning keeps an orange
+  // status header. Body, metadata slot and grey-notation footer match every
+  // other reply.
   if (state === 'completed') {
     return buildAgentReplyCard({
       status: 'done',
@@ -517,17 +520,16 @@ function buildStreamingCard(
     });
   }
 
-  // Streaming state — flat v2 layout for cheap full-card patches.
+  // Streaming state — flat v2 layout for cheap full-card patches. The header is
+  // a fixed status word ("生成中"), never the reply's first line: keeping the
+  // body intact (first line stays in MAIN_CONTENT) means the streaming→terminal
+  // transition no longer shuffles the first line between header and body.
   const optimized = optimizeMarkdownStyle(text || '...', 2);
-  const { title, body } = extractTitleAndBody(optimized);
-  const displayTitle = title || '...';
-  // When the title was extracted from the first line, body is empty — keep the
-  // MAIN_CONTENT slot so streaming patches still target it, but avoid echoing
-  // the title back into the body (issue #488).
+  const streamingTitle = statusHeadline('running');
   const elements: Array<Record<string, unknown>> = [
     {
       tag: 'markdown',
-      content: body,
+      content: optimized,
       element_id: CARD_ELEMENT_IDS.MAIN_CONTENT,
     },
     { ...INTERRUPT_BUTTON_V2, element_id: CARD_ELEMENT_IDS.INTERRUPT_BTN },
@@ -550,10 +552,10 @@ function buildStreamingCard(
     schema: '2.0',
     config: {
       width_mode: 'fill',
-      summary: { content: displayTitle },
+      summary: { content: streamingTitle },
     },
     header: {
-      title: { tag: 'plain_text', content: displayTitle },
+      title: { tag: 'plain_text', content: streamingTitle },
       template: 'blue',
     },
     body: { elements },
@@ -2281,7 +2283,9 @@ export class StreamingCardController {
   /**
    * Build a structured terminal card from the controller's accumulated state.
    * Reuses the shared v2 builder so the visual surface matches non-streaming
-   * replies (metadata row, collapsible overflow, themed header).
+   * replies (metadata row, collapsible thinking/tool panels, grey footer). The
+   * builder decides the header off status: `done` has none, `aborted`→warning
+   * keeps an orange status header.
    */
   private buildStructuredFinalCard(
     finalState: 'completed' | 'aborted',

--- a/tests/feishu-card.test.ts
+++ b/tests/feishu-card.test.ts
@@ -295,7 +295,7 @@ describe('formatters', () => {
 // ─── buildAgentReplyCard shape ─────────────────────────────────
 
 describe('buildAgentReplyCard', () => {
-  test('minimal card: v2 schema + violet done template', () => {
+  test('minimal card: v2 schema, no default header/title, body visible', () => {
     const card = buildAgentReplyCard({ status: 'done', text: 'Hello world' });
     expect(card.schema).toBe('2.0');
     const config = card.config as Record<string, unknown>;
@@ -303,21 +303,20 @@ describe('buildAgentReplyCard', () => {
     expect(config.update_multi).toBe(true);
     expect(config.enable_forward).toBe(true);
     expect(config.wide_screen_mode).toBeUndefined();
+    expect(config.summary).toBeUndefined();
+    expect(card.header).toBeUndefined();
 
-    const header = card.header as Record<string, unknown>;
-    expect(header.template).toBe('violet');
-    // header.icon removed — standard_icon tokens are not supported on all clients
-
-    const tags = header.text_tag_list as Array<Record<string, unknown>>;
-    expect(tags.length).toBeGreaterThan(0);
-    expect((tags.at(-1)!.text as Record<string, unknown>).content).toBe('完成');
-
-    const body = card.body as Record<string, unknown>;
+    const body = card.body as { elements: Array<Record<string, unknown>> } &
+      Record<string, unknown>;
     expect(body.vertical_spacing).toBe('medium');
     expect(body.direction).toBe('vertical');
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main?.content).toBe('Hello world');
   });
 
-  test('header.template reflects CardStatus', () => {
+  test('explicit title renders header.template from CardStatus', () => {
     const cases: Array<[
       'running' | 'done' | 'warning' | 'error',
       string,
@@ -328,58 +327,97 @@ describe('buildAgentReplyCard', () => {
       ['error', 'red'],
     ];
     for (const [status, template] of cases) {
-      const card = buildAgentReplyCard({ status, text: 'x' });
+      const card = buildAgentReplyCard({ status, title: '执行结果', text: 'x' });
       const header = card.header as Record<string, unknown>;
       expect(header.template).toBe(template);
       expect(header.icon).toBeUndefined();
     }
   });
 
-  test('running / warning / error status maps to correct template', () => {
-    for (const [status, template] of [
-      ['running', 'blue'],
-      ['warning', 'orange'],
-      ['error', 'red'],
-    ] as const) {
-      const card = buildAgentReplyCard({ status, text: 'x' });
-      const header = card.header as Record<string, unknown>;
-      expect(header.template).toBe(template);
-    }
-  });
-
-  test('short body → single main_content element, no collapsible overflow', () => {
-    // Multi-line input so body has content after the title is consumed
+  test('short multi-line reply without explicit title → no header and keeps full text in body', () => {
+    const text = 'Summary line\nDetail body text';
     const card = buildAgentReplyCard({
       status: 'done',
-      text: 'Summary line\nDetail body text',
+      text,
     });
+    expect(card.header).toBeUndefined();
     const body = card.body as { elements: Array<Record<string, unknown>> };
-    const mainCount = body.elements.filter(
+    const main = body.elements.find(
       (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
-    ).length;
-    expect(mainCount).toBe(1);
+    );
+    expect(main).toBeDefined();
+    expect(main?.content).toBe(text);
     expect(countTag(card, 'collapsible_panel')).toBe(0);
   });
 
-  test('single-line reply → no body markdown to avoid header/body duplication (issue #488)', () => {
+  test('single-line reply → no header and keeps text in body', () => {
     const card = buildAgentReplyCard({ status: 'done', text: 'short reply' });
+    expect(card.header).toBeUndefined();
     const body = card.body as { elements: Array<Record<string, unknown>> };
-    // Header carries the title; body must not echo the same line back
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main).toBeDefined();
+    expect(main?.content).toBe('short reply');
+  });
+
+  test('long single-line reply → no header and keeps full text in body', () => {
+    const text =
+      'HappyClaw: 脚本 Updated slot: Token usage 明细很长，需要在卡片正文完整展示，不能只剩截断标题';
+    const card = buildAgentReplyCard({ status: 'done', text });
+    expect(card.header).toBeUndefined();
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main).toBeDefined();
+    expect(main?.content).toBe(text);
+  });
+
+  test('markdown heading without explicit title → no header and stays in body', () => {
+    const text = '# Token usage\n明细正文';
+    const card = buildAgentReplyCard({
+      status: 'done',
+      text,
+    });
+    expect(card.header).toBeUndefined();
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main?.content).toContain('Token usage');
+    expect(main?.content).toContain('明细正文');
+  });
+
+  test('list-like first line → no header and not promoted to title', () => {
+    const card = buildAgentReplyCard({
+      status: 'done',
+      text: '- item one\n- item two',
+    });
+    expect(card.header).toBeUndefined();
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main?.content).toContain('- item one');
+  });
+
+  test('explicit title override → uses override and keeps full text in body', () => {
+    const card = buildAgentReplyCard({
+      status: 'done',
+      title: '执行结果',
+      text: 'short reply',
+    });
     const header = card.header as Record<string, unknown>;
     const title = (header.title as Record<string, unknown>).content as string;
-    expect(title).toBe('short reply');
-    const mainCount = body.elements.filter(
+    expect(title).toBe('执行结果');
+    const config = card.config as Record<string, unknown>;
+    expect(config.summary).toEqual({ content: '执行结果' });
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
       (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
-    ).length;
-    expect(mainCount).toBe(0);
-    // No markdown element should contain the title text either
-    const markdownEchoesTitle = body.elements.some(
-      (e) =>
-        e.tag === 'markdown' &&
-        typeof e.content === 'string' &&
-        (e.content as string).includes('short reply'),
     );
-    expect(markdownEchoesTitle).toBe(false);
+    expect(main?.content).toBe('short reply');
   });
 
   test('long body → multiple flat markdown chunks, no "继续阅读" panels', () => {
@@ -932,14 +970,13 @@ describe('buildStreamingAgentCard rich skeleton (Phase F)', () => {
 // ─── feishu.ts:buildInteractiveCard backward-compat ─────────────
 
 describe('feishu.ts wrapper uses new builder', () => {
-  test('buildInteractiveCard delegates to buildAgentReplyCard with done status', async () => {
+  test('buildInteractiveCard delegates to buildAgentReplyCard without default header', async () => {
     const { buildInteractiveCard } = (await import('../src/feishu.js')) as unknown as {
       buildInteractiveCard?: (t: string) => object;
     };
     // buildInteractiveCard is module-private; skip silently if not exported.
     if (!buildInteractiveCard) return;
-    const card = buildInteractiveCard('hi');
-    const header = (card as { header: Record<string, unknown> }).header;
-    expect(header.template).toBe('violet');
+    const card = buildInteractiveCard('hi') as Record<string, unknown>;
+    expect(card.header).toBeUndefined();
   });
 });

--- a/tests/feishu-card.test.ts
+++ b/tests/feishu-card.test.ts
@@ -334,6 +334,69 @@ describe('buildAgentReplyCard', () => {
     }
   });
 
+  test('warning terminal state keeps an orange status header even without a title', () => {
+    const text = '部分文件写入失败，已回滚。';
+    const card = buildAgentReplyCard({ status: 'warning', text });
+    const header = card.header as Record<string, unknown> | undefined;
+    expect(header).toBeDefined();
+    expect(header!.template).toBe('orange');
+    const title = (header!.title as Record<string, unknown>).content as string;
+    expect(title).toBe('已中断');
+    const config = card.config as Record<string, unknown>;
+    expect(config.summary).toEqual({ content: '已中断' });
+    // Body must still carry the full reply text (never promoted into the header).
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main?.content).toBe(text);
+  });
+
+  test('error terminal state keeps a red status header even without a title', () => {
+    const text = '执行 Bash 命令时崩溃。';
+    const card = buildAgentReplyCard({ status: 'error', text });
+    const header = card.header as Record<string, unknown> | undefined;
+    expect(header).toBeDefined();
+    expect(header!.template).toBe('red');
+    const title = (header!.title as Record<string, unknown>).content as string;
+    expect(title).toBe('出错');
+    const config = card.config as Record<string, unknown>;
+    expect(config.summary).toEqual({ content: '出错' });
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main?.content).toBe(text);
+  });
+
+  test('status header never derives its title from the body first line', () => {
+    // The first line is a long heading-ish sentence; it must stay in the body
+    // and never be lifted into the header (issue #488 regression guard).
+    const text = '# 这是一段很长的标题文本，超过四十个字符，绝不能被提升到卡片 header 上当作标题展示\n正文细节';
+    const card = buildAgentReplyCard({ status: 'warning', text });
+    const header = card.header as Record<string, unknown>;
+    const title = (header.title as Record<string, unknown>).content as string;
+    expect(title).toBe('已中断');
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const main = body.elements.find(
+      (e) => e.element_id === CARD_ELEMENT_IDS.MAIN_CONTENT,
+    );
+    expect(main?.content).toContain('这是一段很长的标题文本');
+    expect(main?.content).toContain('正文细节');
+  });
+
+  test('explicit title on a warning state uses the title, not the status word', () => {
+    const card = buildAgentReplyCard({
+      status: 'warning',
+      title: '部分成功',
+      text: 'detail',
+    });
+    const header = card.header as Record<string, unknown>;
+    expect(header.template).toBe('orange');
+    const title = (header.title as Record<string, unknown>).content as string;
+    expect(title).toBe('部分成功');
+  });
+
   test('short multi-line reply without explicit title → no header and keeps full text in body', () => {
     const text = 'Summary line\nDetail body text';
     const card = buildAgentReplyCard({


### PR DESCRIPTION
## 问题描述
飞书终态卡片之前会从回复正文第一行自动推断卡片标题。对于一句话状态消息（例如脚本任务更新 Token usage）来说，这会把完整内容挤进 header，飞书客户端只显示截断后的标题，正文区域为空或信息不完整。

另外，默认标题本身在多数短消息场景里也不明所以：它不能提供额外信息，反而占据首屏注意力，降低信息获取效率，属于画蛇添足。

## 修复方案 / 实现方案

### `src/feishu-cards/builder.ts`
- 取消从正文内容自动推断业务标题。
- 默认不渲染终态卡片 header/title，避免出现“回复”等无信息噪音影响信息效率。
- 仅在调用方显式传入 `title` 时渲染 header，并设置卡片 summary。
- 始终把回复正文完整放入 body。

### `tests/feishu-card.test.ts`
- 覆盖单句回复、多行回复、Markdown heading、列表开头和显式 title 的卡片构造行为。
- 锁定默认场景不渲染 header，正文必须可见。

## 验证
- `npm test -- --run tests/feishu-card.test.ts`
- `npm run typecheck`
- `npm run build`
