### PR TITLE
功能: web:main 作为 active-admins 共享 admin home + 运行时身份隔离 (#519)

### DIFF
--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -39,6 +39,13 @@ export interface ContainerInput {
    * host absolute path for host mode).
    */
   plugins?: Array<{ type: 'local'; path: string }>;
+  /**
+   * Whose plugins / MCP / global memory this run loads (the message sender on
+   * the shared web:main home, #519). The runtime owner is realized entirely by
+   * the launcher's mounts/loads in container-runner; agent-runner does not read
+   * this field. Kept here only to keep the ContainerInput mirror symmetric.
+   */
+  runtimeOwnerId?: string | null;
   /** Runtime context audit bootstrap from the host/container launcher. */
   contextAudit?: ClaudeContextAudit;
 }

--- a/docs/ACL-MATRIX.md
+++ b/docs/ACL-MATRIX.md
@@ -7,7 +7,7 @@ Issue #518 follow-up。记录所有 Web API / WebSocket / IM 操作的权限级�
 | 级别 | 函数 / 中间件 | 含义 |
 |------|--------------|------|
 | Login | `authMiddleware` | 已登录即可 |
-| Access | `canAccessGroup(user, group)` | owner 或 `group_members` 成员 |
+| Access | `canAccessGroup(user, group)` | owner 或 `group_members` 成员；**例外**：`web:main`（admin home）对所有 active admin 开放（见下方说明 + #519） |
 | Modify | `canModifyGroup(user, group)` | 仅 owner（`created_by`） |
 | Delete | `canDeleteGroup(user, group)` | 仅 owner，且非 home group |
 | ManageMembers | `canManageGroupMembers(user, group)` | 仅 owner，且非 home group |
@@ -20,6 +20,8 @@ Issue #518 follow-up。记录所有 Web API / WebSocket / IM 操作的权限级�
 | Public | 无 | 无需认证 |
 
 > **补充说明**：所有涉及 host 执行模式的群组操作，在基础 ACL 检查之上，还会额外检查 `isHostExecutionGroup(group) && hasHostExecutionPermission(user)`，非 admin 无法操作 host 模式群组。下表中标注 `+HostPerm` 表示此额外检查。
+
+> **`web:main` admin 共享例外（issue #519 option B）**：`web:main`（`folder === 'main'`，全库唯一的 admin home）的 **Access 不是 owner-only**——所有 active admin 都可访问，即所有走 `canAccessGroup` 的操作（读/发消息、文件、任务、agents、env 等）对 active admin 开放，由 `canAdminShareMainHome()`（`src/main-home-acl.ts`）放开。但其 **Modify / Delete / ManageMembers 仍是 owner-only**（`created_by`）：第二个 admin 看得到 `web:main` 也能在里面协作，但不能 rename / reset-session / 改成员。这条"访问放开、修改收紧"的非对称是刻意的，详见 `docs/ADMIN-SHARED-WORKSPACE.md`。
 
 ## HTTP 路由
 

--- a/docs/ADMIN-SHARED-WORKSPACE.md
+++ b/docs/ADMIN-SHARED-WORKSPACE.md
@@ -67,19 +67,55 @@ remains owner-only (`created_by`).
 
 ## Known follow-ups (NOT in this slice)
 
-- **Steps 3–4 — runtime isolation.** Cold-start already resolves the runtime
-  owner per active-admin sender (`src/index.ts processGroupMessages`), so a
-  cold run writes global memory to the correct admin. The remaining gap: when
-  admin A's runner is **already active**, admin B's IPC-injected message
-  executes under admin A's loaded plugin/MCP runtime. This is a correctness
-  issue between mutually-trusted admins (not a privilege escalation), to be
-  closed by threading `runtimeOwnerId` through the runner
-  (`ContainerInput.runtimeOwnerId`) and guarding active-runner owner mismatch
-  in the queue. These touch `src/index.ts` / `src/container-runner.ts` /
-  `src/group-queue.ts` and are sequenced as separate PRs.
-- **Frontend button gating.** A second admin sees the `web:main` rename/reset
-  controls (payload `editable: true`) but the owner-only `canModifyGroup` will
-  return 403 — same frontend-shows / backend-enforces pattern as elsewhere.
+- **Steps 3–4 — runtime isolation: DONE for web senders and IM-bound agents.**
+  `runtimeOwnerId` now threads through the runner
+  (`ContainerInput.runtimeOwnerId` → plugins / MCP / user-global memory),
+  `GroupQueue.sendMessage` guards active-runner owner mismatch via
+  `injectOwnerId` (mismatch defers to a fresh cold-start), and the
+  agent-conversation path (`processAgentConversation` + `buildOnAgentMessage`)
+  resolves and pins the per-run owner the same way the main conversation does —
+  closing the sub-agent gap where admin B's agent conversation ran under the
+  bootstrap admin's plugins/MCP and wrote B's memory into the bootstrap admin's
+  user-global directory. Agent conversations additionally prefer the agent's own
+  `created_by` (auto_im agents stamp the binding admin) as the cold-start
+  fallback, so IM-bound agents isolate even though their senders are open_ids.
+- **IM-origin sender on the MAIN conversation — residual.** Runtime owner
+  resolution is *sender-based*, and only senders that map to a HappyClaw user id
+  (web senders) constrain the runtime. An IM message routed to the shared
+  `web:main` **main** conversation carries an open_id sender that maps to no
+  user, so `resolveInjectionOwnerConstraint` / `resolveAdminSharedRuntimeOwner`
+  treat it as "no constraint" and it injects into / cold-starts under whichever
+  active-admin runtime applies (active runner's owner, or the workspace
+  fallback) rather than the IM sender's own. The owning admin IS derivable
+  (`message.source_jid` → source group `created_by`); wiring that mapping into
+  the resolvers (so IM-origin main-conversation traffic isolates like web and
+  agent traffic) is follow-up. This is pre-existing (carried over from the
+  prior latest-sender resolver), not introduced by this slice.
+- **Mixed-admin batch residual.** When messages from two or more active
+  admins accumulate into one pending batch — the window is the remainder of
+  any active run (up to `containerTimeout`) plus any capacity wait, NOT just
+  one poll cycle — the injection constraint resolves to the
+  `MIXED_ADMIN_BATCH` sentinel (`src/runtime-owner.ts`), so the batch always
+  defers instead of piping into one admin's live runtime. Two caveats: (a) the
+  sentinel only counts *web-identifiable* admins, so a batch mixing one IM
+  (open_id) admin and one web admin resolves to the single web admin (see the
+  IM-origin residual above); (b) the subsequent cold-start pins the WHOLE batch
+  to the latest active-admin sender (`resolveAdminSharedRuntimeOwner`).
+  Per-message runtime within one run is impossible — one process = one mount set
+  (plugins / MCP / memory are fixed at spawn) — so splitting a mixed batch into
+  per-admin cold-starts is the remaining follow-up.
+- **Three-identity decoupling.** `created_by` / `runtimeOwnerId` /
+  `actorUserId` (see the identity split above) are still partially conflated
+  downstream: cold-start rewrites `effectiveGroup.created_by` to carry the
+  runtime owner, so usage attribution and other consumers follow the runtime
+  owner rather than receiving the three identities as explicit, independent
+  parameters. Decoupling them is follow-up work.
+- **Modify vs delete on `web:main`.** `canModifyGroup` now admits any active
+  admin on `web:main` (rename / reset / `/clear` / agent + skill management),
+  symmetric with `canAccessGroup`, so a second admin's controls are backed by the
+  API — not a frontend-shows / backend-403 mismatch. Deletion stays blocked for
+  every `is_home` group (`canDeleteGroup` returns false outright), so the shared
+  home cannot be deleted by anyone.
 - **IM siblings of the main folder.** A personal IM channel (feishu/telegram)
   bound to the `main` folder produces a non-home jid (`is_home=false`). Two
   related gaps follow, both rooted in sibling selection being owner-scoped rather

--- a/docs/ADMIN-SHARED-WORKSPACE.md
+++ b/docs/ADMIN-SHARED-WORKSPACE.md
@@ -1,0 +1,96 @@
+# Admin-shared `web:main` workspace (issue #519)
+
+This document **locks** the product/architecture decision for the `web:main`
+workspace so the ACL, UI, and runner layers stop disagreeing about it.
+
+## Decision: option B — active-admins-SHARED
+
+`web:main` (the admin home, `folder = 'main'`) is the **shared admin home
+workspace for every active admin**, NOT an owner-only home.
+
+- **Option A (rejected):** `web:main` is owner-only — only the bootstrap admin
+  recorded in `created_by` may use it.
+- **Option B (chosen):** `web:main` is shared by all active admins. The data
+  layer already behaves this way — `db.ts getUserHomeGroup()` falls back to
+  `web:main` for any active admin without an own home row, and
+  `ensureUserHomeGroup()` reuses the single `web:main` row for every admin
+  rather than minting one per admin. Option A would mean unwinding that, so we
+  formalize B.
+
+There is exactly **one** `web:main` row; `is_home && folder === 'main'`
+uniquely identifies it (see `src/main-home-acl.ts`).
+
+## Identity split
+
+Opening access alone is not enough — three distinct identities must not be
+conflated:
+
+| Identity | Meaning |
+|---|---|
+| `created_by` | Workspace **metadata owner** — the bootstrap admin who first materialized `web:main`. Still governs *modify* (rename/reset), which stays owner-only. |
+| `runtimeOwnerId` | Whose plugins / MCP / skills / global memory **this run** loads. On `web:main` this is the message *sender* (per-admin), not `created_by`. |
+| `actorUserId` | Who is being **audited / permission-checked** for a given action. |
+
+## What this slice implements (steps 1–2)
+
+- **Step 1 — semantics locked:** this document + the existing per-sender
+  runtime-owner tests (`plugin-expander-*`) + `tests/main-home-acl.test.ts`.
+- **Step 2 — list / access / broadcast opened to active admins:**
+  - `src/main-home-acl.ts` — pure predicates `isMainHome()` /
+    `canAdminShareMainHome()` (single source of the rule).
+  - `canAccessGroup()` (`src/web-context.ts`) — active admins may access
+    `web:main` (messages, files, tasks, agents, workspace-config: all 54
+    call sites of `canAccessGroup` inherit this). This is deliberate: the
+    contents of `web:main` (conversation agents, scheduled tasks, files) become
+    collaboratively manageable by every active admin — the same model a shared
+    web workspace already gives its `group_members`. Per-admin privacy of items
+    *inside* the shared workspace is explicitly NOT a goal; only workspace
+    metadata (rename/reset/members) stays owner-only.
+
+  Session-cache note: `canAdminShareMainHome` keys on `user.role`, and the auth
+  session cache (`SESSION_CACHE_TTL_MS`, 30s) holds a copy of the role. So
+  `admin.ts` invalidates a user's cached session on role/permission change —
+  otherwise a just-demoted admin would keep `role:'admin'` (and thus `web:main`
+  access) for up to the TTL.
+  - `buildGroupsPayload()` (`src/routes/groups.ts`) — `web:main` is listed for
+    every active admin, and `is_my_home` is true for them (so the sidebar home
+    slot, default chat selection, and IM-binding panel resolve).
+  - `computeGroupAllowedUserIds()` (`src/web.ts`) — every active admin receives
+    `web:main` broadcasts (`getActiveAdminIds()`). `web:main` is the one group
+    whose allow-set depends on the live admin roster, so `getGroupAllowedUserIds`
+    bypasses the 10s TTL cache for it — a promoted/demoted/re-enabled admin
+    starts/stops receiving immediately, with no roster→cache invalidation hook
+    needed in `admin.ts`.
+
+`canModifyGroup()` is intentionally **unchanged**: renaming/resetting `web:main`
+remains owner-only (`created_by`).
+
+## Known follow-ups (NOT in this slice)
+
+- **Steps 3–4 — runtime isolation.** Cold-start already resolves the runtime
+  owner per active-admin sender (`src/index.ts processGroupMessages`), so a
+  cold run writes global memory to the correct admin. The remaining gap: when
+  admin A's runner is **already active**, admin B's IPC-injected message
+  executes under admin A's loaded plugin/MCP runtime. This is a correctness
+  issue between mutually-trusted admins (not a privilege escalation), to be
+  closed by threading `runtimeOwnerId` through the runner
+  (`ContainerInput.runtimeOwnerId`) and guarding active-runner owner mismatch
+  in the queue. These touch `src/index.ts` / `src/container-runner.ts` /
+  `src/group-queue.ts` and are sequenced as separate PRs.
+- **Frontend button gating.** A second admin sees the `web:main` rename/reset
+  controls (payload `editable: true`) but the owner-only `canModifyGroup` will
+  return 403 — same frontend-shows / backend-enforces pattern as elsewhere.
+- **IM siblings of the main folder.** A personal IM channel (feishu/telegram)
+  bound to the `main` folder produces a non-home jid (`is_home=false`). Two
+  related gaps follow, both rooted in sibling selection being owner-scoped rather
+  than admin-roster-scoped:
+  - *Broadcast:* an IM sibling's `computeGroupAllowedUserIds` resolves to owner +
+    `group_members`, NOT all active admins — so a second admin sees web-sourced
+    `web:main` messages live but an admin's IM-sourced message only on reload.
+  - *Message merge (read):* `GET /api/groups/web:main/messages` merges siblings
+    via `ownerMatch || adminSelfMatch` (same `created_by`, or the caller's own IM
+    channels), so admin C does not see admin B's IM-sibling history — despite the
+    `// admin: merge all siblings in the folder` comment in `routes/groups.ts`
+    overstating it. Both want "merge all active-admin siblings on `folder==='main'`".
+  Live/read parity here belongs with the folder-level broadcast work, not this slice.
+- **Regression tests for the scheduled-task mixed-admin batch** (step 5).

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -228,6 +228,13 @@ export interface ContainerInput {
    * plugins.json; never set by the caller.
    */
   plugins?: Array<{ type: 'local'; path: string }>;
+  /**
+   * Whose plugins / MCP servers / user-global memory this run loads. For the
+   * active-admins-shared web:main home (#519), this is the message *sender* —
+   * not group.created_by (the workspace metadata owner). Falls back to
+   * group.created_by when unset, so non-shared groups behave exactly as before.
+   */
+  runtimeOwnerId?: string | null;
   /** Runtime context audit bootstrap; agent-runner enriches it with SDK usage. */
   contextAudit?: ClaudeContextAudit;
 }
