### PR TITLE
改进: 飞书 IM 配置加 appId 格式校验 + 保存前连通性测试

### DIFF
--- a/src/feishu-connectivity.ts
+++ b/src/feishu-connectivity.ts
@@ -1,0 +1,73 @@
+// 在保存用户飞书配置时,先用 (appId, appSecret) 调一次 tenant_access_token 接口,
+// 验证凭据真能换出 token。这条防御挡掉两类历史事故:
+//  - appId 填成了用户名 / 手机号(没带 cli_ 前缀),schema 已挡;
+//  - appId 格式对但凭据错配(复制错应用、appSecret 被废),schema 挡不住,只能靠
+//    实际 API 响应识别。
+// 飞书 token API 失败时返回非零 code + msg,我们把 code/msg 透传给前端做提示。
+
+const FEISHU_TENANT_TOKEN_ENDPOINT =
+  'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal';
+
+export interface FeishuConnectivityResult {
+  ok: boolean;
+  errorCode?: number;
+  errorMessage?: string;
+}
+
+export async function testFeishuCredentials(
+  appId: string,
+  appSecret: string,
+  options: { timeoutMs?: number; endpoint?: string } = {},
+): Promise<FeishuConnectivityResult> {
+  const timeoutMs = options.timeoutMs ?? 8000;
+  const endpoint = options.endpoint ?? FEISHU_TENANT_TOKEN_ENDPOINT;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        errorMessage: `Feishu API HTTP ${res.status}`,
+      };
+    }
+
+    const data = (await res.json().catch(() => null)) as
+      | { code?: number; msg?: string; tenant_access_token?: string }
+      | null;
+
+    if (!data) {
+      return { ok: false, errorMessage: 'Feishu API returned non-JSON body' };
+    }
+
+    if (data.code === 0 && data.tenant_access_token) {
+      return { ok: true };
+    }
+
+    return {
+      ok: false,
+      errorCode: typeof data.code === 'number' ? data.code : undefined,
+      errorMessage: data.msg || 'Feishu API rejected the credentials',
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // AbortError 在 timeout 时触发,把它翻译成用户能读懂的提示
+    if (msg.includes('aborted') || msg.includes('AbortError')) {
+      return {
+        ok: false,
+        errorMessage: `Feishu API request timed out after ${timeoutMs}ms`,
+      };
+    }
+    return { ok: false, errorMessage: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -95,6 +95,7 @@ import { parseOAuthUsageBucket } from '../runtime-config.js';
 import type { AuthUser, RegisteredGroup } from '../types.js';
 import { hasPermission } from '../permissions.js';
 import { logger } from '../logger.js';
+import { testFeishuCredentials } from '../feishu-connectivity.js';
 import {
   checkImChannelLimit,
   isBillingEnabled,
@@ -1471,6 +1472,54 @@ configRoutes.put('/user-im/feishu', authMiddleware, async (c) => {
   }
   if (typeof validation.data.autoIsolateContext === 'boolean') {
     next.autoIsolateContext = validation.data.autoIsolateContext;
+  }
+
+  // Pre-save connectivity test: 启用且有完整凭据,且 (appId 或 appSecret 跟当前
+  // 持久化值不一致) 时,先调一次 tenant_access_token 接口验证凭据真能换出 token。
+  //
+  // 凭据变更守卫(per PR #572 review):仅 autoIsolateContext / enabled 这类与
+  // 凭据无关的设置变更不应触发 8s 飞书 API 测试;否则飞书抖动期间用户改个无关
+  // 开关都会被 400 阻塞。current 在上方已 decrypt 持有明文 appSecret,可直接比较。
+  //
+  // 不可达 / timeout 不强行阻塞:既然连飞书都连不上,自动重连阶段也会失败,
+  // 此时把错误暴露给用户比"成功保存但实际拿不到 token"更体面。
+  const credentialsChanged =
+    next.appId !== (current?.appId ?? '') ||
+    next.appSecret !== (current?.appSecret ?? '');
+  if (
+    next.enabled === true &&
+    typeof next.appId === 'string' &&
+    typeof next.appSecret === 'string' &&
+    next.appId &&
+    next.appSecret &&
+    credentialsChanged
+  ) {
+    const test = await testFeishuCredentials(
+      next.appId as string,
+      next.appSecret as string,
+    );
+    if (!test.ok) {
+      logger.warn(
+        {
+          userId: user.id,
+          appId: next.appId,
+          errorCode: test.errorCode,
+          errorMessage: test.errorMessage,
+        },
+        'Feishu credentials verification failed before save',
+      );
+      return c.json(
+        {
+          error: 'Feishu credentials verification failed',
+          details: {
+            code: test.errorCode,
+            message: test.errorMessage,
+            hint: 'Check appId/appSecret on the Lark/Feishu developer console',
+          },
+        },
+        400,
+      );
+    }
   }
 
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -436,9 +436,27 @@ export const ClaudeSecretsSchema = z
     { message: 'At least one secret field must be provided' },
   );
 
+// 飞书/Lark 官方 appId 形如 `cli_xxxxxxxxxxxxxxxx`(cli_ 前缀 + 小写字母数字)。
+// 历史上有用户把用户名 / 手机号 / 邮箱前缀填进去,后端不校验直接存,飞书 SDK 拿这串
+// 错误的 appId 反复重试拿 token,导致日志被 axios error dump 灌爆(实测 ~2.5G/天)。
+// 这里挡掉格式不对的;真实的"凭据错配"留给保存前的 testFeishuCredentials 兜底。
+const FEISHU_APP_ID_REGEX = /^cli_[a-z0-9]+$/;
+
 export const FeishuConfigSchema = z
   .object({
-    appId: z.string().max(2000).optional(),
+    appId: z
+      .string()
+      .max(2000)
+      // refine 内先 trim 再匹配,与下游 routes/config.ts 的 trim() 行为对齐
+      // (per PR #572 review minor):粘贴带首尾空白的合法 appId 不被误拒
+      .refine((v) => {
+        const trimmed = v.trim();
+        return trimmed === '' || FEISHU_APP_ID_REGEX.test(trimmed);
+      }, {
+        message:
+          'appId must be in Feishu/Lark official format (cli_ prefix + lowercase alphanumeric)',
+      })
+      .optional(),
     appSecret: z.string().max(2000).optional(),
     clearAppSecret: z.boolean().optional(),
     enabled: z.boolean().optional(),

--- a/tests/feishu-config-validation.test.ts
+++ b/tests/feishu-config-validation.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { FeishuConfigSchema } from '../src/schemas.js';
+import { testFeishuCredentials } from '../src/feishu-connectivity.js';
+
+describe('FeishuConfigSchema appId validation', () => {
+  it('accepts valid Feishu appId format', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'cli_a94258083b789cb3',
+      appSecret: 'secret-placeholder',
+      enabled: true,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts another valid appId variant', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'cli_aa83c54c96b8dbd0',
+      enabled: false,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts empty string appId (partial update)', () => {
+    // 用户只更新 enabled / appSecret,不带 appId,UI 提交空串是合法路径
+    const res = FeishuConfigSchema.safeParse({
+      appId: '',
+      enabled: false,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it('rejects username-shaped appId (historical bug case)', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'waimoon',
+      appSecret: 'x',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects phone-number-shaped appId (historical bug case)', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: '18058136600',
+      appSecret: 'x',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects short string without cli_ prefix', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'ynn',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects uppercase letters in appId', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'cli_AA83C54C96B8DBD0',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects cli_ alone without payload', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'cli_',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects special characters in appId', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: 'cli_abc-123',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('accepts appId with leading/trailing whitespace (will be trimmed)', () => {
+    // per PR #572 review minor: 粘贴带空白的合法 appId 应通过 schema
+    // (refine 内 trim 后再正则匹配,与 routes 层的 trim() 行为对齐)
+    const res = FeishuConfigSchema.safeParse({
+      appId: '  cli_aab0831c21b9dcc2  ',
+      appSecret: 'x',
+      enabled: true,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it('still rejects whitespace-padded invalid appId', () => {
+    const res = FeishuConfigSchema.safeParse({
+      appId: '  waimoon  ',
+      enabled: true,
+    });
+    expect(res.success).toBe(false);
+  });
+});
+
+describe('testFeishuCredentials', () => {
+  it('returns ok when endpoint responds with code 0 and token', async () => {
+    const fakeEndpoint = 'http://127.0.0.1:0/stub'; // never reached, mocked via fetch override
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          code: 0,
+          msg: 'ok',
+          tenant_access_token: 't-stub',
+          expire: 7200,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    try {
+      const res = await testFeishuCredentials('cli_aa83c54c96b8dbd0', 'secret', {
+        endpoint: fakeEndpoint,
+      });
+      expect(res.ok).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns error code+message when API rejects credentials', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          code: 99991663,
+          msg: 'invalid app_id or app_secret',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    try {
+      const res = await testFeishuCredentials('cli_aa83c54c96b8dbd0', 'wrong', {
+        endpoint: 'http://127.0.0.1:0/stub',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.errorCode).toBe(99991663);
+      expect(res.errorMessage).toContain('invalid');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns failure on HTTP non-2xx', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response('Internal Server Error', { status: 500 });
+    try {
+      const res = await testFeishuCredentials('cli_aa83c54c96b8dbd0', 'x', {
+        endpoint: 'http://127.0.0.1:0/stub',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.errorMessage).toContain('500');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns failure with timeout message when aborted', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_url: any, init: any) => {
+      // 模拟一个不会 resolve 的请求,等待 controller.abort()
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    };
+    try {
+      const res = await testFeishuCredentials('cli_aa83c54c96b8dbd0', 'x', {
+        endpoint: 'http://127.0.0.1:0/stub',
+        timeoutMs: 50,
+      });
+      expect(res.ok).toBe(false);
+      expect(res.errorMessage).toContain('timed out');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## 问题描述

实际部署中观察到一类反复发生的事故:

- 至少 4 个用户在 \`PUT /api/config/user-im/feishu\` 把 \`appId\` 填成了**用户名 / 手机号 / 邮箱前缀**(例如 \`waimoon\`、\`ynn\`、\`yueyuedadeveil\`、\`18058136600\`),没有 \`cli_\` 前缀
- 后端只检查长度上限 \`max(2000)\`,直接存进去
- 飞书 SDK 拿错误的 appId 反复重试 \`tenant_access_token\` 接口,每次失败把整个 axios error 对象(含完整 request / response 等嵌套节点)\`console.error\` 出来
- 实测累积 **~2.5G/天** 日志,~700M+ 在 4 天里把单机磁盘从 60% 打到 87%
- 同时这 4 个用户飞书功能其实**全部失效**(token 拿不到),但他们自己看不到任何错误反馈

这是个所有 self-host 用户都会踩的坑 — 一旦某个用户配错,所有人共享的磁盘就被慢性吃掉。

## 修复方案

两层防御,顺序从便宜到贵:

### 1️⃣ Schema 层正则(零成本,早 400)

\`FeishuConfigSchema.appId\` 必须匹配 \`/^cli_[a-z0-9]+\$/\` 或为空串。

- 空串保留是为了**只更新 \`enabled\` / \`appSecret\` 的部分更新路径** — UI 提交时可能不带 appId
- 拦截 4 个历史 bug 案例: \`waimoon\` / \`ynn\` / \`yueyuedadeveil\` / \`18058136600\`
- 也拦截 \`cli_\`(空 payload)、大写、特殊字符 \`-\` 等

### 2️⃣ 保存前调用 \`tenant_access_token\` 接口(挡格式对但凭据错配)

仅在 \`enabled=true\` 且 \`appId + appSecret\` 都齐全时触发,8s timeout。

- 飞书返回 \`code=0\` + \`tenant_access_token\` 才放行
- \`code != 0\` → 把 \`code/msg/hint\` 透传给前端,用户能直接定位是 appId 错还是 appSecret 错
- 网络 timeout 也作 400 处理 —— 既然连飞书都连不上,自动重连阶段同样会失败,把错误暴露给用户比"保存成功但实际拿不到 token"更体面

### \`src/feishu-connectivity.ts\`(新增)

独立模块导出 \`testFeishuCredentials(appId, appSecret, options?)\`,无依赖、可单测。用原生 \`fetch + AbortController\`,不引新包。

### \`src/schemas.ts\`

\`FeishuConfigSchema\` 改 \`appId\` 加 \`.refine()\` 校验,正则用顶部模块常量,带注释说明历史动机。

### \`src/routes/config.ts\`

\`PUT /user-im/feishu\` 在 \`autoIsolateContext\` 处理后、\`saveUserFeishuConfig\` 之前插入 connectivity 测试块,失败 \`return c.json(..., 400)\` 直接退出。

### \`tests/feishu-config-validation.test.ts\`(新增)

13 个新单测:

- 9 个 schema:正面用例(2)+ 空串(1)+ 4 个历史 bug 案例 + 大写 / \`cli_\` 单独 / 特殊字符
- 4 个 connectivity:成功 / 飞书拒绝 / HTTP 5xx / timeout

通过 \`globalThis.fetch\` 局部替换做 mock,不污染其他 test 的 fetch。

## 不在本 PR 范围内(我故意分离)

为了让本 PR 简单可审,我**没有**在这次包含:

- ❌ PM2 logrotate 默认安装(运维层,不是代码功能)
- ❌ 连续 N 次拿不到 token 自动 disable(需要修 \`feishu.ts\` 的连接重试状态机,跨多文件,争议大)
- ❌ Playwright 在 flow 工作目录共享缓存(容器配置层)
- ❌ \`make build\` 时 Docker prune(可能误删用户其他镜像)

后续可以按情况另开 PR。

## 测试

- \`make typecheck\` ✅
- \`make test\` ✅ (**1022/1022** 全过,新增 13 个测试)

## 影响

| 场景 | 行为 |
|---|---|
| 现有正确配置 | ✅ 不变(\`cli_\` 前缀都能通过) |
| 部分更新(只改 enabled) | ✅ 不变(空串 appId 保留) |
| 新填错误 appId 格式 | 🛡️ 400 拒绝(早期防御)|
| 格式对但凭据错配 | 🛡️ 400 拒绝 + 透传飞书 error code/msg |
| 飞书 API 临时网络问题 | 🛡️ 8s timeout → 400 + 明确提示 |
| 已存的 4 个错乱配置 | ⚠️ 不会回溯清理(本 PR 只防新增) |