### PR TITLE
修复: 大文件上传/下载易失败(超时误杀 + 50MB 上限写死)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ HappyClaw 是一个自托管的多用户 AI Agent 系统：
 | `src/web.ts` | Hono 框架：路由挂载、WebSocket 升级、HMAC Cookie 认证、静态文件托管 |
 | `src/routes/auth.ts` | 认证：登录 / 登出 / 注册、`GET /api/auth/me`（含 `setupStatus`）、设置向导、RBAC、邀请码 |
 | `src/routes/groups.ts` | 群组 CRUD、消息分页、会话重置（重建工作区）、群组级容器环境变量 |
-| `src/routes/files.ts` | 文件上传（50MB 限制）/ 下载 / 删除、目录管理、路径遍历防护 |
+| `src/routes/files.ts` | 文件上传（默认 50MB 限制，见 `MAX_FILE_SIZE_MB`）/ 下载 / 删除、目录管理、路径遍历防护 |
 | `src/routes/config.ts` | Claude / 飞书配置（AES-256-GCM 加密存储）、连通性测试、批量应用到所有容器、per-user IM 通道配置（`/api/config/user-im/feishu`、`/api/config/user-im/telegram`、`/api/config/user-im/qq`、`/api/config/user-im/dingtalk`、`/api/config/user-im/whatsapp`） |
 | `src/routes/monitor.ts` | 系统状态：容器列表、队列状态、健康检查（`GET /api/health` 无需认证） |
 | `src/routes/memory.ts` | 记忆文件读写（`groups/global/` + `groups/{folder}/`）、全文检索 |
@@ -40,7 +40,7 @@ HappyClaw 是一个自托管的多用户 AI Agent 系统：
 | `src/dingtalk.ts` | 钉钉连接工厂（`createDingTalkConnection`）：Stream 协议长连接、消息去重（LRU 1000 条 / 30min TTL）；支持 `text`、`picture`（通过 downloadCode 下载）和 `image`（通过 contentUrl 下载）；图片超过 5MB 不发 base64，仅保存到 `downloads/dingtalk/` |
 | `src/whatsapp.ts` | WhatsApp 连接工厂（`createWhatsAppConnection`）：基于 `@whiskeysockets/baileys` 的 WhatsApp Web 协议；`useMultiFileAuthState` 持久化登录态；QR 经 `qrcode` 渲染 PNG data URL 推前端；自动 3s 重连（logged_out 不重连避免 QR 风暴）；`messages.upsert` 转发文本 + 媒体（image/video/audio/document）下载到 `downloads/whatsapp/{date}/`；小图片附 base64 attachment 供 Vision；`group-participants.update` 触发 onBotAddedToGroup / onBotRemovedFromGroup；群组 `require_mention` 通过 `mentionedJid` 与 `sock.user.id` 比对。详见 §8.13 |
 | `src/dingtalk-streaming-card.ts` | 钉钉 AI Card 流式响应控制器（打字机效果） |
-| `src/im-downloader.ts` | IM 文件下载工具：`saveDownloadedFile()` 将 Buffer 写入 `downloads/{channel}/{YYYY-MM-DD}/`，支持 `feishu`/`telegram`/`qq`/`dingtalk` 通道，处理路径安全、文件名冲突和 50MB 限制 |
+| `src/im-downloader.ts` | IM 文件下载工具：`saveDownloadedFile()` 将 Buffer 写入 `downloads/{channel}/{YYYY-MM-DD}/`，支持 `feishu`/`telegram`/`qq`/`dingtalk` 通道，处理路径安全、文件名冲突和大小限制（默认 50MB，见 `MAX_FILE_SIZE_MB`） |
 | `src/im-manager.ts` | IM 连接池管理器（`IMConnectionManager`）：per-user 飞书/Telegram/QQ/钉钉/Discord/WhatsApp 连接管理、热重连、批量断开 |
 | `src/container-runner.ts` | 容器生命周期：Docker run + 宿主机进程模式、卷挂载构建（isAdminHome 区分权限）、环境变量注入 |
 | `src/agent-output-parser.ts` | Agent 输出解析：OUTPUT_MARKER 流式输出解析、stdout/stderr 处理、进程生命周期回调（从 container-runner.ts 提取的共享逻辑） |
@@ -580,6 +580,7 @@ WebSocket：`/ws`（协议详见 §3.6）。
 | `CONTAINER_IMAGE` | `happyclaw-agent:latest` | Docker 镜像名称 |
 | `CONTAINER_TIMEOUT` | `1800000`（30min） | 容器最大运行时间（可通过设置页覆盖） |
 | `CONTAINER_MAX_OUTPUT_SIZE` | `10485760`（10MB） | 单次输出最大字节（可通过设置页覆盖） |
