### PR TITLE
修复: WebSocket Origin 校验拒绝同源请求导致新会话无法发消息

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -963,14 +963,25 @@ function setupWebSocket(server: any): WebSocketServer {
     // CORS preflight。SameSite=Strict cookie 是当前的主防御，origin 检查
     // 是纵深防御 —— SameSite 实现不严的 UA / future SameSite=Lax 回退会
     // 直接暴露 CSWSH（跨站 WebSocket 劫持）。Origin 缺失（同源、无浏览器
-    // origin）放行；存在但不在白名单则拒绝。
+    // origin）放行；同源放行；存在但不在白名单则拒绝。
     const origin = request.headers.origin as string | undefined;
     if (origin) {
-      const allowed = isAllowedOrigin(origin);
-      if (!allowed) {
-        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
-        socket.destroy();
-        return;
+      // 同源请求放行：比较 Origin 的 host 与 Host header
+      const host = request.headers.host as string | undefined;
+      let sameOrigin = false;
+      if (host) {
+        try {
+          const originHost = new URL(origin).host;
+          sameOrigin = originHost === host;
+        } catch { /* invalid origin */ }
+      }
+      if (!sameOrigin) {
+        const allowed = isAllowedOrigin(origin);
+        if (!allowed) {
+          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+          socket.destroy();
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## 问题描述

ed775b8 新增的 CSWSH 防护对 WebSocket 升级请求做了 Origin 白名单校验，但 `isAllowedOrigin()` 只放行 localhost 和 `CORS_ALLOWED_ORIGINS` 白名单，未处理同源请求。

通过域名或非 localhost IP 访问时，浏览器发出的 Origin header 不匹配任何白名单条目，WebSocket 连接被 403 Forbidden 拒绝。

**症状**：创建新会话发消息时提示 "WebSocket 未连接，输入已保留，请稍后重试"，主会话不受影响。

**原因**：主会话走 HTTP POST `/api/messages`（同源请求不需要 CORS），新会话/Agent 对话走 WebSocket `send_message`，WS 连接被 Origin 校验挡掉。

## 修复方案

### `src/web.ts`

在 Origin 白名单校验前增加同源检查：比较 `Origin` header 的 host 与 HTTP `Host` header，匹配则视为同源请求直接放行，不再走白名单校验。

```
Origin: https://example.com:3000
Host: example.com:3000
→ 同源，放行
```

跨站请求（Origin ≠ Host）仍走原有的 `isAllowedOrigin()` 白名单逻辑，CSWSH 防护不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)