@@ -523,13 +530,25 @@ export function buildVolumeMounts(
   ownerHomeFolder?: string,
   taskRunId?: string,
   resolvedProvider?: ResolvedProvider,
+  /**
+   * Runtime owner override (#519): whose user-global memory + MCP servers to
+   * mount/load. Defaults to group.created_by when unset.
+   */
+  ownerOverride?: string | null,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
 
   // Per-user global memory directory:
-  // Each user gets their own user-global/{userId}/ mounted as /workspace/global
-  const ownerId = group.created_by;
+  // Each user gets their own user-global/{userId}/ mounted as /workspace/global.
+  // ownerOverride lets the shared web:main home (#519) mount the message
+  // sender's global memory instead of the metadata owner's.
+  // Note: user *skills* still ride group.created_by (via buildClaudeContextPlan
+  // below) rather than ownerOverride. That is correct today — the cold-start
+  // rewrite keeps created_by == the runtime owner, so they never diverge — and
+  // routing skills through the override is a follow-up for when the three-identity
+  // decoupling removes that rewrite.
+  const ownerId = ownerOverride ?? group.created_by;
   if (ownerId) {
     const userGlobalDir = path.join(GROUPS_DIR, 'user-global', ownerId);
     mkdirForContainer(userGlobalDir);
@@ -950,6 +969,7 @@ export async function runContainerAgent(
       ownerHomeFolder,
       input.taskRunId,
       resolvedProvider,
+      input.runtimeOwnerId ?? group.created_by,
     );
     const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
     const agentSuffix = input.agentId
@@ -1004,10 +1024,11 @@ export async function runContainerAgent(
       });
       // Derive a new input with docker-runtime plugins injected; never mutate
       // the caller's `input` object (queue/log/retry paths reuse the same ref).
+      const dockerRuntimeOwner = input.runtimeOwnerId ?? group.created_by;
       const dockerInput: ContainerInput = {
         ...input,
-        plugins: group.created_by
-          ? loadUserPlugins(group.created_by, { runtime: 'docker' })
+        plugins: dockerRuntimeOwner
+          ? loadUserPlugins(dockerRuntimeOwner, { runtime: 'docker' })
           : [],
         contextAudit: buildClaudeContextPlan({
           executionMode: 'container',
@@ -1429,7 +1450,8 @@ export async function runHostAgent(
   // 3. 写入 settings.json（合并模式，不覆盖已有用户配置）
   // Load user's global MCP servers (same logic as Docker mode).
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
-  const hostMcpServers = group.created_by ? loadUserMcpServers(group.created_by) : {};
+  const hostMcpOwner = input.runtimeOwnerId ?? group.created_by;
+  const hostMcpServers = hostMcpOwner ? loadUserMcpServers(hostMcpOwner) : {};
   ensureSettingsJson(settingsFile, hostMcpServers);
 
   // 4. Skills / Rules / CLAUDE.md 自动链接到 session 目录
@@ -1586,7 +1608,7 @@ export async function runHostAgent(
 
     if (!disableMemoryLayer) {
       // Per-user global memory（HappyClaw 自带 memory 层）
-      const ownerId = group.created_by;
+      const ownerId = input.runtimeOwnerId ?? group.created_by;
       if (ownerId) {
         const userGlobalDir = path.join(GROUPS_DIR, 'user-global', ownerId);
         fs.mkdirSync(userGlobalDir, { recursive: true });
@@ -1775,7 +1797,7 @@ export async function runHostAgent(
       // plugins.
       const hostInput: ContainerInput = {
         ...input,
-        plugins: prepareHostPlugins(group.created_by),
+        plugins: prepareHostPlugins(input.runtimeOwnerId ?? group.created_by),
         contextAudit: hostClaudeContextPlan.audit,
       };
       proc.stdin.write(JSON.stringify(hostInput));

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -811,6 +811,13 @@ export function buildVolumeMounts(
   if (sysSettings.subagentModel && sysSettings.subagentModel !== 'inherit') {
     envLines.push(`SUBAGENT_MODEL=${sysSettings.subagentModel}`);
   }
+  // Per-user MCP servers (whose env/headers may carry credentials) ride the
+  // 0600 env-dir file — sourced by entrypoint into the container's process env —
+  // NOT the `docker run -e` argv, which is visible via `ps`/`docker inspect`
+  // (#519 review). agent-runner reads HAPPYCLAW_USER_MCP_SERVERS_JSON env-first.
+  for (const [key, value] of Object.entries(buildUserMcpEnv(ownerId))) {
+    envLines.push(`${key}=${value}`);
+  }
   if (envLines.length > 0) {
     const envFilePath = path.join(envDir, 'env');
     const quotedLines = shellQuoteEnvLines(envLines);
@@ -923,20 +930,15 @@ function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   tz: string,
-  extraEnv?: Record<string, string>,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
-  // Set timezone so container Node.js processes use local time (Asia/Shanghai)
+  // Set timezone so container Node.js processes use local time (Asia/Shanghai).
+  // NOTE: per-run secrets (Claude creds, per-user MCP server env/headers) are
+  // NEVER passed via `-e` — they would be visible on the `docker run` argv
+  // (`ps aux`) and in `docker inspect`. They ride the 0600 env-dir file mounted
+  // at /workspace/env-dir (sourced by entrypoint) instead. See buildVolumeMounts.
   args.push('-e', `TZ=${tz}`);
-
-  // Per-run env (e.g. per-user MCP servers). Spawned via an arg array, so each
-  // value is passed literally with no shell interpretation.
-  if (extraEnv) {
-    for (const [key, value] of Object.entries(extraEnv)) {
-      args.push('-e', `${key}=${value}`);
-    }
-  }
 
   // Docker: -v with :ro suffix for readonly
   for (const mount of mounts) {
@@ -1013,12 +1015,7 @@ export async function runContainerAgent(
     // Runtime owner for this run (#519): on the shared web:main home this is the
     // message sender, not group.created_by. MCP servers ride it per-run via env.
     const dockerRuntimeOwner = input.runtimeOwnerId ?? group.created_by;
-    const containerArgs = buildContainerArgs(
-      mounts,
-      containerName,
-      TIMEZONE,
-      buildUserMcpEnv(dockerRuntimeOwner),
-    );
+    const containerArgs = buildContainerArgs(mounts, containerName, TIMEZONE);
 
     logger.debug(
       {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -159,11 +159,19 @@ const REQUIRED_SETTINGS_ENV: Record<string, string> = {
   CLAUDE_CODE_DISABLE_ATTACHMENTS: '1',
 };
 
-/** Read existing settings.json, deep-merge required env keys and mcpServers, write only if changed */
-function ensureSettingsJson(
-  settingsFile: string,
-  mcpServers?: Record<string, Record<string, unknown>>,
-): void {
+/**
+ * Read existing settings.json, force the required env keys, and DROP any
+ * persisted `mcpServers` block, writing only if the content changed.
+ *
+ * Per-user MCP servers are injected per-run via the HAPPYCLAW_USER_MCP_SERVERS_JSON
+ * env var (ephemeral, derived from the run's runtime owner — mirrors how plugins
+ * are injected) and are no longer persisted into this per-folder file. Pruning here
+ * also self-heals files written by older builds, where a previous runtime owner's
+ * MCP servers (and their credentials) would otherwise additively accumulate and
+ * leak into the next owner's run on a shared workspace — web:main is shared by every
+ * active admin (#519).
+ */
+export function ensureSettingsJson(settingsFile: string): void {
   let existing: Record<string, unknown> = {};
   try {
     if (fs.existsSync(settingsFile)) {
@@ -177,11 +185,9 @@ function ensureSettingsJson(
   const mergedEnv = { ...existingEnv, ...REQUIRED_SETTINGS_ENV };
   const merged: Record<string, unknown> = { ...existing, env: mergedEnv };
 
-  // Merge user-configured MCP servers into settings
-  if (mcpServers && Object.keys(mcpServers).length > 0) {
-    const existingMcp = (existing.mcpServers as Record<string, unknown>) || {};
-    merged.mcpServers = { ...existingMcp, ...mcpServers };
-  }
+  // MCP servers are injected per-run via env, never persisted into this shared
+  // per-folder file. Drop any block left by this or an older build.
+  delete merged.mcpServers;
 
   const newContent = JSON.stringify(merged, null, 2) + '\n';
 
@@ -196,6 +202,22 @@ function ensureSettingsJson(
   }
 
   fs.writeFileSync(settingsFile, newContent, { mode: 0o644 });
+}
+
+/**
+ * Per-run MCP server env for a given runtime owner. Injected into the agent
+ * process (host: `hostEnv`; docker: `-e`) instead of the shared per-folder
+ * settings.json, so on a shared workspace each runtime owner only ever sees
+ * their own MCP servers (#519). agent-runner's loadUserMcpServers() reads this
+ * env first; the empty `{}` is set explicitly so it overrides any mcpServers a
+ * stale settings.json from an older build still carries. Symmetric with the
+ * per-run plugin injection (loadUserPlugins → ContainerInput.plugins).
+ */
+export function buildUserMcpEnv(
+  ownerId: string | null | undefined,
+): Record<string, string> {
+  const servers = ownerId ? loadUserMcpServers(ownerId) : {};
+  return { HAPPYCLAW_USER_MCP_SERVERS_JSON: JSON.stringify(servers) };
 }
 
 export interface ContainerInput {
@@ -626,9 +648,12 @@ export function buildVolumeMounts(
     groupSessionsDir,
     mountUserSkills,
   });
+  // Per-user MCP servers are injected per-run via env (see buildUserMcpEnv,
+  // passed as `-e` in runContainerAgent), not persisted into this per-folder
+  // settings.json — otherwise a previous runtime owner's servers would leak
+  // into the next owner's run on a shared workspace (#519).
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
-  const mcpServers = ownerId ? loadUserMcpServers(ownerId) : {};
-  ensureSettingsJson(settingsFile, mcpServers);
+  ensureSettingsJson(settingsFile);
 
   mounts.push({
     hostPath: groupSessionsDir,
@@ -898,11 +923,20 @@ function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   tz: string,
+  extraEnv?: Record<string, string>,
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Set timezone so container Node.js processes use local time (Asia/Shanghai)
   args.push('-e', `TZ=${tz}`);
+
+  // Per-run env (e.g. per-user MCP servers). Spawned via an arg array, so each
+  // value is passed literally with no shell interpretation.
+  if (extraEnv) {
+    for (const [key, value] of Object.entries(extraEnv)) {
+      args.push('-e', `${key}=${value}`);
+    }
+  }
 
   // Docker: -v with :ro suffix for readonly
   for (const mount of mounts) {
@@ -976,7 +1010,15 @@ export async function runContainerAgent(
       ? `-${input.agentId.replace(/[^a-zA-Z0-9-]/g, '-')}`
       : '';
     const containerName = `happyclaw-${safeName}${agentSuffix}-${Date.now()}`;
-    const containerArgs = buildContainerArgs(mounts, containerName, TIMEZONE);
+    // Runtime owner for this run (#519): on the shared web:main home this is the
+    // message sender, not group.created_by. MCP servers ride it per-run via env.
+    const dockerRuntimeOwner = input.runtimeOwnerId ?? group.created_by;
+    const containerArgs = buildContainerArgs(
+      mounts,
+      containerName,
+      TIMEZONE,
+      buildUserMcpEnv(dockerRuntimeOwner),
+    );
 
     logger.debug(
       {
@@ -1024,7 +1066,6 @@ export async function runContainerAgent(
       });
       // Derive a new input with docker-runtime plugins injected; never mutate
       // the caller's `input` object (queue/log/retry paths reuse the same ref).
-      const dockerRuntimeOwner = input.runtimeOwnerId ?? group.created_by;
       const dockerInput: ContainerInput = {
         ...input,
         plugins: dockerRuntimeOwner
@@ -1447,12 +1488,12 @@ export async function runHostAgent(
   const localJson = path.join(groupSessionsDir, '.claude.json');
   ensureSymlinkTo(localJson, ensureHostClaudeJson());
 
-  // 3. 写入 settings.json（合并模式，不覆盖已有用户配置）
-  // Load user's global MCP servers (same logic as Docker mode).
+  // 3. 写入 settings.json（仅强制必需 env keys）。per-user MCP servers 改走 env
+  //    透传（见下方 hostEnv），不再写入 per-folder 的 settings.json，避免共享
+  //    web:main 上跨 runtime owner 的 MCP/凭据泄漏（#519）。
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
   const hostMcpOwner = input.runtimeOwnerId ?? group.created_by;
-  const hostMcpServers = hostMcpOwner ? loadUserMcpServers(hostMcpOwner) : {};
-  ensureSettingsJson(settingsFile, hostMcpServers);
+  ensureSettingsJson(settingsFile);
 
   // 4. Skills / Rules / CLAUDE.md 自动链接到 session 目录
   const hostClaudeContextPlan = buildClaudeContextPlan({
@@ -1645,12 +1686,12 @@ export async function runHostAgent(
       for (const [key, value] of Object.entries(REQUIRED_SETTINGS_ENV)) {
         hostEnv[key] = value;
       }
-      // 同样，per-user MCP servers 通过 env 透传，agent-runner 合并进 SDK mcpServers 参数。
-      if (hostMcpServers && Object.keys(hostMcpServers).length > 0) {
-        hostEnv['HAPPYCLAW_USER_MCP_SERVERS_JSON'] =
-          JSON.stringify(hostMcpServers);
-      }
     }
+    // per-user MCP servers 一律通过 env 透传（per-run、不落盘，与 plugins 注入对称）：
+    // 不再写入 per-folder 的 settings.json，避免共享 web:main 上跨 runtime owner
+    // 的 MCP/凭据泄漏（#519）。空集也显式设置以覆盖旧版本残留的 settings.json
+    // 条目（agent-runner loadUserMcpServers() env 优先）。
+    Object.assign(hostEnv, buildUserMcpEnv(hostMcpOwner));
     // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败
     hostEnv['DEBUG_CLAUDE_AGENT_SDK'] = '1';
     // Claude Code 2.1.114+ 禁止 root 使用 --dangerously-skip-permissions，

--- a/src/db.ts
+++ b/src/db.ts
@@ -3728,6 +3728,20 @@ export function getActiveAdminCount(): number {
   return row.count;
 }
 
+/**
+ * Ids of every active admin. `web:main` is the active-admins-shared admin home
+ * (issue #519, option B), so these are the users who may access it and must
+ * receive its broadcasts — beyond the single bootstrap admin in `created_by`.
+ */
+export function getActiveAdminIds(): string[] {
+  const rows = db
+    .prepare(
+      `SELECT id FROM users WHERE role = 'admin' AND status = 'active'`,
+    )
+    .all() as Array<{ id: string }>;
+  return rows.map((r) => r.id);
+}
+
 export function updateUserFields(
   id: string,
   updates: Partial<

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -1332,6 +1332,8 @@ export class GroupQueue {
       state.groupFolder = null;
       state.agentId = null;
       state.taskRunId = null;
+      // #519: clear the per-run runtime owner, symmetric with runForGroup's finally.
+      state.runtimeOwnerId = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -57,6 +57,15 @@ interface GroupState {
    * Subsequent IPC-injected messages during an active run do NOT change it.
    */
   currentRunInitiator: string | null;
+  /**
+   * HappyClaw user id whose runtime (plugins / MCP / global memory) the current
+   * run loaded — the message sender on the active-admins-shared web:main home
+   * (#519 step 3/4), else the group's created_by. Stamped at registerProcess,
+   * cleared on idle. sendMessage() refuses to inject a different admin's message
+   * into this run (it would execute under the wrong admin's runtime); the caller
+   * starts a fresh run instead, whose cold-start re-resolves the owner.
+   */
+  runtimeOwnerId: string | null;
 }
 
 type ActiveGroupState = GroupState & { groupFolder: string };
@@ -116,6 +125,7 @@ export class GroupQueue {
         drainSentinelWritten: false,
         hasIpcInjectedMessages: false,
         currentRunInitiator: null,
+        runtimeOwnerId: null,
       };
       this.groups.set(groupJid, state);
     }
@@ -585,6 +595,8 @@ export class GroupQueue {
       agentId?: string;
       taskRunId?: string;
       selectedProviderId?: string | null;
+      /** Runtime owner of this run (#519): whose plugins/MCP/memory it loaded. */
+      runtimeOwnerId?: string | null;
     },
   ): void {
     const state = this.getGroup(groupJid);
@@ -595,6 +607,7 @@ export class GroupQueue {
     state.agentId = opts.agentId || null;
     state.taskRunId = opts.taskRunId || null;
     state.selectedProviderId = opts.selectedProviderId ?? null;
+    state.runtimeOwnerId = opts.runtimeOwnerId ?? null;
   }
 
   /**
@@ -638,9 +651,29 @@ export class GroupQueue {
     images?: Array<{ data: string; mimeType?: string }>,
     onInjected?: () => void,
     sourceJid?: string,
+    injectOwnerId?: string | null,
   ): SendMessageResult {
     const state = this.resolveActiveState(groupJid);
     if (!state) return 'no_active';
+
+    // #519 step 4: the active runner is loaded for one admin's runtime
+    // (plugins / MCP / global memory). Injecting a *different* admin's message
+    // would run it under the wrong admin's plugins and write to their memory.
+    // Defer to a fresh run instead — its cold-start re-resolves the runtime
+    // owner from the new sender. Only fires on the shared web:main home, where
+    // the new batch's owner differs from the run's owner; on every other group
+    // both equal created_by, so this is a no-op.
+    if (
+      injectOwnerId != null &&
+      state.runtimeOwnerId != null &&
+      injectOwnerId !== state.runtimeOwnerId
+    ) {
+      logger.debug(
+        { groupJid, injectOwnerId, activeOwner: state.runtimeOwnerId },
+        'GroupQueue.sendMessage: runtime owner mismatch, deferring to a fresh run',
+      );
+      return 'no_active';
+    }
 
     // If the active runner is a scheduled task (not a user-message handler),
     // do NOT pipe user messages into it.  The task container has no knowledge
@@ -1209,6 +1242,7 @@ export class GroupQueue {
       state.agentId = null;
       state.taskRunId = null;
       state.currentRunInitiator = null;
+      state.runtimeOwnerId = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import {
   getLastGroupSync,
   getRegisteredGroup,
   getUserById,
-  getActiveAdminIds,
+  getActiveAdminCount,
   getMessagesSince,
   getNewMessages,
   getRouterState,
@@ -3173,24 +3173,41 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     cursorCommitted = true;
   };
 
-  if (effectiveGroup.created_by) {
-    const owner = getUserById(effectiveGroup.created_by);
-    // Defense-in-depth: drop messages whose owner is no longer active
-    // (disabled or deleted). See `src/owner-gate.ts` for rationale.
-    const ownerGate = checkOwnerActive(owner);
-    if (!ownerGate.allowed) {
+  // Defense-in-depth owner gate (#519): web:main is shared by every active
+  // admin, so it gates on active-admin presence — NOT the bootstrap created_by,
+  // which may be a since-disabled/deleted admin (gating on it here re-introduced
+  // the exact lockout the message-loop / agent-conv gates were converted to fix,
+  // dropping IM-origin batches whose cold-start owner stayed the disabled
+  // bootstrap). Other groups still gate on their owner's status. Mirrors the
+  // startMessageLoop / processAgentConversation gates. See main-home-acl.ts.
+  {
+    const ownerGate = evaluateOwnerGate(effectiveGroup, {
+      hasActiveAdmin: () => getActiveAdminCount() > 0,
+      checkOwner: (id) => checkOwnerActive(getUserById(id)),
+    });
+    if (ownerGate.drop) {
       commitCursor();
       await setTyping(chatJid, false);
       logger.info(
-        {
-          chatJid,
-          userId: effectiveGroup.created_by,
-          ownerStatus: ownerGate.status,
-        },
-        'Dropping message: group owner is not active',
+        ownerGate.reason === 'inactive_owner'
+          ? {
+              chatJid,
+              userId: effectiveGroup.created_by,
+              ownerStatus: ownerGate.ownerStatus,
+            }
+          : { chatJid },
+        ownerGate.reason === 'inactive_owner'
+          ? 'Dropping message: group owner is not active'
+          : 'Dropping message: no active admin owns shared web:main',
       );
       return true;
     }
+  }
+  // Billing quota check. Only non-home / non-admin owners are metered; web:main's
+  // owner is an admin, so isMainHome groups (which passed the gate above) never
+  // reach here.
+  if (!isMainHome(effectiveGroup) && effectiveGroup.created_by) {
+    const owner = getUserById(effectiveGroup.created_by);
     if (owner && owner.role !== 'admin') {
       const accessResult = checkBillingAccessFresh(
         effectiveGroup.created_by,
@@ -6132,7 +6149,7 @@ async function processAgentConversation(
   // admin out of shared agent conversations); only drop when no active admin
   // remains. Other groups still gate on their owner's status.
   const ownerGate = evaluateOwnerGate(effectiveGroup, {
-    hasActiveAdmin: () => getActiveAdminIds().length > 0,
+    hasActiveAdmin: () => getActiveAdminCount() > 0,
     checkOwner: (id) => checkOwnerActive(getUserById(id)),
   });
   if (ownerGate.drop) {
@@ -7262,7 +7279,7 @@ async function startMessageLoop(): Promise<void> {
           // which may be a since-disabled/deleted admin. Other groups still gate
           // on their owner's status. See main-home-acl.ts / owner-gate.ts.
           const ownerGate = evaluateOwnerGate(group, {
-            hasActiveAdmin: () => getActiveAdminIds().length > 0,
+            hasActiveAdmin: () => getActiveAdminCount() > 0,
             checkOwner: (id) => checkOwnerActive(getUserById(id)),
           });
           if (ownerGate.drop) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
   getLastGroupSync,
   getRegisteredGroup,
   getUserById,
+  getActiveAdminIds,
   getMessagesSince,
   getNewMessages,
   getRouterState,
@@ -188,6 +189,7 @@ import {
   resolveAdminSharedRuntimeOwner,
 } from './runtime-owner.js';
 import { checkOwnerActive } from './owner-gate.js';
+import { isMainHome, evaluateOwnerGate } from './main-home-acl.js';
 import {
   ensureAgentDirectories,
   isSystemMaintenanceNoise,
@@ -6123,27 +6125,36 @@ async function processAgentConversation(
   // before it), so conversation-agent traffic only reaches this gate. When the
   // owner is disabled/deleted, advance the cursor past the pending messages so
   // they aren't replayed, then drop. See `src/owner-gate.ts` for rationale.
-  if (effectiveGroup.created_by) {
-    const ownerGate = checkOwnerActive(getUserById(effectiveGroup.created_by));
-    if (!ownerGate.allowed) {
-      const lastMsg = missedMessages[missedMessages.length - 1];
-      if (lastMsg) {
-        setCursors(virtualChatJid, {
-          timestamp: lastMsg.timestamp,
-          id: lastMsg.id,
-        });
-      }
-      logger.info(
-        {
-          chatJid,
-          agentId,
-          userId: effectiveGroup.created_by,
-          ownerStatus: ownerGate.status,
-        },
-        'Dropping agent conversation: owner is not active',
-      );
-      return;
+  // Shared web:main (#519): same gate as the main message loop — do not drop on
+  // the bootstrap `created_by` being inactive (that would lock every active
+  // admin out of shared agent conversations); only drop when no active admin
+  // remains. Other groups still gate on their owner's status.
+  const ownerGate = evaluateOwnerGate(effectiveGroup, {
+    hasActiveAdmin: () => getActiveAdminIds().length > 0,
+    checkOwner: (id) => checkOwnerActive(getUserById(id)),
+  });
+  if (ownerGate.drop) {
+    const lastMsg = missedMessages[missedMessages.length - 1];
+    if (lastMsg) {
+      setCursors(virtualChatJid, {
+        timestamp: lastMsg.timestamp,
+        id: lastMsg.id,
+      });
     }
+    logger.info(
+      ownerGate.reason === 'inactive_owner'
+        ? {
+            chatJid,
+            agentId,
+            userId: effectiveGroup.created_by,
+            ownerStatus: ownerGate.ownerStatus,
+          }
+        : { chatJid, agentId },
+      ownerGate.reason === 'inactive_owner'
+        ? 'Dropping agent conversation: owner is not active'
+        : 'Dropping agent conversation: no active admin owns shared web:main',
+    );
+    return;
   }
   if (missedMessages.length === 0) {
     // Spawn agents are fire-and-forget: if no messages are found (race condition
@@ -7206,31 +7217,40 @@ async function startMessageLoop(): Promise<void> {
           // to conversation agents at IM ingestion time (feishu.ts/telegram.ts)
           if (group.target_agent_id) continue;
 
-          // Owner gate + billing share a single owner lookup. Owner status
-          // check first: drop messages from groups whose owner is
-          // disabled/deleted (see `src/owner-gate.ts`); billing quota check
-          // second.
-          if (group.created_by) {
-            const owner = getUserById(group.created_by);
-            const ownerGate = checkOwnerActive(owner);
-            if (!ownerGate.allowed) {
-              const lastMsg = groupMessages[groupMessages.length - 1];
-              setCursors(chatJid, {
-                timestamp: lastMsg.timestamp,
-                id: lastMsg.id,
-              });
-              logger.info(
-                {
-                  chatJid,
-                  userId: group.created_by,
-                  ownerStatus: ownerGate.status,
-                },
-                'Dropping message: group owner is not active',
-              );
-              continue;
-            }
+          // Owner gate (#519): web:main is shared by every active admin, so it
+          // gates on active-admin presence — not the bootstrap `created_by`,
+          // which may be a since-disabled/deleted admin. Other groups still gate
+          // on their owner's status. See main-home-acl.ts / owner-gate.ts.
+          const ownerGate = evaluateOwnerGate(group, {
+            hasActiveAdmin: () => getActiveAdminIds().length > 0,
+            checkOwner: (id) => checkOwnerActive(getUserById(id)),
+          });
+          if (ownerGate.drop) {
+            const lastMsg = groupMessages[groupMessages.length - 1];
+            setCursors(chatJid, {
+              timestamp: lastMsg.timestamp,
+              id: lastMsg.id,
+            });
+            logger.info(
+              ownerGate.reason === 'inactive_owner'
+                ? {
+                    chatJid,
+                    userId: group.created_by,
+                    ownerStatus: ownerGate.ownerStatus,
+                  }
+                : { chatJid },
+              ownerGate.reason === 'inactive_owner'
+                ? 'Dropping message: group owner is not active'
+                : 'Dropping message: no active admin owns shared web:main',
+            );
+            continue;
+          }
 
-            // Billing quota check before processing
+          // Billing quota check before processing. Only non-home / non-admin
+          // owners are metered; web:main's owner is an admin, so isMainHome
+          // groups (which passed the gate above) never reach this.
+          if (!isMainHome(group) && group.created_by) {
+            const owner = getUserById(group.created_by);
             if (owner && owner.role !== 'admin') {
               const accessResult = checkBillingAccessFresh(
                 group.created_by,

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,7 @@ import { resolveTaskOwner } from './task-utils.js';
 import {
   resolvePerMessageRuntimeOwner,
   resolveAdminSharedRuntimeOwner,
+  resolveLatestAdminSenderOverride,
 } from './runtime-owner.js';
 import { checkOwnerActive } from './owner-gate.js';
 import { isMainHome, evaluateOwnerGate } from './main-home-acl.js';
@@ -7394,23 +7395,21 @@ async function startMessageLoop(): Promise<void> {
           const lastSourceJidForRoute =
             messagesToSend[messagesToSend.length - 1]?.source_jid || chatJid;
 
-          // #519 step 4: resolve this injection batch's runtime owner so we never
-          // pipe one admin's message into another admin's already-loaded runtime
-          // on the shared web:main home. On a mismatch sendMessage() returns
-          // 'no_active' → a fresh run is enqueued whose cold-start re-resolves the
-          // owner. On every other group this equals created_by → no behaviour change.
-          // IM-sibling senders (open_id, not a HappyClaw userId) fall back to
-          // created_by, so an IM message arriving mid-run under a different active
-          // owner is safely deferred to a fresh run rather than mis-injected.
+          // #519 step 4: the owner this injection batch *requires* (null = no
+          // constraint). On the shared web:main home, only an identifiable active-
+          // admin sender constrains the inject — so admin B's message never pipes
+          // into admin A's already-loaded runtime (mismatch → sendMessage returns
+          // 'no_active' → a fresh run cold-starts under B). IM-sibling senders
+          // (open_id, not a HappyClaw userId) resolve to null, so a same-admin IM
+          // follow-up still injects into that admin's active run instead of wrongly
+          // deferring to a bootstrap-owned fresh run (#8 — must NOT fall back to
+          // created_by here). On every non-web:main group injectOwnerId is null →
+          // the guard is a no-op (created_by == the run's owner there anyway).
           const { effectiveGroup: injEffectiveGroup } =
             resolveEffectiveGroup(group);
-          const injectOwnerId = resolveAdminSharedRuntimeOwner({
-            chatJid,
-            isHome: !!injEffectiveGroup.is_home,
-            fallbackOwner: injEffectiveGroup.created_by,
-            messages: messagesToSend,
-            getUserById,
-          });
+          const injectOwnerId = isMainHome(injEffectiveGroup)
+            ? resolveLatestAdminSenderOverride(messagesToSend, getUserById)
+            : null;
           const sendResult = queue.sendMessage(
             chatJid,
             formatted,

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,8 @@ import { resolveTaskOwner } from './task-utils.js';
 import {
   resolvePerMessageRuntimeOwner,
   resolveAdminSharedRuntimeOwner,
-  resolveLatestAdminSenderOverride,
+  resolveInjectionOwnerConstraint,
+  preferActiveAdminFallback,
 } from './runtime-owner.js';
 import { checkOwnerActive } from './owner-gate.js';
 import { isMainHome, evaluateOwnerGate } from './main-home-acl.js';
@@ -6111,7 +6112,7 @@ async function processAgentConversation(
   }
   if (!group) return;
 
-  const { effectiveGroup } = resolveEffectiveGroup(group);
+  let { effectiveGroup } = resolveEffectiveGroup(group);
 
   const virtualChatJid = `${chatJid}#agent:${agentId}`;
   const virtualJid = virtualChatJid; // used as queue key
@@ -6176,6 +6177,42 @@ async function processAgentConversation(
       );
     }
     return;
+  }
+
+  // Shared web:main (#519): agent conversations run under the latest active-
+  // admin sender's runtime — that admin's plugins/MCP load and global memory
+  // writes land in their own user-global directory, not the bootstrap admin's.
+  // The resolver strips the `#agent:` suffix (runtime-owner.ts baseJid gate),
+  // so the virtual JID gets web:main semantics. Rewriting effectiveGroup means
+  // every downstream consumer — the expander fallback ctx, registerProcess /
+  // containerInput runtimeOwnerId, and writeUsageRecords attribution — reads
+  // the rewritten created_by, intentionally consistent with the
+  // main-conversation cold-start path (processGroupMessages).
+  // IM-origin agent conversations carry open_id senders the sender walk cannot
+  // map to a HappyClaw admin, so it falls through to the fallback. auto_im
+  // agents stamp created_by = the binding admin (a reliable identity), so prefer
+  // it (when an active admin) over the bootstrap created_by — otherwise admin B's
+  // IM-bound agent would still run under admin A's plugins/MCP/memory, leaving the
+  // sub-agent leak open for the most common (IM-driven) flow.
+  const agentColdStartFallback = isMainHome(effectiveGroup)
+    ? preferActiveAdminFallback(
+        agent.created_by,
+        effectiveGroup.created_by,
+        getUserById,
+      )
+    : effectiveGroup.created_by;
+  const agentColdStartOwner = resolveAdminSharedRuntimeOwner({
+    chatJid: virtualChatJid,
+    isHome: !!effectiveGroup.is_home,
+    fallbackOwner: agentColdStartFallback,
+    messages: missedMessages,
+    getUserById,
+  });
+  if (
+    agentColdStartOwner &&
+    agentColdStartOwner !== effectiveGroup.created_by
+  ) {
+    effectiveGroup = { ...effectiveGroup, created_by: agentColdStartOwner };
   }
 
   const isHome = !!effectiveGroup.is_home;
@@ -6816,6 +6853,7 @@ async function processAgentConversation(
         displayName: identifier,
         agentId,
         selectedProviderId,
+        runtimeOwnerId: effectiveGroup.created_by,
       });
     };
 
@@ -6831,6 +6869,7 @@ async function processAgentConversation(
       agentId,
       agentName: agent.name,
       images: imagesForAgent,
+      runtimeOwnerId: effectiveGroup.created_by,
     };
 
     // Write tasks/groups snapshots
@@ -7395,20 +7434,30 @@ async function startMessageLoop(): Promise<void> {
           const lastSourceJidForRoute =
             messagesToSend[messagesToSend.length - 1]?.source_jid || chatJid;
 
-          // #519 step 4: the owner this injection batch *requires* (null = no
-          // constraint). On the shared web:main home, only an identifiable active-
-          // admin sender constrains the inject — so admin B's message never pipes
-          // into admin A's already-loaded runtime (mismatch → sendMessage returns
-          // 'no_active' → a fresh run cold-starts under B). IM-sibling senders
-          // (open_id, not a HappyClaw userId) resolve to null, so a same-admin IM
-          // follow-up still injects into that admin's active run instead of wrongly
-          // deferring to a bootstrap-owned fresh run (#8 — must NOT fall back to
-          // created_by here). On every non-web:main group injectOwnerId is null →
-          // the guard is a no-op (created_by == the run's owner there anyway).
+          // #519 step 4: the owner constraint this injection batch carries
+          // (null = no constraint). On the shared web:main home:
+          //   - exactly one identifiable active-admin sender → constrain the
+          //     inject to that admin (owner mismatch → sendMessage returns
+          //     'no_active' → a fresh run cold-starts under them);
+          //   - two or more distinct active-admin senders → MIXED_ADMIN_BATCH,
+          //     a sentinel matching no real user id, so the guard always
+          //     defers: a mixed-admin batch must never pipe into one admin's
+          //     live runtime. (The previous latest-sender resolution was
+          //     bypassable by interleave — batch [B_deferred, A_new] resolved
+          //     to A == the active owner, so B's text executed under A's
+          //     runtime.) The deferred cold-start still pins the whole mixed
+          //     batch to the latest active-admin sender — documented residual,
+          //     see docs/ADMIN-SHARED-WORKSPACE.md;
+          //   - IM-sibling senders (open_id, not a HappyClaw userId) → null,
+          //     so a same-admin IM follow-up still injects into that admin's
+          //     active run instead of wrongly deferring to a bootstrap-owned
+          //     fresh run (#8 — must NOT fall back to created_by here).
+          // On every non-web:main group injectOwnerId is null → the guard is
+          // a no-op (created_by == the run's owner there anyway).
           const { effectiveGroup: injEffectiveGroup } =
             resolveEffectiveGroup(group);
           const injectOwnerId = isMainHome(injEffectiveGroup)
-            ? resolveLatestAdminSenderOverride(messagesToSend, getUserById)
+            ? resolveInjectionOwnerConstraint(messagesToSend, getUserById)
             : null;
           const sendResult = queue.sendMessage(
             chatJid,
@@ -8459,6 +8508,24 @@ function buildOnAgentMessage(): (baseChatJid: string, agentId: string) => void {
 
       const lastAgentSourceJid =
         missedMessages[missedMessages.length - 1]?.source_jid || virtualChatJid;
+      // #519 step 4: same owner constraint as the main-loop injection site —
+      // the running agent process is loaded for one admin's runtime
+      // (registerProcess pins runtimeOwnerId), so a batch carrying a different
+      // admin's messages must defer to a fresh cold-start instead of piping
+      // into it. Never fall back to created_by here (#8 — IM open_id senders
+      // resolve to null so same-admin IM continuation still injects).
+      // Gate on the agent's WORKSPACE row (homeChatJid = agent.chat_jid, what
+      // the run actually targets), not the IM-binding row in `group` — a
+      // cross-folder /bind can make those diverge.
+      const workspaceRow =
+        registeredGroups[homeChatJid] ??
+        getRegisteredGroup(homeChatJid) ??
+        group;
+      const { effectiveGroup: agentInjEffectiveGroup } =
+        resolveEffectiveGroup(workspaceRow);
+      const injectOwnerId = isMainHome(agentInjEffectiveGroup)
+        ? resolveInjectionOwnerConstraint(missedMessages, getUserById)
+        : null;
       const sendResult = formatted
         ? queue.sendMessage(
             virtualChatJid,
@@ -8466,9 +8533,19 @@ function buildOnAgentMessage(): (baseChatJid: string, agentId: string) => void {
             imagesForAgent,
             undefined,
             lastAgentSourceJid,
+            injectOwnerId,
           )
         : 'no_active';
       if (sendResult === 'no_active') {
+        // A non-empty batch that returned 'no_active' was deferred by the #519
+        // owner-mismatch guard against a LIVE runner — drain it so the fresh
+        // cold-start starts promptly under the correct owner (mirrors the IM
+        // path above and the web.ts twin). Skip the drain when `formatted` is
+        // empty (no pending messages → nothing was deferred, so we must not
+        // tear down a warm idle runner for nothing).
+        if (formatted) {
+          queue.closeStdin(virtualChatJid);
+        }
         const taskId = `agent-conv:${agentId}:${Date.now()}`;
         queue.enqueueTask(virtualChatJid, taskId, async () => {
           await processAgentConversation(homeChatJid, agentId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,10 @@ import {
 } from './types.js';
 import { logger } from './logger.js';
 import { resolveTaskOwner } from './task-utils.js';
-import { resolvePerMessageRuntimeOwner } from './runtime-owner.js';
+import {
+  resolvePerMessageRuntimeOwner,
+  resolveAdminSharedRuntimeOwner,
+} from './runtime-owner.js';
 import { checkOwnerActive } from './owner-gate.js';
 import {
   ensureAgentDirectories,
@@ -2849,20 +2852,23 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   if (missedMessages.length === 0) return true;
 
-  // Admin home is shared as web:main, so select runtime owner from the latest
-  // active admin sender to avoid writing global memory into another admin's
-  // user-global directory.
-  if (chatJid === 'web:main' && effectiveGroup.is_home) {
-    for (let i = missedMessages.length - 1; i >= 0; i--) {
-      const sender = missedMessages[i]?.sender;
-      if (!sender || sender === 'happyclaw-agent' || sender === '__system__')
-        continue;
-      const senderUser = getUserById(sender);
-      if (senderUser?.status === 'active' && senderUser.role === 'admin') {
-        effectiveGroup = { ...effectiveGroup, created_by: senderUser.id };
-        break;
-      }
-    }
+  // Admin home is shared as web:main (#519): select the runtime owner from the
+  // latest active-admin sender so this run loads that admin's plugins/MCP and
+  // writes global memory into their own user-global directory — not whichever
+  // admin first materialised the group. resolveAdminSharedRuntimeOwner gates on
+  // web:main + is_home internally and returns created_by unchanged elsewhere.
+  const coldStartRuntimeOwner = resolveAdminSharedRuntimeOwner({
+    chatJid,
+    isHome: !!effectiveGroup.is_home,
+    fallbackOwner: effectiveGroup.created_by,
+    messages: missedMessages,
+    getUserById,
+  });
+  if (
+    coldStartRuntimeOwner &&
+    coldStartRuntimeOwner !== effectiveGroup.created_by
+  ) {
+    effectiveGroup = { ...effectiveGroup, created_by: coldStartRuntimeOwner };
   }
 
   // Direct IM chats reply to themselves. Routed IM messages keep their original
@@ -4347,6 +4353,7 @@ async function runAgent(
         groupFolder: group.folder,
         displayName: identifier,
         selectedProviderId,
+        runtimeOwnerId: group.created_by,
       });
     };
 
@@ -4369,6 +4376,7 @@ async function runAgent(
           isAdminHome,
           images,
           messageTaskId,
+          runtimeOwnerId: group.created_by,
         },
         onProcessCb,
         wrappedOnOutput,
@@ -4389,6 +4397,7 @@ async function runAgent(
           isAdminHome,
           images,
           messageTaskId,
+          runtimeOwnerId: group.created_by,
         },
         onProcessCb,
         wrappedOnOutput,
@@ -7365,6 +7374,23 @@ async function startMessageLoop(): Promise<void> {
           const lastSourceJidForRoute =
             messagesToSend[messagesToSend.length - 1]?.source_jid || chatJid;
 
+          // #519 step 4: resolve this injection batch's runtime owner so we never
+          // pipe one admin's message into another admin's already-loaded runtime
+          // on the shared web:main home. On a mismatch sendMessage() returns
+          // 'no_active' → a fresh run is enqueued whose cold-start re-resolves the
+          // owner. On every other group this equals created_by → no behaviour change.
+          // IM-sibling senders (open_id, not a HappyClaw userId) fall back to
+          // created_by, so an IM message arriving mid-run under a different active
+          // owner is safely deferred to a fresh run rather than mis-injected.
+          const { effectiveGroup: injEffectiveGroup } =
+            resolveEffectiveGroup(group);
+          const injectOwnerId = resolveAdminSharedRuntimeOwner({
+            chatJid,
+            isHome: !!injEffectiveGroup.is_home,
+            fallbackOwner: injEffectiveGroup.created_by,
+            messages: messagesToSend,
+            getUserById,
+          });
           const sendResult = queue.sendMessage(
             chatJid,
             formatted,
@@ -7374,6 +7400,7 @@ async function startMessageLoop(): Promise<void> {
               activeRouteUpdaters.get(group.folder)?.(lastSourceJidForRoute);
             },
             lastSourceJidForRoute,
+            injectOwnerId,
           );
           if (sendResult === 'sent') {
             logger.debug(
@@ -7394,7 +7421,12 @@ async function startMessageLoop(): Promise<void> {
               id: lastProcessed.id,
             });
           } else {
-            // no_active — enqueue for a new one
+            // no_active — enqueue a fresh run. Crucially, do NOT advance the pull
+            // cursor here (advanceNextPullCursorOnly is in the 'sent' branch only):
+            // on a runtime-owner mismatch (#519 step 4) the deferred batch must stay
+            // re-pullable so the fresh run's cold-start re-reads it and re-resolves
+            // the owner. Advancing the cursor here would silently drop the deferred
+            // admin's message.
             queue.enqueueMessageCheck(chatJid);
           }
         }

--- a/src/main-home-acl.ts
+++ b/src/main-home-acl.ts
@@ -11,6 +11,7 @@
 // Kept dependency-free (like cross-group-acl.ts / owner-gate.ts) so the rule is
 // unit-testable without mocking the db / queue / socket graph.
 
+import type { OwnerGateResult } from './owner-gate.js';
 import type { UserRole } from './types.js';
 
 /**
@@ -38,4 +39,45 @@ export function canAdminShareMainHome(
   user: { role: UserRole },
 ): boolean {
   return isMainHome(group) && user.role === 'admin';
+}
+
+/** Verdict of the message/agent-conversation owner gate (#519). */
+export type OwnerGateVerdict =
+  | { drop: false }
+  | { drop: true; reason: 'no_active_admin' }
+  | { drop: true; reason: 'inactive_owner'; ownerStatus: string };
+
+/**
+ * Decide whether a dispatch loop must DROP a pending batch because the workspace
+ * has no active owner to run it under (#519).
+ *
+ * - Shared web:main home: do NOT pin to the bootstrap `created_by` (which may be
+ *   a since-disabled/deleted admin) — that would lock every active admin out of
+ *   the shared home. Drop only when no active admin remains to own it; the run's
+ *   cold-start then resolves the runtime owner from the active-admin sender.
+ * - Any other group: drop when its `created_by` owner is disabled/deleted (the
+ *   pre-existing owner gate, see owner-gate.ts).
+ *
+ * Pure: callers inject the lookups, so it is unit-testable without a running
+ * loop (mirrors the runtime-owner.ts resolver style used across #519).
+ */
+export function evaluateOwnerGate(
+  group: { is_home?: boolean | null; folder: string; created_by?: string | null },
+  deps: {
+    hasActiveAdmin: () => boolean;
+    checkOwner: (userId: string) => OwnerGateResult;
+  },
+): OwnerGateVerdict {
+  if (isMainHome(group)) {
+    return deps.hasActiveAdmin()
+      ? { drop: false }
+      : { drop: true, reason: 'no_active_admin' };
+  }
+  if (group.created_by) {
+    const gate = deps.checkOwner(group.created_by);
+    if (!gate.allowed) {
+      return { drop: true, reason: 'inactive_owner', ownerStatus: gate.status };
+    }
+  }
+  return { drop: false };
 }

--- a/src/main-home-acl.ts
+++ b/src/main-home-acl.ts
@@ -1,0 +1,41 @@
+// Pure ACL predicates for the admin-shared main home workspace.
+//
+// `web:main` (the admin home, folder === 'main') is the active-admins-SHARED
+// admin home workspace — issue #519, option B — NOT an owner-only home. Every
+// active admin, not just the bootstrap admin recorded in `created_by`, may
+// access it and receives its broadcasts. The data layer already treats it this
+// way (db.ts getUserHomeGroup falls back to web:main for any active admin); these
+// predicates let the ACL / list / broadcast layers agree on the same rule from a
+// single source instead of inlining `folder === 'main'` checks in three places.
+//
+// Kept dependency-free (like cross-group-acl.ts / owner-gate.ts) so the rule is
+// unit-testable without mocking the db / queue / socket graph.
+
+import type { UserRole } from './types.js';
+
+/**
+ * Whether `group` is the shared admin home workspace (`web:main`). There is
+ * exactly one such group (ensureUserHomeGroup reuses web:main for every admin),
+ * so `is_home && folder === 'main'` uniquely identifies it.
+ */
+export function isMainHome(group: {
+  is_home?: boolean | null;
+  folder: string;
+}): boolean {
+  return !!group.is_home && group.folder === 'main';
+}
+
+/**
+ * Whether `user` gets active-admin-shared access to `group` — true only when the
+ * group is the shared admin home AND the user is an admin.
+ *
+ * Callers reach this only for active users (the auth middleware rejects
+ * disabled/deleted before any route, and the broadcast allow-set is built from a
+ * live active-admin query), so the admin role here implies an *active* admin.
+ */
+export function canAdminShareMainHome(
+  group: { is_home?: boolean | null; folder: string },
+  user: { role: UserRole },
+): boolean {
+  return isMainHome(group) && user.role === 'admin';
+}

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -8,6 +8,7 @@ import {
   ContainerEnvSchema,
 } from '../schemas.js';
 import type { AuthUser, RegisteredGroup, ExecutionMode } from '../types.js';
+import { canAdminShareMainHome } from '../main-home-acl.js';
 import { checkGroupLimit } from '../billing.js';
 import { DATA_DIR, GROUPS_DIR, isDockerAvailable } from '../config.js';
 import {
@@ -149,8 +150,15 @@ function buildGroupsPayload(user: AuthUser): Record<string, GroupPayloadItem> {
     if (!isWeb && !isHome && homeFolders.has(group.folder)) continue;
 
     // Hide other users' home groups from the chat sidebar.
-    // Each user only sees their own home container.
-    if (isHome && group.created_by !== user.id) continue;
+    // Each user only sees their own home container — except web:main
+    // (folder === 'main'), the active-admins-shared admin home (issue #519,
+    // option B), which every active admin sees.
+    if (
+      isHome &&
+      group.created_by !== user.id &&
+      !canAdminShareMainHome(group, user)
+    )
+      continue;
 
     // Host execution groups require admin unless it's the user's own home group
     if (isHost && !isAdmin && !(isHome && group.created_by === user.id))
@@ -225,7 +233,13 @@ function buildGroupsPayload(user: AuthUser): Record<string, GroupPayloadItem> {
       execution_mode: group.executionMode || 'container',
       custom_cwd: isAdmin ? group.customCwd : undefined,
       is_home: isHome || undefined,
-      is_my_home: (isHome && group.created_by === user.id) || undefined,
+      // web:main (folder === 'main') is the active-admins-shared admin home
+      // (issue #519, option B): every active admin treats it as their home so
+      // the sidebar home slot, default selection, and IM-binding panel resolve.
+      is_my_home:
+        ((isHome && group.created_by === user.id) ||
+          canAdminShareMainHome(group, user)) ||
+        undefined,
       is_shared: isShared || undefined,
       member_role: memberInfo?.role ?? undefined,
       member_count: isShared ? memberInfo?.count : undefined,

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -44,6 +44,7 @@ import {
   getGroupMembers,
   getGroupMemberRole,
   getUserById,
+  getUserHomeGroup,
   getAgent,
   listUsers,
   listAgentsByJid,
@@ -210,6 +211,14 @@ function buildGroupsPayload(user: AuthUser): Record<string, GroupPayloadItem> {
     return cached;
   }
 
+  // Canonical home resolver (db.getUserHomeGroup): the exact-match home row
+  // (is_home + created_by) wins; the web:main admin fallback applies only when
+  // the user has no row of their own. Deriving is_my_home from it keeps a
+  // single source of truth — e.g. a member promoted to admin keeps a leftover
+  // home-{userId} row, and flagging BOTH it and web:main would break the
+  // frontend home-slot logic (exactly one group may carry the flag).
+  const homeJid = getUserHomeGroup(user.id)?.jid;
+
   for (const [jid, group] of visibleEntries) {
     const isHome = !!group.is_home;
     const isWeb = jid.startsWith('web:');
@@ -236,10 +245,9 @@ function buildGroupsPayload(user: AuthUser): Record<string, GroupPayloadItem> {
       // web:main (folder === 'main') is the active-admins-shared admin home
       // (issue #519, option B): every active admin treats it as their home so
       // the sidebar home slot, default selection, and IM-binding panel resolve.
-      is_my_home:
-        ((isHome && group.created_by === user.id) ||
-          canAdminShareMainHome(group, user)) ||
-        undefined,
+      // is_my_home mirrors db.getUserHomeGroup exactly (see homeJid above) so
+      // the shared-home fallback never double-flags alongside an own home row.
+      is_my_home: jid === homeJid || undefined,
       is_shared: isShared || undefined,
       member_role: memberInfo?.role ?? undefined,
       member_count: isShared ? memberInfo?.count : undefined,

--- a/src/runtime-owner.ts
+++ b/src/runtime-owner.ts
@@ -83,6 +83,62 @@ export function resolveAdminSharedRuntimeOwner(args: {
 }
 
 /**
+ * Sentinel returned by `resolveInjectionOwnerConstraint` for a batch that
+ * contains messages from two or more distinct active admins. It matches no
+ * real user id, so the group-queue owner-mismatch guard always defers such a
+ * batch with `no_active` instead of piping it into a live runtime.
+ */
+export const MIXED_ADMIN_BATCH = '__mixed_admin_batch__';
+
+/**
+ * Resolve the owner constraint for ACTIVE-INJECTION of a message batch into a
+ * running `web:main` agent (the `injectOwnerId` passed to
+ * `GroupQueue.sendMessage`).
+ *
+ * Why this exists: the previous latest-sender resolution
+ * (`resolveLatestAdminSenderOverride`) was bypassable by interleave — a batch
+ * `[B_deferred, A_new]` resolved to A, which equals the active run's owner,
+ * so B's message was piped into A's live runtime. That defeats the step-4
+ * guard's stated guarantee that admin B's messages never execute under admin
+ * A's identity (plugins / MCP / user-global memory).
+ *
+ * So instead of "latest wins", this walks the WHOLE batch and collects the
+ * distinct active-admin senders (system senders `happyclaw-agent` /
+ * `__system__` are skipped, consistent with
+ * `resolveLatestAdminSenderOverride`; unknown / inactive / member senders
+ * never count):
+ *   - 0 distinct active admins → `null` (no constraint — e.g. IM open_id
+ *     senders; preserves same-admin IM continuation),
+ *   - exactly 1 → that admin's id (inject only if the live run is theirs),
+ *   - 2 or more → `MIXED_ADMIN_BATCH` — a mixed-admin batch must NEVER be
+ *     piped into one admin's live runtime; it always defers to a fresh
+ *     cold-start where each message expands under its own sender's runtime.
+ */
+export function resolveInjectionOwnerConstraint(
+  messages: ReadonlyArray<RuntimeOwnerCandidateMessage>,
+  getUserById: (id: string) => RuntimeOwnerCandidateUser | null | undefined,
+): string | null {
+  const adminIds = new Set<string>();
+  for (const message of messages) {
+    const sender = message?.sender;
+    if (!sender || sender === 'happyclaw-agent' || sender === '__system__') {
+      continue;
+    }
+    const user = getUserById(sender);
+    if (user?.status === 'active' && user.role === 'admin') {
+      adminIds.add(user.id);
+      if (adminIds.size >= 2) {
+        return MIXED_ADMIN_BATCH;
+      }
+    }
+  }
+  if (adminIds.size === 0) {
+    return null;
+  }
+  return adminIds.values().next().value ?? null;
+}
+
+/**
  * Per-message variant of `resolveAdminSharedRuntimeOwner` (#23 round-15
  * P2-2). On the admin-shared `web:main + is_home` workspace, plugin runtime
  * is per-user — so each message in a mixed-admin batch must expand under
@@ -119,4 +175,33 @@ export function resolvePerMessageRuntimeOwner(args: {
     return user.id;
   }
   return args.fallbackOwner;
+}
+
+/**
+ * Choose the fallback runtime owner for an agent conversation: prefer
+ * `candidateId` (the agent's own `created_by` — auto_im agents stamp the
+ * binding admin) over `fallbackId` (the workspace's `created_by`, i.e. the
+ * bootstrap admin on shared web:main) — but only when `candidateId` is a
+ * distinct *active admin*.
+ *
+ * Why this exists: IM-origin agent conversations carry open_id senders that
+ * `resolveAdminSharedRuntimeOwner`'s sender walk cannot map to a HappyClaw
+ * user, so it returns the fallback. Without this preference that fallback is
+ * the bootstrap admin, and admin B's IM-bound agent would load admin A's
+ * plugins/MCP and write B's memory into A's user-global dir. Pure: the caller
+ * injects the user lookup and gates the web:main check, keeping it unit-testable.
+ */
+export function preferActiveAdminFallback(
+  candidateId: string | null | undefined,
+  fallbackId: string | null | undefined,
+  getUserById: (id: string) => RuntimeOwnerCandidateUser | null | undefined,
+): string | null | undefined {
+  if (!candidateId || candidateId === fallbackId) {
+    return fallbackId;
+  }
+  const user = getUserById(candidateId);
+  if (user?.status === 'active' && user.role === 'admin') {
+    return candidateId;
+  }
+  return fallbackId;
 }

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -10,6 +10,7 @@ import type {
   UserSessionWithUser,
 } from './types.js';
 import type { RuntimeOwnerCandidateUser } from './runtime-owner.js';
+import { canAdminShareMainHome } from './main-home-acl.js';
 import {
   getJidsByFolder,
   getRegisteredGroup,
@@ -279,16 +280,23 @@ export function hasHostExecutionPermission(user: AuthUser): boolean {
 /**
  * Check if a user can access (view messages, send messages to) a group.
  * All users (including admin) follow the same visibility rules:
- * - is_home groups → only the owner (created_by) can access
+ * - is_home groups → only the owner (created_by) can access, EXCEPT web:main
+ *   (folder === 'main'), the active-admins-shared admin home (issue #519,
+ *   option B), which any active admin can access
  * - IM groups (jid does not start with 'web:') → owner or group_members
- * - folder === 'main' → only the admin who owns it
  * - Web groups → created_by matches user.id, or user is in group_members
  */
 export function canAccessGroup(
   user: { id: string; role: UserRole },
   group: RegisteredGroup & { jid: string },
 ): boolean {
-  if (group.is_home) return group.created_by === user.id;
+  if (group.is_home) {
+    if (group.created_by === user.id) return true;
+    // web:main is the active-admins-shared admin home (issue #519, option B):
+    // any active admin may access it, not just the bootstrap admin in created_by.
+    if (canAdminShareMainHome(group, user)) return true;
+    return false;
+  }
   // IM groups: check ownership if created_by is set.
   // For legacy rows without created_by, resolve owner from sibling home group.
   if (!group.jid.startsWith('web:')) {
@@ -307,11 +315,11 @@ export function canAccessGroup(
     // Ownership cannot be resolved for this IM group → deny by default.
     return false;
   }
-  // folder === 'main': only accessible by the admin who owns it (via created_by or group_members)
-  if (group.folder === 'main') {
-    if (group.created_by === user.id) return true;
-    return getGroupMemberRole(group.folder, user.id) !== null;
-  }
+  // True web: non-home workspaces: owner or shared member. web:main itself is
+  // is_home and handled in the is_home branch above; and since folder === 'main'
+  // is always is_home, it never reaches here, so no separate branch is needed.
+  // (web:main's IM siblings have non-'web:' jids — feishu:/telegram:/… — so they
+  // are resolved in the !startsWith('web:') branch above, never here.)
   if (group.created_by === user.id) return true;
   // Check group_members table for shared workspaces
   return getGroupMemberRole(group.folder, user.id) !== null;

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -10,7 +10,7 @@ import type {
   UserSessionWithUser,
 } from './types.js';
 import type { RuntimeOwnerCandidateUser } from './runtime-owner.js';
-import { canAdminShareMainHome } from './main-home-acl.js';
+import { canAdminShareMainHome, isMainHome } from './main-home-acl.js';
 import {
   getJidsByFolder,
   getRegisteredGroup,
@@ -326,8 +326,13 @@ export function canAccessGroup(
 }
 
 /**
- * Check if a user can modify (rename, reset) a group.
+ * Check if a user can modify (rename, reset, /clear, manage agents/skills) a group.
  * - Users can modify their own home group.
+ * - web:main is the active-admins-shared admin home (issue #519, option B): any
+ *   active admin may reset/clear it — otherwise, once the bootstrap admin in
+ *   created_by is disabled/deleted, no remaining admin could /clear or reset the
+ *   shared home (it would be permanently un-resettable). Deletion is unaffected:
+ *   canDeleteGroup blocks every is_home group outright.
  * - Users can modify web groups they created.
  * - IM groups can be modified by their owner (created_by).
  */
@@ -335,7 +340,11 @@ export function canModifyGroup(
   user: { id: string; role: UserRole },
   group: RegisteredGroup & { jid: string },
 ): boolean {
-  if (group.is_home) return group.created_by === user.id;
+  if (group.is_home) {
+    if (group.created_by === user.id) return true;
+    if (canAdminShareMainHome(group, user)) return true;
+    return false;
+  }
   if (!group.jid.startsWith('web:')) {
     if (group.created_by) return group.created_by === user.id;
     // Legacy IM group (created_by=null): resolve owner via group_members first.

--- a/src/web-context.ts
+++ b/src/web-context.ts
@@ -10,7 +10,7 @@ import type {
   UserSessionWithUser,
 } from './types.js';
 import type { RuntimeOwnerCandidateUser } from './runtime-owner.js';
-import { canAdminShareMainHome, isMainHome } from './main-home-acl.js';
+import { canAdminShareMainHome } from './main-home-acl.js';
 import {
   getJidsByFolder,
   getRegisteredGroup,

--- a/src/web.ts
+++ b/src/web.ts
@@ -773,21 +773,23 @@ async function handleAgentConversationMessage(
   // injectOwnerId resolution before sendMessage.
   const parentGroup =
     deps.getRegisteredGroups()[chatJid] ?? getRegisteredGroup(chatJid);
+  // Sibling-resolved effective parent: a non-home parent bound to a home sibling
+  // inherits the home's is_home / created_by / executionMode / customCwd. Used by
+  // BOTH the eager expander (#21 round-13 P2-3) AND the #519 injectOwnerId
+  // resolution below, so the owner-mismatch guard gates on the real workspace
+  // (e.g. web:main) rather than the raw binding row — matching the IM twin in
+  // buildOnAgentMessage.
+  const effectiveParent =
+    parentGroup && deps.resolveEffectiveGroup
+      ? deps.resolveEffectiveGroup(parentGroup).effectiveGroup
+      : parentGroup;
   const eagerExpandAgentActive =
     deps.queue.hasActiveMainRunnerForMessage(virtualChatJid);
   if (eagerExpandAgentActive) {
-    if (parentGroup) {
-      // Use the effective (sibling-resolved) parent group so a non-home parent
-      // bound to a home sibling expands plugins via the home's executionMode /
-      // customCwd / created_by — otherwise buildWebExpandContext returns null
-      // for the agent virtual JID and the active runner receives the raw
-      // slash command (#21 round-13 P2-3).
-      const expandParent = deps.resolveEffectiveGroup
-        ? deps.resolveEffectiveGroup(parentGroup).effectiveGroup
-        : parentGroup;
+    if (effectiveParent) {
       const expandCtx = buildWebExpandContext(
         virtualChatJid,
-        expandParent,
+        effectiveParent,
         userId,
       );
       if (expandCtx) {
@@ -895,11 +897,11 @@ async function handleAgentConversationMessage(
   // the sender is always an authenticated HappyClaw user, and on web:main the
   // ACL only admits active admins, so the fallback never bites there. Mirrors
   // the handleWebUserMessage resolution above.
-  const injectOwnerId = parentGroup
+  const injectOwnerId = effectiveParent
     ? resolvePerMessageRuntimeOwner({
         chatJid: virtualChatJid,
-        isHome: !!parentGroup.is_home,
-        fallbackOwner: parentGroup.created_by,
+        isHome: !!effectiveParent.is_home,
+        fallbackOwner: effectiveParent.created_by,
         message: { sender: userId },
         getUserById,
       })
@@ -1833,20 +1835,24 @@ function computeGroupAllowedUserIds(chatJid: string): Set<string> | null {
   // (its created_by is always set), so no folder==='main' special-case is needed.
   if (!ownerId) return null;
 
-  allowed.add(ownerId);
-
-  // For non-home groups, include shared members
-  if (!group.is_home) {
-    const members = getGroupMembers(group.folder);
-    for (const m of members) {
-      allowed.add(m.user_id);
-    }
-  } else if (isMainHome(group)) {
+  if (isMainHome(group)) {
     // web:main is the active-admins-shared admin home (issue #519, option B):
-    // every active admin must receive its broadcasts, not just created_by.
-    // Queried live so a disabled admin stops receiving immediately.
+    // the allow-set IS the live active-admin roster — it already contains
+    // created_by iff that admin is still active. Do NOT add created_by
+    // unconditionally, or a since-disabled/deleted bootstrap admin would linger
+    // in the set (the per-send safeBroadcast status check still catches it, but
+    // the allow-set itself must honor 'disabled admin stops receiving').
     for (const id of getActiveAdminIds()) {
       allowed.add(id);
+    }
+  } else {
+    allowed.add(ownerId);
+    // For non-home groups, include shared members
+    if (!group.is_home) {
+      const members = getGroupMembers(group.folder);
+      for (const m of members) {
+        allowed.add(m.user_id);
+      }
     }
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -24,6 +24,7 @@ import {
   getCachedSessionWithUser,
   invalidateSessionCache,
 } from './web-context.js';
+import { isMainHome } from './main-home-acl.js';
 
 // Schemas
 import {
@@ -74,6 +75,7 @@ import {
   deleteUserSession,
   updateSessionLastActive,
   getGroupMembers,
+  getActiveAdminIds,
   getAgent,
   isGroupShared,
   getUserById,
@@ -1713,6 +1715,13 @@ const ALLOWED_CACHE_TTL = 10_000; // 10 seconds
 
 function getGroupAllowedUserIds(chatJid: string): Set<string> | null {
   const now = Date.now();
+  // web:main's allow-set is the LIVE active-admin roster (issue #519): it changes
+  // via admin role/status mutations (admin.ts) that have no hook into this cache.
+  // Recompute it every time — two tiny indexed queries — rather than risk a
+  // just-promoted admin missing broadcasts, or a just-demoted one still receiving
+  // them, for up to the 10s TTL. Every other group's set only changes on
+  // membership ops, which already call invalidateAllowedUserCache.
+  if (chatJid === 'web:main') return computeGroupAllowedUserIds(chatJid);
   const cached = allowedUserIdsCache.get(chatJid);
   if (cached && cached.expiry > now) return cached.ids;
 
@@ -1760,11 +1769,9 @@ function computeGroupAllowedUserIds(chatJid: string): Set<string> | null {
     }
   }
 
-  if (!ownerId) {
-    if (group.is_home) return null;
-    if (group.folder === 'main') return null;
-    return null; // Unresolvable → deny by default
-  }
+  // Unresolvable owner → deny by default (admin-only). web:main never lands here
+  // (its created_by is always set), so no folder==='main' special-case is needed.
+  if (!ownerId) return null;
 
   allowed.add(ownerId);
 
@@ -1773,6 +1780,13 @@ function computeGroupAllowedUserIds(chatJid: string): Set<string> | null {
     const members = getGroupMembers(group.folder);
     for (const m of members) {
       allowed.add(m.user_id);
+    }
+  } else if (isMainHome(group)) {
+    // web:main is the active-admins-shared admin home (issue #519, option B):
+    // every active admin must receive its broadcasts, not just created_by.
+    // Queried live so a disabled admin stops receiving immediately.
+    for (const id of getActiveAdminIds()) {
+      allowed.add(id);
     }
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -588,6 +588,21 @@ async function handleWebUserMessage(
   let pipedToActive = false;
   const images = toAgentImages(normalizedAttachments);
   const updateRoute = deps.updateReplyRoute;
+  // #519 step 4: on the shared web:main home, resolve this message's runtime
+  // owner (the active-admin sender) so the queue's owner-mismatch guard defers
+  // it to a fresh run instead of injecting admin B's message into admin A's
+  // active runtime (which would run under A's plugins/MCP and write B's memory
+  // into A's user-global dir). The message is already persisted above, so a
+  // 'no_active' result lets the poll loop cold-start it under B's runtime — no
+  // loss. On every other group this resolves to created_by, so the guard is a
+  // no-op (unchanged behavior). Mirrors src/index.ts injection-site resolution.
+  const injectOwnerId = resolvePerMessageRuntimeOwner({
+    chatJid,
+    isHome: !!group.is_home,
+    fallbackOwner: group.created_by,
+    message: { sender: userId },
+    getUserById,
+  });
   const sendResult = deps.queue.sendMessage(
     chatJid,
     formatted,
@@ -598,6 +613,7 @@ async function handleWebUserMessage(
       updateRoute?.(group.folder, null);
     },
     chatJid,
+    injectOwnerId,
   );
   if (sendResult === 'sent') {
     pipedToActive = true;

--- a/src/web.ts
+++ b/src/web.ts
@@ -618,10 +618,17 @@ async function handleWebUserMessage(
   if (sendResult === 'sent') {
     pipedToActive = true;
   } else {
-    if (eagerExpandActive && sendContent !== content) {
+    if (
+      eagerExpandActive &&
+      sendContent !== content &&
+      !deps.queue.hasActiveMainRunnerForMessage(chatJid)
+    ) {
       // Active runner exited between peek and sendMessage → cold-start will
       // re-expand from the ORIGINAL DB content, so inline `!` runs again.
       // Rare but possible — flagged so we can quantify in production.
+      // Re-check the runner: a #519 owner-mismatch deferral also returns
+      // 'no_active' while the runner is still ALIVE — that is the guard working
+      // as intended, not an exit race, so it must not pollute this telemetry.
       logger.warn(
         {
           event: 'plugin_expander_race',
@@ -762,11 +769,13 @@ async function handleAgentConversationMessage(
   //     `expandMessagesIfNeeded`) would re-expand from the original DB row
   //     → inline double-fire. Cold-start handles all three outcomes.
   let agentSendContent = content;
+  // Parent group row: needed by the eager expander below AND by the #519
+  // injectOwnerId resolution before sendMessage.
+  const parentGroup =
+    deps.getRegisteredGroups()[chatJid] ?? getRegisteredGroup(chatJid);
   const eagerExpandAgentActive =
     deps.queue.hasActiveMainRunnerForMessage(virtualChatJid);
   if (eagerExpandAgentActive) {
-    const parentGroup =
-      deps.getRegisteredGroups()[chatJid] ?? getRegisteredGroup(chatJid);
     if (parentGroup) {
       // Use the effective (sibling-resolved) parent group so a non-home parent
       // bound to a home sibling expands plugins via the home's executionMode /
@@ -876,18 +885,46 @@ async function handleAgentConversationMessage(
 
   // Try to pipe into running agent process
   const agentImages = toAgentImages(normalizedAttachments);
+  // #519 step 4: on the shared web:main home, resolve this message's runtime
+  // owner (the active-admin sender) so the queue's owner-mismatch guard defers
+  // it to a fresh run instead of injecting admin B's message into admin A's
+  // active agent conversation (which would run under A's plugins/MCP and write
+  // B's memory into A's user-global dir). The resolver strips the '#agent:'
+  // suffix internally, so the virtual JID gates on the parent base JID.
+  // Fallback-to-created_by is safe here — unlike IM injection sites — because
+  // the sender is always an authenticated HappyClaw user, and on web:main the
+  // ACL only admits active admins, so the fallback never bites there. Mirrors
+  // the handleWebUserMessage resolution above.
+  const injectOwnerId = parentGroup
+    ? resolvePerMessageRuntimeOwner({
+        chatJid: virtualChatJid,
+        isHome: !!parentGroup.is_home,
+        fallbackOwner: parentGroup.created_by,
+        message: { sender: userId },
+        getUserById,
+      })
+    : undefined;
   const agentSendResult = deps.queue.sendMessage(
     virtualChatJid,
     formatted,
     agentImages,
     undefined,
     virtualChatJid,
+    injectOwnerId,
   );
   if (agentSendResult === 'no_active') {
-    if (eagerExpandAgentActive && agentSendContent !== content) {
+    if (
+      eagerExpandAgentActive &&
+      agentSendContent !== content &&
+      !deps.queue.hasActiveMainRunnerForMessage(virtualChatJid)
+    ) {
       // Race: peek said active, but the runner exited before sendMessage.
       // Cold-start re-expands from the original DB row → inline `!` may
       // run twice. Lead-approved edge case; logged for telemetry.
+      // Re-check the runner: a #519 owner-mismatch deferral also returns
+      // 'no_active' with the runner still ALIVE (the guard deferring to a fresh
+      // cold-start); that is not an exit race and the expansion sentinel was
+      // already persisted, so it must not be logged as one.
       logger.warn(
         {
           event: 'plugin_expander_race',
@@ -903,6 +940,13 @@ async function handleAgentConversationMessage(
     }
     // No running process — force close any stale state and start fresh.
     // Mirrors the reliable IM path in buildOnAgentMessage() (#240).
+    // #519 step 4: 'no_active' also covers an owner mismatch (the guard in
+    // GroupQueue.sendMessage deferred the message because the conversation is
+    // actively running under another admin's runtime). In that case closeStdin
+    // drains the other admin's running conversation and the fresh run below
+    // cold-starts under the sender's runtime — the message is already
+    // persisted above, so nothing is lost; acceptable between mutually-trusted
+    // admins sharing web:main.
     deps.queue.closeStdin(virtualChatJid);
     if (deps.processAgentConversation) {
       const taskId = `agent-conv:${agentId}:${Date.now()}`;

--- a/tests/container-runner-plugin-mount.test.ts
+++ b/tests/container-runner-plugin-mount.test.ts
@@ -258,6 +258,49 @@ describe('buildVolumeMounts — Claude triad inheritance', () => {
   });
 });
 
+describe('buildVolumeMounts — runtime owner override (#519 step 3)', () => {
+  test('ownerOverride selects whose user-global memory mounts at /workspace/global', () => {
+    // On the active-admins-shared web:main home, a run triggered by admin B must
+    // mount B's user-global/, not the workspace metadata owner (admin A)'s — else
+    // B's memory_append writes into A's directory (the cross-admin isolation bug
+    // #519 step 3 fixes). This is the load-bearing mount selection.
+    const groupsDir = path.join(tmpDataDir, 'groups');
+    const home = { ...fakeGroup('main', 'adminA'), is_home: true };
+
+    const baseline = buildVolumeMounts(home as any, false, true);
+    expect(
+      baseline.find((m) => m.containerPath === '/workspace/global')!.hostPath,
+    ).toBe(path.join(groupsDir, 'user-global', 'adminA'));
+
+    const overridden = buildVolumeMounts(
+      home as any,
+      false, // isAdminHome
+      true, // mountUserSkills
+      undefined, // agentId
+      undefined, // ownerHomeFolder
+      undefined, // taskRunId
+      undefined, // resolvedProvider
+      'adminB', // ownerOverride (#519): the message sender's runtime owner
+    );
+    const global = overridden.find(
+      (m) => m.containerPath === '/workspace/global',
+    )!;
+    expect(global.hostPath).toBe(path.join(groupsDir, 'user-global', 'adminB'));
+    // created_by is unchanged — the override is per-run, not a metadata mutation.
+    expect(home.created_by).toBe('adminA');
+    // is_home → the mount is writable, so the override genuinely redirects writes.
+    expect(global.readonly).toBe(false);
+  });
+
+  test('ownerOverride is ignored when undefined (falls back to created_by)', () => {
+    const groupsDir = path.join(tmpDataDir, 'groups');
+    const mounts = buildVolumeMounts(fakeGroup('grp-y', 'owner1') as any, false, true);
+    expect(
+      mounts.find((m) => m.containerPath === '/workspace/global')!.hostPath,
+    ).toBe(path.join(groupsDir, 'user-global', 'owner1'));
+  });
+});
+
 describe('prepareHostPlugins — host-mode pre-spawn materialize', () => {
   test('materializes runtime/ on demand when v2 config exists but tree is missing', () => {
     // Reproduces the bug fixed in this task: v2 config is present but

--- a/tests/container-runner-plugin-mount.test.ts
+++ b/tests/container-runner-plugin-mount.test.ts
@@ -366,6 +366,38 @@ describe('per-run MCP server isolation (#519)', () => {
       buildUserMcpEnv('userWithoutServers').HAPPYCLAW_USER_MCP_SERVERS_JSON,
     ).toBe('{}');
   });
+
+  test('docker MCP env rides the 0600 mounted env-dir file, NOT the docker -e argv (#519 review)', () => {
+    // Credential-bearing MCP server env must not land on the `docker run` argv
+    // (visible via ps/docker inspect). It goes into the 0600 env-dir file that is
+    // mounted read-only and sourced by entrypoint.
+    seedUserMcpServers('mcpOwner', {
+      srv: { enabled: true, command: 'c', env: { TOKEN: 'super-secret-token' } },
+    });
+    const grp = fakeGroup('grp-mcp-env', 'bootstrapAdmin'); // is_home:false → docker path
+
+    const mounts = buildVolumeMounts(
+      grp as any,
+      false, // isAdminHome
+      true, // mountUserSkills
+      undefined, // agentId
+      undefined, // ownerHomeFolder
+      undefined, // taskRunId
+      undefined, // resolvedProvider
+      'mcpOwner', // ownerOverride → whose MCP servers ride this run
+    );
+
+    const envFile = path.join(tmpDataDir, 'env', 'grp-mcp-env', 'env');
+    const contents = fs.readFileSync(envFile, 'utf8');
+    expect(contents).toContain('HAPPYCLAW_USER_MCP_SERVERS_JSON=');
+    expect(contents).toContain('super-secret-token'); // the owner's server (incl. token)
+    // …and the env-dir is mounted read-only into the container (off-argv delivery).
+    expect(
+      mounts.some(
+        (m) => m.containerPath === '/workspace/env-dir' && m.readonly === true,
+      ),
+    ).toBe(true);
+  });
 });
 
 describe('prepareHostPlugins — host-mode pre-spawn materialize', () => {

--- a/tests/container-runner-plugin-mount.test.ts
+++ b/tests/container-runner-plugin-mount.test.ts
@@ -57,7 +57,8 @@ const catalog = await import('../src/plugin-catalog.js');
 const utils = await import('../src/plugin-utils.js');
 const materializer = await import('../src/plugin-materializer.js');
 
-const { buildVolumeMounts, prepareHostPlugins } = containerRunner;
+const { buildVolumeMounts, prepareHostPlugins, ensureSettingsJson, buildUserMcpEnv } =
+  containerRunner;
 const { writeCatalogIndex, getCatalogSnapshotDir } = catalog;
 const { CONTAINER_PLUGINS_PATH } = utils;
 const { getUserRuntimeRoot, getUserPluginRuntimeDir } = materializer;
@@ -298,6 +299,72 @@ describe('buildVolumeMounts — runtime owner override (#519 step 3)', () => {
     expect(
       mounts.find((m) => m.containerPath === '/workspace/global')!.hostPath,
     ).toBe(path.join(groupsDir, 'user-global', 'owner1'));
+  });
+});
+
+function seedUserMcpServers(
+  userId: string,
+  servers: Record<string, Record<string, unknown>>,
+): void {
+  const dir = path.join(tmpDataDir, 'mcp-servers', userId);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'servers.json'), JSON.stringify({ servers }));
+}
+
+describe('per-run MCP server isolation (#519)', () => {
+  test('ensureSettingsJson purges a stale mcpServers block and keeps env keys', () => {
+    // Old builds additively merged per-user MCP servers into this per-folder file.
+    // On the now-shared web:main home, admin A's servers (and their credentials)
+    // would survive and leak into admin B's run. ensureSettingsJson must drop the
+    // block entirely (MCP is injected per-run via env instead).
+    const settingsFile = path.join(tmpDataDir, 'settings.json');
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify({
+        mcpServers: { adminA_server: { command: 'secret-a', env: { TOKEN: 'A' } } },
+        env: { USER_CUSTOM: 'keep-me' },
+        otherKey: 42,
+      }),
+    );
+
+    ensureSettingsJson(settingsFile);
+
+    const written = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    expect(written.mcpServers).toBeUndefined(); // leak purged
+    expect(written.env.CLAUDE_CODE_DISABLE_ATTACHMENTS).toBe('1'); // required env forced
+    expect(written.env.USER_CUSTOM).toBe('keep-me'); // user env preserved
+    expect(written.otherKey).toBe(42); // unrelated keys preserved
+  });
+
+  test('buildUserMcpEnv returns only the runtime owner\'s servers, never another admin\'s', () => {
+    seedUserMcpServers('adminA', {
+      adminA_server: { enabled: true, command: 'a-cmd' },
+    });
+    seedUserMcpServers('adminB', {
+      adminB_server: { enabled: true, command: 'b-cmd' },
+    });
+
+    const parsedA = JSON.parse(
+      buildUserMcpEnv('adminA').HAPPYCLAW_USER_MCP_SERVERS_JSON,
+    );
+    const parsedB = JSON.parse(
+      buildUserMcpEnv('adminB').HAPPYCLAW_USER_MCP_SERVERS_JSON,
+    );
+
+    expect(Object.keys(parsedA)).toEqual(['adminA_server']);
+    expect(Object.keys(parsedB)).toEqual(['adminB_server']);
+    // The cross-admin leak: admin B's run must NEVER see admin A's MCP server.
+    expect(parsedB.adminA_server).toBeUndefined();
+  });
+
+  test('buildUserMcpEnv sets explicit {} for no owner / no servers (overrides stale settings.json)', () => {
+    // agent-runner reads this env first; an explicit "{}" overrides any mcpServers
+    // a stale settings.json from an older build still carries.
+    expect(buildUserMcpEnv(null).HAPPYCLAW_USER_MCP_SERVERS_JSON).toBe('{}');
+    expect(buildUserMcpEnv(undefined).HAPPYCLAW_USER_MCP_SERVERS_JSON).toBe('{}');
+    expect(
+      buildUserMcpEnv('userWithoutServers').HAPPYCLAW_USER_MCP_SERVERS_JSON,
+    ).toBe('{}');
   });
 });
 

--- a/tests/group-queue-runtime-owner.test.ts
+++ b/tests/group-queue-runtime-owner.test.ts
@@ -15,7 +15,10 @@
  * registerProcess({ runtimeOwnerId }).
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
 import type { ChildProcess } from 'node:child_process';
+
+const TEST_DATA_DIR = '/tmp/happyclaw-queue-runtime-owner-test';
 
 vi.mock('../src/config.js', async (importOriginal) => {
   const real = (await importOriginal()) as Record<string, unknown>;
@@ -38,6 +41,7 @@ vi.mock('../src/runtime-config.js', () => ({
 vi.mock('../src/db.js', () => ({ getTaskById: () => undefined }));
 
 const { GroupQueue } = await import('../src/group-queue.js');
+const { MIXED_ADMIN_BATCH } = await import('../src/runtime-owner.js');
 
 const tick = () => new Promise((r) => setImmediate(r));
 const JID = 'web:main';
@@ -51,6 +55,10 @@ let resolveGate: (() => void) | null;
 let activeOwner: string | null;
 
 beforeEach(() => {
+  // Hermetic per test: earlier tests' sendMessage calls leave IPC .json files
+  // under the shared tmp DATA_DIR; recoverUnconsumedIpc in the run's finally
+  // would see them, re-arm pendingMessages and start an unwanted fresh run.
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   queue = new GroupQueue();
   resolveGate = null;
   activeOwner = 'adminA';
@@ -85,6 +93,25 @@ describe('GroupQueue sendMessage runtime-owner guard (#519 step 4)', () => {
     ).toBe('no_active');
   });
 
+  test('MIXED_ADMIN_BATCH sentinel always defers (mixed-admin batch never pipes into a live run)', async () => {
+    // resolveInjectionOwnerConstraint returns this sentinel for a batch with two
+    // or more distinct active admins. It matches no real runtimeOwnerId, so the
+    // guard must always defer — this is the queue-side wiring of the interleave
+    // fix (the pure resolver is pinned in injection-owner-constraint.test.ts).
+    queue.enqueueMessageCheck(JID, 'adminA');
+    await tick();
+    expect(
+      queue.sendMessage(
+        JID,
+        'mixed [B, A]',
+        undefined,
+        undefined,
+        undefined,
+        MIXED_ADMIN_BATCH,
+      ),
+    ).toBe('no_active');
+  });
+
   test('allows the same admin to inject into their own active run (→ sent)', async () => {
     queue.enqueueMessageCheck(JID, 'adminA');
     await tick();
@@ -108,5 +135,27 @@ describe('GroupQueue sendMessage runtime-owner guard (#519 step 4)', () => {
     expect(
       queue.sendMessage(JID, 'x', undefined, undefined, undefined, 'adminB'),
     ).toBe('sent');
+  });
+});
+
+describe('GroupQueue runTask runtime-owner cleanup (#519)', () => {
+  test("runTask's finally clears the run's runtime owner (symmetric with runForGroup)", async () => {
+    let ownerDuringTask: string | null | undefined;
+    queue.enqueueTask(JID, 'task-1', async () => {
+      // Mirror production: a task run registers its process (with its runtime
+      // owner) while active, just like a message run does.
+      queue.registerProcess(JID, fakeProc(), {
+        containerName: 'c',
+        groupFolder: FOLDER,
+        runtimeOwnerId: 'adminA',
+      });
+      ownerDuringTask = (queue as any).groups.get(JID)?.runtimeOwnerId;
+    });
+    await tick();
+    await tick();
+    const state = (queue as any).groups.get(JID);
+    expect(ownerDuringTask).toBe('adminA'); // the owner really was stamped mid-run
+    expect(state?.active).toBe(false); // the real runTask finally has executed…
+    expect(state?.runtimeOwnerId).toBeNull(); // …and cleared the per-run owner
   });
 });

--- a/tests/group-queue-runtime-owner.test.ts
+++ b/tests/group-queue-runtime-owner.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for GroupQueue's runtime-owner injection guard (#519 step 4).
+ *
+ * On the active-admins-shared web:main home, an active runner is loaded for one
+ * admin's runtime (plugins / MCP / global memory). A *different* admin's message
+ * must not be IPC-injected into it — that would execute under the wrong admin's
+ * plugins and write to their memory. sendMessage() returns 'no_active' on such a
+ * mismatch so the caller starts a fresh run (whose cold-start re-resolves the
+ * runtime owner from the new sender). On every other group injectOwnerId equals
+ * the run's owner (both = created_by), so the guard is a no-op.
+ *
+ * The run is made active via enqueueMessageCheck + a gated processMessagesFn
+ * that registers the process (with a configurable runtimeOwnerId) the moment it
+ * starts — mirroring production, where runAgent's onProcessCb calls
+ * registerProcess({ runtimeOwnerId }).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ChildProcess } from 'node:child_process';
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return { ...real, DATA_DIR: '/tmp/happyclaw-queue-runtime-owner-test' };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+vi.mock('../src/container-runner.js', () => ({ killProcessTree: () => {} }));
+
+vi.mock('../src/runtime-config.js', () => ({
+  getSystemSettings: () => ({
+    maxConcurrentContainers: 5,
+    maxConcurrentHostProcesses: 5,
+  }),
+}));
+
+vi.mock('../src/db.js', () => ({ getTaskById: () => undefined }));
+
+const { GroupQueue } = await import('../src/group-queue.js');
+
+const tick = () => new Promise((r) => setImmediate(r));
+const JID = 'web:main';
+const FOLDER = 'main';
+
+const fakeProc = () =>
+  ({ pid: 1, kill: () => {}, on: () => {} }) as unknown as ChildProcess;
+
+let queue: InstanceType<typeof GroupQueue>;
+let resolveGate: (() => void) | null;
+let activeOwner: string | null;
+
+beforeEach(() => {
+  queue = new GroupQueue();
+  resolveGate = null;
+  activeOwner = 'adminA';
+  queue.setProcessMessagesFn(async (jid: string) => {
+    // Mirror production: register the run's process (with its runtime owner) the
+    // moment it starts, then stay active while it works.
+    queue.registerProcess(jid, fakeProc(), {
+      containerName: 'c',
+      groupFolder: FOLDER,
+      runtimeOwnerId: activeOwner,
+    });
+    await new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    return true;
+  });
+});
+
+afterEach(async () => {
+  resolveGate?.();
+  await tick();
+  await tick();
+});
+
+describe('GroupQueue sendMessage runtime-owner guard (#519 step 4)', () => {
+  test("rejects a different admin's injection into an active run (→ no_active)", async () => {
+    queue.enqueueMessageCheck(JID, 'adminA');
+    await tick();
+    // adminA's runner is active; adminB's message must defer to a fresh run.
+    expect(
+      queue.sendMessage(JID, 'hi from B', undefined, undefined, undefined, 'adminB'),
+    ).toBe('no_active');
+  });
+
+  test('allows the same admin to inject into their own active run (→ sent)', async () => {
+    queue.enqueueMessageCheck(JID, 'adminA');
+    await tick();
+    expect(
+      queue.sendMessage(JID, 'more from A', undefined, undefined, undefined, 'adminA'),
+    ).toBe('sent');
+  });
+
+  test('no injectOwnerId → guard skipped (backward compatible, → sent)', async () => {
+    queue.enqueueMessageCheck(JID, 'adminA');
+    await tick();
+    expect(queue.sendMessage(JID, 'legacy inject', undefined, undefined, undefined)).toBe(
+      'sent',
+    );
+  });
+
+  test("guard is a no-op when the run has no recorded runtime owner", async () => {
+    activeOwner = null; // run registered without a runtime owner (legacy / non-shared)
+    queue.enqueueMessageCheck(JID, 'adminA');
+    await tick();
+    expect(
+      queue.sendMessage(JID, 'x', undefined, undefined, undefined, 'adminB'),
+    ).toBe('sent');
+  });
+});

--- a/tests/groups-is-my-home.test.ts
+++ b/tests/groups-is-my-home.test.ts
@@ -1,0 +1,218 @@
+/**
+ * is_my_home single-flag invariant (#519 regression).
+ *
+ * buildGroupsPayload used to compute is_my_home as
+ *   (isHome && created_by === user.id) || canAdminShareMainHome(group, user)
+ * which double-flags for a member who was later promoted to admin: the role
+ * change never converts their home-{userId} row (ensureUserHomeGroup
+ * early-returns on the exact match), so BOTH home-{userId} AND web:main got
+ * flagged and the frontend home-slot logic (last-write-wins / first-match)
+ * broke. The fix derives is_my_home from db.getUserHomeGroup — the canonical
+ * resolver where the exact-match home row wins and the web:main admin
+ * fallback applies only otherwise.
+ *
+ * Covered here:
+ *   1. db.getUserHomeGroup canonical resolution (exact match beats fallback;
+ *      fallback is active-admin-only).
+ *   2. GET /api/groups route-level: exactly ONE group carries is_my_home per
+ *      user, and it agrees with getUserHomeGroup in every persona.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const SHARED_TMP =
+  process.env.HAPPYCLAW_TEST_DATA_DIR ??
+  (() => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-groups-is-my-home-'));
+    process.env.HAPPYCLAW_TEST_DATA_DIR = d;
+    return d;
+  })();
+
+const tmpDataDir = SHARED_TMP;
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  const dataDir = process.env.HAPPYCLAW_TEST_DATA_DIR!;
+  return {
+    ...real,
+    DATA_DIR: dataDir,
+    GROUPS_DIR: path.join(dataDir, 'groups'),
+    STORE_DIR: path.join(dataDir, 'db'),
+  };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+vi.mock('../src/middleware/auth.ts', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('user', {
+      id: process.env.HAPPYCLAW_TEST_USER_ID ?? 'bob',
+      username: process.env.HAPPYCLAW_TEST_USER_ID ?? 'bob',
+      role: process.env.HAPPYCLAW_TEST_USER_ROLE ?? 'member',
+      permissions: [],
+    });
+    return next();
+  },
+}));
+
+// groups.ts statically imports these from web.js; mock them so importing the
+// route module doesn't pull in the full Hono app + every route's middleware.
+vi.mock('../src/web.js', () => ({
+  broadcastNewMessage: () => {},
+  invalidateAllowedUserCache: () => {},
+}));
+
+// web-context.ts imports GroupQueue from group-queue.js (type-position only);
+// stub it so this test never loads the queue/runner module graph.
+vi.mock('../src/group-queue.js', () => ({ GroupQueue: class {} }));
+
+const groupRoutesModule = await import('../src/routes/groups.js');
+const db = await import('../src/db.js');
+const webContext = await import('../src/web-context.js');
+
+const groupRoutes = groupRoutesModule.default;
+
+const now = new Date().toISOString();
+
+function seedUser(
+  id: string,
+  role: 'admin' | 'member',
+  status: 'active' | 'disabled' = 'active',
+): void {
+  db.createUser({
+    id,
+    username: id,
+    password_hash: 'x',
+    display_name: id,
+    role,
+    status,
+    created_at: now,
+    updated_at: now,
+  } as Parameters<typeof db.createUser>[0]);
+}
+
+function seedHomeGroup(
+  jid: string,
+  folder: string,
+  createdBy: string,
+  executionMode: 'host' | 'container',
+): void {
+  db.setRegisteredGroup(jid, {
+    name: jid,
+    folder,
+    added_at: now,
+    executionMode,
+    created_by: createdBy,
+    is_home: true,
+  } as Parameters<typeof db.setRegisteredGroup>[1]);
+}
+
+function asUser(userId: string, role: 'admin' | 'member'): void {
+  process.env.HAPPYCLAW_TEST_USER_ID = userId;
+  process.env.HAPPYCLAW_TEST_USER_ROLE = role;
+}
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(tmpDataDir, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDataDir, 'groups'), { recursive: true });
+  db.initDatabase();
+  // Routes guard on getWebDeps(); the paths exercised here only need the
+  // registered-groups cache stub (same shape as routes-groups-owner-acl).
+  webContext.setWebDeps({
+    getRegisteredGroups: () => ({}),
+  } as unknown as Parameters<typeof webContext.setWebDeps>[0]);
+
+  seedUser('adminA', 'admin'); // bootstrap admin (created_by of web:main)
+  seedUser('bob', 'member'); // member, promoted to admin mid-suite
+  seedUser('carol', 'admin'); // second admin, never had an own home row
+  seedUser('dave', 'member'); // ordinary member, stays member
+  seedUser('edgar', 'admin', 'disabled'); // disabled admin without own row
+
+  seedHomeGroup('web:main', 'main', 'adminA', 'host');
+  seedHomeGroup('web:home-bob', 'home-bob', 'bob', 'container');
+  seedHomeGroup('web:home-dave', 'home-dave', 'dave', 'container');
+});
+
+afterEach(() => {
+  delete process.env.HAPPYCLAW_TEST_USER_ID;
+  delete process.env.HAPPYCLAW_TEST_USER_ROLE;
+});
+
+describe('db.getUserHomeGroup — canonical home resolution (#519)', () => {
+  test('bootstrap admin resolves web:main via exact created_by match', () => {
+    expect(db.getUserHomeGroup('adminA')?.jid).toBe('web:main');
+  });
+
+  test('member resolves their own home row', () => {
+    expect(db.getUserHomeGroup('bob')?.jid).toBe('web:home-bob');
+  });
+
+  test('second active admin without an own row falls back to web:main', () => {
+    expect(db.getUserHomeGroup('carol')?.jid).toBe('web:main');
+  });
+
+  test('promoted member keeps their leftover home row (exact match wins over fallback)', () => {
+    db.updateUserFields('bob', { role: 'admin' });
+    expect(db.getUserHomeGroup('bob')?.jid).toBe('web:home-bob');
+  });
+
+  test('disabled admin without an own row gets NO fallback', () => {
+    expect(db.getUserHomeGroup('edgar')).toBeUndefined();
+  });
+});
+
+describe('GET /api/groups — exactly one is_my_home per user', () => {
+  async function fetchGroups(): Promise<Record<string, { is_my_home?: boolean }>> {
+    const res = await groupRoutes.request('/', { method: 'GET' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      groups: Record<string, { is_my_home?: boolean }>;
+    };
+    return body.groups;
+  }
+
+  function flaggedJids(groups: Record<string, { is_my_home?: boolean }>): string[] {
+    return Object.entries(groups)
+      .filter(([, g]) => g.is_my_home === true)
+      .map(([jid]) => jid);
+  }
+
+  test('promoted member-turned-admin: ONLY home-bob is flagged, never web:main too', async () => {
+    // bob was promoted in the db-level suite above; promote idempotently so
+    // this test stands on its own if suites are reordered.
+    db.updateUserFields('bob', { role: 'admin' });
+    asUser('bob', 'admin');
+
+    const groups = await fetchGroups();
+    // As an admin, bob now also SEES the shared web:main...
+    expect(groups['web:main']).toBeDefined();
+    expect(groups['web:home-bob']).toBeDefined();
+    // ...but exactly one group carries the home flag, and it is his own row.
+    // The pre-fix dual-flag expression flagged BOTH (the #519 regression).
+    expect(flaggedJids(groups)).toEqual(['web:home-bob']);
+  });
+
+  test('second admin without an own row: web:main is the (only) flagged home', async () => {
+    asUser('carol', 'admin');
+    const groups = await fetchGroups();
+    expect(flaggedJids(groups)).toEqual(['web:main']);
+  });
+
+  test('bootstrap admin: web:main is the (only) flagged home', async () => {
+    asUser('adminA', 'admin');
+    const groups = await fetchGroups();
+    expect(flaggedJids(groups)).toEqual(['web:main']);
+  });
+
+  test('ordinary member: own home flagged, web:main not even visible', async () => {
+    asUser('dave', 'member');
+    const groups = await fetchGroups();
+    expect(groups['web:main']).toBeUndefined();
+    expect(flaggedJids(groups)).toEqual(['web:home-dave']);
+  });
+});

--- a/tests/injection-owner-constraint.test.ts
+++ b/tests/injection-owner-constraint.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  MIXED_ADMIN_BATCH,
+  resolveInjectionOwnerConstraint,
+  preferActiveAdminFallback,
+  type RuntimeOwnerCandidateUser,
+} from '../src/runtime-owner.js';
+
+/**
+ * Pure-function tests for the active-injection owner constraint (#519).
+ *
+ * The bug this guards: the previous latest-sender resolution at the
+ * active-injection site was bypassable by interleave — a batch
+ * [B_deferred, A_new] resolved to A == the active run's owner, so B's
+ * message was piped into A's live runtime, defeating the step-4 guard.
+ * A batch with two or more distinct active admins must therefore resolve
+ * to the MIXED_ADMIN_BATCH sentinel (matches no real user id → the
+ * group-queue owner-mismatch guard always defers with 'no_active').
+ */
+
+const users: Record<string, RuntimeOwnerCandidateUser> = {
+  adminA: { id: 'adminA', status: 'active', role: 'admin' },
+  adminB: { id: 'adminB', status: 'active', role: 'admin' },
+  disabledAdmin: { id: 'disabledAdmin', status: 'disabled', role: 'admin' },
+  member1: { id: 'member1', status: 'active', role: 'member' },
+};
+
+const getUserById = (id: string) => users[id] ?? null;
+
+const msgs = (...senders: string[]) => senders.map((sender) => ({ sender }));
+
+describe('resolveInjectionOwnerConstraint', () => {
+  test('empty batch → null (no constraint)', () => {
+    expect(resolveInjectionOwnerConstraint([], getUserById)).toBe(null);
+  });
+
+  test('only IM open_id / unknown senders → null (preserves same-admin IM continuation)', () => {
+    expect(
+      resolveInjectionOwnerConstraint(
+        msgs('ou_feishu_open_id_1', 'tg:123456', 'ou_feishu_open_id_2'),
+        getUserById,
+      ),
+    ).toBe(null);
+  });
+
+  test('one active admin, repeated across many messages → that id', () => {
+    expect(
+      resolveInjectionOwnerConstraint(
+        msgs('adminA', 'adminA', 'adminA', 'adminA'),
+        getUserById,
+      ),
+    ).toBe('adminA');
+  });
+
+  test('two distinct active admins → MIXED_ADMIN_BATCH (interleave must defer)', () => {
+    // The exact interleave bypass: B's deferred message followed by A's new
+    // one. Resolving to A would pipe B into A's live runtime.
+    expect(
+      resolveInjectionOwnerConstraint(msgs('adminB', 'adminA'), getUserById),
+    ).toBe(MIXED_ADMIN_BATCH);
+  });
+
+  test('active admin + disabled admin sender → the active one (disabled never counts)', () => {
+    expect(
+      resolveInjectionOwnerConstraint(
+        msgs('disabledAdmin', 'adminA'),
+        getUserById,
+      ),
+    ).toBe('adminA');
+  });
+
+  test('active admin + member sender → the admin (members never count)', () => {
+    expect(
+      resolveInjectionOwnerConstraint(msgs('member1', 'adminA'), getUserById),
+    ).toBe('adminA');
+  });
+
+  test("system senders ('happyclaw-agent', '__system__', '') are skipped", () => {
+    expect(
+      resolveInjectionOwnerConstraint(
+        msgs('happyclaw-agent', '__system__', '', 'adminA'),
+        getUserById,
+      ),
+    ).toBe('adminA');
+    // Skipped without being treated as a distinct admin: a lookup for them
+    // must never even be attempted.
+    const lookups: string[] = [];
+    resolveInjectionOwnerConstraint(
+      msgs('happyclaw-agent', '__system__', ''),
+      (id) => {
+        lookups.push(id);
+        return null;
+      },
+    );
+    expect(lookups).toEqual([]);
+  });
+
+  test('MIXED_ADMIN_BATCH is the exported non-empty sentinel, not a plausible user id', () => {
+    expect(MIXED_ADMIN_BATCH).toBe('__mixed_admin_batch__');
+    expect(MIXED_ADMIN_BATCH.length).toBeGreaterThan(0);
+    // Dunder-wrapped like the existing '__system__' reserved sender — no real
+    // user id in this codebase takes that shape.
+    expect(MIXED_ADMIN_BATCH.startsWith('__')).toBe(true);
+    expect(MIXED_ADMIN_BATCH.endsWith('__')).toBe(true);
+    expect(Object.keys(users)).not.toContain(MIXED_ADMIN_BATCH);
+  });
+});
+
+describe('preferActiveAdminFallback (#519 — IM-bound agent isolation)', () => {
+  // The bug this guards: an auto_im agent owned by admin B runs under the
+  // bootstrap admin A's runtime because every IM sender is an open_id the
+  // resolver can't map. The agent's own created_by (B) is the reliable owner.
+  test('active-admin candidate distinct from fallback → candidate wins', () => {
+    expect(preferActiveAdminFallback('adminB', 'adminA', getUserById)).toBe(
+      'adminB',
+    );
+  });
+
+  test('disabled-admin candidate → fallback (never an inactive owner)', () => {
+    expect(
+      preferActiveAdminFallback('disabledAdmin', 'adminA', getUserById),
+    ).toBe('adminA');
+  });
+
+  test('member candidate → fallback (agents owned by non-admins do not override)', () => {
+    expect(preferActiveAdminFallback('member1', 'adminA', getUserById)).toBe(
+      'adminA',
+    );
+  });
+
+  test('unknown candidate → fallback', () => {
+    expect(preferActiveAdminFallback('ghost', 'adminA', getUserById)).toBe(
+      'adminA',
+    );
+  });
+
+  test('null/empty candidate or candidate === fallback → fallback (no lookup)', () => {
+    const lookups: string[] = [];
+    const spy = (id: string) => {
+      lookups.push(id);
+      return users[id] ?? null;
+    };
+    expect(preferActiveAdminFallback(null, 'adminA', spy)).toBe('adminA');
+    expect(preferActiveAdminFallback(undefined, 'adminA', spy)).toBe('adminA');
+    expect(preferActiveAdminFallback('adminA', 'adminA', spy)).toBe('adminA');
+    expect(lookups).toEqual([]); // short-circuits before consulting the DB
+  });
+});

--- a/tests/main-home-acl-wiring.test.ts
+++ b/tests/main-home-acl-wiring.test.ts
@@ -48,7 +48,9 @@ vi.mock('../src/logger.js', () => ({
 }));
 
 const db = await import('../src/db.js');
-const { canAccessGroup } = await import('../src/web-context.js');
+const { canAccessGroup, canModifyGroup, canDeleteGroup } = await import(
+  '../src/web-context.js'
+);
 
 beforeAll(() => {
   fs.mkdirSync(path.join(tmpDataDir, 'db'), { recursive: true });
@@ -103,6 +105,34 @@ describe('canAccessGroup wiring — web:main is active-admins-shared (#519 optio
 
   test('the home owner can always access their own home', () => {
     expect(canAccessGroup({ id: 'u2', role: 'member' }, memberHome)).toBe(true);
+  });
+});
+
+describe('canModifyGroup wiring — web:main reset/clear is active-admins-shared (#519)', () => {
+  test('a second active admin (created_by mismatch) CAN modify web:main', () => {
+    // The #519 fix: once the bootstrap admin is disabled/deleted, another active
+    // admin must still be able to /clear or reset the shared home. Regresses if
+    // the is_home branch reverts to `return group.created_by === user.id`.
+    expect(canModifyGroup({ id: 'adminB', role: 'admin' }, webMain)).toBe(true);
+  });
+
+  test('the bootstrap admin still modifies web:main', () => {
+    expect(canModifyGroup({ id: 'adminA', role: 'admin' }, webMain)).toBe(true);
+  });
+
+  test('a member CANNOT modify web:main', () => {
+    expect(canModifyGroup({ id: 'mallory', role: 'member' }, webMain)).toBe(false);
+  });
+
+  test("an admin does NOT gain modify rights on another user's home", () => {
+    expect(canModifyGroup({ id: 'adminB', role: 'admin' }, memberHome)).toBe(false);
+  });
+
+  test('the share exception opens reset/clear but NOT delete of web:main', () => {
+    // Deletion of any is_home group is blocked outright (canDeleteGroup), so the
+    // shared-modify exception must not leak into a delete capability.
+    expect(canDeleteGroup({ id: 'adminB', role: 'admin' }, webMain)).toBe(false);
+    expect(canDeleteGroup({ id: 'adminA', role: 'admin' }, webMain)).toBe(false);
   });
 });
 

--- a/tests/main-home-acl-wiring.test.ts
+++ b/tests/main-home-acl-wiring.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Wiring tests for the admin-shared `web:main` slice (issue #519 option B).
+ *
+ * tests/main-home-acl.test.ts covers the pure predicates (isMainHome /
+ * canAdminShareMainHome). But predicate-green ≠ wiring-green: if the call sites
+ * that consume those predicates are deleted, reordered, or inverted, the pure
+ * tests still pass. These tests pin the two security-critical wirings the slice
+ * introduces:
+ *
+ *   1. canAccessGroup (web-context.ts) — the access decision. Its is_home branch
+ *      returns before touching the db, so it is testable directly with group
+ *      objects (no rows needed).
+ *   2. getActiveAdminIds (db.ts) — the live broadcast/allow-set roster. Must
+ *      include only role='admin' AND status='active' users (a disabled or
+ *      deleted admin must drop out so they stop receiving web:main broadcasts).
+ *
+ * (buildGroupsPayload's is_my_home / sidebar visibility is cosmetic and derives
+ * from the same tested predicate; its route-level coverage is folded into the
+ * step-5 mixed-admin integration tests, not this slice.)
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+const tmpDataDir =
+  process.env.HAPPYCLAW_TEST_DATA_DIR ??
+  (() => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-main-home-wiring-'));
+    process.env.HAPPYCLAW_TEST_DATA_DIR = d;
+    return d;
+  })();
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  const dataDir = process.env.HAPPYCLAW_TEST_DATA_DIR!;
+  return {
+    ...real,
+    DATA_DIR: dataDir,
+    GROUPS_DIR: path.join(dataDir, 'groups'),
+    STORE_DIR: path.join(dataDir, 'db'),
+  };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+const db = await import('../src/db.js');
+const { canAccessGroup } = await import('../src/web-context.js');
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(tmpDataDir, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDataDir, 'groups'), { recursive: true });
+  db.initDatabase();
+});
+
+// canAccessGroup only reads jid / is_home / created_by / folder for the cases
+// below; cast a minimal object to the full type.
+function group(partial: {
+  jid: string;
+  is_home?: boolean;
+  folder: string;
+  created_by?: string;
+}): Parameters<typeof canAccessGroup>[1] {
+  return partial as unknown as Parameters<typeof canAccessGroup>[1];
+}
+
+const webMain = group({
+  jid: 'web:main',
+  is_home: true,
+  folder: 'main',
+  created_by: 'adminA',
+});
+const memberHome = group({
+  jid: 'web:home-u2',
+  is_home: true,
+  folder: 'home-u2',
+  created_by: 'u2',
+});
+
+describe('canAccessGroup wiring — web:main is active-admins-shared (#519 option B)', () => {
+  test('a second active admin (created_by mismatch) CAN access web:main', () => {
+    // This is the whole point of option B and the line most likely to regress:
+    // `if (canAdminShareMainHome(group, user)) return true;` in the is_home branch.
+    expect(canAccessGroup({ id: 'adminB', role: 'admin' }, webMain)).toBe(true);
+  });
+
+  test('the bootstrap admin (created_by match) still accesses web:main', () => {
+    expect(canAccessGroup({ id: 'adminA', role: 'admin' }, webMain)).toBe(true);
+  });
+
+  test('a member CANNOT access web:main', () => {
+    expect(canAccessGroup({ id: 'mallory', role: 'member' }, webMain)).toBe(false);
+  });
+
+  test("an admin does NOT gain access to another user's home via the share rule", () => {
+    // isMainHome gates on folder === 'main', so the share exception must NOT leak
+    // to a member's personal home (folder = home-{userId}).
+    expect(canAccessGroup({ id: 'adminB', role: 'admin' }, memberHome)).toBe(false);
+  });
+
+  test('the home owner can always access their own home', () => {
+    expect(canAccessGroup({ id: 'u2', role: 'member' }, memberHome)).toBe(true);
+  });
+});
+
+describe('getActiveAdminIds wiring — live broadcast roster', () => {
+  const now = new Date().toISOString();
+  function seedUser(
+    id: string,
+    role: 'admin' | 'member',
+    status: 'active' | 'disabled' | 'deleted',
+  ): void {
+    db.createUser({
+      id,
+      username: id,
+      password_hash: 'x',
+      display_name: id,
+      role,
+      status,
+      created_at: now,
+      updated_at: now,
+      ...(status === 'deleted' ? { deleted_at: now } : {}),
+    } as Parameters<typeof db.createUser>[0]);
+  }
+
+  beforeAll(() => {
+    seedUser('wadminA', 'admin', 'active');
+    seedUser('wadminB', 'admin', 'active');
+    seedUser('wadminDisabled', 'admin', 'disabled');
+    seedUser('wadminDeleted', 'admin', 'deleted');
+    seedUser('wmember', 'member', 'active');
+  });
+
+  test('returns exactly the active admins (excludes disabled, deleted, members)', () => {
+    const ids = db.getActiveAdminIds().sort();
+    expect(ids).toContain('wadminA');
+    expect(ids).toContain('wadminB');
+    expect(ids).not.toContain('wadminDisabled');
+    expect(ids).not.toContain('wadminDeleted');
+    expect(ids).not.toContain('wmember');
+  });
+
+  test('a demoted/disabled admin drops out of the roster immediately', () => {
+    // Self-contained (own user) so it never disturbs the roster other tests read.
+    seedUser('wadminToggle', 'admin', 'active');
+    expect(db.getActiveAdminIds()).toContain('wadminToggle');
+    db.updateUserFields('wadminToggle', { status: 'disabled' });
+    expect(db.getActiveAdminIds()).not.toContain('wadminToggle');
+  });
+});

--- a/tests/main-home-acl.test.ts
+++ b/tests/main-home-acl.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest';
+
+import { isMainHome, canAdminShareMainHome } from '../src/main-home-acl.js';
+
+/**
+ * Pure-predicate tests for the active-admins-shared admin home (`web:main`),
+ * issue #519 option B. These predicates are the single source of the
+ * `is_home && folder === 'main'` rule used by canAccessGroup (web-context.ts),
+ * the group-list filter + is_my_home flag (routes/groups.ts), and the broadcast
+ * allow-set (web.ts) — so getting them right here covers all three call sites.
+ *
+ * The defining property of option B: access does NOT depend on `created_by`.
+ * A second admin whose id differs from the bootstrap admin still qualifies, and
+ * a member never does — these predicates take no created_by at all.
+ */
+
+const mainHome = { is_home: true, folder: 'main' };
+const memberHome = { is_home: true, folder: 'home-u2' };
+const sharedWeb = { is_home: false, folder: 'ws-x' };
+// A non-home row on folder 'main' — this is exactly an IM sibling auto-bound to
+// the admin's main folder (e.g. feishu:xxx, is_home=false, folder='main'). The
+// predicate must reject it: only the is_home web:main row is the shared admin
+// home. (IM siblings are a documented broadcast-parity follow-up, not this slice.)
+const nonHomeMain = { is_home: false, folder: 'main' };
+
+describe('isMainHome', () => {
+  test('web:main (is_home + folder main) is the shared admin home', () => {
+    expect(isMainHome(mainHome)).toBe(true);
+  });
+
+  test("a member's own home is NOT the shared admin home", () => {
+    expect(isMainHome(memberHome)).toBe(false);
+  });
+
+  test('a shared/web non-home workspace is not the admin home', () => {
+    expect(isMainHome(sharedWeb)).toBe(false);
+  });
+
+  test("folder 'main' without is_home does not qualify", () => {
+    expect(isMainHome(nonHomeMain)).toBe(false);
+  });
+
+  test('null/undefined is_home is treated as not-home', () => {
+    expect(isMainHome({ is_home: null, folder: 'main' })).toBe(false);
+    expect(isMainHome({ folder: 'main' })).toBe(false);
+  });
+});
+
+describe('canAdminShareMainHome', () => {
+  test('any admin gets shared access to web:main (independent of created_by)', () => {
+    // The bootstrap admin and a second admin are indistinguishable here — the
+    // predicate never sees created_by, which is exactly option B.
+    expect(canAdminShareMainHome(mainHome, { role: 'admin' })).toBe(true);
+  });
+
+  test('a member is denied shared access to web:main', () => {
+    expect(canAdminShareMainHome(mainHome, { role: 'member' })).toBe(false);
+  });
+
+  test("an admin does NOT get shared access to a member's home", () => {
+    expect(canAdminShareMainHome(memberHome, { role: 'admin' })).toBe(false);
+  });
+
+  test('an admin does NOT get shared access to a normal web workspace', () => {
+    expect(canAdminShareMainHome(sharedWeb, { role: 'admin' })).toBe(false);
+  });
+
+  test("folder 'main' without is_home is rejected even for an admin", () => {
+    expect(canAdminShareMainHome(nonHomeMain, { role: 'admin' })).toBe(false);
+  });
+});

--- a/tests/main-home-acl.test.ts
+++ b/tests/main-home-acl.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
-import { isMainHome, canAdminShareMainHome } from '../src/main-home-acl.js';
+import {
+  isMainHome,
+  canAdminShareMainHome,
+  evaluateOwnerGate,
+} from '../src/main-home-acl.js';
+import { checkOwnerActive } from '../src/owner-gate.js';
 
 /**
  * Pure-predicate tests for the active-admins-shared admin home (`web:main`),
@@ -67,5 +72,67 @@ describe('canAdminShareMainHome', () => {
 
   test("folder 'main' without is_home is rejected even for an admin", () => {
     expect(canAdminShareMainHome(nonHomeMain, { role: 'admin' })).toBe(false);
+  });
+});
+
+describe('evaluateOwnerGate (#519 — owner-gate lockout)', () => {
+  // The bug this guards: the dispatch loops gated web:main on the bootstrap
+  // `created_by`. Once that admin is disabled/deleted, every active admin's
+  // message was dropped (permanent loss + lockout), contradicting option B.
+  const allAdminsGone = { hasActiveAdmin: () => false, checkOwner: noOwner };
+  function noOwner(): ReturnType<typeof checkOwnerActive> {
+    throw new Error('checkOwner must not be consulted on web:main');
+  }
+  const usersById: Record<string, { status: string } | null> = {
+    bootstrapAdmin: { status: 'deleted' },
+    activeMember: { status: 'active' },
+    disabledMember: { status: 'disabled' },
+  };
+  const checkOwner = (id: string) => checkOwnerActive(usersById[id]);
+
+  test('web:main: an active admin exists → process even if bootstrap created_by is deleted', () => {
+    // The defining option-B fix: the gate must NOT consult created_by for
+    // web:main — it gates purely on active-admin presence.
+    const gate = evaluateOwnerGate(
+      { ...mainHome, created_by: 'bootstrapAdmin' },
+      { hasActiveAdmin: () => true, checkOwner: noOwner },
+    );
+    expect(gate.drop).toBe(false);
+  });
+
+  test('web:main: NO active admin remains → drop with no_active_admin reason', () => {
+    const gate = evaluateOwnerGate(
+      { ...mainHome, created_by: 'bootstrapAdmin' },
+      allAdminsGone,
+    );
+    expect(gate).toEqual({ drop: true, reason: 'no_active_admin' });
+  });
+
+  test('non-home group: active owner → process', () => {
+    const gate = evaluateOwnerGate(
+      { is_home: false, folder: 'ws-x', created_by: 'activeMember' },
+      { hasActiveAdmin: () => true, checkOwner },
+    );
+    expect(gate.drop).toBe(false);
+  });
+
+  test('non-home group: disabled owner → drop with inactive_owner reason + status', () => {
+    const gate = evaluateOwnerGate(
+      { is_home: false, folder: 'ws-x', created_by: 'disabledMember' },
+      { hasActiveAdmin: () => true, checkOwner },
+    );
+    expect(gate).toEqual({
+      drop: true,
+      reason: 'inactive_owner',
+      ownerStatus: 'disabled',
+    });
+  });
+
+  test('group without created_by is never dropped (legacy)', () => {
+    const gate = evaluateOwnerGate(
+      { is_home: false, folder: 'ws-x' },
+      { hasActiveAdmin: () => false, checkOwner: noOwner },
+    );
+    expect(gate.drop).toBe(false);
   });
 });


### PR DESCRIPTION
## 问题描述

实现 #519(作者裁定 option B):`web:main`(folder=`main`、`is_home=true` 的唯一 admin home)由**所有活跃 admin 共享**,而非仅由首次创建它的 bootstrap admin(`created_by`)独占。难点在于共享的同时保证**运行时身份隔离**——每个 admin 用自己的 plugins / MCP / 记忆,互不串台。

引入三身份模型:`created_by`(工作区元数据归属)/ `runtimeOwnerId`(本次运行加载谁的 plugins/MCP/skills/全局记忆)/ `actorUserId`(审计/计费,后续)。完整设计与 follow-up 见 `docs/ADMIN-SHARED-WORKSPACE.md`。

## 实现方案

### 共享访问层 — `main-home-acl.ts` / `web-context.ts` / `routes/groups.ts` / `web.ts` / `db.ts`
- 纯谓词 `isMainHome` / `canAdminShareMainHome` 作单一真相源
- `canAccessGroup` / `canModifyGroup`(reset / `/clear` / 改名 / agent+skill 管理)对活跃 admin 放开;`canDeleteGroup` 仍封死所有 `is_home`(共享 home 谁都不能删)
- 广播 allow-set / 群组列表 / `is_my_home` 走活跃 admin 名册(`getActiveAdminIds`),禁用/删除的 admin 自动掉出;`is_my_home` 以 `getUserHomeGroup` 为单一真相源

### 运行时身份隔离 — `container-runner.ts` / `runtime-owner.ts` / `index.ts` / `group-queue.ts`
- `ContainerInput.runtimeOwnerId` 贯穿 runner;plugins / MCP / user-global 挂载按 `runtimeOwnerId ?? created_by` 派生
- 冷启动按发送者解析 runtime owner(主对话 + sub-agent 对话);sub-agent 额外优先 `agent.created_by`(IM 绑定的 auto_im agent,其发送者是 open_id)
- `GroupQueue.sendMessage` owner-mismatch 守卫:别的 admin 的消息不注入进活跃 runtime,改起新 run
- **MCP per-run 隔离**:不再落 per-folder `settings.json`(共享 web:main 上会跨 admin 累积泄漏凭据),改走 per-run env(host=hostEnv,docker=0600 挂载文件,均不上 `docker run` argv)
- **混批守卫**:一批里出现 ≥2 个不同活跃 admin → `MIXED_ADMIN_BATCH` 哨兵必 defer(堵住 `[B_defer, A_new]` 解析成 A 把 B 注进 A live runtime 的 interleave 绕过)

### owner-gate 防锁死
- 三处 owner-gate(消息循环 / sub-agent 会话 / `processGroupMessages`)统一为纯函数 `evaluateOwnerGate`:web:main 只在**无任何活跃 admin**时才丢弃消息,不再 pin 可能已禁用的 bootstrap `created_by`

## 测试与验证
- 新增 6 个测试文件(ACL 谓词 + wiring、runtime-owner constraint、`is_my_home`、queue 守卫、MCP 落点);关键修复均做了「去掉修复→对应测试必 fail」的反向证明
- `make typecheck` 干净;全套测试通过(注:2 个 `feishu-card` 测试在 upstream 最新 main 上即失败,与本 PR 无关——本 PR 未改任何 feishu 文件)
- 经多轮多 agent 对抗式 review,所有 CONFIRMED 正确性项已闭环

## 已知后续(不在本 PR,已文档化)
IM-origin 主对话 `source_jid→admin` 映射(预存残留)、混批冷启动整批拆分、三身份完全解耦、IM-sibling 主 folder 广播/读 parity、spawn 级 wiring 测试 harness。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
