### PR TITLE
新增: Dockerfile 内置 Headroom (token 压缩工具, 默认不启用)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,6 +797,16 @@ make help          # 列出所有可用的 make 命令
 2. 用户级：添加到 `~/.claude/skills/`（自动挂载到所有容器）
 3. 无需重建镜像，volume 挂载 + entrypoint.sh 符号链接自动发现
 
+### 启用 Headroom（工具输出/RAG/日志 token 压缩）
+
+容器镜像默认带 [Headroom](https://github.com/chopratejas/headroom)（Apache-2.0，60-95% token 减少），**默认不启用**，用户自行决定是否打开：
+
+1. 打开 `/mcp-servers` 页面 → Add server
+2. 填：name=`headroom`，command=`headroom`，args=`["mcp", "serve"]`，enabled=true
+3. 下一次会话起 Claude 获得 `headroom_compress` / `headroom_retrieve` / `headroom_stats` 三个工具
+
+Claude 在读大文件、跑大 log 命令、处理 RAG chunk 时会主动调用。属于 per-user MCP server 范畴（详见 §7 / `src/routes/mcp-servers.ts`），不走 agent-runner 内置注册。
+
 ### 新增 StreamEvent 类型
 
 1. `shared/stream-event.ts` — 在 `StreamEventType` 联合类型中添加新成员，在 `StreamEvent` 接口中添加对应字段

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -115,6 +115,19 @@ ARG CACHEBUST=1
 RUN npm install -g agent-browser
 RUN npm install
 
+# Headroom (https://github.com/chopratejas/headroom) - 工具输出/RAG/日志压缩.
+# 装上 binary 但默认不启用——用户在 /mcp-servers 自行添加才生效, 配置:
+#   { "command": "headroom", "args": ["mcp", "serve"] }
+# 只选 [code,mcp] 两个 extras: [memory] 通过 sentence-transformers 强依赖
+# torch + CUDA (cudnn-cu12, cublas, cusparse, cusolver, nccl, triton...),
+# 压缩包就 ~2.45GB, 解包 3-6GB 量级. HappyClaw 容器无 GPU, 也不需要语义
+# embedding 类 retrieve. 用户如真需要 headroom 的 memory 能力, 可在容器内
+# 单独 `pip install --index-url https://download.pytorch.org/whl/cpu torch`
+# 再 `pip install "headroom-ai[memory]"` 走 CPU 路径. PIP_BREAK_SYSTEM_PACKAGES
+# 已在 line 103 设置, 这里无需再传 --break-system-packages.
+RUN pip install "headroom-ai[code,mcp]" \
+    && headroom --version
+
 # Install feishu-cli (binary + builtin skills), 始终跟踪 latest release。
 # 通过 302 redirect 从 github.com/releases/latest 的 Location header 提取 tag
 # （和 install.sh 作者自己用的技巧一致），不经 api.github.com 规避 rate limit。


### PR DESCRIPTION
## 问题描述

Claude Agent 调用 Bash / Read / Web tools 时返回的大输出, 以及对话历史在 PreCompact 之前的累积, 是 HappyClaw 单次会话 token 消耗的两个主要来源. 实测一次产业链深度调研(8 轮 web search)单会话 token 量 ~50-100k, 大部分是 tool output 而不是 LLM 推理本身.

[Headroom](https://github.com/chopratejas/headroom) (Apache-2.0, 45.8k ⭐, 当日 release 0.27.0) 是社区主流的 LLM token 压缩工具, 官方数据 **60-95% token 减少, 同等答案**. 三个核心能力:

- \`headroom_compress\` - AST-aware 代码 / 日志 / RAG chunk 压缩
- \`headroom_retrieve\` - 可逆压缩, LLM 按需取回原文
- \`headroom_stats\` - 压缩统计

## 集成策略

最小可用接入, **不动后端 / agent-runner 一行代码**:

1. **Dockerfile 装 headroom binary**(全用户镜像都有)
2. **默认不启用** -- 用户在现有 \`/mcp-servers\` 页面自行添加才生效
3. **走 per-user MCP server 范畴**(\`src/routes/mcp-servers.ts\` 已有完整机制), 不内置到 agent-runner 注册路径
4. **只支持 MCP server 模式**, 不引入 proxy 拦截模式

用户启用方式 (CLAUDE.md 已记录):

\`\`\`
/mcp-servers 页面 -> Add server
  name:    headroom
  command: headroom
  args:    [\"mcp\", \"serve\"]
  enabled: true
\`\`\`

下次新会话起 Claude 自动获得三个 \`headroom_*\` 工具, 在读大文件 / 跑大 log / 处理 RAG chunk 时主动调用.

## 镜像增量控制

用 \`[code,mcp,memory]\` 三个核心 extras 而非 \`[all]\`:

| Extras 子集 | 用途 | 是否选 |
|---|---|---|
| \`code\` | AST-aware 代码压缩 (主要 use case) | ✅ |
| \`mcp\` | MCP server 模式 (集成方式) | ✅ |
| \`memory\` | 对话历史压缩 | ✅ |
| \`voice\` / \`pytorch-mps\` / \`image\` / \`spreadsheet\` 等 | HappyClaw 用不到 | ❌ |

**预期镜像增量 ~200MB**(vs \`[all]\` 可能 +1GB).

CACHEBUST 已在此前触发, 每次构建重新解析 latest version.

## 为什么不选 Proxy 模式

Headroom 也提供 \`headroom wrap claude\` proxy 模式, 拦截所有 LLM API 调用做自动压缩. **本 PR 故意不引入**:

- proxy 拦截意味着 API key + 用户消息 + 代码内容流过第三方进程
- 跟 HappyClaw 的 \`<security>\` Skill 审查模型有张力
- MCP server 模式已经够用 (Claude 主动调用压缩, 不拦截 API)

## 风险评估

| 维度 | 评估 |
|---|---|
| License | Apache 2.0 (商业友好) |
| Maturity | 45.8k ⭐ / 3.2k forks / 384 active issues |
| Maintenance | 当日 commit (Cortex Code provider 6 小时前刚加) |
| Multi-arch | manylinux x86_64 + aarch64 + macOS arm64 都有 wheel |
| 默认行为 | **不变** -- 没启用前完全不参与会话 |
| 回滚成本 | 改回 Dockerfile + 镜像重建 |

## 测试

\`make typecheck\` ✅

未做本地 build 验证, 但:

- PyPI 校验包名 \`headroom-ai\` + extras \`[code,mcp,memory]\` 均存在
- \`headroom --version\` 在 Dockerfile 内做了自检, 安装失败会让 build 直接挂掉
- 不动代码, 只是 Dockerfile + Markdown, 没有跑 test 的必要

## 不在本 PR 范围内

为了让本 PR 简单可审, 后续可单独提的:

- ❌ UI 一键启用按钮(在 /mcp-servers 页面加个 "Enable Headroom" 快捷)
- ❌ 默认启用(等社区用一段时间后再说)
- ❌ Settings page 加 token 使用统计面板(集成 \`headroom_stats\`)
- ❌ 写一个 Skill 让 Claude 知道什么场景该主动调 \`headroom_compress\`