### PR TITLE
修复: 注册在非官方目录下的 marketplace 不会被插件 catalog 扫描发现

### DIFF
--- a/src/plugin-importer.ts
+++ b/src/plugin-importer.ts
@@ -1,9 +1,16 @@
 /**
  * plugin-importer.ts
  *
- * Scan host marketplaces (default `~/.claude/plugins/marketplaces`, override via
- * SystemSettings.externalClaudeDir) and import each plugin into the immutable
- * catalog snapshot tree.
+ * Scan host marketplaces and import each plugin into the immutable catalog
+ * snapshot tree. The set of marketplaces is the UNION of:
+ *   - physical subdirs of `<externalDir>/plugins/marketplaces/` (where Claude
+ *     Code clones github-source marketplaces), and
+ *   - every `installLocation` registered in
+ *     `<externalDir>/plugins/known_marketplaces.json` — the only place a
+ *     `directory`-source marketplace (referenced in place, never copied into
+ *     marketplaces/) is recorded.
+ * `<externalDir>` defaults to `~/.claude`, overridable via
+ * SystemSettings.externalClaudeDir.
  *
  * Properties guaranteed:
  * - **Single concurrent scan per process**: a module-level mutex serializes
@@ -96,7 +103,6 @@ export function isScanInFlight(): boolean {
 // --- Internal scan implementation --------------------------------------------
 
 async function runScan(opts: ScanOptions): Promise<ImportReport> {
-  const root = resolveScanRoot(opts);
   const report: ImportReport = {
     marketplacesScanned: 0,
     pluginsScanned: 0,
@@ -108,26 +114,15 @@ async function runScan(opts: ScanOptions): Promise<ImportReport> {
   // Ensure catalog root exists so writes don't have to mkdir each time.
   fs.mkdirSync(getCatalogRoot(), { recursive: true });
 
-  let mpEntries: string[];
-  try {
-    mpEntries = fs.readdirSync(root);
-  } catch (err) {
-    const msg = `Marketplace root not readable at ${root}: ${
-      err instanceof Error ? err.message : String(err)
-    }`;
-    logger.warn({ root, err }, 'plugin-importer: marketplace root unreadable');
-    report.warnings.push(msg);
-    return report;
-  }
+  const marketplaces = resolveMarketplaceDirs(opts, report);
 
   const idx = readCatalogIndex();
 
-  for (const mpName of mpEntries) {
+  for (const { name: mpName, dir: mpDir } of marketplaces) {
     if (!isValidNameSegment(mpName)) {
       report.warnings.push(`Skipped invalid marketplace name: ${mpName}`);
       continue;
     }
-    const mpDir = path.join(root, mpName);
     let mpStat: fs.Stats;
     try {
       mpStat = fs.statSync(mpDir);
@@ -255,11 +250,139 @@ async function runScan(opts: ScanOptions): Promise<ImportReport> {
   return report;
 }
 
-function resolveScanRoot(opts: ScanOptions): string {
+/** A marketplace root directory resolved for scanning. */
+interface ResolvedMarketplace {
+  name: string;
+  /** Path to the marketplace root directory. */
+  dir: string;
+}
+
+/**
+ * Resolve the set of marketplace directories to scan, as the union of two
+ * sources (deduped by name; the known-registry entry wins on collision —
+ * github entries resolve to the same dir as the physical clone anyway):
+ *
+ *   (a) physical subdirectories of `<externalDir>/plugins/marketplaces/`, and
+ *   (b) every `installLocation` in `<externalDir>/plugins/known_marketplaces
+ *       .json`. This is the ONLY place a `directory`-source marketplace
+ *       appears: Claude Code references it in place (never copying into
+ *       marketplaces/), so a readdir of marketplaces/ alone can never discover
+ *       it. `installLocation` points at the real on-disk dir for github AND
+ *       directory sources, so it is a uniform anchor regardless of `source`
+ *       shape.
+ *
+ * Non-fatal problems (unreadable marketplaces/ root, malformed
+ * known_marketplaces.json) push a warning onto `report` so a partial host
+ * layout is visible in the scan result rather than failing silently.
+ */
+function resolveMarketplaceDirs(
+  opts: ScanOptions,
+  report: ImportReport,
+): ResolvedMarketplace[] {
+  // Legacy explicit-directory source: treat the given path as a container root
+  // whose subdirectories are marketplaces. Kept for API compatibility; no
+  // production caller currently passes this.
   if (opts.source && opts.source.type === 'directory') {
-    return opts.source.path;
+    return readMarketplacesRoot(opts.source.path, report);
   }
-  return path.join(getEffectiveExternalDir(), 'plugins', 'marketplaces');
+
+  const pluginsBase = path.join(getEffectiveExternalDir(), 'plugins');
+  const byName = new Map<string, ResolvedMarketplace>();
+
+  // (a) physical marketplaces/ subdirs (github-source clones live here).
+  for (const mp of readMarketplacesRoot(
+    path.join(pluginsBase, 'marketplaces'),
+    report,
+  )) {
+    byName.set(mp.name, mp);
+  }
+
+  // (b) known_marketplaces.json installLocation entries (directory sources
+  // only appear here). Registry wins on name collision.
+  for (const mp of readKnownMarketplaces(pluginsBase, report)) {
+    byName.set(mp.name, mp);
+  }
+
+  return [...byName.values()];
+}
+
+/**
+ * List the immediate subdirectories of a marketplaces container `root` as
+ * candidate marketplaces. Names are NOT validated here — the caller's main
+ * loop validates each `name` against `isValidNameSegment` and warns, matching
+ * the historical behaviour. An unreadable `root` (e.g. a host with no
+ * plugins/marketplaces dir) yields a warning + empty list rather than throwing.
+ */
+function readMarketplacesRoot(
+  root: string,
+  report: ImportReport,
+): ResolvedMarketplace[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch (err) {
+    const msg = `Marketplace root not readable at ${root}: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    logger.warn({ root, err }, 'plugin-importer: marketplace root unreadable');
+    report.warnings.push(msg);
+    return [];
+  }
+  return entries.map((name) => ({ name, dir: path.join(root, name) }));
+}
+
+/**
+ * Read Claude Code's `<pluginsBase>/known_marketplaces.json` and return one
+ * entry per registered marketplace, anchored on its `installLocation` (the
+ * real on-disk path). Non-throwing: a missing file is normal (returns []); a
+ * malformed file warns and returns []. Names are validated by the caller.
+ */
+function readKnownMarketplaces(
+  pluginsBase: string,
+  report: ImportReport,
+): ResolvedMarketplace[] {
+  const file = path.join(pluginsBase, 'known_marketplaces.json');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch {
+    // No registry file (or unreadable). Normal on hosts that only have
+    // marketplaces/ clones — not worth a warning.
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = `known_marketplaces.json parse failed at ${file}: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    logger.warn(
+      { file, err },
+      'plugin-importer: known_marketplaces.json parse failed',
+    );
+    report.warnings.push(msg);
+    return [];
+  }
+  // Reject arrays too (`typeof [] === 'object'`): a CC registry is always an
+  // object map. An array would otherwise fall through to Object.entries() and
+  // be iterated as bogus marketplaces named "0", "1", … (numeric keys pass
+  // isValidNameSegment).
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+
+  const out: ResolvedMarketplace[] = [];
+  for (const [name, rawEntry] of Object.entries(
+    parsed as Record<string, unknown>,
+  )) {
+    if (!rawEntry || typeof rawEntry !== 'object') continue;
+    const loc = (rawEntry as Record<string, unknown>).installLocation;
+    if (typeof loc !== 'string' || loc.length === 0) continue;
+    // installLocation is documented as absolute; resolve defensively against
+    // the plugins dir if a relative path ever slips through (CC issue #23978).
+    const dir = path.isAbsolute(loc) ? loc : path.resolve(pluginsBase, loc);
+    out.push({ name, dir });
+  }
+  return out;
 }
 
 interface ImportPluginArgs {

--- a/src/routes/plugins.ts
+++ b/src/routes/plugins.ts
@@ -517,9 +517,12 @@ pluginsRoutes.get('/catalog/marketplaces/:mp', authMiddleware, async (c) => {
 });
 
 // POST /catalog/scan — trigger an immediate host scan + import. Admin-only:
-// scanning hits arbitrary host paths under `getEffectiveExternalDir()/plugins/
-// marketplaces/*` and copies them into the shared catalog. Member roles must
-// not influence what plugins become available system-wide.
+// scanning copies into the shared catalog from `getEffectiveExternalDir()/
+// plugins/marketplaces/*` AND from any `installLocation` registered in
+// `known_marketplaces.json` (covers directory-source marketplaces living
+// outside marketplaces/). Those are paths the host admin has themselves
+// registered in Claude Code, so they're within the existing trust boundary —
+// but member roles still must not influence what becomes available system-wide.
 pluginsRoutes.post('/catalog/scan', authMiddleware, async (c) => {
   const authUser = c.get('user') as AuthUser;
   if (authUser.role !== 'admin') {

--- a/tests/plugin-importer.test.ts
+++ b/tests/plugin-importer.test.ts
@@ -24,19 +24,16 @@ const catalog = await import('../src/plugin-catalog.js');
 const { scanHostMarketplaces, hashDirectoryContents } = importer;
 const { readCatalogIndex, getCatalogSnapshotDir } = catalog;
 
-function seedHostPlugin(opts: {
+/** Seed a marketplace under an arbitrary container `baseDir`. */
+function seedMarketplaceAt(opts: {
+  baseDir: string;
   marketplace: string;
   plugin: string;
   pluginManifest: Record<string, unknown>;
   marketplaceManifest?: Record<string, unknown>;
   files?: Record<string, string>;
 }) {
-  const mpDir = path.join(
-    tmpHostDir,
-    'plugins',
-    'marketplaces',
-    opts.marketplace,
-  );
+  const mpDir = path.join(opts.baseDir, opts.marketplace);
   const pluginDir = path.join(mpDir, 'plugins', opts.plugin);
   fs.mkdirSync(path.join(pluginDir, '.claude-plugin'), { recursive: true });
   fs.writeFileSync(
@@ -57,7 +54,40 @@ function seedHostPlugin(opts: {
       fs.writeFileSync(full, content);
     }
   }
+  return { mpDir, pluginDir };
+}
+
+/** Seed a marketplace under the conventional `<host>/plugins/marketplaces/`. */
+function seedHostPlugin(opts: {
+  marketplace: string;
+  plugin: string;
+  pluginManifest: Record<string, unknown>;
+  marketplaceManifest?: Record<string, unknown>;
+  files?: Record<string, string>;
+}) {
+  const { pluginDir } = seedMarketplaceAt({
+    ...opts,
+    baseDir: path.join(tmpHostDir, 'plugins', 'marketplaces'),
+  });
   return pluginDir;
+}
+
+/** Ensure an empty `<host>/plugins/marketplaces/` exists (no clones). */
+function seedEmptyMarketplacesRoot(): void {
+  fs.mkdirSync(path.join(tmpHostDir, 'plugins', 'marketplaces'), {
+    recursive: true,
+  });
+}
+
+/** Write `<host>/plugins/known_marketplaces.json` (Claude Code's registry). */
+function seedKnownMarketplaces(entries: Record<string, unknown>): void {
+  seedKnownMarketplacesRaw(JSON.stringify(entries));
+}
+
+function seedKnownMarketplacesRaw(raw: string): void {
+  const file = path.join(tmpHostDir, 'plugins', 'known_marketplaces.json');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, raw);
 }
 
 beforeEach(() => {
@@ -474,9 +504,243 @@ describe('scanHostMarketplaces', () => {
   });
 
   test('missing host root produces a warning, not a throw', async () => {
-    // tmpHostDir exists but has no plugins/marketplaces subdir
+    // tmpHostDir exists but has no plugins/marketplaces subdir AND no
+    // known_marketplaces.json — nothing to scan, but must warn not throw.
     const r = await scanHostMarketplaces();
     expect(r.marketplacesScanned).toBe(0);
     expect(r.warnings.length).toBeGreaterThan(0);
+  });
+
+  test('discovers a directory-source marketplace via known_marketplaces.json', async () => {
+    // wx-cli style: the marketplace lives OUTSIDE plugins/marketplaces/ and is
+    // registered only by its installLocation in known_marketplaces.json. A
+    // readdir of marketplaces/ alone (old behaviour) could never find it.
+    seedEmptyMarketplacesRoot();
+    const { mpDir } = seedMarketplaceAt({
+      baseDir: path.join(tmpHostDir, 'external'),
+      marketplace: 'wx-cli',
+      plugin: 'wx-cli',
+      pluginManifest: { name: 'wx-cli', version: '0.2.0' },
+      files: { 'commands/send.md': 'send body' },
+    });
+    seedKnownMarketplaces({
+      'wx-cli': {
+        source: { source: 'directory', path: mpDir },
+        installLocation: mpDir,
+      },
+    });
+
+    const report = await scanHostMarketplaces();
+    expect(report.marketplacesScanned).toBe(1);
+    expect(report.pluginsScanned).toBe(1);
+    expect(report.snapshotsCreated).toBe(1);
+
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.plugins)).toEqual(['wx-cli@wx-cli']);
+    expect(idx.marketplaces['wx-cli'].sourcePath).toBe(mpDir);
+  });
+
+  test('unions marketplaces/ clones with known_marketplaces.json directory sources', async () => {
+    // (a) a github-style clone physically under marketplaces/
+    seedHostPlugin({
+      marketplace: 'official',
+      plugin: 'p-official',
+      pluginManifest: { name: 'p-official', version: '1.0.0' },
+      files: { 'commands/a.md': 'a' },
+    });
+    // (b) a directory-source marketplace registered elsewhere
+    const { mpDir } = seedMarketplaceAt({
+      baseDir: path.join(tmpHostDir, 'external'),
+      marketplace: 'local-dir',
+      plugin: 'p-local',
+      pluginManifest: { name: 'p-local', version: '1.0.0' },
+      files: { 'commands/b.md': 'b' },
+    });
+    seedKnownMarketplaces({ 'local-dir': { installLocation: mpDir } });
+
+    const report = await scanHostMarketplaces();
+    expect(report.marketplacesScanned).toBe(2);
+    expect(report.pluginsScanned).toBe(2);
+
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.plugins).sort()).toEqual(
+      ['p-local@local-dir', 'p-official@official'].sort(),
+    );
+  });
+
+  test('dedupes a marketplace present in both marketplaces/ and known_marketplaces.json', async () => {
+    // github sources appear in BOTH: a physical clone under marketplaces/ AND
+    // a known_marketplaces.json entry whose installLocation points at that same
+    // dir. Must scan/import once — never double-count or double-import.
+    seedHostPlugin({
+      marketplace: 'official',
+      plugin: 'codex',
+      pluginManifest: { name: 'codex', version: '1.0.0' },
+      files: { 'commands/a.md': 'a' },
+    });
+    const physicalDir = path.join(
+      tmpHostDir,
+      'plugins',
+      'marketplaces',
+      'official',
+    );
+    seedKnownMarketplaces({
+      official: {
+        source: { source: 'github', repo: 'x/official' },
+        installLocation: physicalDir,
+      },
+    });
+
+    const report = await scanHostMarketplaces();
+    expect(report.marketplacesScanned).toBe(1);
+    expect(report.pluginsScanned).toBe(1);
+    expect(report.snapshotsCreated).toBe(1);
+
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.plugins)).toEqual(['codex@official']);
+    // Single marketplace row too — not just a single plugin key.
+    expect(Object.keys(idx.marketplaces)).toEqual(['official']);
+  });
+
+  test('falls back to marketplaces/ only when known_marketplaces.json is absent', async () => {
+    seedHostPlugin({
+      marketplace: 'mp1',
+      plugin: 'p1',
+      pluginManifest: { name: 'p1', version: '1.0.0' },
+      files: { 'commands/run.md': 'body' },
+    });
+    // No seedKnownMarketplaces() → registry file absent. Must not warn or crash.
+    const report = await scanHostMarketplaces();
+    expect(report.marketplacesScanned).toBe(1);
+    expect(report.pluginsScanned).toBe(1);
+    expect(
+      report.warnings.some((w) => w.includes('known_marketplaces')),
+    ).toBe(false);
+  });
+
+  test('malformed known_marketplaces.json warns but does not block marketplaces/ scan', async () => {
+    seedHostPlugin({
+      marketplace: 'mp1',
+      plugin: 'p1',
+      pluginManifest: { name: 'p1', version: '1.0.0' },
+      files: { 'commands/run.md': 'body' },
+    });
+    seedKnownMarketplacesRaw('{ not valid json');
+
+    const report = await scanHostMarketplaces();
+    // marketplaces/ clone still imported despite the bad registry file.
+    expect(report.pluginsScanned).toBe(1);
+    expect(
+      report.warnings.some((w) => w.includes('known_marketplaces.json')),
+    ).toBe(true);
+  });
+
+  test('resolves a relative installLocation against the plugins dir', async () => {
+    // Defensive: CC normally writes absolute paths, but guard the relative
+    // case (CC issue #23978). 'rel-mp' resolves to <host>/plugins/rel-mp.
+    seedEmptyMarketplacesRoot();
+    const { mpDir } = seedMarketplaceAt({
+      baseDir: path.join(tmpHostDir, 'plugins'),
+      marketplace: 'rel-mp',
+      plugin: 'p-rel',
+      pluginManifest: { name: 'p-rel', version: '1.0.0' },
+      files: { 'commands/a.md': 'a' },
+    });
+    seedKnownMarketplaces({ 'rel-mp': { installLocation: 'rel-mp' } });
+
+    const report = await scanHostMarketplaces();
+    expect(report.pluginsScanned).toBe(1);
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.plugins)).toEqual(['p-rel@rel-mp']);
+    expect(idx.marketplaces['rel-mp'].sourcePath).toBe(mpDir);
+  });
+
+  test('skips registry entries with missing/empty/non-string installLocation or non-object value', async () => {
+    // Exercises every per-entry guard in readKnownMarketplaces: a missing
+    // installLocation, empty string, non-string, null entry and primitive
+    // entry must all be skipped (no throw) while valid entries still import.
+    // The empty-string case is load-bearing: without the `length === 0` guard,
+    // '' would resolve to the plugins base dir itself and pollute the catalog.
+    seedHostPlugin({
+      marketplace: 'clone',
+      plugin: 'p-clone',
+      pluginManifest: { name: 'p-clone', version: '1.0.0' },
+      files: { 'commands/a.md': 'a' },
+    });
+    const { mpDir } = seedMarketplaceAt({
+      baseDir: path.join(tmpHostDir, 'external'),
+      marketplace: 'good',
+      plugin: 'p-good',
+      pluginManifest: { name: 'p-good', version: '1.0.0' },
+      files: { 'commands/b.md': 'b' },
+    });
+    seedKnownMarketplaces({
+      good: { installLocation: mpDir },
+      noLoc: { source: { source: 'github', repo: 'x/y' } },
+      emptyLoc: { installLocation: '' },
+      numLoc: { installLocation: 123 },
+      nullEntry: null,
+      strEntry: 'oops',
+    });
+
+    const report = await scanHostMarketplaces();
+    // Only the clone + 'good' import; the five malformed entries are skipped.
+    expect(report.marketplacesScanned).toBe(2);
+    expect(report.pluginsScanned).toBe(2);
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.marketplaces).sort()).toEqual(['clone', 'good']);
+  });
+
+  test('skips a stale installLocation (deleted dir or a regular file) without throwing', async () => {
+    // The directory-source feature's most likely real-world failure mode: a
+    // registry entry whose installLocation was removed, or now points at a
+    // file. readKnownMarketplaces does not stat — runScan's statSync (throw →
+    // continue) and !isDirectory() guards must absorb both, no bogus count.
+    seedHostPlugin({
+      marketplace: 'clone',
+      plugin: 'p-clone',
+      pluginManifest: { name: 'p-clone', version: '1.0.0' },
+      files: { 'commands/a.md': 'a' },
+    });
+    const ghostDir = path.join(tmpHostDir, 'external', 'ghost'); // never created
+    const filePath = path.join(tmpHostDir, 'external', 'not-a-dir');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'i am a file');
+    seedKnownMarketplaces({
+      ghost: { installLocation: ghostDir },
+      fileMp: { installLocation: filePath },
+    });
+
+    const report = await scanHostMarketplaces();
+    // Both stale entries skipped; only the marketplaces/ clone imports.
+    expect(report.marketplacesScanned).toBe(1);
+    expect(report.pluginsScanned).toBe(1);
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.marketplaces)).toEqual(['clone']);
+  });
+
+  test('rejects an array-shaped known_marketplaces.json without polluting the catalog', async () => {
+    // `typeof [] === 'object'`, so without the Array.isArray guard an array
+    // registry would be iterated as marketplaces named "0", "1", …
+    seedHostPlugin({
+      marketplace: 'clone',
+      plugin: 'p-clone',
+      pluginManifest: { name: 'p-clone', version: '1.0.0' },
+      files: { 'commands/a.md': 'a' },
+    });
+    const { mpDir } = seedMarketplaceAt({
+      baseDir: path.join(tmpHostDir, 'external'),
+      marketplace: 'arr',
+      plugin: 'p-arr',
+      pluginManifest: { name: 'p-arr', version: '1.0.0' },
+    });
+    seedKnownMarketplacesRaw(JSON.stringify([{ installLocation: mpDir }]));
+
+    const report = await scanHostMarketplaces();
+    // Array registry ignored; only the marketplaces/ clone imports.
+    expect(report.pluginsScanned).toBe(1);
+    const idx = readCatalogIndex();
+    expect(Object.keys(idx.marketplaces)).toEqual(['clone']);
+    expect(idx.marketplaces['0']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 问题描述

使用时发现，通过 Claude Code 的 `known_marketplaces.json` 注册的 **directory 源** marketplace（位于 `~/.claude/plugins/marketplaces/` 之外、被 Claude Code 原地引用而非克隆）即便已注册，也不会被 HappyClaw 的插件 catalog 扫描发现，因而无法在 UI 中启用。

**根因**：`scanHostMarketplaces` / `runScan` 只 `readdir` `~/.claude/plugins/marketplaces/*`，从不读取 Claude Code 的 `known_marketplaces.json`。directory 源 marketplace 不会被克隆到 `marketplaces/` 下，只在 `known_marketplaces.json` 以 `installLocation` 登记，因此对 catalog 完全不可见。

## 修复方案

### `src/plugin-importer.ts`（核心）

- 新增 `resolveMarketplaceDirs()`：把扫描目标从「单个 `marketplaces/` 目录」改为两个来源的**并集**——
  - (a) `marketplaces/` 下的物理子目录（github 源克隆所在）；
  - (b) `known_marketplaces.json` 中每条记录的 `installLocation`（directory 源唯一登记处）。
- 以 `installLocation` 为锚点，对 `source` 形状（`github` / `directory`）不敏感；按 marketplace 名去重（registry 优先；与物理 clone 路径一致时幂等，不会重复导入）。
- 拆出 `readMarketplacesRoot` / `readKnownMarketplaces` 两个非抛出 helper；`known_marketplaces.json` 缺失 / 解析失败 / 数组形态（`Array.isArray` 守卫）时优雅回退，不影响 `marketplaces/*` 扫描。
- per-marketplace 导入逻辑、快照内容哈希、catalog 目录布局、admin-only 扫描门槛**均未改动**。

### `src/routes/plugins.ts`

- 更新 `POST /catalog/scan` 注释：扫描范围现含 registry 登记的外部 `installLocation`（仍是管理员自己在 Claude Code 注册的路径，信任边界不变）。

### `tests/plugin-importer.test.ts`

- 新增用例：directory 源发现、与 `marketplaces/*` 并集、同名去重、`known_marketplaces.json` 缺失 / 损坏 / 数组形态回退、缺失 / 空串 / 非字符串 `installLocation`、stale installLocation（目录被删 / 指向文件）、相对 `installLocation` 解析。
- `tsc --noEmit` 通过；`plugin-importer` 23 个用例全绿。

## 范围说明

本 PR 仅修复**发现层**。importer 仍假设插件位于 `mpDir/plugins/{name}/`，**不**解析 marketplace.json 的 `plugins[].source`——非标准布局（如单插件在仓库根 `source: "."`）仍不被认，但会通过既有 warning（如 `has no plugins/ directory`）显式暴露，属 marketplace 作者侧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
