### PR TITLE
修复: IPC send_message 跨重试去重因 folder/chatJid 键错配对普通群恒失效

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -127,6 +127,28 @@ export class GroupQueue {
     return this.groups.get(groupJid)?.retryCount ?? 0;
   }
 
+  /**
+   * 某 workspace folder 上当前活跃 runner 的最大重试轮次（0 = 无重试）。
+   *
+   * retryCount 存在以 chatJid 为键的 GroupState 上，但 IPC send_message 去重只
+   * 知道源 folder（来自 IPC 目录名）。普通 web 群的 chatJid = `web:<uuid>` 与
+   * folder（`flow-...`）互不相等，按 `web:<folder>` / `<folder>` 猜键必然落空，
+   * 只有 admin home 因 folder=`main`、chatJid=`web:main` 巧合命中。这里直接按
+   * 活跃 runner 的 groupFolder 命中真实重试状态，home 与非 home 一致生效。
+   * （重试重放期间 registerProcess 已设好 groupFolder 且 retryCount>0，正是去重
+   * 窗口；groupFolder 仅在活跃 run 内非空——退出时两处 finally 必置 null——故空闲/
+   * 已退出的残留 state 不会误命中。）
+   */
+  getRetryCountByFolder(folder: string): number {
+    let max = 0;
+    for (const state of this.groups.values()) {
+      if (state.groupFolder === folder && state.retryCount > max) {
+        max = state.retryCount;
+      }
+    }
+    return max;
+  }
+
   /** 本轮失败后队列是否还会再次重试（决定错误提示发本轮还是等最终失败）。 */
   willRetryAfterFailure(groupJid: string): boolean {
     if (this.contextOverflowGroups.has(groupJid)) return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -736,8 +736,9 @@ function isRetryDuplicateIpcSend(
   const now = Date.now();
   const exp = recentIpcSends.get(key);
   // 仅在该 group 处于重试重放时，已见过的指纹才视为重复并抑制。
-  const inRetry = queue.getRetryCount(`web:${sourceGroup}`) > 0
-    || queue.getRetryCount(sourceGroup) > 0;
+  // sourceGroup 是 folder（IPC 目录名），retryCount 却以 chatJid 为键，二者只在
+  // admin home 巧合相等，故必须按 folder 域查询活跃 runner 的重试状态。
+  const inRetry = queue.getRetryCountByFolder(sourceGroup) > 0;
   const isDup = !!(exp && exp > now) && inRetry;
   recentIpcSends.set(key, now + IPC_SEND_DEDUP_TTL_MS);
   // 容量控制：Map 迭代为插入序，先进先出淘汰

--- a/tests/group-queue-retry-by-folder.test.ts
+++ b/tests/group-queue-retry-by-folder.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression tests for GroupQueue.getRetryCountByFolder — the folder-domain
+ * retry lookup behind the IPC send_message 跨重试去重 (isRetryDuplicateIpcSend).
+ *
+ * The bug it fixes: retryCount lives on the GroupState keyed by chatJid, but the
+ * dedup only knows the source FOLDER (the IPC directory name). The old code
+ * guessed the key as `web:<folder>` / `<folder>`, which only ever matched admin
+ * home (folder=`main`, chatJid=`web:main`). For a normal web group the chatJid
+ * is `web:<uuid>` (routes/groups.ts) — unrelated to the folder — so both guesses
+ * missed → inRetry was永远 false → 去重永不触发 → 重试重放的 send_message 重复刷屏。
+ *
+ * These tests pin the state exactly as it exists DURING a replay run (active +
+ * groupFolder set by registerProcess + retryCount bumped by a prior failure).
+ * groupFolder / retryCount are otherwise only mutated by the private run loop,
+ * so we reach in to seed that precise shape for a deterministic unit test.
+ */
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return { ...real, DATA_DIR: '/tmp/happyclaw-queue-retry-folder-test' };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+// killProcessTree pulls the heavy container-runner graph; these tests never
+// spawn a real process, so stub it out.
+vi.mock('../src/container-runner.js', () => ({
+  killProcessTree: () => {},
+}));
+
+vi.mock('../src/runtime-config.js', () => ({
+  getSystemSettings: () => ({ maxConcurrentContainers: 20, maxConcurrentHostProcesses: 5 }),
+}));
+
+vi.mock('../src/db.js', () => ({
+  getTaskById: () => undefined,
+}));
+
+const { GroupQueue } = await import('../src/group-queue.js');
+
+type AnyQueue = InstanceType<typeof GroupQueue> & {
+  getGroup(jid: string): { active: boolean; groupFolder: string | null; retryCount: number };
+};
+
+/**
+ * Seed a GroupState as it exists DURING an active (replay) run: active=true,
+ * groupFolder populated (registerProcess does this in the real path), and
+ * retryCount bumped by a previous failure's scheduleRetry.
+ */
+function seedActiveRun(q: AnyQueue, chatJid: string, folder: string, retryCount: number): void {
+  const state = q.getGroup(chatJid);
+  state.active = true;
+  state.groupFolder = folder;
+  state.retryCount = retryCount;
+}
+
+describe('GroupQueue.getRetryCountByFolder (IPC send dedup retry key)', () => {
+  test('finds retry state for a normal web group whose chatJid ≠ web:<folder>', () => {
+    const q = new GroupQueue() as AnyQueue;
+    // 普通 web 群：jid = web:<uuid>，folder = flow-...，两者互不相等。
+    seedActiveRun(q, 'web:7b1f0c1e-1234-dead-beef', 'flow-abc123', 2);
+
+    // 修复后：按 folder 域查询命中真实重试轮次。
+    expect(q.getRetryCountByFolder('flow-abc123')).toBe(2);
+
+    // 回归证据：旧的按键猜测（web:<folder> / <folder>）必然落空 → inRetry 恒 false。
+    expect(q.getRetryCount('web:flow-abc123')).toBe(0);
+    expect(q.getRetryCount('flow-abc123')).toBe(0);
+  });
+
+  test('admin home (folder=main, chatJid=web:main) still works — no regression', () => {
+    const q = new GroupQueue() as AnyQueue;
+    seedActiveRun(q, 'web:main', 'main', 1);
+
+    expect(q.getRetryCountByFolder('main')).toBe(1);
+    // 旧逻辑在 home 上巧合命中（web:${folder} === chatJid），修复后仍命中。
+    expect(q.getRetryCount('web:main')).toBe(1);
+  });
+
+  test('returns 0 when the folder has no active run (no false suppression)', () => {
+    const q = new GroupQueue() as AnyQueue;
+    expect(q.getRetryCountByFolder('flow-nonexistent')).toBe(0);
+  });
+
+  test('first attempt (retryCount=0) is never treated as in-retry', () => {
+    const q = new GroupQueue() as AnyQueue;
+    seedActiveRun(q, 'web:uuid-first-try', 'flow-def456', 0);
+    expect(q.getRetryCountByFolder('flow-def456')).toBe(0);
+  });
+
+  test('takes the max across multiple chatJids mapped to the same folder', () => {
+    const q = new GroupQueue() as AnyQueue;
+    // 一个 folder 可被多个 chatJid 触达（如 web:main + feishu 群共享 folder）；
+    // 取 max 做保守判定，只要有任一活跃 runner 在重试就算 inRetry。
+    seedActiveRun(q, 'web:sibling-1', 'shared-folder', 0);
+    seedActiveRun(q, 'web:sibling-2', 'shared-folder', 3);
+    expect(q.getRetryCountByFolder('shared-folder')).toBe(3);
+  });
+});


### PR DESCRIPTION
## 问题描述

`isRetryDuplicateIpcSend`（IPC `send_message` 跨重试去重）用 `web:${sourceGroup}` / `sourceGroup` 查 `retryCount`，但 `sourceGroup` 是 **folder**（IPC 目录名），`retryCount` 却以 **chatJid** 为键存在 `GroupQueue.groups` 上。

普通 web 群 `jid = web:<uuid>`（`src/routes/groups.ts`），与 folder（`flow-...`）互不相等，两个猜测键都落空 → `getRetryCount` 恒返回 0 → `inRetry` 恒 `false` → `isDup` 恒 `false`，**去重对非 home 群永不触发**。唯一巧合命中的是 admin home（`folder=main`、`chatJid=web:main`，使 `web:${folder}===chatJid`）。

**用户现象**：agent 在 `send_message` 之后中途报错 → 退避重试整批重放 prompt → 已执行过的 `send_message` 被再次即时投递，普通群用户收到**重复刷屏**消息——而这套去重正是为压掉这种重放重复而加的。

## 修复方案

`retryCount` 本质是 **folder 域**语义（一个 folder 同时只有一个活跃 run），故新增按 folder 查询的访问器，让 home / 非 home 一致生效。

### `src/group-queue.ts`
- 新增 `getRetryCountByFolder(folder)`：遍历 `groups`，按活跃 runner 的 `groupFolder` 取 max `retryCount`。`groupFolder` 仅在活跃 run 内非空（`registerProcess` 置位、退出时两处 `finally` 必清 `null`），故空闲 / 已退出的残留 state 不会误命中；重放期间 `groupFolder` 已置位且 `retryCount>0`，正是去重窗口。

### `src/index.ts`
- `isRetryDuplicateIpcSend` 改用 `queue.getRetryCountByFolder(sourceGroup)`。

### `tests/group-queue-retry-by-folder.test.ts`
- 回归测试：普通群（`web:<uuid>` vs `folder=flow-xxx`）命中、home 不回归、无活跃 run 返回 0、首轮不误判、同 folder 多 chatJid 取 max。

## 验证

- `tsc --noEmit` 0 错；全量 `vitest` 983 passed / 0 fail（含新增 5 个）。
- 已逐一核对其余 `getRetryCount` 调用点（`processGroupMessages(chatJid)` 作用域内）均为 chatJid 键，正确无需改；`isRetryDuplicateIpcSend` 是唯一 folder-vs-chatJid 错配点。

## 已知取舍（fail-safe，非回归）

去重指纹 `sourceGroup|chatJid|md5(text)` 本就是 **folder 维度**（旧代码亦然），故 `inRetry` 门控天然 folder-wide：同 folder 上若主消息 run 在重试，并发的 sub-agent / 定时任务发送了**逐字节相同**的内容（10min 内）也会被一并抑制。这是既有特性而非本次引入，且 fail-safe——只会丢 10 分钟内见过的完全相同载荷，绝不丢首次投递 / 不同内容 / 跨窗口；`retryCount=0` 时（绝大多数时间）完全不抑制。收窄它需要让指纹与门控都带上 run 身份，属另一独立改动，故此处保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