+| `MAX_FILE_SIZE_MB` | `50` | 文件大小上限（MB）。Web 文件面板上传与 IM 渠道收文件共用（Web 下载为流式返回，不受此限制）；在 `config.ts` 统一定义，`file-manager.ts` 与 `im-downloader.ts` re-export |
 | `IDLE_TIMEOUT` | `1800000`（30min） | 容器空闲超时（可通过设置页覆盖） |
 | `MAX_CONCURRENT_CONTAINERS` | `20` | 最大并发容器数（可通过设置页覆盖） |
 | `MAX_CONCURRENT_HOST_PROCESSES` | `5` | 宿主机模式并发上限（可通过设置页覆盖） |

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,15 @@ export const STORE_DIR = path.join(DATA_DIR, 'db');
 export const GROUPS_DIR = path.join(DATA_DIR, 'groups');
 export const MAIN_GROUP_FOLDER = 'main';
 
+// 文件大小上限（MB）。Web 文件面板上传与 IM 渠道收文件（feishu/telegram/qq/
+// dingtalk/discord/wechat inbound）共用此上限。注意：Web 下载是流式返回已存在
+// 的文件，不受此上限约束。通过 MAX_FILE_SIZE_MB 环境变量调整（默认 50MB）；
+// 非法值回退到 50。
+const _maxFileSizeMb = parseInt(process.env.MAX_FILE_SIZE_MB || '50', 10);
+export const MAX_FILE_SIZE_MB =
+  Number.isFinite(_maxFileSizeMb) && _maxFileSizeMb > 0 ? _maxFileSizeMb : 50;
+export const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
+
 export const CONTAINER_IMAGE =
   process.env.CONTAINER_IMAGE || 'happyclaw-agent:latest';
 // Timezone for scheduled tasks (cron expressions, etc.)

--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { DATA_DIR, GROUPS_DIR } from './config.js';
+import { DATA_DIR, GROUPS_DIR, MAX_FILE_SIZE } from './config.js';
 import { deleteContainerEnvConfig } from './runtime-config.js';
 import { logger } from './logger.js';
 
@@ -24,7 +24,9 @@ export interface FileEntry {
 }
 
 // 常量
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+// MAX_FILE_SIZE 统一由 config.ts 定义（可通过 MAX_FILE_SIZE_MB 环境变量配置），
+// 此处 re-export 保持既有 import 路径不变。
+export { MAX_FILE_SIZE };
 const SYSTEM_PATHS = ['logs', 'CLAUDE.md', '.claude', 'conversations'];
 // 预先转小写一次，匹配大小写不敏感文件系统（macOS APFS / Windows NTFS）。
 const SYSTEM_PATHS_LOWER = SYSTEM_PATHS.map((p) => p.toLowerCase());

