### PR TITLE
修复: host agent 派生时剥离 XPC_FLAGS,避免后台启动下 DNS 解析失败

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1449,6 +1449,18 @@ export async function runHostAgent(
     ...(process.env as Record<string, string>),
   };
 
+  // Strip macOS launch-context vars that must not be inherited by child
+  // processes. When happyclaw is started by a background process manager
+  // (pm2 / launchd / ssh / cron) outside a normal login session, XPC_FLAGS=0x2
+  // leaks into the environment. The bundled bun/CFNetwork-based claude CLI then
+  // can't reach mDNSResponder/securityd through XPC, so DNS resolution and the
+  // system CA store fail and every model request dies with FailedToOpenSocket.
+  // Plain Node uses its own resolver/TLS stack and is unaffected, which is why
+  // this only breaks the host agent. The var is meaningless to a child spawned
+  // in a different way, so dropping it restores normal name resolution. No-op
+  // on non-macOS hosts (the var does not exist there).
+  delete hostEnv['XPC_FLAGS'];
+
   // ─── Provider Pool selection (host mode) ───
   const containerOverride = getContainerEnvConfig(group.folder);
   const hostPoolResult = trySelectPoolProvider(group.folder, input.agentId);


### PR DESCRIPTION
## 问题描述

在 macOS 上,当 happyclaw 由**后台进程管理器**(pm2 / launchd / ssh / cron 等,即非正常登录会话)启动时,host 模式下派生的 Agent 会持续报 `API Error: Unable to connect to API`,SDK 日志里是 `FailedToOpenSocket` / `ConnectionRefused`,重试 11 次后退出。

诡异之处:同一台机器上,手动 `curl`、`node fetch`、甚至**直接运行 SDK 自带的同一个 claude 二进制**都能正常连上 API(HTTP 200)——唯独 happyclaw 派生出来的 Agent 连不上。

> 注:与 provider 类型**无关**。官方 `api.anthropic.com` 与第三方 base URL 一样会失败——因为失败发生在"解析 API 域名"这一步,对任何域名都成立(实测同一上下文里连 `github.com` 也解析不了)。

## 根因

SDK 自带的 claude CLI 是 **bun** 编译的二进制,联网走 macOS 系统网络/安全栈(CFNetwork / Security),其 DNS 解析与系统 CA 证书读取都要**通过 XPC 访问系统守护进程**(mDNSResponder / securityd)。

当 happyclaw 由后台进程管理器(daemon 化、脱离登录会话)启动时,环境里会带上 `XPC_FLAGS=0x2`(macOS 标记"非会话托管"的启动上下文)。这个变量经 `{ ...process.env }` 一路继承给 host agent 的 bun CLI 后,导致它的 CFNetwork 接入系统守护进程的 XPC 通道处于受限上下文:

- DNS 解析失败(系统 keychain 也读不到:日志 `CA certs: system store returned empty`)
- 于是每个模型请求都 `FailedToOpenSocket`

而普通 Node(主进程)用自带的 c-ares + OpenSSL,不依赖这套系统栈,所以不受影响——这正是"主进程一切正常、只有 host agent 挂"的判别特征。

## 复现路径

1. macOS 上用 pm2(或任何 daemon 化的进程管理器)在非登录会话里启动 happyclaw
2. 以 host 模式跑一个 Agent(provider 官方 / 第三方均可,与本问题无关)
3. 期望:Agent 正常调用模型
4. 实际:`Unable to connect to API` / `FailedToOpenSocket`,但同机直跑 SDK 二进制可连通

定位方法:对比"登录会话 shell 环境"与"pm2 子进程环境"运行同一 bun 二进制做 A/B 复现,dump 两边环境变量逐项二分,锁定 `XPC_FLAGS=0x2` 为唯一触发变量(`delete` 或置 `0x0` 后立即恢复)。

## 触发条件

需要两个条件叠加(因此非普适,但对自建用户真实可踩):

1. **后台启动**(daemon 化 → `XPC_FLAGS=0x2`):pm2 / launchd / ssh / cron 等非登录会话方式
2. **DNS 走系统解析器**:尤其是 fake-ip TUN 代理(Clash/Surge 这类)把所有域名解析劫持到 mDNSResponder 时必现;此时受限 XPC 上下文的 bun 够不到该守护进程

## 必要性

`XPC_FLAGS` 是 macOS 按"进程如何启动"现场打的标记,**本就不应被以不同方式启动的子进程继承**——把它透传给 host agent 在语义上是错的。这里的修复属于**派生子进程时的环境卫生**,与相邻已有的 `delete hostEnv['ANTHROPIC_AUTH_TOKEN']` 同类。

症状极具误导性(看起来像网络 / relay / 鉴权问题,实则是启动上下文),且修复成本是一行、零副作用:

- 在 **Linux** 上 `XPC_FLAGS` 根本不存在,`delete` 是 no-op,对绝大多数 Docker 部署毫无影响
- 在 macOS 登录会话里启动时该变量本就是 `0x0`,删除等价于默认

## 修复方案

### `src/container-runner.ts`

构建 host agent 环境变量(`hostEnv`)后、派生进程前,剥离这个不该被继承的启动上下文变量:

```ts
const hostEnv: Record<string, string> = { ...(process.env as Record<string, string>) };
// ...
delete hostEnv['XPC_FLAGS'];
```

子进程的 bun/CFNetwork 找不到该变量即回退默认(等价 `0x0`)→ 正常通过 XPC 访问 mDNSResponder / securityd → DNS 解析与系统 CA 恢复 → Agent 正常连接模型。
