### PR TITLE
修复: provider 限额失败后切换并恢复上下文

### DIFF
--- a/src/agent-output-parser.ts
+++ b/src/agent-output-parser.ts
@@ -612,12 +612,53 @@ const API_ERROR_PATTERNS = [
   /ECONNREFUSED|ECONNRESET|ETIMEDOUT/,
 ];
 
-const PROVIDER_FAILURE_RESULT_PATTERNS = [
+/**
+ * Detection for "the provider returned a quota/limit notice as the agent's
+ * final text" (rather than a normal reply).
+ *
+ * CRITICAL: this runs against the agent's *normal reply body* (parsed.result),
+ * not stderr. A match triggers killing the container, clearing the Claude
+ * session and marking the provider unhealthy — all user-visible side effects.
+ * So the match must be near-zero false-positive: generic substrings like
+ * "rate limit" or "quota exceeded" appear constantly in legitimate technical
+ * conversations ("to avoid hitting the API rate limit…", "disk quota
+ * exceeded") and must NEVER be treated as a provider failure here.
+ *
+ * We therefore require a *structured* Claude account-limit signal:
+ *  - a Claude-specific limit phrase ("out of extra usage", "you've hit your
+ *    limit", "usage limit reached", "upgrade to increase your usage limit"),
+ *    AND
+ *  - the message reads as a short system-style notice, not a long answer that
+ *    merely quotes the phrase. Real Claude limit notices are a single terse
+ *    line; agent replies discussing rate limits are much longer.
+ *
+ * The strongest, length-independent signal is the reset timestamp Claude
+ * appends to genuine limit notices ("· resets 2:10am (Asia/Shanghai)"); when a
+ * Claude limit phrase co-occurs with that timestamp we accept regardless of
+ * length, since no normal reply produces both together.
+ */
+
+/** Claude-specific account/usage-limit phrases (not generic provider errors). */
+const CLAUDE_LIMIT_PHRASE_PATTERNS = [
   /\bout of extra usage\b/i,
   /\byou(?:'ve|'re| are)\s+(?:hit|out of)\s+(?:your\s+)?(?:limit|extra usage)\b/i,
-  /\brate[_ ]?limit(?:ed)?\b/i,
-  /\bquota\s+(?:exceeded|exhausted)\b/i,
+  // "usage limit reached" — anchored on "usage" so a generic "rate limit
+  // reached" / "request limit reached" in a normal reply does not match.
+  /\busage\s+limit\s+reached\b/i,
+  /\bupgrade\s+to\s+(?:increase|raise)\s+your\s+usage\s+limit\b/i,
+  /\byour\s+(?:usage\s+)?limit\s+will\s+reset\b/i,
 ];
+
+/** The reset-timestamp suffix Claude appends to genuine limit notices. */
+const CLAUDE_LIMIT_RESET_PATTERN =
+  /\bresets?\b[^.\n]*?\d{1,2}(?::\d{2})?\s*(?:am|pm)?\s*\([^)]*\)/i;
+
+/**
+ * Upper bound (chars) for treating a Claude limit phrase as a *standalone*
+ * system notice. Genuine notices are a single short line; this guards against
+ * a long agent reply that merely mentions the phrase mid-answer.
+ */
+const CLAUDE_LIMIT_NOTICE_MAX_LEN = 200;
 
 /**
  * Classify whether stderr output indicates an API-level error
@@ -631,9 +672,26 @@ export function isApiError(stderr: string): boolean {
   return API_ERROR_PATTERNS.some((pattern) => pattern.test(stderr));
 }
 
+/**
+ * Whether the agent's final text is actually a Claude account-limit notice the
+ * SDK surfaced as a "successful" result. See CLAUDE_LIMIT_* above for why this
+ * deliberately avoids generic rate-limit/quota substrings.
+ */
 export function isProviderFailureResult(result: string | null): boolean {
   if (!result) return false;
-  return PROVIDER_FAILURE_RESULT_PATTERNS.some((pattern) =>
-    pattern.test(result),
+  const trimmed = result.trim();
+  if (!trimmed) return false;
+
+  const hasLimitPhrase = CLAUDE_LIMIT_PHRASE_PATTERNS.some((p) =>
+    p.test(trimmed),
+  );
+  if (!hasLimitPhrase) return false;
+
+  // Accept when a Claude reset timestamp accompanies the phrase (length-
+  // independent: no normal reply emits both), or when the whole result is a
+  // short standalone notice rather than a long answer quoting the phrase.
+  return (
+    CLAUDE_LIMIT_RESET_PATTERN.test(trimmed) ||
+    trimmed.length <= CLAUDE_LIMIT_NOTICE_MAX_LEN
   );
 }

--- a/src/agent-output-parser.ts
+++ b/src/agent-output-parser.ts
@@ -25,6 +25,8 @@ export interface StdoutParserState {
   hasSuccessOutput: boolean;
   /** True when agent emitted a { status: 'closed' } marker (exit due to _close sentinel). */
   hasClosedOutput: boolean;
+  /** True when SDK returned an API/provider failure as a successful final text. */
+  hasProviderFailureOutput: boolean;
   /** True when agent emitted a stream event with statusText='interrupted'. */
   hasInterruptedOutput: boolean;
 }
@@ -46,6 +48,7 @@ export function createStdoutParserState(): StdoutParserState {
     outputChain: Promise.resolve(),
     hasSuccessOutput: false,
     hasClosedOutput: false,
+    hasProviderFailureOutput: false,
     hasInterruptedOutput: false,
   };
 }
