### PR TITLE
修复: Windows host 模式下路径兼容

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import { query, HookCallback, PreCompactHookInput, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { detectImageMimeTypeFromBase64Strict } from './image-detector.js';
@@ -111,8 +112,12 @@ const IMAGE_MAX_DIMENSION = 8000; // Anthropic API 限制
 // ── 系统提示词从独立 Markdown 文件加载（启动期一次性 readFileSync 缓存到模块级常量）──
 // 文件位于 container/agent-runner/prompts/，便于改提示词无需重编译 + CR 友好。
 
+// 用 fileURLToPath 而非 new URL(...).pathname：后者在 Windows 上返回
+// "/E:/.../index.js"（带前导斜杠 + 盘符），path.join 后会丢盘符变成 "\E:\..."，
+// 再被 Node 按当前盘根解析成 "E:\E:\..." 导致 ENOENT。fileURLToPath 在
+// Linux 容器与 Windows host 模式下都返回正确的本地路径。
 const PROMPTS_DIR = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   '..',
   'prompts',
 );
@@ -1338,24 +1343,43 @@ async function runQuery(
   // SDK 的 optionalDependencies（@anthropic-ai/claude-agent-sdk-linux-x64 等）在 npm 上是空包，
   // 无法通过 node_modules/.bin/ 找到 working binary。通过 which 找到实际路径后传给 SDK。
   let pathToClaudeCodeExecutable: string | undefined;
-  try {
-    const resolvedPath = execFileSync('which', ['claude'], { timeout: 5_000, encoding: 'utf-8' }).trim();
-    if (resolvedPath) {
-      pathToClaudeCodeExecutable = resolvedPath;
+  // Windows host 模式：SDK 的 win32 平台包（@anthropic-ai/claude-agent-sdk-win32-x64）
+  // 带的是真实 claude.exe，直接解析它——`which` 在 Windows 上多半不存在/找不到，
+  // 且 SDK 自带的 win32 解析会漏 `.exe`。注意：Linux 容器里这些 optionalDependencies
+  // 是空包，必须走下面的 `which`（指向全局安装的 @anthropic-ai/claude-code），故仅 win32 走此分支。
+  if (process.platform === 'win32') {
+    const sdkBundled = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'node_modules',
+      '@anthropic-ai',
+      `claude-agent-sdk-${process.platform}-${process.arch}`,
+      'claude.exe',
+    );
+    if (fs.existsSync(sdkBundled)) {
+      pathToClaudeCodeExecutable = sdkBundled;
     }
-  } catch {
-    // Fallback: try to find it in common locations
-    const commonPaths = [
-      '/usr/local/bin/claude',
-      '/usr/bin/claude',
-      path.join(process.env.HOME || '/root', '.local/bin/claude'),
-      // 容器内 agent-runner 的本地依赖（package.json 声明了 @anthropic-ai/claude-code）
-      '/app/node_modules/.bin/claude',
-    ];
-    for (const p of commonPaths) {
-      if (fs.existsSync(p)) {
-        pathToClaudeCodeExecutable = p;
-        break;
+  }
+  if (!pathToClaudeCodeExecutable) {
+    try {
+      const resolvedPath = execFileSync('which', ['claude'], { timeout: 5_000, encoding: 'utf-8' }).trim();
+      if (resolvedPath) {
+        pathToClaudeCodeExecutable = resolvedPath;
+      }
+    } catch {
+      // Fallback: try to find it in common locations
+      const commonPaths = [
+        '/usr/local/bin/claude',
+        '/usr/bin/claude',
+        path.join(process.env.HOME || '/root', '.local/bin/claude'),
+        // 容器内 agent-runner 的本地依赖（package.json 声明了 @anthropic-ai/claude-code）
+        '/app/node_modules/.bin/claude',
+      ];
+      for (const p of commonPaths) {
+        if (fs.existsSync(p)) {
+          pathToClaudeCodeExecutable = p;
+          break;
+        }
       }
     }
   }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1350,7 +1350,7 @@ export async function runHostAgent(
       for (const root of allowlist.allowedRoots) {
         const expandedRoot = root.path.startsWith('~')
           ? path.join(
-              process.env.HOME || '/Users/user',
+              process.env.HOME || os.homedir(),
               root.path.slice(root.path.startsWith('~/') ? 2 : 1),
             )
           : path.resolve(root.path);
@@ -1651,7 +1651,9 @@ export async function runHostAgent(
     if (capResult.resolvedPaths['claude']) {
       const resolvedClaudeDir = path.dirname(capResult.resolvedPaths['claude']);
       const currentPath = hostEnv['PATH'] || process.env.PATH || '';
-      hostEnv['PATH'] = `${resolvedClaudeDir}:${currentPath}`;
+      // path.delimiter（Windows ';'，POSIX ':'）——硬编码 ':' 会在 Windows 上
+      // 把盘符（E:）也当分隔符，PATH 被拼烂导致 claude 目录无法生效。
+      hostEnv['PATH'] = `${resolvedClaudeDir}${path.delimiter}${currentPath}`;
       logger.info(
         { group: group.name, resolvedClaudeDir, resolvedPath: capResult.resolvedPaths['claude'] },
         'Host preflight: claude binary resolved',


### PR DESCRIPTION
## 问题描述

`agent-runner` 最初为 Linux 容器编写,在 **Windows host 模式**下暴露多处 POSIX 假设,导致 host 模式无法启动 agent。

## 修复方案

### `container/agent-runner/src/index.ts`

- **PROMPTS_DIR 盘符翻倍**:`new URL(import.meta.url).pathname` 在 Windows 上返回 `/E:/.../index.js`(带前导斜杠 + 盘符),`path.join` 后丢盘符变成 `\E:\...`,再被 Node 按当前盘根解析成 `E:\E:\...` 导致 ENOENT。改用 `fileURLToPath`,Linux 容器与 Windows host 下都返回正确本地路径。
- **claude.exe 解析**:`which claude` 在 Windows 上多半找不到,fallback 全是 Linux 路径,导致 `pathToClaudeCodeExecutable` 为空、SDK 自找漏 `.exe` 报 "native binary not found"。win32 下直接解析 SDK 自带的 `@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe`(与 `agent-capabilities.ts` 主进程侧解析逻辑一致);Linux 容器里这些 optionalDependencies 是空包,仍走原 `which` 分支。

### `src/container-runner.ts`

- **PATH 分隔符**:`hostEnv['PATH']` 拼接硬编码 `:`,Windows 上会把盘符(`E:`)也当分隔符拼烂 PATH。改用 `path.delimiter`(Windows `;` / POSIX `:`)。
- **~ 展开 fallback**:mount allowlist 的 `~` 展开 fallback 到 macOS 风格 `/Users/user`。改用 `os.homedir()`。

## 验证

- `make typecheck` 全量通过
- 改动均为平台分支隔离,Linux 容器路径行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)