### PR TITLE
bugfix:解决Claude Agent SDK升级后的编译报错

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1589,7 +1589,7 @@ async function runQuery(
       if (!visibleOutputStarted && resultCount === 0) {
         suppressOutputAfterInterrupt = true;
       }
-      queryRef.interrupt().catch((err: unknown) => log(`Immediate interrupt call failed: ${err}`));
+      queryRef!.interrupt().catch((err: unknown) => log(`Immediate interrupt call failed: ${err}`));  
       stream.end();
       ipcPolling = false;
     }

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1283,7 +1283,7 @@ async function runQuery(
   let resultReceivedAt: number | null = null;
   const POST_RESULT_TIMEOUT_MS = 5_000;
   // queryRef is set just before the for-await loop so pollIpcDuringQuery can call interrupt()
-  let queryRef: { interrupt(): Promise<void> } | null = null;
+  let queryRef: { interrupt(): Promise<unknown> } | null = null;       
   let messageCount = 0;
   let resultCount = 0;
   let postResultInterruptRequested = false;


### PR DESCRIPTION
## 问题描述                                                                                                                                                          
                                                                                                                                                                       
  关联 SDK 升级至 0.3.211。                                                                                                                                            
                                                                                                                                                                       
  `@anthropic-ai/claude-agent-sdk` 0.3.211 将 `Query.interrupt()` 的返回类型从 `Promise<void>` 改为 `Promise<SDKControlInterruptResponse | undefined>`，导致           
  `container/agent-runner` 构建时出现两处 TS 类型错误，`make start` 无法启动。    
  ### 具体报错内容
src/index.ts(1585,5): error TS2322: Type 'Query' is not assignable to type '{ interrupt(): Promise<void>; }'.
  The types returned by 'interrupt()' are incompatible between these types.
    Type 'Promise<SDKControlInterruptResponse | undefined>' is not assignable to type 'Promise<void>'.
      Type 'SDKControlInterruptResponse | undefined' is not assignable to type 'void'.
        Type 'SDKControlInterruptResponse' is not assignable to type 'void'.
src/index.ts(1592,7): error TS18047: 'queryRef' is possibly 'null'.                                    
                                                                                                                                                                       
  ## 修复方案                                                                                                                                                          
                                                                                                                                                                       
  ### `container/agent-runner/src/index.ts`                                                                                                                            
                                                                                                                                                                       
  - 将 `queryRef` 的类型声明从 `{ interrupt(): Promise<void> }` 放宽为 `{ interrupt(): Promise<unknown> }`，兼容新 SDK 的返回类型                                      
  - 在赋值后的立即中断调用处改用 `queryRef!.interrupt()`，消除误报的 null check 错误（该行紧跟在 `queryRef = q` 赋值之后，实际不可能为 null，但 TS 因中间有函数调用导致
  narrowing 失效）