### PR TITLE
test: cover IPC send retry dedup path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from './config.js';
 import { detectImageMimeType } from './image-detector.js';
 import { interruptibleSleep } from './message-notifier.js';
+import { createIpcSendDeduplicator } from './ipc-send-dedup.js';
 import {
   AvailableGroup,
   ContainerInput,
@@ -722,43 +723,16 @@ const activeImReplyRoutes = new Map<string, string | null>();
 // （周期定时任务每次报告相同文案、用户明确要求重发同一句话）。因此始终记录
 // 每条 send 的指纹，但仅当该源 group 当前正处于失败重试轮次（retryCount>0）
 // 时，命中已记录的指纹才抑制——正常首轮永不抑制。
-const IPC_SEND_DEDUP_TTL_MS = 10 * 60_000;
-const IPC_SEND_DEDUP_MAX = 500;
-const recentIpcSends = new Map<string, number>(); // key → expireAt
+const ipcSendDedup = createIpcSendDeduplicator({
+  getRetryCount: (jid) => queue.getRetryCount(jid),
+  getJidsByFolder,
+});
 function isRetryDuplicateIpcSend(
   sourceGroup: string,
   chatJid: string,
   text: string,
 ): boolean {
-  const key = `${sourceGroup}|${chatJid}|${crypto
-    .createHash('md5')
-    .update(text)
-    .digest('hex')}`;
-  const now = Date.now();
-  const exp = recentIpcSends.get(key);
-  // 仅在该 group 处于重试重放时，已见过的指纹才视为重复并抑制。
-  // retryCount 挂在「入队时的原始 chatJid」上——对直连 IM 群组是带前缀的
-  // IM jid（如 feishu:oc_xxx），仅查 web:{folder}/{folder} 会漏掉它们导致
-  // 去重对所有 IM 来源失效。故用 folder 反查其全部注册 jid 逐一检查。
-  let inRetry =
-    queue.getRetryCount(`web:${sourceGroup}`) > 0 ||
-    queue.getRetryCount(sourceGroup) > 0;
-  if (!inRetry) {
-    for (const jid of getJidsByFolder(sourceGroup)) {
-      if (queue.getRetryCount(jid) > 0) {
-        inRetry = true;
-        break;
-      }
-    }
-  }
-  const isDup = !!(exp && exp > now) && inRetry;
-  recentIpcSends.set(key, now + IPC_SEND_DEDUP_TTL_MS);
-  // 容量控制：Map 迭代为插入序，先进先出淘汰
-  for (const k of recentIpcSends.keys()) {
-    if (recentIpcSends.size <= IPC_SEND_DEDUP_MAX) break;
-    recentIpcSends.delete(k);
-  }
-  return isDup;
+  return ipcSendDedup.isRetryDuplicate(sourceGroup, chatJid, text);
 }
 
 // Track consecutive IM send failures per JID for auto-unbind

--- a/src/ipc-send-dedup.ts
+++ b/src/ipc-send-dedup.ts
@@ -1,0 +1,52 @@
+import crypto from 'crypto';
+
+const IPC_SEND_DEDUP_TTL_MS = 10 * 60_000;
+const IPC_SEND_DEDUP_MAX = 500;
+
+export interface IpcSendDedupDeps {
+  getRetryCount(jid: string): number;
+  getJidsByFolder(folder: string): string[];
+  now?: () => number;
+}
+
+export function createIpcSendDeduplicator(deps: IpcSendDedupDeps): {
+  isRetryDuplicate(sourceGroup: string, chatJid: string, text: string): boolean;
+} {
+  const recentSends = new Map<string, number>(); // key -> expireAt
+  const now = deps.now ?? Date.now;
+
+  return {
+    isRetryDuplicate(
+      sourceGroup: string,
+      chatJid: string,
+      text: string,
+    ): boolean {
+      const key = `${sourceGroup}|${chatJid}|${crypto
+        .createHash('md5')
+        .update(text)
+        .digest('hex')}`;
+      const currentTime = now();
+      const exp = recentSends.get(key);
+      // retryCount lives on the original chatJid used at enqueue time. For IM
+      // jids such as feishu:oc_xxx, folder-only guesses miss the active retry.
+      let inRetry =
+        deps.getRetryCount(`web:${sourceGroup}`) > 0 ||
+        deps.getRetryCount(sourceGroup) > 0;
+      if (!inRetry) {
+        for (const jid of deps.getJidsByFolder(sourceGroup)) {
+          if (deps.getRetryCount(jid) > 0) {
+            inRetry = true;
+            break;
+          }
+        }
+      }
+      const isDup = !!(exp && exp > currentTime) && inRetry;
+      recentSends.set(key, currentTime + IPC_SEND_DEDUP_TTL_MS);
+      for (const k of recentSends.keys()) {
+        if (recentSends.size <= IPC_SEND_DEDUP_MAX) break;
+        recentSends.delete(k);
+      }
+      return isDup;
+    },
+  };
+}

--- a/tests/ipc-send-dedup.test.ts
+++ b/tests/ipc-send-dedup.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createIpcSendDeduplicator } from '../src/ipc-send-dedup.js';
+
+function makeDedup(opts: {
+  retryCounts?: Record<string, number>;
+  jidsByFolder?: Record<string, string[]>;
+  now?: () => number;
+}) {
+  const getRetryCount = vi.fn((jid: string) => opts.retryCounts?.[jid] ?? 0);
+  const getJidsByFolder = vi.fn(
+    (folder: string) => opts.jidsByFolder?.[folder] ?? [],
+  );
+  const dedup = createIpcSendDeduplicator({
+    getRetryCount,
+    getJidsByFolder,
+    now: opts.now,
+  });
+  return { dedup, getRetryCount, getJidsByFolder };
+}
+
+describe('IPC send_message retry dedup', () => {
+  test('finds retry state for a normal web group whose chatJid differs from web:<folder>', () => {
+    const { dedup, getJidsByFolder } = makeDedup({
+      retryCounts: { 'web:7b1f0c1e-1234-dead-beef': 2 },
+      jidsByFolder: { 'flow-abc123': ['web:7b1f0c1e-1234-dead-beef'] },
+    });
+
+    expect(
+      dedup.isRetryDuplicate(
+        'flow-abc123',
+        'web:7b1f0c1e-1234-dead-beef',
+        'hello',
+      ),
+    ).toBe(false);
+    expect(
+      dedup.isRetryDuplicate(
+        'flow-abc123',
+        'web:7b1f0c1e-1234-dead-beef',
+        'hello',
+      ),
+    ).toBe(true);
+    expect(getJidsByFolder).toHaveBeenCalledWith('flow-abc123');
+  });
+
+  test('admin home still works through the legacy web:<folder> lookup', () => {
+    const { dedup, getJidsByFolder } = makeDedup({
+      retryCounts: { 'web:main': 1 },
+    });
+
+    expect(dedup.isRetryDuplicate('main', 'web:main', 'same')).toBe(false);
+    expect(dedup.isRetryDuplicate('main', 'web:main', 'same')).toBe(true);
+    expect(getJidsByFolder).not.toHaveBeenCalled();
+  });
+
+  test('does not suppress a repeated send when the folder has no active retry', () => {
+    const { dedup } = makeDedup({
+      jidsByFolder: { 'flow-nonexistent': ['web:idle'] },
+    });
+
+    expect(
+      dedup.isRetryDuplicate('flow-nonexistent', 'web:idle', 'status'),
+    ).toBe(false);
+    expect(
+      dedup.isRetryDuplicate('flow-nonexistent', 'web:idle', 'status'),
+    ).toBe(false);
+  });
+
+  test('first attempt with retryCount=0 is never treated as in-retry', () => {
+    const { dedup } = makeDedup({
+      retryCounts: { 'web:uuid-first-try': 0 },
+      jidsByFolder: { 'flow-def456': ['web:uuid-first-try'] },
+    });
+
+    expect(
+      dedup.isRetryDuplicate('flow-def456', 'web:uuid-first-try', 'first'),
+    ).toBe(false);
+    expect(
+      dedup.isRetryDuplicate('flow-def456', 'web:uuid-first-try', 'first'),
+    ).toBe(false);
+  });
+
+  test('treats any sibling jid in the same folder as in-retry, including IM jids', () => {
+    const { dedup, getRetryCount } = makeDedup({
+      retryCounts: {
+        'web:sibling-1': 0,
+        'feishu:oc_retrying': 3,
+      },
+      jidsByFolder: {
+        'shared-folder': ['web:sibling-1', 'feishu:oc_retrying'],
+      },
+    });
+
+    expect(
+      dedup.isRetryDuplicate('shared-folder', 'feishu:oc_retrying', 'report'),
+    ).toBe(false);
+    expect(
+      dedup.isRetryDuplicate('shared-folder', 'feishu:oc_retrying', 'report'),
+    ).toBe(true);
+    expect(getRetryCount).toHaveBeenCalledWith('feishu:oc_retrying');
+  });
+});


### PR DESCRIPTION
## Summary
- Extract IPC send retry dedup logic into a side-effect-free helper so the current main implementation is directly testable
- Cover the getJidsByFolder retry lookup path requested after PR #568, including non-home web groups and IM sibling jids
- Preserve the existing legacy web:<folder> fallback and no-retry fail-open behavior

## Verification
- npm test -- tests/ipc-send-dedup.test.ts --run
- npm run typecheck
- npx prettier --check src/ipc-send-dedup.ts tests/ipc-send-dedup.test.ts
- npm test -- --run