### PR TITLE
修复: 群组模式定时任务输出丢失任务身份导致 notify 失效 (#559)

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -638,6 +638,7 @@ export class GroupQueue {
     images?: Array<{ data: string; mimeType?: string }>,
     onInjected?: () => void,
     sourceJid?: string,
+    taskId?: string,
   ): SendMessageResult {
     const state = this.resolveActiveState(groupJid);
     if (!state) return 'no_active';
@@ -673,9 +674,13 @@ export class GroupQueue {
       const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}.json`;
       const filepath = path.join(inputDir, filename);
       const tempPath = `${filepath}.tmp`;
+      // Stamp taskId when this injection carries a scheduled-task prompt so the
+      // agent-runner can attribute the resulting send_message output to the task
+      // (drives notify_channels broadcast on the host). Omitted for regular
+      // user messages, matching the cold-start path's messageTaskId handling.
       fs.writeFileSync(
         tempPath,
-        JSON.stringify({ type: 'message', text, images, sourceJid }),
+        JSON.stringify({ type: 'message', text, images, sourceJid, taskId }),
       );
       fs.renameSync(tempPath, filepath);
       state.queryInFlight = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7365,6 +7365,14 @@ async function startMessageLoop(): Promise<void> {
           const lastSourceJidForRoute =
             messagesToSend[messagesToSend.length - 1]?.source_jid || chatJid;
 
+          // Propagate scheduled-task identity into the running agent. Group-mode
+          // tasks inject their prompt as a normal message; when a runner is
+          // already active this IPC path (not the cold-start runContainerAgent
+          // path) handles delivery, so it must carry task_id too — otherwise the
+          // task's send_message output loses task attribution and the host skips
+          // the notify_channels broadcast (riba2534/happyclaw#559).
+          const injectionTaskId = extractLastTaskId(messagesToSend);
+
           const sendResult = queue.sendMessage(
             chatJid,
             formatted,
@@ -7374,6 +7382,7 @@ async function startMessageLoop(): Promise<void> {
               activeRouteUpdaters.get(group.folder)?.(lastSourceJidForRoute);
             },
             lastSourceJidForRoute,
+            injectionTaskId,
           );
           if (sendResult === 'sent') {
             logger.debug(

--- a/tests/group-queue-task-injection.test.ts
+++ b/tests/group-queue-task-injection.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test for riba2534/happyclaw#559 ("notify 失效").
+ *
+ * Group-mode scheduled tasks inject their prompt into the source workspace as a
+ * normal message. When a runner is ALREADY active, delivery goes through
+ * GroupQueue.sendMessage() (the IPC-injection path), not the cold-start
+ * runContainerAgent() path. That IPC payload must carry `taskId` — otherwise the
+ * agent-runner can't attribute the resulting send_message output to the task, so
+ * the host's resolveTaskRoutingDecision() returns `none` and the configured
+ * notify_channels broadcast (Feishu etc.) is silently skipped.
+ *
+ * These tests pin the contract at the filesystem boundary: the written IPC input
+ * JSON carries `taskId` when (and only when) one is supplied.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const TEST_DATA_DIR = '/tmp/happyclaw-queue-taskid-test';
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return { ...real, DATA_DIR: TEST_DATA_DIR };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+vi.mock('../src/container-runner.js', () => ({ killProcessTree: () => {} }));
+
+vi.mock('../src/runtime-config.js', () => ({
+  getSystemSettings: () => ({
+    maxConcurrentContainers: 1,
+    maxConcurrentHostProcesses: 1,
+  }),
+}));
+
+vi.mock('../src/db.js', () => ({ getTaskById: () => undefined }));
+
+const { GroupQueue } = await import('../src/group-queue.js');
+
+const tick = () => new Promise((r) => setImmediate(r));
+const JID = 'web:taskid-inject';
+const FOLDER = 'taskid-inject';
+
+let queue: InstanceType<typeof GroupQueue>;
+let resolveGate: (() => void) | null;
+
+function readInjectedPayloads(): Array<Record<string, unknown>> {
+  const dir = path.join(TEST_DATA_DIR, 'ipc', FOLDER, 'input');
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')));
+}
+
+beforeEach(() => {
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  queue = new GroupQueue();
+  resolveGate = null;
+  // Keep the run gate-blocked so the runner stays active while we inject.
+  queue.setProcessMessagesFn(async () => {
+    await new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    return true;
+  });
+});
+
+afterEach(async () => {
+  resolveGate?.();
+  await tick();
+  await tick();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+async function startActiveRunner(): Promise<void> {
+  queue.enqueueMessageCheck(JID); // run goes active, blocks on the gate
+  await tick();
+  // registerProcess sets groupFolder so resolveActiveState() accepts the state
+  // and resolveIpcInputDir() can locate data/ipc/{folder}/input.
+  queue.registerProcess(JID, { kill: () => {}, killed: false } as never, {
+    containerName: null,
+    groupFolder: FOLDER,
+  });
+}
+
+describe('GroupQueue.sendMessage taskId propagation (#559)', () => {
+  test('stamps taskId into the IPC payload when provided', async () => {
+    await startActiveRunner();
+
+    const result = queue.sendMessage(
+      JID,
+      'task output',
+      undefined,
+      undefined,
+      undefined,
+      'task-abc',
+    );
+
+    expect(result).toBe('sent');
+    const payloads = readInjectedPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].type).toBe('message');
+    expect(payloads[0].text).toBe('task output');
+    expect(payloads[0].taskId).toBe('task-abc');
+  });
+
+  test('omits taskId for regular user messages', async () => {
+    await startActiveRunner();
+
+    const result = queue.sendMessage(
+      JID,
+      'hi',
+      undefined,
+      undefined,
+      'feishu:u1',
+    );
+
+    expect(result).toBe('sent');
+    const payloads = readInjectedPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].taskId).toBeUndefined();
+    expect(payloads[0].sourceJid).toBe('feishu:u1');
+  });
+});


### PR DESCRIPTION
## 问题描述

关闭 #559。

群组模式（`context_mode='group'`）定时任务的产出未带任务身份，导致 `resolveTaskRoutingDecision` 判定 `isTaskMessage=false` 返回 `none`，`notify_channels`（飞书等）广播被跳过——Web 创建任务时即使勾选了飞书也收不到推送。

## 根因

群组模式任务通过 `runGroupModeTask` 把 prompt 作为普通消息注入源工作区（带 `task_id`），再触发常规消息处理。消息处理有两条交付路径：

- **冷启动路径**（容器空闲）：`processMessages` 用 `extractLastTaskId(missedMessages)` 取出 `task_id`，经 `ContainerInput.messageTaskId` → agent-runner `currentTaskId` 传入，`send_message` 输出正确带上 `taskId`。✅
- **活跃注入路径**（容器已在运行）：`src/index.ts` 主轮询循环走 `queue.sendMessage()`（IPC 文件注入），而 `GroupQueue.sendMessage()` 写入的 IPC payload **只有 `{ type, text, images, sourceJid }`，丢了 `taskId`**。❌

于是 agent-runner `drainIpcInput` 读到 `taskId=undefined` → `currentTaskId=null` → `buildSendMessageData` 不 stamp `taskId` → 宿主机 `resolveTaskRoutingDecision` 返回 `none` → notify 广播被跳过。

agent-runner 侧本就完整支持 per-message `taskId`（IPC 读取、批次合并、`currentTaskId` 复位），唯一缺口在宿主机注入端没把 `task_id` 带过去。

## 修复方案

补齐活跃注入路径的任务身份传递，与冷启动路径对齐。

### `src/group-queue.ts`
- `sendMessage()` 新增可选参数 `taskId`，写入 IPC payload（普通用户消息不传，保持 `taskId` 缺省 → 不影响常规回复路由）。

### `src/index.ts`
- 主轮询循环活跃注入调用点用 `extractLastTaskId(messagesToSend)` 取出批次任务身份，传给 `queue.sendMessage()`。

### `tests/group-queue-task-injection.test.ts`（新增）
- 在文件系统边界锁定契约：注入带 `taskId` 时 IPC payload 携带 `taskId`；普通用户消息不携带。

## 验证

- `make build`：backend + agent-runner 编译通过（web 端 `workspace-config.ts` 的 implicit-any 报错为上游既有问题，与本改动无关）。
- 新增回归测试 2 项全部通过。
- 其余既有失败（`feishu-card` 颜色枚举、`chat-agent-messages` 缺 `zustand`）在 clean upstream/main 上同样失败，与本改动无关。