### PR TITLE
新增: 基于内容的智能路由 (content-based routing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ HappyClaw 是一个基于 [Claude Agent SDK](https://github.com/anthropics/claud
 
 支持配置多个 Claude API 提供商（Anthropic 官方、各类中转服务、Coding Plan），实现高可用部署：
 
-- **三种负载均衡策略** — Round-Robin（轮询）、Weighted（加权）、Failover（主备切换）
+- **四种负载均衡策略** — Round-Robin（轮询）、Weighted（加权）、Failover（主备切换）、Content-Based（智能路由）
+- **智能路由（Content-Based）** — 根据用户输入内容自动选择不同模型，支持关键词、正则、文本长度等条件匹配，未命中时降级到 fallback 策略
 - **自动健康检测** — 连续错误追踪（默认 3 次标记不健康），5 分钟自动恢复探测
 - **Per-group 提供商切换** — 在监控页面可为每个工作区指定使用哪个提供商
+- **Sticky Session** — 同一会话自动绑定首次选中的提供商，避免 thinking block 签名错误
 - **OAuth 凭据支持** — 支持 Claude Code OAuth Token，兼容各类认证方式
 - **活跃会话计数** — 实时显示每个提供商的并发使用量
 
@@ -428,7 +430,7 @@ admin 用户默认使用宿主机模式（无需 Docker），开箱即用。如�
 | 命令 | 缩写 | 用途 |
 |------|------|------|
 | `/list` | `/ls` | 查看所有工作区和对话列表 |
-| `/status` | - | 查看当前工作区/对话状态 |
+| `/status` | - | 查看当前工作区/对话状态及提供商/模型信息 |
 | `/where` | - | 查看当前绑定位置和回复策略 |
 | `/bind <target>` | - | 绑定到指定工作区或 Agent（如 `/bind myws` 或 `/bind myws/a3b`） |
 | `/unbind` | - | 解绑回默认工作区 |

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,12 @@
 - `GET|PUT /api/config/claude` · `PUT /api/config/claude/secrets`
 - `GET|PUT /api/config/claude/custom-env`
 - `POST /api/config/claude/test`（连通性测试） · `POST /api/config/claude/apply`（应用到所有容器）
+- `GET /api/config/claude/providers`（列出所有供应商 + 健康状态 + 负载均衡配置）
+- `POST /api/config/claude/providers`（创建供应商） · `PATCH /api/config/claude/providers/:id`（更新供应商） · `DELETE /api/config/claude/providers/:id`
+- `PUT /api/config/claude/providers/:id/secrets`（更新密钥） · `POST /api/config/claude/providers/:id/toggle`（切换 enabled） · `POST /api/config/claude/providers/:id/reset-health`（重置健康状态）
+- `GET /api/config/claude/providers/health`（健康状态轮询） · `GET /api/config/claude/providers/:id/usage`（OAuth 用量数据）
+- `PUT /api/config/claude/balancing`（更新负载均衡配置，支持 `content-based` 策略及 `routingRules`）
+- `POST /api/config/claude/routing-rules/test`（测试内容路由规则，传入 `prompt` 返回匹配的规则和目标提供商）
 - `GET|PUT /api/config/feishu`（**deprecated**，使用 `/api/config/user-im/feishu` 代替）
 - `GET|PUT /api/config/telegram` · `POST /api/config/telegram/test`（**deprecated**，使用 `/api/config/user-im/telegram` 代替）
 - `GET|PUT /api/config/appearance` · `GET /api/config/appearance/public`（外观配置，public 端点无需认证）

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -285,6 +285,7 @@ export function setProviderOverride(groupFolder: string, providerId: string): vo
 function trySelectPoolProvider(
   groupFolder: string,
   agentId?: string | null,
+  prompt?: string,
 ): { profileId: string; resolved: ResolvedProvider } | null {
   const override = getContainerEnvConfig(groupFolder);
   const hasOverride = !!(
@@ -371,7 +372,7 @@ function trySelectPoolProvider(
   providerPool.refreshFromConfig(enabledProviders, balancing);
 
   try {
-    const profileId = providerPool.selectProvider();
+    const profileId = providerPool.selectProvider(prompt);
     const resolved = resolveProviderById(profileId);
     providerPool.acquireSession(profileId);
     setSessionProviderId(groupFolder, agentId, profileId);
@@ -826,7 +827,7 @@ export async function runContainerAgent(
   mkdirForContainer(groupDir);
 
   // ─── Provider Pool selection ───
-  const poolResult = trySelectPoolProvider(group.folder, input.agentId);
+  const poolResult = trySelectPoolProvider(group.folder, input.agentId, input.prompt);
   const selectedProfileId = poolResult?.profileId ?? null;
   const resolvedProvider = poolResult?.resolved;
 
@@ -1390,7 +1391,7 @@ export async function runHostAgent(
 
   // ─── Provider Pool selection (host mode) ───
   const containerOverride = getContainerEnvConfig(group.folder);
-  const hostPoolResult = trySelectPoolProvider(group.folder, input.agentId);
+  const hostPoolResult = trySelectPoolProvider(group.folder, input.agentId, input.prompt);
   const hostSelectedProfileId = hostPoolResult?.profileId ?? null;
   const globalConfig = hostPoolResult?.resolved.config ?? getClaudeProviderConfig();
 

--- a/src/im-command-utils.ts
+++ b/src/im-command-utils.ts
@@ -216,6 +216,11 @@ export interface QueueStatusInfo {
   waitingGroupJids: string[];
 }
 
+export interface ProviderStatusInfo {
+  providers: Array<{ name: string; model: string; enabled: boolean }>;
+  strategy: string;
+}
+
 /**
  * Format system status output for /status command.
  */
@@ -224,6 +229,7 @@ export function formatSystemStatus(
   queueStatus: QueueStatusInfo,
   isActive: boolean,
   queuePosition: number | null,
+  providerStatus?: ProviderStatusInfo,
 ): string {
   const statusText = isActive
     ? '运行中'
@@ -237,9 +243,17 @@ export function formatSystemStatus(
     `📍 位置: ${location.locationLine}`,
     `⚡ 状态: ${statusText}`,
     `📦 负载: ${queueStatus.activeContainerCount}/${queueStatus.maxContainers} 容器, ${queueStatus.activeHostProcessCount}/${queueStatus.maxHostProcesses} 进程`,
-    '',
-    '💡 /sw <消息> 并行任务 · /where 绑定 · /list 全部',
   ];
+
+  if (providerStatus) {
+    lines.push(`🔀 策略: ${providerStatus.strategy}`);
+    for (const p of providerStatus.providers) {
+      const flag = p.enabled ? '✅' : '⏸️';
+      lines.push(`  ${flag} ${p.name} (${p.model})`);
+    }
+  }
+
+  lines.push('', '💡 /sw <消息> 并行任务 · /where 绑定 · /list 全部');
 
   return lines.join('\n');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,8 @@ import {
   saveFeishuOwnerOpenId,
   saveUserTelegramConfig,
   updateAllSessionCredentials,
+  getEnabledProviders,
+  getBalancingConfig,
 } from './runtime-config.js';
 import type {
   FeishuConnectConfig,
@@ -1450,6 +1452,14 @@ function handleStatusCommand(chatJid: string): string {
     },
     isActive,
     queuePosition,
+    {
+      providers: getEnabledProviders().map((p) => ({
+        name: p.name,
+        model: p.anthropicModel,
+        enabled: p.enabled,
+      })),
+      strategy: getBalancingConfig().strategy,
+    },
   );
 }
 

--- a/src/provider-pool.ts
+++ b/src/provider-pool.ts
@@ -1,11 +1,15 @@
 /**
  * Provider Pool — 多提供商负载均衡
  *
- * 支持三种策略：round-robin、weighted-round-robin、failover
+ * 支持四种策略：round-robin、weighted-round-robin、failover、content-based
  * 健康状态纯内存管理，配置由 runtime-config V4 注入（不再自行管理配置文件）
  */
 import { logger } from './logger.js';
-import type { BalancingConfig } from './runtime-config.js';
+import type {
+  BalancingConfig,
+  ContentCondition,
+  ContentRoutingRule,
+} from './runtime-config.js';
 
 // ─── 类型定义 ──────────────────────────────────────────────
 
@@ -51,6 +55,9 @@ export class ProviderPool {
   private recoveryIntervalMs = DEFAULT_RECOVERY_INTERVAL_MS;
   private healthMap: Map<string, ProviderHealthStatus> = new Map();
   private roundRobinIndex = 0;
+  private routingRules: ContentRoutingRule[] = [];
+  private fallbackStrategy: 'round-robin' | 'weighted-round-robin' | 'failover' =
+    'round-robin';
 
   /**
    * Refresh internal state from V4 provider config.
@@ -68,6 +75,8 @@ export class ProviderPool {
     this.strategy = balancing.strategy;
     this.unhealthyThreshold = balancing.unhealthyThreshold;
     this.recoveryIntervalMs = balancing.recoveryIntervalMs;
+    this.routingRules = balancing.routingRules || [];
+    this.fallbackStrategy = balancing.fallbackStrategy || 'round-robin';
 
     // Clean up health entries for removed members
     const memberIds = new Set(this.members.map((m) => m.profileId));
@@ -84,7 +93,7 @@ export class ProviderPool {
   // ─── 选择算法 ────────────────────────────────────────────
 
   /** 选择一个提供商，返回 profileId */
-  selectProvider(): string {
+  selectProvider(prompt?: string): string {
     const { strategy, members, recoveryIntervalMs } = this;
     const now = Date.now();
 
@@ -130,6 +139,86 @@ export class ProviderPool {
       throw new Error('Provider pool has no members configured');
     }
 
+    // Content-based strategy: classify prompt then fallback
+    if (strategy === 'content-based') {
+      if (prompt) {
+        const targetId = this.classifyContent(prompt);
+        if (targetId) {
+          const target = candidates.find((c) => c.profileId === targetId);
+          if (target) {
+            logger.info(
+              { targetId, strategy },
+              'Content-based routing matched provider',
+            );
+            return target.profileId;
+          }
+          logger.info(
+            { targetId },
+            'Content-routed provider unhealthy or disabled, falling back',
+          );
+        }
+      }
+      return this.selectByStrategy(this.fallbackStrategy, candidates);
+    }
+
+    return this.selectByStrategy(strategy, candidates);
+  }
+
+  /** Classify prompt against routing rules, return matched provider ID or null */
+  classifyContent(
+    prompt: string,
+    rules?: ContentRoutingRule[],
+  ): string | null {
+    const effectiveRules = (rules || this.routingRules)
+      .filter((r) => r.enabled)
+      .sort((a, b) => a.priority - b.priority);
+
+    for (const rule of effectiveRules) {
+      const matched = rule.conditions.some((cond) =>
+        this.evalCondition(prompt, cond),
+      );
+      if (matched) return rule.targetProviderId;
+    }
+    return null;
+  }
+
+  private evalCondition(prompt: string, cond: ContentCondition): boolean {
+    switch (cond.type) {
+      case 'keyword': {
+        const text = cond.caseInsensitive ? prompt.toLowerCase() : prompt;
+        const kw = cond.caseInsensitive
+          ? cond.value.toLowerCase()
+          : cond.value;
+        return text.includes(kw);
+      }
+      case 'regex': {
+        try {
+          const flags = cond.caseInsensitive ? 'is' : 's';
+          return new RegExp(cond.value, flags).test(prompt);
+        } catch {
+          return false;
+        }
+      }
+      case 'length_gt':
+        return prompt.length > parseInt(cond.value, 10);
+      case 'length_lt':
+        return prompt.length < parseInt(cond.value, 10);
+      case 'starts_with': {
+        const text = cond.caseInsensitive ? prompt.toLowerCase() : prompt;
+        const prefix = cond.caseInsensitive
+          ? cond.value.toLowerCase()
+          : cond.value;
+        return text.startsWith(prefix);
+      }
+      default:
+        return false;
+    }
+  }
+
+  private selectByStrategy(
+    strategy: string,
+    candidates: ProviderPoolMember[],
+  ): string {
     let selected: ProviderPoolMember;
 
     switch (strategy) {

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -680,6 +680,30 @@ configRoutes.put(
   },
 );
 
+// ─── POST /claude/routing-rules/test — 测试内容路由规则 ─────
+configRoutes.post(
+  '/claude/routing-rules/test',
+  authMiddleware,
+  async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const prompt = body?.prompt;
+    if (!prompt || typeof prompt !== 'string') {
+      return c.json({ error: 'Missing or invalid "prompt" field' }, 400);
+    }
+
+    const balancing = getBalancingConfig();
+    const enabledProviders = getEnabledProviders();
+    providerPool.refreshFromConfig(enabledProviders, balancing);
+
+    const matchedId = providerPool.classifyContent(prompt);
+    const matchedRule =
+      balancing.routingRules?.find((r) => r.targetProviderId === matchedId) ||
+      null;
+
+    return c.json({ matchedRule, targetProviderId: matchedId });
+  },
+);
+
 // ─── POST /claude/apply — 应用配置到所有容器 ─────
 configRoutes.post(
   '/claude/apply',

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -296,10 +296,33 @@ interface ClaudeStoredProfileResolved {
 
 // ─── V4 统一供应商模型 ────────────────────────────────────────
 
+// ─── 内容路由规则 ────────────────────────────────────────
+
+export interface ContentCondition {
+  type: 'keyword' | 'regex' | 'length_gt' | 'length_lt' | 'starts_with';
+  value: string;
+  caseInsensitive?: boolean;
+}
+
+export interface ContentRoutingRule {
+  id: string;
+  name: string;
+  conditions: ContentCondition[];
+  targetProviderId: string;
+  priority: number;
+  enabled: boolean;
+}
+
 export interface BalancingConfig {
-  strategy: 'round-robin' | 'weighted-round-robin' | 'failover';
+  strategy:
+    | 'round-robin'
+    | 'weighted-round-robin'
+    | 'failover'
+    | 'content-based';
   unhealthyThreshold: number;
   recoveryIntervalMs: number;
+  routingRules?: ContentRoutingRule[];
+  fallbackStrategy?: 'round-robin' | 'weighted-round-robin' | 'failover';
 }
 
 const DEFAULT_BALANCING_CONFIG: BalancingConfig = {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -709,12 +709,36 @@ export const UnifiedProviderSecretsSchema = z
     { message: 'At least one secret field must be provided' },
   );
 
+export const ContentConditionSchema = z.object({
+  type: z.enum(['keyword', 'regex', 'length_gt', 'length_lt', 'starts_with']),
+  value: z.string().min(1).max(500),
+  caseInsensitive: z.boolean().optional(),
+});
+
+export const ContentRoutingRuleSchema = z.object({
+  id: z.string().min(1).max(64),
+  name: z.string().min(1).max(100),
+  conditions: z.array(ContentConditionSchema).min(1).max(20),
+  targetProviderId: z.string().min(1).max(64),
+  priority: z.number().int().min(0).max(1000),
+  enabled: z.boolean(),
+});
+
 export const BalancingConfigSchema = z.object({
   strategy: z
-    .enum(['round-robin', 'weighted-round-robin', 'failover'])
+    .enum([
+      'round-robin',
+      'weighted-round-robin',
+      'failover',
+      'content-based',
+    ])
     .optional(),
   unhealthyThreshold: z.number().int().min(1).max(20).optional(),
   recoveryIntervalMs: z.number().int().min(30000).max(3600000).optional(),
+  routingRules: z.array(ContentRoutingRuleSchema).max(50).optional(),
+  fallbackStrategy: z
+    .enum(['round-robin', 'weighted-round-robin', 'failover'])
+    .optional(),
 });
 
 export const WeChatConfigSchema = z.object({

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -890,7 +890,7 @@ export function extractMessageText(content: proto.IMessage): string | null {
  * Returns 0 if not a usable value (caller falls back to Date.now()).
  */
 export function normalizeTimestamp(
-  ts: number | Long.Long | null | undefined,
+  ts: number | Long | null | undefined,
 ): number {
   if (ts === null || ts === undefined) return 0;
   if (typeof ts === 'number') return ts * 1000;


### PR DESCRIPTION
## 概述

新增 `content-based` 负载均衡策略，根据用户输入内容自动将请求路由到不同的 AI 提供商/模型。

例如：简单文本任务用 DeepSeek，多模态任务用 GLM。

## 主要改动

### 核心逻辑
- **`src/runtime-config.ts`** — 新增 `ContentCondition`、`ContentRoutingRule` 接口，扩展 `BalancingConfig` 支持 `content-based` 策略、`routingRules`、`fallbackStrategy`
- **`src/schemas.ts`** — 新增对应 Zod 校验 schema
- **`src/provider-pool.ts`** — 新增 `classifyContent()` / `evalCondition()` 方法，`selectProvider(prompt?)` 支持 content-based 分支，提取 `selectByStrategy()` 复用原有逻辑
- **`src/container-runner.ts`** — `trySelectPoolProvider` 签名加 `prompt?` 参数，两处调用传入 `input.prompt`

### API & 命令
- **`src/routes/config.ts`** — 新增 `POST /api/config/claude/routing-rules/test` 测试端点
- **`src/im-command-utils.ts`** — `/status` 命令新增提供商/模型/策略信息展示
- **`src/index.ts`** — `handleStatusCommand` 传入 provider 状态

### 文档
- **`README.md`** — 负载均衡策略从三种更新为四种，新增智能路由和 Sticky Session 说明
- **`docs/API.md`** — 补全 providers 相关端点，新增 balancing 和 routing-rules/test 端点

### 附带修复
- **`src/whatsapp.ts`** — `Long.Long` 类型引用修正为 `Long`

## 路由规则配置示例

```json
{
  "balancing": {
    "strategy": "content-based",
    "fallbackStrategy": "round-robin",
    "routingRules": [
      {
        "id": "rule-multimodal",
        "name": "多模态任务 → GLM",
        "conditions": [
          { "type": "keyword", "value": "这张图", "caseInsensitive": true },
          { "type": "regex", "value": "截图|图中|图片" }
        ],
        "targetProviderId": "glm-5.1",
        "priority": 1,
        "enabled": true
      },
      {
        "id": "rule-text",
        "name": "默认文本任务 → DeepSeek",
        "conditions": [{ "type": "length_gt", "value": "0" }],
        "targetProviderId": "deepseek-v4-flash",
        "priority": 99,
        "enabled": true
      }
    ]
  }
}
```

## 向后兼容

- `routingRules` 和 `fallbackStrategy` 均为可选字段，旧配置无需修改
- `trySelectPoolProvider` 第三参数为可选，不影响现有调用
- `selectProvider(prompt?)` 参数可选，非 content-based 策略不使用

## 决策流程

```
用户消息 → trySelectPoolProvider(groupFolder, agentId, prompt)
  → ① env 覆盖 → 跳过 pool
  → ② 一次性 switchProvider → 消费
  → ③ sticky session → 复用（不再重新分类）
  → ④ content-based → classifyContent(prompt) → 匹配则使用，否则降级
  → ⑤ 单 provider / pool 选择
```

首条消息做分类，后续消息通过 sticky binding 自动复用同一 provider。