@@ -111,6 +114,10 @@ export function attachStdoutHandler(
           }
           if (parsed.status === 'success') {
             state.hasSuccessOutput = true;
+            if (isProviderFailureResult(parsed.result)) {
+              state.hasProviderFailureOutput = true;
+              parsed.providerFailure = true;
+            }
           }
           if (parsed.status === 'closed') {
             state.hasClosedOutput = true;
@@ -499,7 +506,7 @@ export function handleSuccessClose(
 
   // Streaming mode: wait for output chain to settle
   if (ctx.onOutput) {
-    const { hasClosedOutput } = ctx.stdoutState;
+    const { hasClosedOutput, hasProviderFailureOutput } = ctx.stdoutState;
     waitForOutputChain(
       outputChain,
       ctx.groupName,
@@ -518,6 +525,7 @@ export function handleSuccessClose(
           status: finalStatus,
           result: null,
           newSessionId,
+          providerFailure: hasProviderFailureOutput,
         });
       },
     );
@@ -597,8 +605,18 @@ const API_ERROR_PATTERNS = [
   /\binvalid[_ ]?api\b/i,
   /\bbilling\s+(error|issue|limit)\b/i,
   /\bcredit(s)?\s+(exhausted|insufficient)\b/i,
+  /\bout of extra usage\b/i,
+  /\byou(?:'ve|'re| are)\s+(?:hit|out of)\s+(?:your\s+)?(?:limit|extra usage)\b/i,
+  /\bresets?\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?\s*\([^)]*\)/i,
   /connection\s*(refused|reset|timed?\s*out)/i,
   /ECONNREFUSED|ECONNRESET|ETIMEDOUT/,
+];
+
+const PROVIDER_FAILURE_RESULT_PATTERNS = [
+  /\bout of extra usage\b/i,
+  /\byou(?:'ve|'re| are)\s+(?:hit|out of)\s+(?:your\s+)?(?:limit|extra usage)\b/i,
+  /\brate[_ ]?limit(?:ed)?\b/i,
+  /\bquota\s+(?:exceeded|exhausted)\b/i,
 ];
 
 /**
@@ -611,4 +629,11 @@ const API_ERROR_PATTERNS = [
 export function isApiError(stderr: string): boolean {
   if (!stderr) return false;
   return API_ERROR_PATTERNS.some((pattern) => pattern.test(stderr));
+}
+
+export function isProviderFailureResult(result: string | null): boolean {
+  if (!result) return false;
+  return PROVIDER_FAILURE_RESULT_PATTERNS.some((pattern) =>
+    pattern.test(result),
+  );
 }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -282,6 +282,66 @@ export function setProviderOverride(groupFolder: string, providerId: string): vo
 }
 
 /**
+ * Read-only prediction of whether the next provider selection will *clear* the
+ * resumable Claude session because it has to switch away from the bound
+ * provider (the binding is unhealthy or no longer enabled, or a one-time
+ * override targets a different provider). Mirrors the `resetSession` conditions
+ * in trySelectPoolProvider without mutating sticky bindings.
+ *
+ * The orchestration layer calls this *before* building the prompt so a
+ * proactive provider switch injects recent conversation history into the fresh
+ * session — matching the reactive (mid-stream provider-failure) path. Without
+ * this, the first turn under the new provider would see an empty conversation.
+ *
+ * Conservative by design: a false positive only injects redundant history
+ * (harmless), never the reverse.
+ */
+export function willClearSessionOnProviderSwitch(
+  groupFolder: string,
+  agentId?: string | null,
+): boolean {
+  // Env-level provider override means the pool is bypassed entirely — no
+  // pool-driven switch, so the session is never cleared on this account.
+  const override = getContainerEnvConfig(groupFolder);
+  if (
+    override.anthropicApiKey ||
+    override.anthropicAuthToken ||
+    override.anthropicBaseUrl
+  ) {
+    return false;
+  }
+
+  const boundId = getSessionProviderId(groupFolder, agentId);
+  if (!boundId) return false;
+
+  // One-time override (from switchProvider) targeting a different provider will
+  // reset. Peek without consuming — trySelectPoolProvider consumes it later.
+  const overrideProviderId = providerOverrides.get(groupFolder);
+  if (overrideProviderId) {
+    return overrideProviderId !== boundId;
+  }
+
+  const enabledProviders = getEnabledProviders();
+  if (enabledProviders.length === 0) return false;
+
+  // Bound provider removed/disabled → a fresh one gets picked → reset.
+  const stillEnabled = enabledProviders.some((p) => p.id === boundId);
+  if (!stillEnabled) return true;
+
+  // Single enabled provider equal to the binding → sticky, no reset.
+  if (enabledProviders.length === 1) {
+    return enabledProviders[0].id !== boundId;
+  }
+
+  // Multiple providers: sticky reuse only when the binding is still healthy.
+  // Unhealthy binding falls through to pool selection, which prefers a
+  // different healthy provider → reset.
+  const balancing = getBalancingConfig();
+  providerPool.refreshFromConfig(enabledProviders, balancing);
+  return !providerPool.getHealthStatus(boundId).healthy;
+}
+
+/**
  * Try to select a provider from the pool. Returns profileId + resolved config,
  * or null if no providers are enabled / group has env-level provider override / selection fails.
  * For single-provider setups, returns the provider for display without pool balancing.
@@ -861,7 +921,14 @@ export async function runContainerAgent(
       },
       'Clearing Claude session after switching providers',
     );
+    // deleteSession removes the whole sessions row, including the provider_id
+    // binding trySelectPoolProvider just wrote. Re-bind the freshly-selected
+    // provider so the next turn stays sticky to it instead of degrading to a
+    // fresh pool pick.
     deleteSession(group.folder, input.agentId);
+    if (selectedProfileId) {
+      setSessionProviderId(group.folder, input.agentId, selectedProfileId);
+    }
     input = { ...input, sessionId: undefined };
   }
 
@@ -1398,7 +1465,13 @@ export async function runHostAgent(
       },
       'Clearing Claude session after switching providers',
     );
+    // deleteSession removes the whole sessions row, including the provider_id
+    // binding trySelectPoolProvider just wrote. Re-bind so the next turn stays
+    // sticky to the freshly-selected provider (mirrors the container path).
     deleteSession(group.folder, input.agentId);
+    if (hostSelectedProfileId) {
+      setSessionProviderId(group.folder, input.agentId, hostSelectedProfileId);
+    }
     input = { ...input, sessionId: undefined };
   }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -34,7 +34,11 @@ import {
   writeCredentialsFile,
 } from './runtime-config.js';
 import { providerPool } from './provider-pool.js';
-import { getSessionProviderId, setSessionProviderId } from './db.js';
+import {
+  deleteSession,
+  getSessionProviderId,
+  setSessionProviderId,
+} from './db.js';
 import { isApiError } from './agent-output-parser.js';
 import type { ClaudeProviderConfig } from './runtime-config.js';
 import { loadUserMcpServers } from './mcp-utils.js';
@@ -233,6 +237,7 @@ export interface ContainerOutput {
   result: string | null;
   newSessionId?: string;
   error?: string;
+  providerFailure?: boolean;
   streamEvent?: StreamEvent;
   turnId?: string;
   sessionId?: string;
@@ -293,7 +298,12 @@ export function setProviderOverride(groupFolder: string, providerId: string): vo
 function trySelectPoolProvider(
   groupFolder: string,
   agentId?: string | null,
-): { profileId: string; resolved: ResolvedProvider } | null {
+): {
+  profileId: string;
+  resolved: ResolvedProvider;
+  previousProviderId?: string;
+  resetSession?: boolean;
+} | null {
   const override = getContainerEnvConfig(groupFolder);
   const hasOverride = !!(
     override.anthropicApiKey ||
@@ -301,6 +311,8 @@ function trySelectPoolProvider(
     override.anthropicBaseUrl
   );
   if (hasOverride) return null;
+
+  const existingBoundId = getSessionProviderId(groupFolder, agentId);
 
   // Check one-time override (consumed on use)
   const overrideProviderId = providerOverrides.get(groupFolder);
@@ -318,38 +330,57 @@ function trySelectPoolProvider(
       return {
         profileId: overrideProviderId,
         resolved: { config: resolved.config, customEnv: resolved.customEnv },
+        previousProviderId: existingBoundId,
+        resetSession:
+          !!existingBoundId && existingBoundId !== overrideProviderId,
       };
     } catch (err) {
-      logger.warn({ err, providerId: overrideProviderId }, 'Provider override failed, falling back to pool');
+      logger.warn(
+        { err, providerId: overrideProviderId },
+        'Provider override failed, falling back to pool',
+      );
     }
   }
 
   // Refresh pool state from V4 config
   const enabledProviders = getEnabledProviders();
   if (enabledProviders.length === 0) return null;
+  const balancing = getBalancingConfig();
+  providerPool.refreshFromConfig(enabledProviders, balancing);
+  const boundId = existingBoundId;
 
   // Sticky path: respect previous session→provider binding when the bound
   // provider is still enabled. Skip when only one provider exists (single
   // provider already gives stickiness implicitly).
   if (enabledProviders.length > 1) {
-    const boundId = getSessionProviderId(groupFolder, agentId);
     if (boundId && enabledProviders.some((p) => p.id === boundId)) {
-      try {
-        const resolved = resolveProviderById(boundId);
-        providerPool.acquireSession(boundId);
-        logger.debug(
+      const boundHealth = providerPool.getHealthStatus(boundId);
+      if (!boundHealth.healthy) {
+        logger.info(
           { groupFolder, agentId: agentId || null, providerId: boundId },
-          'Reusing sticky provider binding for resumed session',
+          'Sticky provider is unhealthy, falling back to pool selection',
         );
-        return {
-          profileId: boundId,
-          resolved: { config: resolved.config, customEnv: resolved.customEnv },
-        };
-      } catch (err) {
-        logger.warn(
-          { err, providerId: boundId },
-          'Sticky provider resolution failed, falling back to pool selection',
-        );
+      } else {
+        try {
+          const resolved = resolveProviderById(boundId);
+          providerPool.acquireSession(boundId);
+          logger.debug(
+            { groupFolder, agentId: agentId || null, providerId: boundId },
+            'Reusing sticky provider binding for resumed session',
+          );
+          return {
+            profileId: boundId,
+            resolved: {
+              config: resolved.config,
+              customEnv: resolved.customEnv,
+            },
+          };
+        } catch (err) {
+          logger.warn(
+            { err, providerId: boundId },
+            'Sticky provider resolution failed, falling back to pool selection',
+          );
+        }
       }
     } else if (boundId) {
       // Bound provider was disabled or removed — fall through and pick a fresh one.
@@ -369,14 +400,13 @@ function trySelectPoolProvider(
       return {
         profileId: enabledProviders[0].id,
         resolved: { config: resolved.config, customEnv: resolved.customEnv },
+        previousProviderId: boundId,
+        resetSession: !!boundId && boundId !== enabledProviders[0].id,
       };
     } catch {
       return null;
     }
   }
-
-  const balancing = getBalancingConfig();
-  providerPool.refreshFromConfig(enabledProviders, balancing);
 
   try {
     const profileId = providerPool.selectProvider();
@@ -386,9 +416,14 @@ function trySelectPoolProvider(
     return {
       profileId,
       resolved: { config: resolved.config, customEnv: resolved.customEnv },
+      previousProviderId: boundId,
+      resetSession: !!boundId && boundId !== profileId,
     };
   } catch (err) {
-    logger.warn({ err }, 'Provider pool selection failed, falling back to active profile');
+    logger.warn(
+      { err },
+      'Provider pool selection failed, falling back to active profile',
+    );
     return null;
   }
 }
@@ -815,6 +850,20 @@ export async function runContainerAgent(
   const poolResult = trySelectPoolProvider(group.folder, input.agentId);
   const selectedProfileId = poolResult?.profileId ?? null;
   const resolvedProvider = poolResult?.resolved;
+  let providerFailureReported = false;
+  if (poolResult?.resetSession && input.sessionId) {
+    logger.info(
+      {
+        groupFolder: group.folder,
+        agentId: input.agentId || null,
+        previousProviderId: poolResult.previousProviderId,
+        providerId: selectedProfileId,
+      },
+      'Clearing Claude session after switching providers',
+    );
+    deleteSession(group.folder, input.agentId);
+    input = { ...input, sessionId: undefined };
+  }
 
   try {
     // Determine if this is an admin home container (full privileges)
@@ -936,12 +985,41 @@ export async function runContainerAgent(
         clearTimeout(timeout);
         timeout = setTimeout(killOnTimeout, timeoutMs);
       };
+      const handleOutput = onOutput
+        ? async (output: ContainerOutput): Promise<void> => {
+            await onOutput(output);
+            if (output.providerFailure && selectedProfileId) {
+              if (!providerFailureReported) {
+                providerFailureReported = true;
+                providerPool.reportFailure(selectedProfileId, true);
+                logger.warn(
+                  {
+                    group: group.name,
+                    containerName,
+                    providerId: selectedProfileId,
+                    result: output.result,
+                  },
+                  'Provider failure detected from streamed output, stopping container',
+                );
+              }
+              exec(`docker stop ${containerName}`, (err) => {
+                if (err) {
+                  logger.warn(
+                    { group: group.name, containerName, err },
+                    'Failed to stop container after provider failure',
+                  );
+                  container.kill('SIGTERM');
+                }
+              });
+            }
+          }
+        : undefined;
 
       // Attach stdout/stderr handlers using shared parser
       attachStdoutHandler(container.stdout, stdoutState, {
         groupName: group.name,
         label: 'Container',
-        onOutput,
+        onOutput: handleOutput,
         resetTimeout,
       });
       attachStderrHandler(container.stderr, stderrState, group.name, {
@@ -1009,7 +1087,11 @@ export async function runContainerAgent(
 
     // ─── Provider Pool health reporting ───
     if (selectedProfileId) {
-      if (result.status === 'success' || result.status === 'closed') {
+      if (result.providerFailure) {
+        if (!providerFailureReported) {
+          providerPool.reportFailure(selectedProfileId, true);
+        }
+      } else if (result.status === 'success' || result.status === 'closed') {
         providerPool.reportSuccess(selectedProfileId);
       } else if (result.status === 'error' && isApiError(result.error || '')) {
         providerPool.reportFailure(selectedProfileId);
@@ -1305,6 +1387,20 @@ export async function runHostAgent(
   const hostPoolResult = trySelectPoolProvider(group.folder, input.agentId);
   const hostSelectedProfileId = hostPoolResult?.profileId ?? null;
   const globalConfig = hostPoolResult?.resolved.config ?? getClaudeProviderConfig();
+  let hostProviderFailureReported = false;
+  if (hostPoolResult?.resetSession && input.sessionId) {
+    logger.info(
+      {
+        groupFolder: group.folder,
+        agentId: input.agentId || null,
+        previousProviderId: hostPoolResult.previousProviderId,
+        providerId: hostSelectedProfileId,
+      },
+      'Clearing Claude session after switching providers',
+    );
+    deleteSession(group.folder, input.agentId);
+    input = { ...input, sessionId: undefined };
+  }
 
   try {
     // 配置层环境变量
@@ -1618,12 +1714,33 @@ export async function runHostAgent(
         clearTimeout(timeout);
         timeout = setTimeout(killOnTimeout, timeoutMs);
       };
+      const handleOutput = onOutput
+        ? async (output: ContainerOutput): Promise<void> => {
+            await onOutput(output);
+            if (output.providerFailure && hostSelectedProfileId) {
+              if (!hostProviderFailureReported) {
+                hostProviderFailureReported = true;
+                providerPool.reportFailure(hostSelectedProfileId, true);
+                logger.warn(
+                  {
+                    group: group.name,
+                    processId,
+                    providerId: hostSelectedProfileId,
+                    result: output.result,
+                  },
+                  'Provider failure detected from streamed output, stopping host agent',
+                );
+              }
+              killProcessTree(proc, 'SIGTERM');
+            }
+          }
+        : undefined;
 
       // 10. stdout/stderr 解析
       attachStdoutHandler(proc.stdout, stdoutState, {
         groupName: group.name,
         label: 'Host agent',
-        onOutput,
+        onOutput: handleOutput,
         resetTimeout,
       });
       attachStderrHandler(proc.stderr, stderrState, group.name, {
@@ -1687,7 +1804,14 @@ export async function runHostAgent(
 
     // ─── Provider Pool health reporting (host mode) ───
     if (hostSelectedProfileId) {
-      if (hostResult.status === 'success' || hostResult.status === 'closed') {
+      if (hostResult.providerFailure) {
+        if (!hostProviderFailureReported) {
+          providerPool.reportFailure(hostSelectedProfileId, true);
+        }
+      } else if (
+        hostResult.status === 'success' ||
+        hostResult.status === 'closed'
+      ) {
         providerPool.reportSuccess(hostSelectedProfileId);
       } else if (
         hostResult.status === 'error' &&

--- a/src/conversation-history.ts
+++ b/src/conversation-history.ts
@@ -1,0 +1,61 @@
+import { getMessagesPage } from './db.js';
+
+/**
+ * Build a `<system_context>` block of recent persisted HappyClaw chat history
+ * to prepend to a prompt when the underlying Claude SDK session is fresh
+ * (recovery after a crash, or after switching provider/model so the old
+ * thinking-block-bearing session was cleared). Without this the new model sees
+ * an empty conversation and loses context the user already established.
+ *
+ * Shared by the orchestration layer (index.ts: recovery + agent fresh-session)
+ * and the container/host runner (proactive provider switch that clears the
+ * session). Keeping a single implementation ensures the injected framing — and
+ * the lone-surrogate / closing-tag sanitisation — stays byte-for-byte
+ * consistent across every path that feeds the same Anthropic API.
+ */
+export function buildRecentConversationHistoryContext(
+  chatJid: string,
+  pendingMessageIds: Set<string>,
+  opts: {
+    limit?: number;
+    maxMessageLength?: number;
+    intro: string;
+  },
+): { context: string; count: number } | null {
+  const recentHistory = getMessagesPage(chatJid, undefined, opts.limit ?? 30);
+  const historyMsgs = recentHistory
+    .reverse()
+    .filter((m) => !pendingMessageIds.has(m.id))
+    .filter((m) => m.content.trim().length > 0);
+
+  if (historyMsgs.length === 0) return null;
+
+  const maxLen = opts.maxMessageLength ?? 700;
+  const historyLines = historyMsgs.map((m) => {
+    const role = m.is_from_me ? 'assistant' : m.sender_name;
+    const truncated =
+      m.content.length > maxLen ? m.content.slice(0, maxLen) + '…' : m.content;
+    // Strip lone (unpaired) surrogates while preserving valid surrogate pairs
+    // such as emoji. Must stay byte-for-byte aligned with the matching regex in
+    // container/agent-runner/src/index.ts:extractSessionHistory — both sides
+    // feed the same Anthropic API and must produce identical strings.
+    let cleaned = truncated.replace(
+      /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g,
+      '',
+    );
+    // Defense in depth: strip the closing tag we use to fence this block so a
+    // user message containing "</system_context>" can't escape early.
+    cleaned = cleaned.replace(/<\/system_context>/gi, '</system_context_>');
+    return `[${role}] ${cleaned}`;
+  });
+
+  return {
+    count: historyMsgs.length,
+    context:
+      '<system_context>\n' +
+      opts.intro +
+      '\n重要：这些只是 HappyClaw 持久化的历史聊天记录，用来在新模型/新 session 中恢复上下文。回答当前用户消息时，请优先依据当前消息和当前文件状态；如果历史与当前问题无关，请直接忽略。\n\n' +
+      historyLines.join('\n') +
+      '\n</system_context>\n\n',
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   ContainerOutput,
   runContainerAgent,
   runHostAgent,
+  willClearSessionOnProviderSwitch,
   writeGroupsSnapshot,
   writeTasksSnapshot,
 } from './container-runner.js';
@@ -211,6 +212,7 @@ import {
 import { verifyPairingCode } from './telegram-pairing.js';
 import { sdkQuery } from './sdk-query.js';
 import { executeSessionReset } from './commands.js';
+import { buildRecentConversationHistoryContext } from './conversation-history.js';
 import { scanHostMarketplaces } from './plugin-importer.js';
 import { expandMessagesIfNeeded } from './plugin-expander-core.js';
 import { makeExpandContext } from './plugin-expander-context.js';
@@ -2675,47 +2677,6 @@ export function formatMessages(
   return `<messages>\n${lines.join('\n')}\n</messages>`;
 }
 
-function buildRecentConversationHistoryContext(
-  chatJid: string,
-  pendingMessageIds: Set<string>,
-  opts: {
-    limit?: number;
-    maxMessageLength?: number;
-    intro: string;
-  },
-): { context: string; count: number } | null {
-  const recentHistory = getMessagesPage(chatJid, undefined, opts.limit ?? 30);
-  const historyMsgs = recentHistory
-    .reverse()
-    .filter((m) => !pendingMessageIds.has(m.id))
-    .filter((m) => m.content.trim().length > 0);
-
-  if (historyMsgs.length === 0) return null;
-
-  const maxLen = opts.maxMessageLength ?? 700;
-  const historyLines = historyMsgs.map((m) => {
-    const role = m.is_from_me ? 'assistant' : m.sender_name;
-    const truncated =
-      m.content.length > maxLen ? m.content.slice(0, maxLen) + '…' : m.content;
-    let cleaned = truncated.replace(
-      /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g,
-      '',
-    );
-    cleaned = cleaned.replace(/<\/system_context>/gi, '</system_context_>');
-    return `[${role}] ${cleaned}`;
-  });
-
-  return {
-    count: historyMsgs.length,
-    context:
-      '<system_context>\n' +
-      opts.intro +
-      '\n重要：这些只是 HappyClaw 持久化的历史聊天记录，用来在新模型/新 session 中恢复上下文。回答当前用户消息时，请优先依据当前消息和当前文件状态；如果历史与当前问题无关，请直接忽略。\n\n' +
-      historyLines.join('\n') +
-      '\n</system_context>\n\n',
-  };
-}
-
 export function collectMessageImages(
   chatJid: string,
   messages: NewMessage[],
@@ -2919,6 +2880,27 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       logger.info(
         { group: group.name, historyCount: historyContext.count },
         'Recovery: injected recent conversation history into prompt',
+      );
+    }
+  } else if (willClearSessionOnProviderSwitch(effectiveGroup.folder)) {
+    // Proactive provider switch (sticky binding unhealthy/disabled) will clear
+    // the SDK session inside the runner. Inject history so the new provider's
+    // first turn keeps context, matching the recovery + reactive-failure paths.
+    const historyContext = buildRecentConversationHistoryContext(
+      chatJid,
+      new Set(missedMessages.map((m) => m.id)),
+      {
+        limit: 30,
+        maxMessageLength: 700,
+        intro:
+          '检测到本次因切换 provider 需要使用新的底层模型 session。以下是 HappyClaw 保存的最近对话记录，供你延续上下文。',
+      },
+    );
+    if (historyContext) {
+      prompt = historyContext.context + prompt;
+      logger.info(
+        { group: group.name, historyCount: historyContext.count },
+        'Provider switch: injected recent conversation history into prompt',
       );
     }
   }
@@ -3457,6 +3439,26 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             // Reset idle timer on stream events so long-running tool calls
             // (e.g. MCP batch writes) don't get killed while the agent is
             // actively working. Previously only final results triggered a reset.
+            resetIdleTimer();
+            return;
+          }
+
+          // Provider quota/limit notice surfaced as a "successful" result.
+          // The switch is silent to the user (decided in #549): never deliver
+          // the English limit text to IM/web — only log for admin/monitoring.
+          // The runner already stops the container and re-routes to another
+          // provider on the next turn.
+          if (result.providerFailure) {
+            logger.warn(
+              {
+                group: group.name,
+                result:
+                  typeof result.result === 'string'
+                    ? result.result.slice(0, 200)
+                    : result.result,
+              },
+              'Provider failure result suppressed from user (silent switch)',
+            );
             resetIdleTimer();
             return;
           }
