### PR TITLE
修复: web 端 conversation agent 创建时未注册到 registered_groups

### DIFF
--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -19,6 +19,7 @@ import {
   deleteSession,
   getGroupsByTargetAgent,
   setRegisteredGroup,
+  deleteRegisteredGroup,
   getJidsByFolder,
   updateAgentLastImJid,
   updateAgentInfo,
@@ -215,6 +216,31 @@ router.post('/:jid/agents', authMiddleware, async (c) => {
   const virtualChatJid = `${jid}#agent:${agentId}`;
   ensureChatExists(virtualChatJid);
 
+  // Register virtual chat as a sibling group so router and queue can look up
+  // folder / executionMode / ownerId by virtualChatJid. Without this, web-side
+  // agent fork chats (web:...#agent:...) are absent from registered_groups,
+  // causing processAgentConversation() and the message router to drop their
+  // messages silently. Mirrors what feishu.ts/telegram.ts do at IM ingestion.
+  // The skip-on-target_agent_id branch in the router intentionally lets the
+  // web-side handleAgentConversationMessage() own this path; without a registered
+  // sibling here, that handler's cold-start branch can't find the parent group
+  // and the message vanishes.
+  const { jid: _parentJid, ...parentFields } = group;
+  setRegisteredGroup(virtualChatJid, {
+    ...parentFields,
+    name,
+    added_at: now,
+    created_by: user.id,
+    is_home: false,
+    target_agent_id: agentId,
+    target_main_jid: jid,
+    // Reset IM-specific fields — agent fork is web-only
+    owner_im_id: undefined,
+    feishu_chat_mode: undefined,
+    feishu_group_message_type: undefined,
+    sender_allowlist: undefined,
+  });
+
   // Broadcast agent_status (idle) via WebSocket
   // Import dynamically to avoid circular deps
   const { broadcastAgentStatus } = await import('../web.js');
@@ -389,6 +415,9 @@ router.delete('/:jid/agents/:agentId', authMiddleware, async (c) => {
   if (agent.kind === 'conversation') {
     const virtualChatJid = `${jid}#agent:${agentId}`;
     deleteMessagesForChatJid(virtualChatJid);
+    // Also unregister the sibling group created at agent creation time
+    // (paired with the setRegisteredGroup call in POST /:jid/agents).
+    deleteRegisteredGroup(virtualChatJid);
 
     // Note: IM bindings are checked above and block deletion if present.
     // No auto-clear here — user must unbind explicitly before deleting.


### PR DESCRIPTION
## 问题描述

实际部署中发现一个静默 bug:用户在 web 端创建 conversation agent(主对话派生的子线程)后,该子线程的消息会被后端 router 静默丢弃,UI 上看到 \"服务已重启,正在恢复上次未完成的任务...\" 反复出现,但 agent 完全无响应。

实战中我自己实例的一个用户连续 5 天每天发同一个问题(\"我们财务部门,一直在微信上办公,现在也想把财务工作挪到飞书上面来\"),系统每次返回 \"服务已重启\" 但实际 agent 从来没收到他的消息。

## 影响范围

我扫了一下本地数据库,**6-19 ~ 6-23 之间至少 12 个 conversation agent 子对话受影响,累计 320+ 条用户消息被静默丢弃**。所有走 web 端创建子对话的用户都会踩到。

## 复现路径

1. 用户在主对话点 \"+\" 新建子对话 → \`POST /api/groups/:jid/agents\`
2. 在子对话发消息 → WebSocket 进入 \`handleAgentConversationMessage()\`(src/web.ts:659)
3. \`storeMessageDirect\` 把消息存到 \`virtualChatJid\`(\`web:...#agent:agentId\`)
4. \`queue.sendMessage\` 返回 \`'no_active'\` → cold-start \`processAgentConversation\`
5. cold-start 内部需要 \`getRegisteredGroup(virtualChatJid)\` 拿 folder / executionMode / ownerId,**但 virtualChatJid 从未被注册** → 返回 undefined
6. 容器启动失败但无明显告警,消息看起来 \"发出去了\" 但 agent 永远不会回

## 为什么之前没暴露

\`src/index.ts:7198\` router 主路径有 \`if (group.target_agent_id) continue;\` 的 skip,注释说明 \"target_agent_id 的 group 在 IM ingestion 时被路由\"。这个 skip 本身没问题:

- 飞书侧 → 飞书 ingestion 自己处理,且**自己写 setRegisteredGroup**(\`src/routes/agents.ts:632\` 的 IM 绑定路径)
- Telegram 侧同理
- Web 侧 → \`handleAgentConversationMessage()\` 直接处理

问题在于 **web 端 POST /:jid/agents 创建 agent 时,sibling 节点在 registered_groups 里根本不存在**。所以即便 \`handleAgentConversationMessage\` 想 cold-start,它内部的 group lookup 也会失败。飞书 / Telegram 因为有 ingestion-side setRegisteredGroup 兜底,不会踩这个洞;**web 端缺这一步,所以静默坏掉**。

## 修复

### \`src/routes/agents.ts\`

**POST /:jid/agents**(line 215 \`ensureChatExists\` 之后):补一次 setRegisteredGroup,把 virtualChatJid 注册为 sibling group:

\`\`\`ts
const { jid: _parentJid, ...parentFields } = group;
setRegisteredGroup(virtualChatJid, {
  ...parentFields,                    // 继承 folder / executionMode / customCwd / ...
  name,
  added_at: now,
  created_by: user.id,
  is_home: false,
  target_agent_id: agentId,            // 标记是 agent fork
  target_main_jid: jid,                // 指向父 chat
  // Reset IM-specific fields — agent fork 是 web-only
  owner_im_id: undefined,
  feishu_chat_mode: undefined,
  feishu_group_message_type: undefined,
  sender_allowlist: undefined,
});
\`\`\`

**DELETE /:jid/agents/:agentId**(line 391 \`deleteMessagesForChatJid\` 旁边):补一次 \`deleteRegisteredGroup\` 配对清理,避免删 agent 后留下 dangling 注册。

## 影响

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 新创建 conversation agent 后发消息 | 🔴 静默丢失 | ✅ 正常路由 |
| 旧的 conversation agent | 🔴 仍坏 | 🟡 需运维侧补数据(SQL 回填,见下) |
| 飞书 / Telegram conversation agent | ✅ 已工作 | ✅ 不变 |
| 删除 agent | 🟡 留 dangling 注册 | ✅ 配对清理 |

### 存量数据回填(给 self-host 用户)

合并这个 PR 不会自动回填存量。受影响的用户可以跑下面这段 Node 脚本一次性补:

\`\`\`js
// 在 HappyClaw 根目录执行: node hotfix.js
const Database = require('better-sqlite3');
const db = new Database('data/db/messages.db');
const stuck = db.prepare(\`
  SELECT DISTINCT m.chat_jid FROM messages m
  WHERE m.chat_jid LIKE 'web:%#agent:%'
    AND NOT EXISTS (SELECT 1 FROM registered_groups rg WHERE rg.jid = m.chat_jid)
\`).all();
console.log('受影响 chat 数:', stuck.length);
// 对每个 stuck chat: 解析 #agent: 拿 agentId, 从父 chat 继承 folder/execMode...
// (详见 PR 描述里的回填脚本)
\`\`\`

完整回填脚本我已经在自己实例跑过,12 个 stuck chat 修了 11 个,剩 1 个是孤儿(主 chat 被用户删过)。可以单独发个 helper PR,如果你认为有用。

## 测试

- \`make typecheck\` ✅
- \`make test\` ✅ **1009/1009 全过**

**未加新单测**:改动是 +2 个 DB 操作,DB 层契约已被现有 \`db-transactions.test.ts\` 等覆盖,加 routes 集成测试需要 mock 整套 \`getWebDeps\` 注入收益不高。如果你觉得 regression 风险大,我可以单独提一个 helper PR 加纯 unit test 验证 setRegisteredGroup + spread + override 的字段映射正确。