### PR TITLE
修复: stop/interrupt 收紧为资源级 ACL（owner 或查询发起者）

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -48,6 +48,15 @@ interface GroupState {
    *  re-read those messages.  The close handler uses this flag to force pendingMessages
    *  so drainGroup triggers a fresh run. */
   hasIpcInjectedMessages: boolean;
+  /**
+   * HappyClaw user id that started the current run (idle→active), or null when
+   * unknown (IM / task / agent / drain runs, or no initiator supplied). The
+   * stop/interrupt routes use it for a resource-level "owner OR initiator"
+   * check, so a shared member can stop/interrupt only the run they started, not
+   * the owner's. Set by the enqueue that starts a fresh run; cleared on idle.
+   * Subsequent IPC-injected messages during an active run do NOT change it.
+   */
+  currentRunInitiator: string | null;
 }
 
 type ActiveGroupState = GroupState & { groupFolder: string };
@@ -99,6 +108,7 @@ export class GroupQueue {
         selectedProviderId: null,
         drainSentinelWritten: false,
         hasIpcInjectedMessages: false,
+        currentRunInitiator: null,
       };
       this.groups.set(groupJid, state);
     }
@@ -250,6 +260,39 @@ export class GroupQueue {
     return state?.active === true;
   }
 
+  /**
+   * The HappyClaw user id that started the currently-active *message* run owning
+   * this jid's serialization key, or null if unknown / no active run. Used by
+   * the stop/interrupt routes for a resource-level "owner OR initiator" ACL: a
+   * shared member may stop/interrupt only a message run they started themselves.
+   *
+   * Task runs (`activeRunnerIsTask` — scheduled tasks, agent conversations,
+   * terminal warmup) are deliberately EXCLUDED and return null → owner-only.
+   * currentRunInitiator is stamped at message-enqueue time and is NOT touched by
+   * runTask, so a base-jid task (e.g. terminal-warmup, index.ts) sharing the
+   * GroupState can go active while a member's still-pending message left an
+   * initiator on it; gating on `!activeRunnerIsTask` prevents that member from
+   * being mis-read as the task run's initiator (which would let them stop the
+   * owner's task). Not clearing the field in runTask is intentional — it lets
+   * the member's own pending message run still expose them once it starts.
+   *
+   * Unlike resolveActiveState this does NOT require groupFolder to be set, so
+   * the initiator is readable from the instant the run goes active (idle→active)
+   * — even during the cold-start window before registerProcess. It matches on
+   * `active` (+ not-a-task) + serialization key only.
+   */
+  getActiveRunInitiator(groupJid: string): string | null {
+    const own = this.groups.get(groupJid);
+    if (own?.active) {
+      return own.activeRunnerIsTask ? null : (own.currentRunInitiator ?? null);
+    }
+    const activeRunner = this.findActiveRunnerFor(groupJid);
+    if (!activeRunner) return null;
+    const runner = this.groups.get(activeRunner);
+    if (!runner || runner.activeRunnerIsTask) return null;
+    return runner.currentRunInitiator ?? null;
+  }
+
   /** Count active task runners whose JID starts with the given base JID + '#task:' */
   countActiveTaskRunners(baseJid: string): number {
     const prefix = baseJid + '#task:';
@@ -391,7 +434,7 @@ export class GroupQueue {
     return true;
   }
 
-  enqueueMessageCheck(groupJid: string): void {
+  enqueueMessageCheck(groupJid: string, initiatorUserId?: string): void {
     if (this.shuttingDown) return;
 
     const state = this.getGroup(groupJid);
@@ -411,6 +454,15 @@ export class GroupQueue {
         'Group runner active, message queued',
       );
       return;
+    }
+
+    // Past the active / shared-active check → this jid will start its OWN fresh
+    // run (now, or once capacity frees). Record who initiated it so the
+    // stop/interrupt routes can do an owner-or-initiator check. Only overwrite
+    // when an initiator is explicitly supplied, so internal drain re-enqueues
+    // (no initiator) don't wipe a pending run's initiator.
+    if (initiatorUserId !== undefined) {
+      state.currentRunInitiator = initiatorUserId;
     }
 
     if (!this.hasCapacityFor(groupJid)) {
@@ -1073,6 +1125,7 @@ export class GroupQueue {
       state.groupFolder = null;
       state.agentId = null;
       state.taskRunId = null;
+      state.currentRunInitiator = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -904,6 +904,18 @@ groupRoutes.post('/:jid/stop', authMiddleware, async (c) => {
   if (!canAccessGroup({ id: authUser.id, role: authUser.role }, group)) {
     return c.json({ error: 'Group not found' }, 404);
   }
+  // Resource-level ACL: the owner (canModifyGroup) can always stop; a shared
+  // member may stop only a run they started themselves (the queue's current-run
+  // initiator), not the owner's. Mirrors the delete-message owner-or-sender model.
+  if (
+    !canModifyGroup({ id: authUser.id, role: authUser.role }, { ...group, jid }) &&
+    deps.queue.getActiveRunInitiator(jid) !== authUser.id
+  ) {
+    return c.json(
+      { error: 'Only the workspace owner or the run initiator can stop it' },
+      403,
+    );
+  }
 
   try {
     await deps.queue.stopGroup(jid);
@@ -929,6 +941,24 @@ groupRoutes.post('/:jid/interrupt', authMiddleware, async (c) => {
   const authUser = c.get('user') as AuthUser;
   if (!canAccessGroup({ id: authUser.id, role: authUser.role }, group)) {
     return c.json({ error: 'Group not found' }, 404);
+  }
+  // Resource-level ACL (see /stop): owner OR the run's initiator. Uses the full
+  // (possibly virtual #agent:) jid so an agent-conversation run resolves to its
+  // own runner. Agent/task runs carry no message initiator (getActiveRunInitiator
+  // excludes activeRunnerIsTask) → owner-only. Known safe-direction limitation:
+  // a member who started their own agent/task run can't interrupt it — only the
+  // owner can; revisit if member-initiated agent interrupt is wanted (see PR notes).
+  if (
+    !canModifyGroup(
+      { id: authUser.id, role: authUser.role },
+      { ...group, jid: baseJid },
+    ) &&
+    deps.queue.getActiveRunInitiator(jid) !== authUser.id
+  ) {
+    return c.json(
+      { error: 'Only the workspace owner or the run initiator can interrupt it' },
+      403,
+    );
   }
 
   const interrupted = deps.queue.interruptQuery(jid);

--- a/src/web.ts
+++ b/src/web.ts
@@ -603,7 +603,10 @@ async function handleWebUserMessage(
         'Race: eager-expanded but runner exited before sendMessage; cold-start will re-expand (inline may run twice)',
       );
     }
-    deps.queue.enqueueMessageCheck(chatJid);
+    // Pass the sender as the run initiator so the stop/interrupt routes can do
+    // a resource-level "owner OR initiator" check — a shared member can stop /
+    // interrupt the run they started, but not the owner's.
+    deps.queue.enqueueMessageCheck(chatJid, userId);
   }
 
   // Only advance per-group cursor when we piped directly into a running container.

--- a/tests/group-queue-initiator.test.ts
+++ b/tests/group-queue-initiator.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for GroupQueue's current-run-initiator tracking (the queue half of
+ * the stop/interrupt resource-level ACL).
+ *
+ * Invariants under test:
+ *   - the initiator passed to enqueueMessageCheck is visible via
+ *     getActiveRunInitiator while that run is active;
+ *   - a sender whose message is IPC-injected into an already-active run does
+ *     NOT become the initiator (方案 A: only the run-starter);
+ *   - the initiator is cleared back to null once the run goes idle;
+ *   - an enqueue with no initiator yields a null initiator (→ owner-only).
+ *
+ * processMessagesFn is stubbed and observes the initiator from inside the run,
+ * so assertions don't depend on fragile external timing.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return { ...real, DATA_DIR: '/tmp/happyclaw-queue-initiator-test' };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+// killProcessTree pulls the heavy container-runner graph; the gated tests never
+// spawn a real process, so stub it out.
+vi.mock('../src/container-runner.js', () => ({
+  killProcessTree: () => {},
+}));
+
+// Force capacity to 1 so the leak test can hold the single slot with one run and
+// keep a second jid capacity-queued (the exact precondition for the task-leak).
+vi.mock('../src/runtime-config.js', () => ({
+  getSystemSettings: () => ({ maxConcurrentContainers: 1, maxConcurrentHostProcesses: 1 }),
+}));
+
+// drainWaiting calls getTaskById to skip cancelled scheduled tasks; a dynamic
+// task (no DB row) must be treated as live → return undefined.
+vi.mock('../src/db.js', () => ({
+  getTaskById: () => undefined,
+}));
+
+const { GroupQueue } = await import('../src/group-queue.js');
+
+const tick = () => new Promise((r) => setImmediate(r));
+const JID = 'web:initiator-test';
+
+let queue: InstanceType<typeof GroupQueue>;
+let observed: Array<string | null>;
+let blocking: boolean;
+let resolveGate: (() => void) | null;
+
+beforeEach(() => {
+  queue = new GroupQueue();
+  observed = [];
+  blocking = true;
+  resolveGate = null;
+  queue.setProcessMessagesFn(async (jid: string) => {
+    observed.push(queue.getActiveRunInitiator(jid));
+    if (blocking) {
+      await new Promise<void>((r) => {
+        resolveGate = r;
+      });
+    }
+    return true;
+  });
+});
+
+afterEach(async () => {
+  // Release any still-gated run so the queue settles before the next test.
+  blocking = false;
+  resolveGate?.();
+  await tick();
+  await tick();
+});
+
+describe('GroupQueue current-run initiator', () => {
+  test('records the initiator and exposes it while the run is active', async () => {
+    expect(queue.getActiveRunInitiator(JID)).toBe(null); // idle
+
+    queue.enqueueMessageCheck(JID, 'alice');
+    await tick();
+
+    expect(observed[0]).toBe('alice'); // visible from inside the run
+    expect(queue.getActiveRunInitiator(JID)).toBe('alice');
+  });
+
+  test('IPC-injected sender does not become the initiator', async () => {
+    queue.enqueueMessageCheck(JID, 'alice'); // starts the run (blocks on gate)
+    await tick();
+    expect(queue.getActiveRunInitiator(JID)).toBe('alice');
+
+    queue.enqueueMessageCheck(JID, 'bob'); // active → injected, must not override
+    expect(queue.getActiveRunInitiator(JID)).toBe('alice');
+  });
+
+  test('clears the initiator once the run goes idle', async () => {
+    queue.enqueueMessageCheck(JID, 'alice');
+    await tick();
+    expect(queue.getActiveRunInitiator(JID)).toBe('alice');
+
+    blocking = false;
+    resolveGate?.();
+    await tick();
+    await tick();
+
+    expect(queue.getActiveRunInitiator(JID)).toBe(null);
+  });
+
+  test('an enqueue with no initiator yields a null initiator (owner-only)', async () => {
+    queue.enqueueMessageCheck(JID); // no initiator supplied
+    await tick();
+    expect(observed[0]).toBe(null);
+    expect(queue.getActiveRunInitiator(JID)).toBe(null);
+  });
+
+  test('a TASK run does not expose a pending message initiator (no over-grant)', async () => {
+    // Hold the single capacity slot with an unrelated message run.
+    queue.enqueueMessageCheck('web:holder', 'holder');
+    await tick();
+    // JID's message is now capacity-queued: it records initiator 'bob' but does
+    // NOT go active (capacity full).
+    queue.enqueueMessageCheck(JID, 'bob');
+    // A base-jid task (e.g. terminal warmup) is queued on the SAME jid.
+    let taskObserved: string | null | undefined;
+    let releaseTask: () => void = () => {};
+    let signalObserved: () => void = () => {};
+    // Wait on an explicit signal fired from inside the task fn rather than a
+    // fixed tick count: the fn samples getActiveRunInitiator while THIS task run
+    // is active (activeRunnerIsTask=true), so the read is deterministic
+    // regardless of how many microtask turns the holder-free → drain → runTask
+    // chain takes under load. (A fixed `await tick()` count was flaky in the
+    // full parallel suite.)
+    const observed = new Promise<void>((r) => {
+      signalObserved = r;
+    });
+    queue.enqueueTask(JID, 'warmup-dynamic', async () => {
+      taskObserved = queue.getActiveRunInitiator(JID);
+      signalObserved();
+      await new Promise<void>((r) => {
+        releaseTask = r;
+      });
+    });
+    // Free the slot → drain runs JID's TASK first (tasks-first) while
+    // currentRunInitiator(JID) still holds 'bob'.
+    blocking = false;
+    resolveGate?.();
+    await observed;
+    // The task run must NOT report 'bob' (it's a task, not bob's message run).
+    expect(taskObserved).toBe(null);
+    releaseTask();
+    await tick();
+  });
+
+  test('resolves the initiator across sibling jids sharing a serialization key', async () => {
+    queue.setSerializationKeyResolver((jid: string) =>
+      jid.startsWith('web:sib') ? 'shared-folder' : jid,
+    );
+    queue.enqueueMessageCheck('web:sib1', 'alice'); // run starts on sib1
+    await tick();
+    // sib2 shares the serialization key → resolves to sib1's active runner.
+    expect(queue.getActiveRunInitiator('web:sib2')).toBe('alice');
+  });
+});

--- a/tests/routes-stop-interrupt-acl.test.ts
+++ b/tests/routes-stop-interrupt-acl.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Resource-level ACL for POST /:jid/stop and /:jid/interrupt.
+ *
+ * Both routes were `canAccessGroup` (any shared member could stop/interrupt the
+ * owner's container). They now additionally require the caller to be the owner
+ * (canModifyGroup) OR the initiator of the currently-running query (queue's
+ * getActiveRunInitiator). Coverage:
+ *   - owner                              → 200 (canModifyGroup)
+ *   - shared member, they are initiator  → 200
+ *   - shared member, owner is initiator  → 403
+ *   - shared member, no active initiator → 403
+ *   - non-member                         → 404 (hidden by canAccessGroup)
+ *
+ * The queue is stubbed (getActiveRunInitiator returns a per-test value); the
+ * deps.queue.stopGroup / interruptQuery happy paths are no-ops so the test
+ * isolates the ACL decision.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const SHARED_TMP =
+  process.env.HAPPYCLAW_TEST_DATA_DIR ??
+  (() => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-stop-interrupt-'));
+    process.env.HAPPYCLAW_TEST_DATA_DIR = d;
+    return d;
+  })();
+
+const tmpDataDir = SHARED_TMP;
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  const dataDir = process.env.HAPPYCLAW_TEST_DATA_DIR!;
+  return {
+    ...real,
+    DATA_DIR: dataDir,
+    GROUPS_DIR: path.join(dataDir, 'groups'),
+    STORE_DIR: path.join(dataDir, 'db'),
+  };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+vi.mock('../src/middleware/auth.ts', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    authMiddleware: async (c: any, next: any) => {
+      c.set('user', {
+        id: process.env.HAPPYCLAW_TEST_USER_ID ?? 'alice',
+        username: 'alice',
+        role: (process.env.HAPPYCLAW_TEST_USER_ROLE ?? 'member') as 'admin' | 'member',
+        permissions: [],
+      });
+      return next();
+    },
+  };
+});
+
+// groups.ts statically imports these from web.js — mock so importing the route
+// module doesn't pull in the full Hono app + WebSocket.
+vi.mock('../src/web.js', () => ({
+  broadcastNewMessage: () => {},
+  invalidateAllowedUserCache: () => {},
+}));
+
+const groupRoutesModule = await import('../src/routes/groups.js');
+const db = await import('../src/db.js');
+const webContext = await import('../src/web-context.js');
+
+const groupRoutes = groupRoutesModule.default;
+
+const OWNER_ID = 'alice';
+const MEMBER_ID = 'bob';
+const OUTSIDER_ID = 'charlie';
+const GROUP_JID = 'web:stop-interrupt-group';
+const GROUP_FOLDER = 'stop-interrupt-group';
+
+// Per-test value returned by the stubbed queue.getActiveRunInitiator, and the
+// last jid it was asked about (to assert the route's full-vs-base jid choice).
+let activeInitiator: string | null = null;
+let lastInitiatorJid: string | null = null;
+
+function seedTestGroup(): void {
+  db.setRegisteredGroup(GROUP_JID, {
+    name: 'Stop/Interrupt ACL Group',
+    folder: GROUP_FOLDER,
+    added_at: new Date().toISOString(),
+    executionMode: 'container',
+    created_by: OWNER_ID,
+    is_home: false,
+  } as any);
+  db.addGroupMember(GROUP_FOLDER, OWNER_ID, 'owner');
+  db.addGroupMember(GROUP_FOLDER, MEMBER_ID, 'member');
+}
+
+function asUser(userId: string, role: 'admin' | 'member' = 'member'): void {
+  process.env.HAPPYCLAW_TEST_USER_ID = userId;
+  process.env.HAPPYCLAW_TEST_USER_ROLE = role;
+}
+
+async function post(pathSuffix: string): Promise<{ status: number; body: any }> {
+  const res = await groupRoutes.request(
+    `/${encodeURIComponent(GROUP_JID)}${pathSuffix}`,
+    { method: 'POST' },
+  );
+  return { status: res.status, body: await res.json().catch(() => ({})) };
+}
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(tmpDataDir, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDataDir, 'groups'), { recursive: true });
+  db.initDatabase();
+  webContext.setWebDeps({
+    queue: {
+      stopGroup: async () => {},
+      interruptQuery: () => false,
+      getActiveRunInitiator: (jid: string) => {
+        lastInitiatorJid = jid;
+        return activeInitiator;
+      },
+    },
+  } as unknown as Parameters<typeof webContext.setWebDeps>[0]);
+});
+
+beforeEach(() => {
+  activeInitiator = null;
+  lastInitiatorJid = null;
+  try {
+    db.removeGroupMember(GROUP_FOLDER, OWNER_ID);
+    db.removeGroupMember(GROUP_FOLDER, MEMBER_ID);
+  } catch {
+    /* ignore */
+  }
+  try {
+    db.deleteRegisteredGroup(GROUP_JID);
+  } catch {
+    /* ignore */
+  }
+});
+
+afterEach(() => {
+  delete process.env.HAPPYCLAW_TEST_USER_ID;
+  delete process.env.HAPPYCLAW_TEST_USER_ROLE;
+});
+
+for (const route of ['/stop', '/interrupt'] as const) {
+  describe(`POST /:jid${route} resource-level ACL`, () => {
+    test('owner is allowed (200)', async () => {
+      seedTestGroup();
+      asUser(OWNER_ID);
+      activeInitiator = MEMBER_ID; // even when someone else initiated
+      const { status } = await post(route);
+      expect(status).toBe(200);
+    });
+
+    test('shared member who initiated the run is allowed (200)', async () => {
+      seedTestGroup();
+      asUser(MEMBER_ID);
+      activeInitiator = MEMBER_ID;
+      const { status } = await post(route);
+      expect(status).toBe(200);
+    });
+
+    test('shared member is denied when the owner initiated the run (403)', async () => {
+      seedTestGroup();
+      asUser(MEMBER_ID);
+      activeInitiator = OWNER_ID;
+      const { status, body } = await post(route);
+      expect(status).toBe(403);
+      expect(body.error).toMatch(/owner or the run initiator/i);
+    });
+
+    test('shared member is denied when there is no active initiator (403)', async () => {
+      seedTestGroup();
+      asUser(MEMBER_ID);
+      activeInitiator = null;
+      const { status } = await post(route);
+      expect(status).toBe(403);
+    });
+
+    test('non-member gets 404 (group hidden by canAccessGroup)', async () => {
+      seedTestGroup();
+      asUser(OUTSIDER_ID);
+      activeInitiator = OUTSIDER_ID; // irrelevant — fails canAccessGroup first
+      const { status, body } = await post(route);
+      expect(status).toBe(404);
+      expect(body.error).toMatch(/not found/i);
+    });
+  });
+}
+
+describe('interrupt resolves the initiator by the FULL #agent: jid', () => {
+  test('passes the full virtual jid (not baseJid) to getActiveRunInitiator', async () => {
+    seedTestGroup();
+    asUser(MEMBER_ID); // non-owner → canModifyGroup false → getActiveRunInitiator IS consulted
+    activeInitiator = MEMBER_ID;
+    const agentJid = `${GROUP_JID}#agent:abc`;
+    const res = await groupRoutes.request(
+      `/${encodeURIComponent(agentJid)}/interrupt`,
+      { method: 'POST' },
+    );
+    expect(res.status).toBe(200); // member is the agent run's initiator
+    // The route must look up the AGENT runner (full jid), not the base group.
+    expect(lastInitiatorJid).toBe(agentJid);
+  });
+});


### PR DESCRIPTION
## 问题描述

`POST /api/groups/:jid/stop`（停止容器）和 `/interrupt`（中断查询）原先只校验 `canAccessGroup` —— 任何共享工作区成员都能停止/中断 **owner 正在运行的容器和查询**，这是越权。

直接收紧为 `canModifyGroup`（owner-only）会引入相反的 UX 回归：共享成员将无法中断**自己发起**的查询。因此正确做法是**资源级**判断 —— 看"当前正在跑的 run 是不是你发起的"（参照 `DELETE /:jid/messages/:messageId` 的 owner-or-sender 模型）。

本 PR 是 #518 ACL 收紧的后续项之一（见 `docs/ACL-MATRIX.md` 的「待后续 PR 修复的」）。

## 实现方案（方案 A：单一发起者）

在 queue 层追踪"当前消息 run 的发起者"，stop/interrupt 改为 `canModifyGroup(owner)` **或** 发起者本人才放行，否则 403。

### `src/group-queue.ts`
- `GroupState` 新增 `currentRunInitiator: string | null`。
- `enqueueMessageCheck(jid, initiatorUserId?)`：该 jid 启动一个新消息 run 时记录发起者（仅显式传入时覆盖，内部 drain re-enqueue 不传 → 不抹掉 pending 发起者）；运行中注入（coalesce）的消息走 inject 分支，**不改**发起者。
- `runForGroup` 的 idle finally 清空 `currentRunInitiator`。
- 新增 `getActiveRunInitiator(jid)`：按 serialization key 解析活跃 runner，**门控 `!activeRunnerIsTask`** —— task / agent 会话 / 终端预热 run 一律返回 null → owner-only。（这一门控堵住了：裸 base-jid 的 terminal-warmup task 复用同一 `GroupState` 时，会读到一个仍排队的成员消息的 `currentRunInitiator`，从而让成员能停 owner 的 task run。）

### `src/web.ts`
- `enqueueMessageCheck(chatJid, userId)` 把 web 发送者作为发起者传入。

### `src/routes/groups.ts`
- stop / interrupt：`canAccessGroup`（可见性，非成员 404 隐藏）之后，`canModifyGroup(owner)` 或 `getActiveRunInitiator(jid) === authUser.id`，否则 403。
- interrupt 用完整（可能含 `#agent:`）jid 解析发起者，用 `baseJid` 做 `canModifyGroup`。

### 测试
- `tests/group-queue-initiator.test.ts`：发起者记录 / 注入者不改 / idle 清空 / 无发起者 → null / **task run 不暴露 pending 发起者** / sibling serialization-key 解析。
- `tests/routes-stop-interrupt-acl.test.ts`：owner / 发起者成员 / 非发起者成员 / 非成员 四象限 × stop+interrupt，外加 interrupt 传完整 `#agent:` jid 的解析断言。

## 已知限制（方案 A 的取舍，均为安全方向）

以下场景成员会"降级到 owner-only"（拿不到停/中断权，但**绝不越权** —— 只有 owner 或真正的发起者能操作）：

- **容量排队期**：run 还在等并发槽位（未 active）时，`getActiveRunInitiator` 返回 null（只对 active run 暴露发起者）。
- **重试 / 重启恢复**：失败重试与崩溃恢复经内部 re-enqueue（不带发起者）→ null。
- **task / agent 会话 / 终端预热 run**：本就无消息发起者 → owner-only。
- **多成员排队竞争**：两个成员在 run 启动前都排队时 last-writer-wins，run 归后者。

## ⚠️ 请 reviewer 定夺：合并（coalescing）run 的归属语义

方案 A 把一个 run 归属于**单一发起者**，运行中注入的消息**不改**发起者。一个直接后果：

> 成员 Bob 的 run 正在跑（发起者 = Bob），owner Alice 发一条消息合并（注入）进 Bob 的 run。此时这个 run 同时处理 Bob 和 Alice 的消息，但归属仍是 Bob → **Bob 能停/中断这个夹带了 owner 消息的 run**。

这在日常多人聊天里就会发生（无需特殊时机）。它是方案 A 的固有取舍（"发起者拥有整个 run，含后合并进来的消息"），**不是 bug**，且核心安全目标已达成（成员无法停一个**纯** owner 的 run；owner 的消息也不会丢，只是被中断后重新处理）。

如果希望"owner 的消息一旦合并进来，这个 run 就不该被非 owner 停"，可收紧为 **coalescing-clear**：一个 run 只要合并了 >1 个不同用户的消息就清空发起者 → owner-only。代价是成员在多人聊天里只要 owner 插一句，就停不了自己的 run。

倾向哪种语义？需要的话可以跟一个 PR 实现 coalescing-clear。

## 后续（可选）

- **前端按钮收口**：本 PR 只动后端 ACL，非发起者在 UI 上仍能看到"停止/中断"按钮，点击会收到 403。可作为小 follow-up：后端把"当前发起者"通过 WS/接口暴露，前端对非发起者隐藏按钮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
