### PR TITLE
新增: WebSocket Origin 被 403 拒绝时输出诊断日志

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -944,6 +944,11 @@ app.use(
 
 // --- WebSocket ---
 
+// Origin 被 403 拒绝时,每个 origin 只 warn 一次,避免反复连接刷屏。
+// 反向代理 + 公网域名场景下,管理员只能通过日志才能定位"为什么 WS 连不上"
+// (前端只看到 onclose、后端默认静默 destroy socket),没有这行日志运维成本极高。
+const warnedRejectedOrigins = new Set<string>();
+
 function setupWebSocket(server: any): WebSocketServer {
   // 8 MiB 上限：覆盖单条消息含 10 张 5MB base64 image 的合法上限（~70MB 是
   // attachments 上限里的极端情形——通过 schema 上的 attachments.max(10) 控制
@@ -968,6 +973,16 @@ function setupWebSocket(server: any): WebSocketServer {
     if (origin) {
       const allowed = isAllowedOrigin(origin);
       if (!allowed) {
+        if (!warnedRejectedOrigins.has(origin)) {
+          warnedRejectedOrigins.add(origin);
+          logger.warn(
+            {
+              origin,
+              hint: 'add this origin to CORS_ALLOWED_ORIGINS env var (comma-separated) or set it to "*" to allow all',
+            },
+            'WebSocket upgrade rejected: Origin not in allowlist (CSWSH defense)',
+          );
+        }
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
         socket.destroy();
         return;


### PR DESCRIPTION
## 问题描述

CLAUDE.md §9 已经说明:公网域名访问必须配置 `CORS_ALLOWED_ORIGINS`,否则 WebSocket upgrade 会被 CSWSH 防御 403 拒绝。但实际部署时,**这条 403 是完全静默的**:

- 前端只看到 WebSocket onclose,无错误码细节
- 后端默认配置下没有任何日志输出 (`socket.destroy()` 直接断开)
- 管理员看到"WS 连不上、流式卡片不出"只能反复翻代码 + CLAUDE.md 才能定位

实战中我自己的部署就因为合 upstream 后没及时加这个 env var, 服务跑了一天 WS 全部 403, 翻了 20 分钟才想起来是这个防御机制。

这是个**所有走反向代理 + 公网域名的部署者**都会踩一次的坑。

## 修复方案

`src/web.ts` 的 WS Origin 校验分支拒绝时输出一行 `logger.warn`, 包含被拒的 origin 和如何配置的 hint:

```
WARN: WebSocket upgrade rejected: Origin not in allowlist (CSWSH defense)
  origin: "https://example.com"
  hint: "add this origin to CORS_ALLOWED_ORIGINS env var (comma-separated) or set it to \"*\" to allow all"
```

每个被拒 origin 只 warn 一次 (`warnedRejectedOrigins: Set<string>` 内存去重),避免恶意 / 错误配置导致日志刷屏。

### `src/web.ts`

- 新增模块级 `warnedRejectedOrigins` Set 用于去重
- WS upgrade 的 Origin 拒绝分支新增首次告警日志, 含 origin 和配置 hint

## 不改动的部分

- **没有放宽 Origin 防御**: CSWSH 检查本身是对的, 这个 PR 只让拒绝有日志, 不改变拒绝行为
- **没有动启动时告警**: 本机无法判断"是否对外暴露",误报概率高,价值不及拒绝时点位
- **没有改默认值**: `CORS_ALLOWED_ORIGINS` 仍需用户显式配置,只是失败时更容易诊断

## 测试

- `make typecheck` ✅
- `make test` ✅ (976/976 测试通过)