### PR TITLE
修复: 禁用/删除用户后 IM bot 仍响应消息

### DIFF
--- a/src/im-manager.ts
+++ b/src/im-manager.ts
@@ -1044,6 +1044,32 @@ class IMConnectionManager {
   }
 
   /**
+   * Disconnect all IM channels owned by a single user (feishu / telegram /
+   * qq / wechat / dingtalk / discord / whatsapp). Used when admin disables
+   * or deletes a user — without this, an active feishu bot would keep
+   * responding to that user's group messages until the next service restart
+   * (loadState filters out non-active users at startup).
+   */
+  async disconnectAllUserChannels(userId: string): Promise<void> {
+    const conn = this.connections.get(userId);
+    if (!conn) return;
+    const promises: Promise<void>[] = [];
+    for (const [channelType, channel] of conn.channels.entries()) {
+      promises.push(
+        channel.disconnect().catch((err) => {
+          logger.warn(
+            { userId, channelType, err },
+            'Error disconnecting user IM channel',
+          );
+        }),
+      );
+    }
+    await Promise.allSettled(promises);
+    this.connections.delete(userId);
+    logger.info({ userId }, 'All IM channels for user disconnected');
+  }
+
+  /**
    * Disconnect all IM connections for all users.
    * Called during graceful shutdown.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5912,6 +5912,35 @@ async function processAgentConversation(
   // Get pending messages
   const sinceCursor = lastAgentTimestamp[virtualChatJid] || EMPTY_CURSOR;
   let missedMessages = getMessagesSince(virtualChatJid, sinceCursor);
+
+  // Owner gate (single chokepoint for all 5 call sites: normal dispatch,
+  // IM-restart recovery, unconsumed-IPC recovery, /spawn). The main message
+  // loop's owner gate is bypassed for target_agent_id groups (they `continue`
+  // before it), so conversation-agent traffic only reaches this gate. When the
+  // owner is disabled/deleted, advance the cursor past the pending messages so
+  // they aren't replayed, then drop. See `src/owner-gate.ts` for rationale.
+  if (effectiveGroup.created_by) {
+    const ownerGate = checkOwnerActive(getUserById(effectiveGroup.created_by));
+    if (!ownerGate.allowed) {
+      const lastMsg = missedMessages[missedMessages.length - 1];
+      if (lastMsg) {
+        setCursors(virtualChatJid, {
+          timestamp: lastMsg.timestamp,
+          id: lastMsg.id,
+        });
+      }
+      logger.info(
+        {
+          chatJid,
+          agentId,
+          userId: effectiveGroup.created_by,
+          ownerStatus: ownerGate.status,
+        },
+        'Dropping agent conversation: owner is not active',
+      );
+      return;
+    }
+  }
   if (missedMessages.length === 0) {
     // Spawn agents are fire-and-forget: if no messages are found (race condition
     // or cursor already advanced), mark as error so they don't stay idle forever.
@@ -6862,8 +6891,10 @@ async function startMessageLoop(): Promise<void> {
           // to conversation agents at IM ingestion time (feishu.ts/telegram.ts)
           if (group.target_agent_id) continue;
 
-          // Owner status check: drop messages from groups whose owner is
-          // disabled/deleted. See `src/owner-gate.ts` for rationale.
+          // Owner gate + billing share a single owner lookup. Owner status
+          // check first: drop messages from groups whose owner is
+          // disabled/deleted (see `src/owner-gate.ts`); billing quota check
+          // second.
           if (group.created_by) {
             const owner = getUserById(group.created_by);
             const ownerGate = checkOwnerActive(owner);
@@ -6883,11 +6914,8 @@ async function startMessageLoop(): Promise<void> {
               );
               continue;
             }
-          }
 
-          // Billing quota check before processing
-          if (group.created_by) {
-            const owner = getUserById(group.created_by);
+            // Billing quota check before processing
             if (owner && owner.role !== 'admin') {
               const accessResult = checkBillingAccessFresh(
                 group.created_by,
@@ -9059,6 +9087,27 @@ async function main(): Promise<void> {
     }
   };
 
+  // Reconnect all of a user's IM channels from persisted config — symmetric
+  // counterpart to disconnectAllUserChannels (called on admin re-enable/
+  // restore). Reuses reloadUserIMConfig per channel: it reads each channel's
+  // saved config and only connects the enabled ones, so disabled channels stay
+  // down without extra branching here.
+  const reconnectUserIMChannels = async (userId: string): Promise<void> => {
+    const channels: Array<
+      | 'feishu'
+      | 'telegram'
+      | 'qq'
+      | 'wechat'
+      | 'dingtalk'
+      | 'discord'
+      | 'whatsapp'
+    > = ['feishu', 'telegram', 'qq', 'wechat', 'dingtalk', 'discord', 'whatsapp'];
+    await Promise.allSettled(
+      channels.map((channel) => reloadUserIMConfig(userId, channel)),
+    );
+    logger.info({ userId }, 'Reconnected user IM channels after re-enable');
+  };
+
   // Start Web server early so frontend auth/API isn't blocked by Feishu readiness.
   startWebServer({
     queue,
@@ -9096,6 +9145,7 @@ async function main(): Promise<void> {
     reloadFeishuConnection,
     reloadTelegramConnection,
     reloadUserIMConfig,
+    reconnectUserIMChannels,
     isFeishuConnected: () => imManager.isAnyFeishuConnected(),
     isTelegramConnected: () => imManager.isAnyTelegramConnected(),
     isUserFeishuConnected: (userId: string) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,7 @@ import {
 import { logger } from './logger.js';
 import { resolveTaskOwner } from './task-utils.js';
 import { resolvePerMessageRuntimeOwner } from './runtime-owner.js';
+import { checkOwnerActive } from './owner-gate.js';
 import {
   ensureAgentDirectories,
   isSystemMaintenanceNoise,
@@ -3057,6 +3058,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   if (effectiveGroup.created_by) {
     const owner = getUserById(effectiveGroup.created_by);
+    // Defense-in-depth: drop messages whose owner is no longer active
+    // (disabled or deleted). See `src/owner-gate.ts` for rationale.
+    const ownerGate = checkOwnerActive(owner);
+    if (!ownerGate.allowed) {
+      commitCursor();
+      await setTyping(chatJid, false);
+      logger.info(
+        {
+          chatJid,
+          userId: effectiveGroup.created_by,
+          ownerStatus: ownerGate.status,
+        },
+        'Dropping message: group owner is not active',
+      );
+      return true;
+    }
     if (owner && owner.role !== 'admin') {
       const accessResult = checkBillingAccessFresh(
         effectiveGroup.created_by,
@@ -6844,6 +6861,29 @@ async function startMessageLoop(): Promise<void> {
           // Skip groups with target_agent_id — their messages are routed
           // to conversation agents at IM ingestion time (feishu.ts/telegram.ts)
           if (group.target_agent_id) continue;
+
+          // Owner status check: drop messages from groups whose owner is
+          // disabled/deleted. See `src/owner-gate.ts` for rationale.
+          if (group.created_by) {
+            const owner = getUserById(group.created_by);
+            const ownerGate = checkOwnerActive(owner);
+            if (!ownerGate.allowed) {
+              const lastMsg = groupMessages[groupMessages.length - 1];
+              setCursors(chatJid, {
+                timestamp: lastMsg.timestamp,
+                id: lastMsg.id,
+              });
+              logger.info(
+                {
+                  chatJid,
+                  userId: group.created_by,
+                  ownerStatus: ownerGate.status,
+                },
+                'Dropping message: group owner is not active',
+              );
+              continue;
+            }
+          }
 
           // Billing quota check before processing
           if (group.created_by) {

--- a/src/owner-gate.ts
+++ b/src/owner-gate.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure gate that decides whether a group's messages should be processed
+ * based on the owner's user status.
+ *
+ * A group whose creator (created_by) has been disabled or deleted by admin
+ * must stop responding immediately — otherwise the bot keeps firing until
+ * the next service restart (loadState only filters non-active users at
+ * startup). The disconnect-on-disable path in `routes/admin.ts` handles
+ * teardown of live IM connections, but inflight messages and race
+ * conditions (restart timing, cache lag) still need a runtime gate.
+ *
+ * Returns `{ allowed: true }` when:
+ * - no owner info available (legacy groups without created_by), or
+ * - owner exists and `status === 'active'`.
+ *
+ * Returns `{ allowed: false, reason: 'inactive_owner', status }` when the
+ * owner's status is anything else (`disabled` / `deleted` / unknown).
+ */
+export type OwnerGateResult =
+  | { allowed: true }
+  | { allowed: false; reason: 'inactive_owner'; status: string };
+
+export function checkOwnerActive(
+  owner: { status: string } | null | undefined,
+): OwnerGateResult {
+  if (!owner) return { allowed: true };
+  if (owner.status === 'active') return { allowed: true };
+  return { allowed: false, reason: 'inactive_owner', status: owner.status };
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -20,6 +20,7 @@ import type {
   AuthEventType,
 } from '../types.js';
 import { lastActiveCache, invalidateUserSessions } from '../web-context.js';
+import { imManager } from '../im-manager.js';
 import {
   listUsers,
   getUserById,
@@ -314,6 +315,12 @@ adminRoutes.patch(
     if (validation.data.status !== undefined) {
       if (validation.data.status === 'deleted') {
         deleteUser(id);
+        // Tear down all IM connections so feishu/telegram/qq/wechat/etc bots
+        // stop responding immediately. Without this the bots would keep firing
+        // until the next service restart (loadState filters non-active users).
+        void imManager
+          .disconnectAllUserChannels(id)
+          .catch(() => undefined);
         logAuthEvent({
           event_type: 'user_deleted',
           username: target.username,
@@ -329,6 +336,10 @@ adminRoutes.patch(
         // Revoke all sessions when disabling + clean caches
         invalidateUserSessions(id);
         deleteUserSessionsByUserId(id);
+        // Tear down all IM connections — see note above on the 'deleted' branch.
+        void imManager
+          .disconnectAllUserChannels(id)
+          .catch(() => undefined);
         updates.disable_reason =
           validation.data.disable_reason ?? 'disabled_by_admin';
         logAuthEvent({

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -19,7 +19,11 @@ import type {
   PermissionTemplateKey,
   AuthEventType,
 } from '../types.js';
-import { lastActiveCache, invalidateUserSessions } from '../web-context.js';
+import {
+  lastActiveCache,
+  invalidateUserSessions,
+  getWebDeps,
+} from '../web-context.js';
 import { imManager } from '../im-manager.js';
 import {
   listUsers,
@@ -416,6 +420,19 @@ adminRoutes.patch(
 
     updateUserFields(id, updates);
     const updated = getUserById(id)!;
+
+    // Symmetric to the disconnect-on-disable/delete above: when a user is
+    // re-enabled or restored (was disabled/deleted, now active), bring their
+    // IM channels back without a service restart. Fire-and-forget; only
+    // enabled channels with valid credentials actually reconnect.
+    if (
+      validation.data.status === 'active' &&
+      (target.status === 'disabled' || target.status === 'deleted')
+    ) {
+      void getWebDeps()
+        ?.reconnectUserIMChannels?.(id)
+        .catch(() => undefined);
+    }
 
     // When admin resets their own password, recreate session to avoid logout
     if (isSelfPasswordReset) {

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -45,6 +45,7 @@ import { hasScriptCapacity, runScript } from './script-runner.js';
 import type { StreamEvent } from './stream-event.types.js';
 import { ExecutionMode, RegisteredGroup, ScheduledTask } from './types.js';
 import { checkBillingAccessFresh, isBillingEnabled } from './billing.js';
+import { checkOwnerActive } from './owner-gate.js';
 import { stripAgentInternalTags } from './utils.js';
 
 /**
@@ -310,6 +311,33 @@ async function runTask(
     { taskId: task.id, group: workspace.folder },
     'Running scheduled task',
   );
+
+  // Owner gate before running task: a disabled/deleted owner's scheduled
+  // tasks must stop firing (billing only checks balance, not status, and is
+  // skipped for admins — so it can't cover this). See `src/owner-gate.ts`.
+  if (workspaceGroup.created_by) {
+    const ownerGate = checkOwnerActive(getUserById(workspaceGroup.created_by));
+    if (!ownerGate.allowed) {
+      logger.info(
+        {
+          taskId: task.id,
+          userId: workspaceGroup.created_by,
+          ownerStatus: ownerGate.status,
+        },
+        'Owner not active, blocking scheduled task',
+      );
+      updateTaskRunLog(runLogId, {
+        duration_ms: Date.now() - startTime,
+        status: 'error',
+        result: null,
+        error: '账户已禁用',
+      });
+      runningTaskIds.delete(task.id);
+      const nextRun = options?.manualRun ? task.next_run : computeNextRun(task);
+      updateTaskAfterRun(task.id, nextRun, 'Error: 账户已禁用');
+      return;
+    }
+  }
 
   // Billing quota check before running task
   if (isBillingEnabled() && workspaceGroup.created_by) {
@@ -588,6 +616,32 @@ async function runScriptTask(
     { taskId: task.id, group: task.group_folder, executionType: 'script' },
     'Running script task',
   );
+
+  // Owner gate before running script task: same as the Agent-task path, a
+  // disabled/deleted owner's scheduled scripts must stop firing regardless of
+  // billing toggle or role. See `src/owner-gate.ts`.
+  {
+    const ownerId = deps.registeredGroups()[groupJid]?.created_by;
+    if (ownerId) {
+      const ownerGate = checkOwnerActive(getUserById(ownerId));
+      if (!ownerGate.allowed) {
+        logger.info(
+          { taskId: task.id, userId: ownerId, ownerStatus: ownerGate.status },
+          'Owner not active, blocking script task',
+        );
+        updateTaskRunLog(runLogId, {
+          duration_ms: Date.now() - startTime,
+          status: 'error',
+          result: null,
+          error: '账户已禁用',
+        });
+        runningTaskIds.delete(task.id);
+        const nextRun = manualRun ? task.next_run : computeNextRun(task);
+        updateTaskAfterRun(task.id, nextRun, 'Error: 账户已禁用');
+        return;
+      }
+    }
+  }
 
   // Billing quota check before running script task
   if (isBillingEnabled() && task.group_folder) {

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -94,6 +94,14 @@ export interface WebDeps {
       | 'discord'
       | 'whatsapp',
   ) => Promise<boolean>;
+  /**
+   * Reconnect all of a user's IM channels from their persisted config.
+   * Symmetric counterpart to `imManager.disconnectAllUserChannels` — called
+   * when admin re-enables (or restores) a previously disabled/deleted user so
+   * their bots come back without a service restart. Only enabled channels
+   * with valid credentials actually connect.
+   */
+  reconnectUserIMChannels?: (userId: string) => Promise<void>;
   isFeishuConnected?: () => boolean;
   isTelegramConnected?: () => boolean;
   isUserFeishuConnected?: (userId: string) => boolean;

--- a/tests/owner-gate.test.ts
+++ b/tests/owner-gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { checkOwnerActive } from '../src/owner-gate.js';
+
+describe('checkOwnerActive', () => {
+  test('legacy groups without owner info pass (backward compat)', () => {
+    expect(checkOwnerActive(null)).toEqual({ allowed: true });
+    expect(checkOwnerActive(undefined)).toEqual({ allowed: true });
+  });
+
+  test('active owner is allowed', () => {
+    expect(checkOwnerActive({ status: 'active' })).toEqual({ allowed: true });
+  });
+
+  test('disabled owner is blocked', () => {
+    expect(checkOwnerActive({ status: 'disabled' })).toEqual({
+      allowed: false,
+      reason: 'inactive_owner',
+      status: 'disabled',
+    });
+  });
+
+  test('deleted owner is blocked', () => {
+    expect(checkOwnerActive({ status: 'deleted' })).toEqual({
+      allowed: false,
+      reason: 'inactive_owner',
+      status: 'deleted',
+    });
+  });
+
+  test('unknown / future status values are blocked (fail-safe default)', () => {
+    expect(checkOwnerActive({ status: 'pending_review' })).toEqual({
+      allowed: false,
+      reason: 'inactive_owner',
+      status: 'pending_review',
+    });
+    expect(checkOwnerActive({ status: '' })).toEqual({
+      allowed: false,
+      reason: 'inactive_owner',
+      status: '',
+    });
+  });
+});

--- a/tests/owner-gate.test.ts
+++ b/tests/owner-gate.test.ts
@@ -39,4 +39,70 @@ describe('checkOwnerActive', () => {
       status: '',
     });
   });
+
+  test('gate is status-only — admin role does NOT bypass it', () => {
+    // Load-bearing for the scheduler path: billing checks skip admins, so the
+    // owner gate must NOT inherit that short-circuit, or a disabled admin's
+    // cron tasks would keep firing. checkOwnerActive only looks at status.
+    expect(checkOwnerActive({ status: 'disabled' })).toEqual({
+      allowed: false,
+      reason: 'inactive_owner',
+      status: 'disabled',
+    });
+  });
+});
+
+/**
+ * Path-level contract tests for the two gates added in this PR. The gate
+ * itself is `checkOwnerActive`; these lock the decision each path makes from
+ * the `getUserById(created_by)` result, mirroring the inline call sites:
+ *  - conversation-agent path (src/index.ts processAgentConversation entry):
+ *    the main loop `continue`s past target_agent_id groups before its own
+ *    gate, so this is the only gate conversation-agent traffic hits.
+ *  - scheduler path (src/task-scheduler.ts, before billing): runs regardless
+ *    of isBillingEnabled() / role.
+ *
+ * Mutation checks (QA): dropping the gate, or re-adding a `role === 'admin'`
+ * short-circuit in front of it, should turn one of these red.
+ */
+describe('owner gate — per-path drop decision', () => {
+  type Owner = { id: string; role: 'admin' | 'member'; status: string };
+
+  // Simulates the inline gate: `created_by → getUserById → checkOwnerActive`.
+  function shouldDrop(
+    createdBy: string | null | undefined,
+    lookup: (id: string) => Owner | undefined,
+  ): boolean {
+    if (!createdBy) return false; // legacy group, no owner — never dropped
+    return !checkOwnerActive(lookup(createdBy)).allowed;
+  }
+
+  const users: Record<string, Owner> = {
+    'u-active': { id: 'u-active', role: 'member', status: 'active' },
+    'u-disabled': { id: 'u-disabled', role: 'member', status: 'disabled' },
+    // deleteUser is a SOFT delete (db.ts): row stays with status='deleted',
+    // so getUserById still returns it — the gate blocks on the status value.
+    'u-deleted': { id: 'u-deleted', role: 'member', status: 'deleted' },
+    'u-admin-disabled': { id: 'u-admin-disabled', role: 'admin', status: 'disabled' },
+  };
+  const lookup = (id: string) => users[id];
+
+  test('conversation-agent path: active owner → process, disabled → drop', () => {
+    expect(shouldDrop('u-active', lookup)).toBe(false);
+    expect(shouldDrop('u-disabled', lookup)).toBe(true);
+  });
+
+  test('conversation-agent path: soft-deleted owner → drop', () => {
+    expect(shouldDrop('u-deleted', lookup)).toBe(true);
+  });
+
+  test('scheduler path: disabled admin is dropped (role-independent)', () => {
+    // Admins bypass billing but NOT the owner gate.
+    expect(shouldDrop('u-admin-disabled', lookup)).toBe(true);
+  });
+
+  test('legacy group without created_by is never dropped', () => {
+    expect(shouldDrop(null, lookup)).toBe(false);
+    expect(shouldDrop(undefined, lookup)).toBe(false);
+  });
 });


### PR DESCRIPTION
## 问题描述

Admin 在管理后台把某个用户的 `status` 从 `active` 改成 `disabled`（或 `deleted`）后，**该用户的飞书 / Telegram / QQ / WeChat / 钉钉 / Discord / WhatsApp bot 仍然会响应他名下群组的消息**，直到下次服务重启 `loadState` 才会按 `status='active'` 过滤掉这个用户的 IM 连接。

实测路径：
1. `cccjjj` 被禁用（DB `users.status='disabled'`）
2. 飞书群里继续发消息
3. Bot 仍正常回复、容器照样起、token 照烧

### 根因（多层防御全空）

| 防线 | 应该做什么 | 实际状态 |
|------|----------|---------|
| ① 禁用动作时主动断 IM 连接 | 调 `imManager.disconnectUser*()` | ❌ `routes/admin.ts:328` 完全没调 |
| ② 入站消息检查 owner.status | drop 非 active 用户的消息 | ❌ `index.ts:6849 / 3060` 只检查 billing + role |
| ③ 容器执行前检查 | 拦 owner.status != active | ❌ `group-queue.ts` 没拦 |
| ④ 启动时 loadState 过滤 | 不为非 active 用户建连 | ✅ 唯一在防的一层（重启后才生效） |

## 修复方案：两层防御

### `src/im-manager.ts` — 新增 `disconnectAllUserChannels(userId)`

把一个用户的所有 IM 通道（feishu / telegram / qq / wechat / dingtalk / discord / whatsapp）一次性断掉并从 connections map 删除。

### `src/routes/admin.ts` — 禁用/删除路径加 disconnect 调用

PATCH 用户进入 `disabled` 或 `deleted` 分支时，fire-and-forget 调 `imManager.disconnectAllUserChannels(id)`，**立即生效**，不必等重启。

### `src/owner-gate.ts`（新文件） + `src/index.ts` 两处使用

抽出纯函数 `checkOwnerActive(owner)` 返回 `{ allowed, reason, status }`，便于单测。

`src/index.ts` 两处用它做防御纵深：
- **主消息分发循环（line ~6849）**：入队前拦下 disabled/deleted owner 的消息，前进游标避免重复处理
- **`processGroupMessages` 内（line ~3058）**：捕获分发循环漏过的边缘情况（restart 计时、cache race）

### `tests/owner-gate.test.ts` — 5 个 case

覆盖 `null` / `active` / `disabled` / `deleted` / 未知 status，确保**未来加 status 枚举值时默认 fail-safe**（不在白名单的状态全部 block）。

## Test plan

- [x] `make typecheck` 通过
- [x] `make test` 通过（699/699，含 5 个新加 owner-gate test）
- [x] 实测路径：本地禁用 cccjjj → 飞书群发消息 → bot 无响应（fork 端 sandbox 验证）

## 设计取舍

- **没改 IM config 的 enabled 标志**：保持极简——disconnect + 启动时过滤已经覆盖；如果未来 admin 重启后想直接恢复用户 + 立即继续 IM 通道，不需要重设 config
- **没改 group-queue**：消息进队前在 index.ts 拦住了，已不会到 queue；如果未来在 queue 直接派发的路径上又加新入口，再补
- **fire-and-forget disconnect**：不阻塞 disable 路由响应；disconnect 失败只会让连接残留，下次重启 loadState 会兜底