@@ -6082,7 +6084,10 @@ async function processAgentConversation(
   const sessionId = getSession(effectiveGroup.folder, agentId) || undefined;
   let currentAgentSessionId = sessionId;
   let prompt = formatMessages(missedMessages, false);
-  if (!sessionId) {
+  // Inject history when the SDK session is fresh, or when a proactive provider
+  // switch (sticky binding unhealthy/disabled) will clear the existing session
+  // inside the runner — otherwise the new provider's first turn loses context.
+  if (!sessionId || willClearSessionOnProviderSwitch(effectiveGroup.folder, agentId)) {
     const historyContext = buildRecentConversationHistoryContext(
       virtualChatJid,
       new Set(missedMessages.map((m) => m.id)),
@@ -6359,6 +6364,25 @@ async function processAgentConversation(
 
       // Reset idle timer on stream events so long-running tool calls
       // don't get killed while the agent is actively working.
+      resetIdleTimer();
+      return;
+    }
+
+    // Provider quota/limit notice surfaced as a "successful" result — silent
+    // switch (#549): suppress the English limit text from the user, log only.
+    // Session was already cleared at the top of this callback.
+    if (output.providerFailure) {
+      logger.warn(
+        {
+          chatJid,
+          agentId,
+          result:
+            typeof output.result === 'string'
+              ? output.result.slice(0, 200)
+              : output.result,
+        },
+        'Provider failure result suppressed from user (silent switch)',
+      );
       resetIdleTimer();
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2675,6 +2675,47 @@ export function formatMessages(
   return `<messages>\n${lines.join('\n')}\n</messages>`;
 }
 
+function buildRecentConversationHistoryContext(
+  chatJid: string,
+  pendingMessageIds: Set<string>,
+  opts: {
+    limit?: number;
+    maxMessageLength?: number;
+    intro: string;
+  },
+): { context: string; count: number } | null {
+  const recentHistory = getMessagesPage(chatJid, undefined, opts.limit ?? 30);
+  const historyMsgs = recentHistory
+    .reverse()
+    .filter((m) => !pendingMessageIds.has(m.id))
+    .filter((m) => m.content.trim().length > 0);
+
+  if (historyMsgs.length === 0) return null;
+
+  const maxLen = opts.maxMessageLength ?? 700;
+  const historyLines = historyMsgs.map((m) => {
+    const role = m.is_from_me ? 'assistant' : m.sender_name;
+    const truncated =
+      m.content.length > maxLen ? m.content.slice(0, maxLen) + '…' : m.content;
+    let cleaned = truncated.replace(
+      /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g,
+      '',
+    );
+    cleaned = cleaned.replace(/<\/system_context>/gi, '</system_context_>');
+    return `[${role}] ${cleaned}`;
+  });
+
+  return {
+    count: historyMsgs.length,
+    context:
+      '<system_context>\n' +
+      opts.intro +
+      '\n重要：这些只是 HappyClaw 持久化的历史聊天记录，用来在新模型/新 session 中恢复上下文。回答当前用户消息时，请优先依据当前消息和当前文件状态；如果历史与当前问题无关，请直接忽略。\n\n' +
+      historyLines.join('\n') +
+      '\n</system_context>\n\n',
+  };
+}
+
 export function collectMessageImages(
   chatJid: string,
   messages: NewMessage[],
@@ -2863,45 +2904,20 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   // recent conversation history to give the fresh session context.
   const isRecovery = recoveryGroups.delete(chatJid);
   if (isRecovery) {
-    const RECOVERY_HISTORY_LIMIT = 20;
-    const recentHistory = getMessagesPage(
+    const historyContext = buildRecentConversationHistoryContext(
       chatJid,
-      undefined,
-      RECOVERY_HISTORY_LIMIT,
+      new Set(missedMessages.map((m) => m.id)),
+      {
+        limit: 20,
+        maxMessageLength: 500,
+        intro:
+          '检测到上次有未完成消息，当前使用新会话恢复处理。以下是恢复前的最近对话记录，供你了解上下文。',
+      },
     );
-    // getMessagesPage returns DESC order; reverse to chronological, exclude
-    // the pending messages themselves (already in prompt).
-    const pendingIds = new Set(missedMessages.map((m) => m.id));
-    const historyMsgs = recentHistory
-      .reverse()
-      .filter((m) => !pendingIds.has(m.id));
-    if (historyMsgs.length > 0) {
-      const historyLines = historyMsgs.map((m) => {
-        const role = m.is_from_me ? 'assistant' : m.sender_name;
-        const truncated =
-          m.content.length > 500 ? m.content.slice(0, 500) + '…' : m.content;
-        // Strip lone (unpaired) surrogates while preserving valid surrogate pairs
-        // such as emoji. Must stay byte-for-byte aligned with the matching regex
-        // in container/agent-runner/src/index.ts:extractSessionHistory — both
-        // sides feed the same Anthropic API and must produce identical strings.
-        let cleaned = truncated.replace(
-          /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/g,
-          '',
-        );
-        // Defense in depth: strip the closing tag we use to fence this block
-        // so a user message containing "</system_context>" can't escape early.
-        cleaned = cleaned.replace(/<\/system_context>/gi, '</system_context_>');
-        return `[${role}] ${cleaned}`;
-      });
-      prompt =
-        '<system_context>\n' +
-        '检测到上次有未完成消息，当前使用新会话恢复处理。以下是恢复前的最近对话记录，供你了解上下文。\n' +
-        '重要：这些只是历史记录，可能包含不准确或过时的信息。回答当前用户消息时，请优先依据当前消息里的内容和文件；如果历史与当前问题无关，请直接忽略。\n\n' +
-        historyLines.join('\n') +
-        '\n</system_context>\n\n' +
-        prompt;
+    if (historyContext) {
+      prompt = historyContext.context + prompt;
       logger.info(
-        { group: group.name, historyCount: historyMsgs.length },
+        { group: group.name, historyCount: historyContext.count },
         'Recovery: injected recent conversation history into prompt',
       );
     }
@@ -4141,7 +4157,11 @@ async function runAgent(
         }
         // 仅从成功的输出中更新 session ID；
         // error 输出可能携带 stale ID，会覆盖流式传递的有效 session
-        if (output.newSessionId && output.status !== 'error') {
+        if (
+          output.newSessionId &&
+          output.status !== 'error' &&
+          !output.providerFailure
+        ) {
           sessions[group.folder] = output.newSessionId;
           setSession(group.folder, output.newSessionId);
         }
@@ -4216,7 +4236,11 @@ async function runAgent(
 
     // 仅从成功的最终输出中更新 session ID；
     // error 状态的输出可能携带 stale ID，覆盖流式阶段已写入的有效 session
-    if (output.newSessionId && output.status !== 'error') {
+    if (
+      output.newSessionId &&
+      output.status !== 'error' &&
+      !output.providerFailure
+    ) {
       sessions[group.folder] = output.newSessionId;
       setSession(group.folder, output.newSessionId);
     }
@@ -6051,7 +6075,32 @@ async function processAgentConversation(
   updateAgentStatus(agentId, 'running');
   broadcastAgentStatus(chatJid, agentId, 'running', agent.name, agent.prompt);
 
-  const prompt = formatMessages(missedMessages, false);
+  // Get or use agent-specific session before building the prompt. If the
+  // session was cleared by provider/model switching, inject persisted HappyClaw
+  // chat history so the new model does not mistake the fresh SDK session for
+  // an empty conversation.
+  const sessionId = getSession(effectiveGroup.folder, agentId) || undefined;
+  let currentAgentSessionId = sessionId;
+  let prompt = formatMessages(missedMessages, false);
+  if (!sessionId) {
+    const historyContext = buildRecentConversationHistoryContext(
+      virtualChatJid,
+      new Set(missedMessages.map((m) => m.id)),
+      {
+        limit: 30,
+        maxMessageLength: 700,
+        intro:
+          '检测到当前 agent 的底层模型 session 是新的（可能因为切换 provider/model 或恢复失败）。以下是 HappyClaw 保存的最近对话记录，供你延续上下文。',
+      },
+    );
+    if (historyContext) {
+      prompt = historyContext.context + prompt;
+      logger.info(
+        { chatJid, agentId, historyCount: historyContext.count },
+        'Agent fresh session: injected recent conversation history into prompt',
+      );
+    }
+  }
   const images = collectMessageImages(virtualChatJid, missedMessages);
   const imagesForAgent = images.length > 0 ? images : undefined;
   // For agent conversations, route reply to IM based on the most recent
@@ -6155,11 +6204,9 @@ async function processAgentConversation(
     cursorCommitted = true;
   };
 
-  // Get or use agent-specific session
-  const sessionId = getSession(effectiveGroup.folder, agentId) || undefined;
-  let currentAgentSessionId = sessionId;
-
   const wrappedOnOutput = async (output: ContainerOutput) => {
+    // #547: warm-lifecycle bookkeeping — mark activity, and flag query-idle on
+    // a substantive result / interruption so the runner can be kept warm.
     queue.markRunnerActivity(virtualJid);
     if (
       (output.status === 'success' && output.result !== null) ||
@@ -6170,8 +6217,26 @@ async function processAgentConversation(
       queue.markRunnerQueryIdle(virtualJid);
     }
 
+    // #549: a provider switch surfaced as a failure clears the agent session so
+    // the next turn starts fresh on the newly-selected provider.
+    if (output.providerFailure) {
+      try {
+        deleteSession(effectiveGroup.folder, agentId);
+        currentAgentSessionId = undefined;
+      } catch (err) {
+        logger.warn(
+          { err, chatJid, agentId, folder: effectiveGroup.folder },
+          'Failed to clear agent session after provider failure',
+        );
+      }
+    }
+
     // Track session
-    if (output.newSessionId && output.status !== 'error') {
+    if (
+      output.newSessionId &&
+      output.status !== 'error' &&
+      !output.providerFailure
+    ) {
       setSession(effectiveGroup.folder, output.newSessionId, agentId);
       currentAgentSessionId = output.newSessionId;
     }
@@ -6590,7 +6655,11 @@ async function processAgentConversation(
     }
 
     // Finalize session
-    if (output.newSessionId && output.status !== 'error') {
+    if (
+      output.newSessionId &&
+      output.status !== 'error' &&
+      !output.providerFailure
+    ) {
       setSession(effectiveGroup.folder, output.newSessionId, agentId);
     }
 

--- a/src/provider-pool.ts
+++ b/src/provider-pool.ts
@@ -190,9 +190,11 @@ export class ProviderPool {
     }
   }
 
-  reportFailure(profileId: string): void {
+  reportFailure(profileId: string, immediate = false): void {
     const health = this.getOrCreateHealth(profileId);
-    health.consecutiveErrors += 1;
+    health.consecutiveErrors = immediate
+      ? Math.max(health.consecutiveErrors + 1, this.unhealthyThreshold)
+      : health.consecutiveErrors + 1;
     health.lastErrorAt = Date.now();
 
     if (

--- a/tests/agent-output-parser.test.ts
+++ b/tests/agent-output-parser.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  isApiError,
+  isProviderFailureResult,
+} from '../src/agent-output-parser.js';
+
+describe('agent-output-parser provider failure detection', () => {
+  test('detects Claude extra-usage exhaustion returned as final text', () => {
+    const msg = "You're out of extra usage · resets 2:10am (Asia/Shanghai)";
+
+    expect(isProviderFailureResult(msg)).toBe(true);
+    expect(isApiError(msg)).toBe(true);
+  });
+
+  test('detects legacy Claude limit final text', () => {
+    const msg = "You've hit your limit · resets 3am (Asia/Shanghai)";
+
+    expect(isProviderFailureResult(msg)).toBe(true);
+    expect(isApiError(msg)).toBe(true);
+  });
+});

--- a/tests/agent-output-parser.test.ts
+++ b/tests/agent-output-parser.test.ts
@@ -5,18 +5,137 @@ import {
   isProviderFailureResult,
 } from '../src/agent-output-parser.js';
 
-describe('agent-output-parser provider failure detection', () => {
+describe('isProviderFailureResult — positive (genuine Claude limit notices)', () => {
   test('detects Claude extra-usage exhaustion returned as final text', () => {
     const msg = "You're out of extra usage · resets 2:10am (Asia/Shanghai)";
-
     expect(isProviderFailureResult(msg)).toBe(true);
-    expect(isApiError(msg)).toBe(true);
   });
 
-  test('detects legacy Claude limit final text', () => {
+  test('detects legacy Claude "hit your limit" final text', () => {
     const msg = "You've hit your limit · resets 3am (Asia/Shanghai)";
-
     expect(isProviderFailureResult(msg)).toBe(true);
-    expect(isApiError(msg)).toBe(true);
+  });
+
+  test('detects "usage limit reached" notice with reset time', () => {
+    const msg =
+      'Claude usage limit reached. Your limit will reset at 3pm (America/New_York)';
+    expect(isProviderFailureResult(msg)).toBe(true);
+  });
+
+  test('detects "out of extra usage" as a short standalone notice (no reset stamp)', () => {
+    const msg = "You're out of extra usage.";
+    expect(isProviderFailureResult(msg)).toBe(true);
+  });
+
+  test('detects upgrade prompt with reset stamp', () => {
+    const msg =
+      'Upgrade to increase your usage limit · resets 9:00pm (Asia/Tokyo)';
+    expect(isProviderFailureResult(msg)).toBe(true);
+  });
+
+  test('tolerates surrounding whitespace', () => {
+    const msg =
+      "\n  You're out of extra usage · resets 2:10am (Asia/Shanghai)  \n";
+    expect(isProviderFailureResult(msg)).toBe(true);
+  });
+});
+
+describe('isProviderFailureResult — negative (normal replies must NOT be flagged)', () => {
+  // CRITICAL regression guard: a false positive here kills the container,
+  // clears the Claude session, and marks the provider unhealthy for ALL users.
+  // The original PR used generic /rate.limit/ and /quota (exceeded|exhausted)/
+  // patterns that fired on ordinary technical conversation. These cases pin
+  // that down — they are the 5/8 mislabelled examples called out in review.
+
+  test('does not flag a reply that mentions avoiding the API rate limit', () => {
+    const msg =
+      '为避免触发 API rate limit，我在循环里加了 200ms 的 sleep，并对 429 做了指数退避重试。';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a reply discussing disk quota exceeded', () => {
+    const msg =
+      'The upload failed with "disk quota exceeded" — you need to free up space on /var before retrying.';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a reply explaining how to handle rate-limited requests', () => {
+    const msg =
+      'When the endpoint is rate limited it returns HTTP 429; wrap the call in a retry with backoff so the job is not rate-limited again.';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a reply about a database quota being exhausted', () => {
+    const msg =
+      'The connection pool quota was exhausted because every request opened a new connection without closing it.';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a reply quoting the word "limit" generically', () => {
+    const msg =
+      'I lowered the rate limit on the gateway from 1000 to 200 req/s and added a quota per tenant.';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a long answer that merely mentions a Claude limit phrase mid-text', () => {
+    // A genuine notice is a single short line. A long answer that happens to
+    // quote "you've hit your limit" (e.g. explaining the UI) and has no reset
+    // stamp must NOT be treated as a provider failure.
+    const msg =
+      'When Claude shows the banner that says "you\'ve hit your limit", it means the account ran out of usage for the window. ' +
+      'To diagnose this in our app you can inspect the ContainerOutput.providerFailure flag, look at the provider-pool health map, ' +
+      'and confirm the sticky binding was cleared. The full investigation usually takes a few minutes and involves checking the logs, ' +
+      'the session table, and the env overrides for that group folder before you decide whether to switch providers manually.';
+    expect(msg.length).toBeGreaterThan(200);
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a short reply saying a generic "rate limit reached"', () => {
+    // "usage limit reached" is the Claude phrase; a generic "rate limit
+    // reached" must not match even though it is short.
+    const msg = 'The gateway rate limit reached its cap, so requests got 429s.';
+    expect(msg.length).toBeLessThan(200);
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag a short reply mentioning a request limit reached', () => {
+    const msg = 'Heads up: the per-minute request limit reached 100% briefly.';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+
+  test('does not flag null or empty result', () => {
+    expect(isProviderFailureResult(null)).toBe(false);
+    expect(isProviderFailureResult('')).toBe(false);
+    expect(isProviderFailureResult('   ')).toBe(false);
+  });
+
+  test('does not flag an ordinary successful answer', () => {
+    const msg =
+      '我已经把函数重命名为 buildVolumeMounts 并更新了所有调用点，测试全部通过。';
+    expect(isProviderFailureResult(msg)).toBe(false);
+  });
+});
+
+describe('isApiError — stderr classification still detects provider issues', () => {
+  // isApiError runs against STDERR (process error stream), not the agent's
+  // reply body, so generic rate-limit/quota matching is appropriate there.
+  test('detects rate limit in stderr', () => {
+    expect(isApiError('Error: rate limit exceeded (429)')).toBe(true);
+  });
+
+  test('detects quota exhausted in stderr', () => {
+    expect(isApiError('quota exhausted for this API key')).toBe(true);
+  });
+
+  test('detects Claude extra-usage phrasing in stderr', () => {
+    expect(isApiError("You're out of extra usage")).toBe(true);
+  });
+
+  test('detects connection errors in stderr', () => {
+    expect(isApiError('connect ECONNREFUSED 127.0.0.1:443')).toBe(true);
+  });
+
+  test('returns false for empty stderr', () => {
+    expect(isApiError('')).toBe(false);
   });
 });

--- a/tests/provider-switch-predictor.test.ts
+++ b/tests/provider-switch-predictor.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// container-runner.willClearSessionOnProviderSwitch reads enabled providers,
+// the group env override, and the balancing config from runtime-config, the
+// sticky binding from db, and provider health from the shared providerPool
+// singleton. We mock the config/db reads and drive the real pool's health so
+// the test exercises the actual decision branches.
+
+const mocks = vi.hoisted(() => ({
+  enabledProviders: [] as Array<{
+    id: string;
+    enabled: boolean;
+    weight: number;
+  }>,
+  envOverride: {} as {
+    anthropicApiKey?: string;
+    anthropicAuthToken?: string;
+    anthropicBaseUrl?: string;
+  },
+  boundId: undefined as string | undefined,
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/runtime-config.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../src/runtime-config.js')
+  >('../src/runtime-config.js');
+  return {
+    ...actual,
+    getEnabledProviders: () => mocks.enabledProviders,
+    getContainerEnvConfig: () => mocks.envOverride,
+    getBalancingConfig: () => ({
+      strategy: 'round-robin' as const,
+      unhealthyThreshold: 3,
+      recoveryIntervalMs: 300_000,
+    }),
+  };
+});
+
+vi.mock('../src/db.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/db.js')>('../src/db.js');
+  return {
+    ...actual,
+    getSessionProviderId: () => mocks.boundId,
+  };
+});
+
+const { willClearSessionOnProviderSwitch } =
+  await import('../src/container-runner.ts');
+const { providerPool } = await import('../src/provider-pool.ts');
+
+function setProviders(...ids: string[]) {
+  mocks.enabledProviders = ids.map((id) => ({ id, enabled: true, weight: 1 }));
+  providerPool.refreshFromConfig(mocks.enabledProviders, {
+    strategy: 'round-robin',
+    unhealthyThreshold: 3,
+    recoveryIntervalMs: 300_000,
+  });
+  for (const id of ids) providerPool.resetHealth(id);
+}
+
+beforeEach(() => {
+  mocks.enabledProviders = [];
+  mocks.envOverride = {};
+  mocks.boundId = undefined;
+});
+
+/**
+ * Story (PR #549, ACCEPTANCE #3): a proactive provider switch clears the SDK
+ * session inside the runner, so the orchestration layer must inject recent
+ * history beforehand. willClearSessionOnProviderSwitch is the trigger; it must
+ * fire exactly when trySelectPoolProvider would set resetSession.
+ */
+describe('willClearSessionOnProviderSwitch', () => {
+  test('false when there is no bound provider (fresh session)', () => {
+    setProviders('A', 'B');
+    mocks.boundId = undefined;
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(false);
+  });
+
+  test('false when the bound provider is still healthy and enabled', () => {
+    setProviders('A', 'B');
+    mocks.boundId = 'A';
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(false);
+  });
+
+  test('true when the bound provider is unhealthy (will switch away)', () => {
+    setProviders('A', 'B');
+    mocks.boundId = 'A';
+    providerPool.reportFailure('A', true); // force unhealthy immediately
+    expect(providerPool.getHealthStatus('A').healthy).toBe(false);
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(true);
+  });
+
+  test('true when the bound provider was removed/disabled', () => {
+    setProviders('B', 'C'); // A no longer enabled
+    mocks.boundId = 'A';
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(true);
+  });
+
+  test('false when an env-level override bypasses the pool entirely', () => {
+    setProviders('B', 'C');
+    mocks.boundId = 'A'; // would otherwise be a switch
+    mocks.envOverride = { anthropicApiKey: 'sk-xxx' };
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(false);
+  });
+
+  test('false for a single enabled provider equal to the binding', () => {
+    setProviders('A');
+    mocks.boundId = 'A';
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(false);
+  });
+
+  test('true for a single enabled provider different from the binding', () => {
+    setProviders('B');
+    mocks.boundId = 'A';
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(true);
+  });
+
+  test('false when no providers are enabled', () => {
+    mocks.enabledProviders = [];
+    mocks.boundId = 'A';
+    expect(willClearSessionOnProviderSwitch('grp', null)).toBe(false);
+  });
+});

--- a/tests/provider-switch-session.test.ts
+++ b/tests/provider-switch-session.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Isolated temp DATA_DIR so the suite never touches the real database.
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-provider-'));
+
+vi.mock('../src/config.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/config.js')>(
+      '../src/config.js',
+    );
+  return {
+    ...actual,
+    DATA_DIR: tmpRoot,
+    STORE_DIR: path.join(tmpRoot, 'db'),
+    GROUPS_DIR: path.join(tmpRoot, 'groups'),
+  };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const db = await import('../src/db.ts');
+
+beforeAll(() => {
+  db.initDatabase();
+});
+
+beforeEach(() => {
+  db.deleteAllSessionsForFolder('grp');
+});
+
+/**
+ * Story (PR #549, ACCEPTANCE #2): when a provider switch clears the SDK
+ * session, deleteSession() removes the whole sessions row — including the
+ * provider_id binding trySelectPoolProvider just wrote. The fix re-binds the
+ * freshly-selected provider right after deleteSession so the next turn stays
+ * sticky. These tests pin the db-level invariant the runner code now upholds.
+ */
+describe('provider switch: session clear must not lose the provider_id binding', () => {
+  test('bare deleteSession drops the provider_id binding (the bug)', () => {
+    db.setSession('grp', 'sess-A', null);
+    db.setSessionProviderId('grp', null, 'provider-A');
+    expect(db.getSessionProviderId('grp', null)).toBe('provider-A');
+
+    // Reproduce the pre-fix behaviour: clearing the session also wipes the bind.
+    db.deleteSession('grp', null);
+    expect(db.getSessionProviderId('grp', null)).toBeUndefined();
+  });
+
+  test('deleteSession + re-bind keeps the freshly selected provider sticky (the fix)', () => {
+    db.setSession('grp', 'sess-A', null);
+    db.setSessionProviderId('grp', null, 'provider-A');
+
+    // Runner sequence on a provider switch: clear session, then re-bind the
+    // newly selected provider (container-runner.ts).
+    db.deleteSession('grp', null);
+    db.setSessionProviderId('grp', null, 'provider-B');
+
+    // The SDK session id is cleared: setSessionProviderId upserts a row with an
+    // empty session_id, which callers normalise via `getSession(...) || undefined`
+    // (index.ts) — so no stale session gets resumed.
+    expect(db.getSession('grp', null) || undefined).toBeUndefined();
+    // The new binding survives so the next turn routes sticky to provider-B
+    // instead of re-balancing.
+    expect(db.getSessionProviderId('grp', null)).toBe('provider-B');
+  });
+
+  test('re-bind is agent-scoped — does not leak across agent_ids', () => {
+    db.setSession('grp', 'sess-main', null);
+    db.setSessionProviderId('grp', null, 'provider-A');
+    db.setSession('grp', 'sess-agent', 'agent-1');
+    db.setSessionProviderId('grp', 'agent-1', 'provider-A');
+
+    // Switch only the agent-1 session.
+    db.deleteSession('grp', 'agent-1');
+    db.setSessionProviderId('grp', 'agent-1', 'provider-B');
+
+    expect(db.getSessionProviderId('grp', 'agent-1')).toBe('provider-B');
+    // Default (main) binding untouched.
+    expect(db.getSession('grp', null)).toBe('sess-main');
+    expect(db.getSessionProviderId('grp', null)).toBe('provider-A');
+  });
+});


### PR DESCRIPTION
## 问题描述

修复 provider 额度耗尽后，长驻 conversation agent 仍粘在已耗尽 provider、切换 provider 后上下文丢失的问题。

根因有三点：

- Claude SDK 可能把 `You're out of extra usage · resets ...` 作为成功的最终文本返回，旧逻辑会把它记为 provider 成功。
- 长驻 host agent 只有在进程退出时才会上报 provider 健康状态，导致连续限额失败时不会立刻从池中摘掉 official。
- 切换 provider/model 会清掉底层 Claude session，但 agent conversation 没有从 HappyClaw DB 注入近期聊天历史，新模型会误以为是全新会话。

## 修复内容

- 识别限额/配额类最终文本为 `providerFailure`，并将其纳入 API error 分类。
- providerFailure 立即标记 provider unhealthy，并停止当前 host/container agent，避免继续复用坏 provider。
- provider 切换时跳过不健康的 sticky binding，并在跨 provider 切换时清理旧 session。
- agent 新 session 启动时，从 HappyClaw 持久化消息中注入近期聊天历史，恢复切模型后的上下文连续性。
- providerFailure 不再保存返回里的 `newSessionId`，避免把失败 session 又写回 DB。

## 用户影响

- official extra usage 用尽后，不会继续死循环粘在 official。
- 下一轮会切到可用 provider，并以新 session 携带近期 HappyClaw 历史继续。
- 手动/自动切 provider 后，agent 不会只看 `memory/` / `sessions-all/` 就误判“今天没有记忆”。

## 验证

- `npm run typecheck`
- `npx vitest run tests/agent-output-parser.test.ts tests/session-provider-binding.test.ts tests/chat-agent-messages.test.ts`
- `npm run build`
