### PR TITLE
fix: make start 在 Node 26 下启动失败

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1391,10 +1391,11 @@ async function runQuery(
         allowDangerouslySkipPermissions: true,
         agentProgressSummaries: true,
         settingSources: ['project', 'user'],
-        // 技能挂载：SDK 0.2.110 起 Options.skills 类型从 'all' 改为 string[]（要预加载的技能名列表）。
-        // 不传 skills 时，技能仍由 settingSources（project/user）自动发现并挂载到主会话——
+        // 技能挂载：SDK 0.2.110 起顶层 Options 已不再接受 skills 字段，技能改由
+        // settingSources（project/user）做文件系统发现并挂载到主会话——
         // 这正是原 'all' 想要的“全部技能生效”行为，故此处不再显式传 skills。
-        // 如需强制预加载特定技能，改为 skills: ['name1', 'name2']。
+        // 注意：string[] 形态的 skills（预加载技能名列表）仅适用于 AgentDefinition，
+        // 不能传给 query() 的顶层 Options。
         includePartialMessages: true,
         // Forward sub-agent (Task) text/thinking as stream events so the card's
         // sub-agent transcript lights up live instead of only filling in when the
@@ -1402,8 +1403,11 @@ async function runQuery(
         // (agentScope:'subagent' deltas, stream-processor.ts ~979); this flag is
         // what actually makes the SDK emit them.
         // NOTE: SDK 0.2.110 从 Options 类型中移除了 forwardSubagentText（子代理转录
-        // 改走 SubagentStart/Stop hooks + getSubagentMessages）。这里用 as any 保留传值，
-        // 运行时若仍被支持则生效，否则被忽略——不影响启动。
+        // 改走 SubagentStart/Stop hooks + getSubagentMessages）。这里用 as any 保留传值
+        // 以消除 tsc 报错、不阻塞启动。
+        // TODO（已知待跟进项）：若新版 SDK 已彻底改走 hooks 路径，则卡片中子代理转录的
+        // “实时点亮”可能已静默失效。后续应迁移到 SubagentStart/Stop hooks，或确认
+        // 该 flag 运行时仍生效。
         ...({ forwardSubagentText: true } as any),
         ...(Object.keys(flagSettings).length > 0 ? { settings: flagSettings as any } : {}),
         ...(userPlugins && { plugins: userPlugins }),

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1391,17 +1391,20 @@ async function runQuery(
         allowDangerouslySkipPermissions: true,
         agentProgressSummaries: true,
         settingSources: ['project', 'user'],
-        // 启用全部已发现的技能到主会话。SDK 0.3.x 起 skills 是"打开技能的唯一正确位置"
-        // （用了它就无需再往 allowedTools 塞已废弃的 'Skill'）。'all' = 启用所有发现的技能，
-        // 显式声明比依赖 CLI 隐式默认更可靠，确保全局/项目/用户技能完整挂载生效。
-        skills: 'all',
+        // 技能挂载：SDK 0.2.110 起 Options.skills 类型从 'all' 改为 string[]（要预加载的技能名列表）。
+        // 不传 skills 时，技能仍由 settingSources（project/user）自动发现并挂载到主会话——
+        // 这正是原 'all' 想要的“全部技能生效”行为，故此处不再显式传 skills。
+        // 如需强制预加载特定技能，改为 skills: ['name1', 'name2']。
         includePartialMessages: true,
         // Forward sub-agent (Task) text/thinking as stream events so the card's
         // sub-agent transcript lights up live instead of only filling in when the
         // Task completes. The stream-processor already renders these
         // (agentScope:'subagent' deltas, stream-processor.ts ~979); this flag is
         // what actually makes the SDK emit them.
-        forwardSubagentText: true,
+        // NOTE: SDK 0.2.110 从 Options 类型中移除了 forwardSubagentText（子代理转录
+        // 改走 SubagentStart/Stop hooks + getSubagentMessages）。这里用 as any 保留传值，
+        // 运行时若仍被支持则生效，否则被忽略——不影响启动。
+        ...({ forwardSubagentText: true } as any),
         ...(Object.keys(flagSettings).length > 0 ? { settings: flagSettings as any } : {}),
         ...(userPlugins && { plugins: userPlugins }),
         mcpServers: {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@larksuiteoapi/node-sdk": "^1.58.0",
     "@whiskeysockets/baileys": "^6.17.16",
     "bcryptjs": "^3.0.3",
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^12.10.0",
     "cron-parser": "^5.5.0",
     "dingtalk-stream": "2.1.6-beta.1",
     "discord.js": "^14.26.2",


### PR DESCRIPTION
## 问题

`make start` 在 Node 26 下编译失败,无法启动。

## 根因 & 修复

### 1. `better-sqlite3` 不兼容 Node 26
`package.json` 钉的是 `^11.8.1`,而 11.x 的原生扩展在编译 `better_sqlite3.o` 时引用了 V8 废弃 API:

```
info.Data().As<v8::External>()->Value()
```

该 API 在 Node 26 自带的 V8 头(`v8-external.h`)里已从「废弃」变为「编译错误」,导致 node-gyp build 报 6 个 error。注意:11.x 本身**未声明 engines**(npm 不会凭 engines 拦截安装),真正根因就是上述原生扩展的编译错误;12.x 的 `engines` 已显式列出 26.x,表明上游官方支持 Node 26。

**修复**:放宽依赖范围 `^11.8.1` → `^12.10.0`,使全新 `npm install` 解析到对 Node 26 原生编译兼容的 12.x。仓库仅用 `new Database` / `prepare` / `exec` / `pragma` 等稳定核心 API,11→12 大版本跳跃对本用法安全。

### 2. agent-runner `tsc` 报错:SDK 升级后 `Options` 字段失效
`@anthropic-ai/claude-agent-sdk` 升到 `0.2.110` 后,两个原先传给 `query()` 的 `Options` 字段不再合法:

- `skills: 'all'` —— `0.2.110` 的顶层 `Options` 已不再接受 `skills` 字段;技能改由 `settingSources` 做文件系统发现并挂载。(`string[]` 形态的 `skills` 实际属于 `AgentDefinition` 而非顶层 `Options`。)
  **修复**:移除该行。不传 `skills` 时,技能仍由 `settingSources: [project,user]` 自动发现并挂载到主会话,等价于原 `'all'` 的「全部技能生效」行为,功能不丢。
- `forwardSubagentText: true` —— `0.2.110` 已从 `Options` 移除该字段,子代理转录改走 `SubagentStart/Stop` hooks + `getSubagentMessages()`。
  **修复**:以 `...({ forwardSubagentText: true } as any)` 透传以消除 tsc 报错、不阻塞启动。⚠️ **已知待跟进项**:若新版 SDK 已彻底改走 hooks 路径,卡片中子代理转录的「实时点亮」可能已静默失效。后续应迁移到 `SubagentStart/Stop` hooks 机制,或确认该 flag 运行时仍生效。

## 验证

- `better-sqlite3@12.10.0` 在 Node 26 下 `require` 加载成功
- `container/agent-runner` `npm run build`(tsc)通过

本分支无 CI checks,亦无自动化测试覆盖本次改动。建议后续在 CI 中补一个 Node 26 矩阵的 build smoke 以防回归。

## 备注(后续可考虑)

本次 SDK 相关报错的根源是 `make start` 里的 `ensure-latest-sdk` 每次启动都把 SDK 自动升到最新,新版频繁改 API 易把代码编挂。建议后续考虑给 SDK 钉一个版本范围,而非每次盲目升级。
