### PR TITLE
Handle SDK permission prompts non-interactively

### DIFF
--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test test/*.test.mjs",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -42,6 +42,7 @@ import {
 import { StreamEventProcessor } from './stream-processor.js';
 import { PREDEFINED_AGENTS } from './agent-definitions.js';
 import { createMcpTools } from './mcp-tools.js';
+import { createCanUseToolHandler } from './permission-handler.js';
 
 // 路径解析：优先读取环境变量，降级到容器内默认路径（保持向后兼容）
 const WORKSPACE_GROUP = process.env.HAPPYCLAW_WORKSPACE_GROUP || '/workspace/group';
@@ -1265,6 +1266,17 @@ async function runQuery(
   });
   // Initial drain to process any pre-existing files
   pollIpcDuringQuery();
+  const canUseTool = createCanUseToolHandler({
+    getPermissionMode: () => 'bypassPermissions',
+    log,
+    emitStatus: (statusText) => {
+      emit({
+        status: 'stream',
+        result: null,
+        streamEvent: { eventType: 'status', statusText },
+      });
+    },
+  });
 
   const processor = new StreamEventProcessor(emit, log);
 
@@ -1389,6 +1401,7 @@ async function runQuery(
         thinking: { type: 'adaptive' as const, display: 'summarized' as const },
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
+        canUseTool,
         agentProgressSummaries: true,
         settingSources: ['project', 'user'],
         // 启用全部已发现的技能到主会话。SDK 0.3.x 起 skills 是"打开技能的唯一正确位置"

--- a/container/agent-runner/src/permission-handler.ts
+++ b/container/agent-runner/src/permission-handler.ts
@@ -1,0 +1,92 @@
+import type {
+  CanUseTool,
+  PermissionMode,
+  PermissionResult,
+  PermissionUpdate,
+} from '@anthropic-ai/claude-agent-sdk';
+
+const PLAN_MODE_ALLOWED_PERMISSION_TOOLS = new Set([
+  'ExitPlanMode',
+  'EnterPlanMode',
+]);
+
+export interface PermissionDecisionInput {
+  mode: PermissionMode;
+  toolName: string;
+  toolUseID?: string;
+  suggestions?: PermissionUpdate[];
+  decisionReason?: string;
+  blockedPath?: string;
+}
+
+export interface CanUseToolHandlerOptions {
+  getPermissionMode: () => PermissionMode;
+  log?: (message: string) => void;
+  emitStatus?: (statusText: string) => void;
+}
+
+export function decidePermissionRequest(input: PermissionDecisionInput): PermissionResult {
+  const { mode, toolName, toolUseID, suggestions, decisionReason, blockedPath } = input;
+
+  if (mode === 'plan' && !PLAN_MODE_ALLOWED_PERMISSION_TOOLS.has(toolName)) {
+    return {
+      behavior: 'deny',
+      message: [
+        `Plan mode is active, so HappyClaw did not run ${toolName}.`,
+        decisionReason ? `Reason: ${decisionReason}.` : '',
+        blockedPath ? `Blocked path: ${blockedPath}.` : '',
+        'Switch to Code mode or approve the plan before running execution tools.',
+      ].filter(Boolean).join(' '),
+      interrupt: false,
+      toolUseID,
+    };
+  }
+
+  if (mode === 'dontAsk') {
+    return {
+      behavior: 'deny',
+      message: [
+        `Permission request for ${toolName} was denied because permission mode is dontAsk.`,
+        decisionReason ? `Reason: ${decisionReason}.` : '',
+      ].filter(Boolean).join(' '),
+      interrupt: false,
+      toolUseID,
+    };
+  }
+
+  return {
+    behavior: 'allow',
+    updatedPermissions: suggestions && suggestions.length > 0 ? suggestions : undefined,
+    toolUseID,
+  };
+}
+
+export function createCanUseToolHandler(options: CanUseToolHandlerOptions): CanUseTool {
+  return async (toolName, _input, requestOptions) => {
+    const mode = options.getPermissionMode();
+
+    if (requestOptions.signal.aborted) {
+      options.log?.(`Permission request aborted before decision for ${toolName}`);
+      return {
+        behavior: 'deny',
+        message: `Permission request for ${toolName} was aborted.`,
+        interrupt: true,
+        toolUseID: requestOptions.toolUseID,
+      };
+    }
+
+    const result = decidePermissionRequest({
+      mode,
+      toolName,
+      toolUseID: requestOptions.toolUseID,
+      suggestions: requestOptions.suggestions,
+      decisionReason: requestOptions.decisionReason,
+      blockedPath: requestOptions.blockedPath,
+    });
+
+    options.log?.(`Permission request: ${result.behavior} ${toolName} in ${mode} mode`);
+    options.emitStatus?.(`permission_${result.behavior}:${toolName}`);
+
+    return result;
+  };
+}

--- a/container/agent-runner/test/permission-handler.test.mjs
+++ b/container/agent-runner/test/permission-handler.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createCanUseToolHandler,
+  decidePermissionRequest,
+} from '../dist/permission-handler.js';
+
+test('bypass mode allows permission requests immediately', async () => {
+  const suggestions = [
+    {
+      rules: [{ toolName: 'Bash' }],
+      behavior: 'allow',
+      destination: 'session',
+    },
+  ];
+
+  const result = decidePermissionRequest({
+    mode: 'bypassPermissions',
+    toolName: 'Bash',
+    suggestions,
+  });
+
+  assert.equal(result.behavior, 'allow');
+  assert.equal(result.toolUseID, undefined);
+  assert.deepEqual(result.updatedPermissions, suggestions);
+});
+
+test('plan mode allows exiting plan mode', () => {
+  const result = decidePermissionRequest({
+    mode: 'plan',
+    toolName: 'ExitPlanMode',
+  });
+
+  assert.equal(result.behavior, 'allow');
+});
+
+test('plan mode denies execution tools instead of waiting for approval', () => {
+  const result = decidePermissionRequest({
+    mode: 'plan',
+    toolName: 'Bash',
+    decisionReason: 'requires user approval',
+  });
+
+  assert.equal(result.behavior, 'deny');
+  assert.match(result.message, /Plan mode/);
+  assert.equal(result.interrupt, false);
+});
+
+test('canUseTool handler resolves SDK requests with the current mode', async () => {
+  const seen = [];
+  const handler = createCanUseToolHandler({
+    getPermissionMode: () => 'bypassPermissions',
+    log: (message) => seen.push(message),
+  });
+
+  const result = await handler(
+    'Write',
+    { file_path: 'notes.md' },
+    {
+      signal: new AbortController().signal,
+      toolUseID: 'toolu_123',
+    },
+  );
+
+  assert.equal(result.behavior, 'allow');
+  assert.equal(result.toolUseID, 'toolu_123');
+  assert.ok(seen.some((message) => message.includes('allow Write')));
+});


### PR DESCRIPTION
## Summary
- Add a non-interactive SDK `canUseTool` permission handler for the agent runner so permission prompts are resolved immediately instead of hanging until the outer timeout.
- Emit a lightweight status stream event when handling permission requests, keeping the host timeout alive and making the permission path observable.
- Cover bypass/plan-mode permission decisions with a small Node test suite.

## Test Plan
- `npm --prefix container/agent-runner test`
- `npm run typecheck`