--- a/src/im-downloader.ts
+++ b/src/im-downloader.ts
@@ -1,8 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { GROUPS_DIR } from './config.js';
+import { GROUPS_DIR, MAX_FILE_SIZE } from './config.js';
 
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+// MAX_FILE_SIZE 统一由 config.ts 定义（可通过 MAX_FILE_SIZE_MB 环境变量配置），
+// 此处 re-export 保持既有 import 路径不变。IM 渠道收文件与 Web 上传共用此上限。
+export { MAX_FILE_SIZE };
 
 export class FileTooLargeError extends Error {
   constructor(filename: string, size: number) {

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -22,6 +22,7 @@ import {
   getFileRoot,
 } from '../file-manager.js';
 import { checkStorageLimit, isBillingEnabled } from '../billing.js';
+import { MAX_FILE_SIZE_MB } from '../config.js';
 import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -327,7 +328,9 @@ fileRoutes.post('/:jid/files', authMiddleware, async (c) => {
       // 检查文件大小
       if (file.size > MAX_FILE_SIZE) {
         return c.json(
-          { error: `File ${file.name} exceeds maximum size of 50MB` },
+          {
+            error: `File ${file.name} exceeds maximum size of ${MAX_FILE_SIZE_MB}MB`,
+          },
           400,
         );
       }

--- a/src/web.ts
+++ b/src/web.ts
@@ -2517,6 +2517,17 @@ export function startWebServer(webDeps: WebDeps): void {
     {
       fetch: app.fetch,
       port: WEB_PORT,
+      // Node HTTP server 默认 requestTimeout=300s（5min）会掐断慢速的大文件
+      // 上传/下载。放宽到 10min，让大文件在一般网络下也能传完。
+      // 取舍：requestTimeout 是服务器全局设置、对所有路由生效，且是"整个请求
+      // 到达"的硬期限（收到数据也不重置），拉长必然同步放大 slow-POST 的连接
+      // 占用窗口（此处 5min→10min，2×）。headersTimeout 仍为 60s，只挡
+      // header-slowloris，挡不住慢速 body；暴露在不可信网络时应在前置反向代理
+      // 上做 body 限速/超时。10min 是"支持大文件"与"限制 DoS 占用"的折中默认值。
+      serverOptions: {
+        requestTimeout: 10 * 60 * 1000,
+        headersTimeout: 60 * 1000,
+      },
     },
     (info) => {
       logger.info({ port: info.port }, 'Web server started');

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -62,6 +62,14 @@ export async function apiFetch<T>(path: string, options?: RequestInit & { timeou
   return res.json();
 }
 
+/**
+ * 按上传字节数推算请求超时，避免大文件在慢网络下被固定的 120s 超时误杀。
+ * 以 20KB/s 的保守下限估算，最少 120s，最多 10min（与后端 requestTimeout 对齐）。
+ */
+export function computeUploadTimeoutMs(bytes: number): number {
+  return Math.min(10 * 60_000, Math.max(120_000, Math.ceil(bytes / (20 * 1024)) * 1000));
+}
+
 export const api = {
   get: <T>(path: string) => apiFetch<T>(path),
   post: <T>(path: string, body?: unknown, timeoutMs?: number) => apiFetch<T>(path, { method: 'POST', body: body ? JSON.stringify(body) : undefined, ...(timeoutMs ? { timeoutMs } : {}) }),
@@ -70,9 +78,13 @@ export const api = {
   delete: <T>(path: string) => apiFetch<T>(path, { method: 'DELETE' }),
   uploadFiles: async <T>(path: string, files: FileList, extraFields?: Record<string, string>) => {
     const formData = new FormData();
-    for (const file of files) formData.append('files', file);
+    let totalBytes = 0;
+    for (const file of files) {
+      formData.append('files', file);
+      totalBytes += file.size;
+    }
     if (extraFields) for (const [k, v] of Object.entries(extraFields)) formData.append(k, v);
     // 不设 Content-Type，浏览器自动加 boundary
-    return apiFetch<T>(path, { method: 'POST', body: formData, headers: {} });
+    return apiFetch<T>(path, { method: 'POST', body: formData, headers: {}, timeoutMs: computeUploadTimeoutMs(totalBytes) });
   },
 };

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { api, apiFetch } from '../api/client';
+import { api, apiFetch, computeUploadTimeoutMs } from '../api/client';
 
 export interface FileEntry {
   name: string;
@@ -119,6 +119,7 @@ export const useFileStore = create<FileState>((set, get) => ({
           method: 'POST',
           body: formData,
           headers: {},
+          timeoutMs: computeUploadTimeoutMs(file.size),
         });
 
         uploadedBytes += file.size;


### PR DESCRIPTION
## 问题描述

Web 文件面板上传/下载大文件经常失败。根因是传输链路上多个共性卡口（与用户本地网络无关，所有部署都会撞）：

- 前端对所有 FormData 上传固定 **120s 超时**，稍大文件 / 网慢一点就被 `AbortController` 误杀，报假的 408 Request timeout
- 后端 `serve()` 未设 `requestTimeout`，走 Node 默认 **5min**，慢速大传输超 5 分钟被服务器杀断
- **50MB 上限硬编码**在 `src/file-manager.ts` 与 `src/im-downloader.ts` 两处，无法调整且易漂移

## 修复方案

### `web/src/api/client.ts`、`web/src/stores/files.ts`
- 抽出 `computeUploadTimeoutMs(bytes)`，上传超时按文件大小自适应（20KB/s 下限估算，120s ~ 10min，与后端 `requestTimeout` 对齐），取代原来固定的 120s

### `src/web.ts`
- `serve()` 传入 `serverOptions`：`requestTimeout` 5min → 10min（覆盖慢速大文件传输），`headersTimeout` 保留 60s
- 取舍已在注释说明：该值全局生效、是整个请求的硬期限（收到数据也不重置），拉长会同步放大 slow-POST 的连接占用窗口，故取 2× 默认的折中值；暴露在不可信网络时应在前置反代做 body 限速/超时

### `src/config.ts`、`src/file-manager.ts`、`src/im-downloader.ts`
- `MAX_FILE_SIZE` 统一到 `config.ts`，新增 `MAX_FILE_SIZE_MB` 环境变量（默认 50，非法值回退到 50）
- 两处重复常量改为 re-export，Web 上传与所有 IM 渠道收文件共用一个可配上限（Web 下载为流式返回，不受此限）

### `src/routes/files.ts`
- 超限错误信息改用动态上限值 `${MAX_FILE_SIZE_MB}MB`

## 测试
- `make typecheck` 通过
- `make test` 1026 项全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
