### PR TITLE
修复: 注入环境变量绕过 Claude CLI 对非标准模型的验证

### DIFF
--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -37,6 +37,7 @@ const RESERVED_CLAUDE_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_MODEL',
+  'ANTHROPIC_CUSTOM_MODEL_OPTION',
 ]);
 const DANGEROUS_ENV_VARS = new Set([
   // Code execution / preload attacks
@@ -2343,6 +2344,9 @@ export function buildClaudeEnvLines(
   }
   if (config.anthropicModel) {
     lines.push(`ANTHROPIC_MODEL=${sanitizeEnvValue(config.anthropicModel)}`);
+    lines.push(
+      `ANTHROPIC_CUSTOM_MODEL_OPTION=${sanitizeEnvValue(config.anthropicModel)}`,
+    );
   }
 
   // Use explicit profileCustomEnv if provided (pool mode), otherwise active profile


### PR DESCRIPTION
## 问题描述
在使用非标准第三方模型（如 `mimo-v2.5-pro`）时，底层 `@anthropic-ai/claude-agent-sdk` 调用的 Claude Code CLI 运行时在启动时会进行硬编码的模型验证，导致非官方的模型名称直接抛出 `There's an issue with the selected model...` 的错误。

## 修复方案 / 实现方案
利用上游 Claude CLI 支持的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 环境变量，自动将自定义的模型 ID 传入以绕过启动硬编码验证。

### `src/runtime-config.ts`
- 在 `RESERVED_CLAUDE_ENV_KEYS` 集合中加入 `'ANTHROPIC_CUSTOM_MODEL_OPTION'`。
- 在 `buildClaudeEnvLines` 中，当 `config.anthropicModel` 存在时，向生成的环境变量行中额外注入 `ANTHROPIC_CUSTOM_MODEL_OPTION`。