### PR TITLE
修复: 切换 provider 模型后 agent 子进程仍使用旧模型

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -6689,27 +6689,44 @@ export function backfillAgentProfileDefaultsAndWorkspaceMappings(): void {
  * Returns the affected `group_folder` values so callers can also evict the
  * in-memory sessions cache and the row count for telemetry.
  */
-export function deleteSessionsByProviderId(providerId: string): {
+export function deleteSessionsByProviderId(
+  providerId: string,
+  options?: { includeUnbound?: boolean },
+): {
   deletedCount: number;
   affectedFolders: string[];
 } {
+  const includeUnbound = options?.includeUnbound ?? false;
   const tx = db.transaction((id: string) => {
-    const rows = db
+    let rows: Array<{ group_folder: string }>;
+    if (includeUnbound) {
+      rows = db
+        .prepare(
+          'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ? OR provider_id IS NULL',
+        )
+        .all(id) as Array<{ group_folder: string }>;
+      db.prepare(
+        'DELETE FROM workspace_runtime_sessions WHERE provider_id = ? OR provider_id IS NULL',
+      ).run(id);
+      const result = db
+        .prepare(
+          'DELETE FROM sessions WHERE provider_id = ? OR provider_id IS NULL',
+        )
+        .run(id);
+      return { deletedCount: result.changes, affectedFolders: rows.map((r) => r.group_folder) };
+    }
+    rows = db
       .prepare(
         'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?',
       )
       .all(id) as Array<{ group_folder: string }>;
-    const affectedFolders = rows.map((r) => r.group_folder);
     db.prepare(
       'DELETE FROM workspace_runtime_sessions WHERE provider_id = ?',
     ).run(id);
     const result = db
       .prepare('DELETE FROM sessions WHERE provider_id = ?')
       .run(id);
-    return {
-      deletedCount: result.changes,
-      affectedFolders,
-    };
+    return { deletedCount: result.changes, affectedFolders: rows.map((r) => r.group_folder) };
   });
   return tx(providerId);
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -6689,7 +6689,7 @@ export function backfillAgentProfileDefaultsAndWorkspaceMappings(): void {
  * Returns the affected `group_folder` values so callers can also evict the
  * in-memory sessions cache and the row count for telemetry.
  */
-export function deleteSessionsByProviderId(
+function deleteSessionsByProviderIdInCurrentTransaction(
   providerId: string,
   options?: { includeUnboundFolders?: string[] },
 ): {
@@ -6703,29 +6703,63 @@ export function deleteSessionsByProviderId(
       ),
     ),
   );
-  const tx = db.transaction((id: string) => {
-    const placeholders = includeUnboundFolders.map(() => '?').join(', ');
-    const unboundClause = includeUnboundFolders.length
-      ? ` OR (provider_id IS NULL AND group_folder IN (${placeholders}))`
-      : '';
-    const params = [id, ...includeUnboundFolders];
-    const rows = db
-      .prepare(
-        `SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?${unboundClause}`,
-      )
-      .all(...params) as Array<{ group_folder: string }>;
-    db.prepare(
-      `DELETE FROM workspace_runtime_sessions WHERE provider_id = ?${unboundClause}`,
-    ).run(...params);
-    const result = db
-      .prepare(`DELETE FROM sessions WHERE provider_id = ?${unboundClause}`)
-      .run(...params);
-    return {
-      deletedCount: result.changes,
-      affectedFolders: rows.map((r) => r.group_folder),
-    };
-  });
-  return tx(providerId);
+  const placeholders = includeUnboundFolders.map(() => '?').join(', ');
+  const unboundClause = includeUnboundFolders.length
+    ? ` OR (provider_id IS NULL AND group_folder IN (${placeholders}))`
+    : '';
+  const params = [providerId, ...includeUnboundFolders];
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?${unboundClause}`,
+    )
+    .all(...params) as Array<{ group_folder: string }>;
+  db.prepare(
+    `DELETE FROM workspace_runtime_sessions WHERE provider_id = ?${unboundClause}`,
+  ).run(...params);
+  const result = db
+    .prepare(`DELETE FROM sessions WHERE provider_id = ?${unboundClause}`)
+    .run(...params);
+  return {
+    deletedCount: result.changes,
+    affectedFolders: rows.map((r) => r.group_folder),
+  };
+}
+
+export function deleteSessionsByProviderId(
+  providerId: string,
+  options?: { includeUnboundFolders?: string[] },
+): {
+  deletedCount: number;
+  affectedFolders: string[];
+} {
+  return db.transaction(() =>
+    deleteSessionsByProviderIdInCurrentTransaction(providerId, options),
+  )();
+}
+
+/**
+ * Delete attributable provider sessions and execute a synchronous config
+ * commit in one SQLite transaction. If config validation/persistence throws,
+ * session deletion rolls back, so an invalid provider PATCH cannot destroy a
+ * still-valid resume token.
+ */
+export function deleteSessionsByProviderIdAroundCommit<T>(
+  providerId: string,
+  options: { includeUnboundFolders?: string[] } | undefined,
+  commit: () => T,
+): {
+  value: T;
+  deletedCount: number;
+  affectedFolders: string[];
+} {
+  return db.transaction(() => {
+    const cleanup = deleteSessionsByProviderIdInCurrentTransaction(
+      providerId,
+      options,
+    );
+    const value = commit();
+    return { value, ...cleanup };
+  })();
 }
 
 export function getAllSessions(): Record<string, string> {

--- a/src/db.ts
+++ b/src/db.ts
@@ -6691,44 +6691,35 @@ export function backfillAgentProfileDefaultsAndWorkspaceMappings(): void {
  */
 export function deleteSessionsByProviderId(
   providerId: string,
-  options?: { includeUnbound?: boolean },
+  options?: { includeUnboundFolders?: string[] },
 ): {
   deletedCount: number;
   affectedFolders: string[];
 } {
-  const includeUnbound = options?.includeUnbound ?? false;
+  const includeUnboundFolders = Array.from(
+    new Set(
+      (options?.includeUnboundFolders ?? []).filter(
+        (folder): folder is string => typeof folder === 'string' && !!folder,
+      ),
+    ),
+  );
   const tx = db.transaction((id: string) => {
-    let rows: Array<{ group_folder: string }>;
-    if (includeUnbound) {
-      rows = db
-        .prepare(
-          'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ? OR provider_id IS NULL',
-        )
-        .all(id) as Array<{ group_folder: string }>;
-      db.prepare(
-        'DELETE FROM workspace_runtime_sessions WHERE provider_id = ? OR provider_id IS NULL',
-      ).run(id);
-      const result = db
-        .prepare(
-          'DELETE FROM sessions WHERE provider_id = ? OR provider_id IS NULL',
-        )
-        .run(id);
-      return {
-        deletedCount: result.changes,
-        affectedFolders: rows.map((r) => r.group_folder),
-      };
-    }
-    rows = db
+    const placeholders = includeUnboundFolders.map(() => '?').join(', ');
+    const unboundClause = includeUnboundFolders.length
+      ? ` OR (provider_id IS NULL AND group_folder IN (${placeholders}))`
+      : '';
+    const params = [id, ...includeUnboundFolders];
+    const rows = db
       .prepare(
-        'SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?',
+        `SELECT DISTINCT group_folder FROM sessions WHERE provider_id = ?${unboundClause}`,
       )
-      .all(id) as Array<{ group_folder: string }>;
+      .all(...params) as Array<{ group_folder: string }>;
     db.prepare(
-      'DELETE FROM workspace_runtime_sessions WHERE provider_id = ?',
-    ).run(id);
+      `DELETE FROM workspace_runtime_sessions WHERE provider_id = ?${unboundClause}`,
+    ).run(...params);
     const result = db
-      .prepare('DELETE FROM sessions WHERE provider_id = ?')
-      .run(id);
+      .prepare(`DELETE FROM sessions WHERE provider_id = ?${unboundClause}`)
+      .run(...params);
     return {
       deletedCount: result.changes,
       affectedFolders: rows.map((r) => r.group_folder),

--- a/src/db.ts
+++ b/src/db.ts
@@ -6713,7 +6713,10 @@ export function deleteSessionsByProviderId(
           'DELETE FROM sessions WHERE provider_id = ? OR provider_id IS NULL',
         )
         .run(id);
-      return { deletedCount: result.changes, affectedFolders: rows.map((r) => r.group_folder) };
+      return {
+        deletedCount: result.changes,
+        affectedFolders: rows.map((r) => r.group_folder),
+      };
     }
     rows = db
       .prepare(
@@ -6726,7 +6729,10 @@ export function deleteSessionsByProviderId(
     const result = db
       .prepare('DELETE FROM sessions WHERE provider_id = ?')
       .run(id);
-    return { deletedCount: result.changes, affectedFolders: rows.map((r) => r.group_folder) };
+    return {
+      deletedCount: result.changes,
+      affectedFolders: rows.map((r) => r.group_folder),
+    };
   });
   return tx(providerId);
 }

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -111,8 +111,10 @@ export class GroupQueue {
   private waitingGroups = new Set<string>();
   private mutationPauseCounts = new Map<string, number>();
   /** Persistent fail-closed gates used when a security-sensitive mutation was
-   * committed but the old runtime could not be confirmed stopped. */
-  private runtimeSafetyBlocks = new Map<string, string>();
+   * committed but the old runtime could not be confirmed stopped. Each
+   * mutation source independently owns its gate so one subsystem cannot
+   * release another subsystem's fail-closed state. */
+  private runtimeSafetyBlocks = new Map<string, Map<string, string>>();
   private mutationPauseTokens = new Map<number, string[]>();
   private terminalDiscardMutationKeys = new Set<string>();
   private mutationBaseKeyAliases = new Map<string, string>();
@@ -224,20 +226,36 @@ export class GroupQueue {
     return paused;
   }
 
-  blockGroupsForRuntimeSafety(groupJids: string[], reason: string): void {
+  blockGroupsForRuntimeSafety(
+    groupJids: string[],
+    reason: string,
+    source = 'default',
+  ): void {
     for (const jid of groupJids) {
       const key = this.getMutationPauseKey(jid);
       this.getGroup(jid).mutationKey = key;
       this.mutationBaseKeyAliases.set(this.getMutationBaseJid(jid), key);
-      this.runtimeSafetyBlocks.set(key, reason);
+      let sourceBlocks = this.runtimeSafetyBlocks.get(key);
+      if (!sourceBlocks) {
+        sourceBlocks = new Map<string, string>();
+        this.runtimeSafetyBlocks.set(key, sourceBlocks);
+      }
+      // Re-blocking the same source is idempotent (for example repeated deps
+      // injection during startup); only the latest diagnostic reason changes.
+      sourceBlocks.set(source, reason);
     }
   }
 
-  unblockGroupsForRuntimeSafety(groupJids: string[]): void {
+  unblockGroupsForRuntimeSafety(groupJids: string[], source = 'default'): void {
     const released = new Set<string>();
     for (const jid of groupJids) {
       const key = this.getMutationPauseKey(jid);
-      if (this.runtimeSafetyBlocks.delete(key)) released.add(key);
+      const sourceBlocks = this.runtimeSafetyBlocks.get(key);
+      if (!sourceBlocks?.delete(source)) continue;
+      if (sourceBlocks.size === 0) {
+        this.runtimeSafetyBlocks.delete(key);
+        released.add(key);
+      }
     }
     if (released.size === 0) return;
     for (const [jid, state] of this.groups) {

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -527,6 +527,17 @@ function getClaudeRuntimeTargets(): Array<{
   return [...targets.values()];
 }
 
+function getKnownClaudeRuntimeJids(): string[] {
+  if (!deps) return [];
+  return Array.from(
+    new Set(
+      getClaudeRuntimeTargets().flatMap((target) =>
+        getWorkspaceRuntimeJids(deps, target.folder, target.primaryJid),
+      ),
+    ),
+  );
+}
+
 async function mutateClaudeConfigForAllGroups<T>(
   actor: string,
   metadata: Record<string, unknown> | undefined,
@@ -537,13 +548,7 @@ async function mutateClaudeConfigForAllGroups<T>(
 
   const targets = getClaudeRuntimeTargets();
   const reason = String(metadata?.trigger ?? 'claude_config_apply');
-  const knownRuntimeJids = Array.from(
-    new Set(
-      targets.flatMap((target) =>
-        getWorkspaceRuntimeJids(deps, target.folder, target.primaryJid),
-      ),
-    ),
-  );
+  const knownRuntimeJids = getKnownClaudeRuntimeJids();
   try {
     const result = await quiesceWorkspaceRunnersAroundCommit(
       deps,
@@ -963,6 +968,11 @@ configRoutes.patch(
           const clearedSessionsCount = committed.clearedSessionsCount;
           if (shouldClearSessions) {
             clearPendingProviderSessionInvalidation(id);
+            if (!hasPendingProviderSessionInvalidations()) {
+              deps?.queue?.unblockGroupsForRuntimeSafety?.(
+                getKnownClaudeRuntimeJids(),
+              );
+            }
           }
           mutation = {
             value: updated,
@@ -1108,14 +1118,49 @@ configRoutes.delete(
   '/claude/providers/:id',
   authMiddleware,
   systemConfigMiddleware,
-  (c) => {
+  async (c) => {
     const { id } = c.req.param();
     const actor = (c.get('user') as AuthUser).username;
 
     try {
-      deleteProvider(id);
-      appendClaudeConfigAudit(actor, 'delete_provider', [`id:${id}`]);
-      return c.json({ ok: true });
+      return await withClaudeConfigMutationLock(async () => {
+        const previous = getProviders().find((provider) => provider.id === id);
+        const pendingInvalidation = getPendingProviderSessionInvalidation(id);
+        if (!previous && !pendingInvalidation) {
+          throw new Error('未找到指定供应商');
+        }
+        const sessionInvalidation = pendingInvalidation ?? {
+          modelChanged: true,
+          baseUrlChanged: true,
+        };
+        const mutation = await mutateClaudeConfigForAllGroups(
+          actor,
+          { trigger: 'provider_delete', providerId: id },
+          () => {
+            if (previous) {
+              deleteProvider(id);
+              appendClaudeConfigAuditBestEffort(actor, 'delete_provider', [
+                `id:${id}`,
+              ]);
+            }
+            return { id };
+          },
+          {
+            clearSessionsForProviderId: id,
+            sessionInvalidation,
+          },
+        );
+        if (!mutation.applied.success) {
+          return c.json(
+            {
+              error: mutation.applied.error,
+              applied: mutation.applied,
+            },
+            503,
+          );
+        }
+        return c.json({ ok: true, applied: mutation.applied });
+      });
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to delete provider';

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -133,6 +133,7 @@ import { checkImChannelLimit, isBillingEnabled } from '../billing.js';
 import { providerPool } from '../provider-pool.js';
 import { getClientIp } from '../utils.js';
 import {
+  getWorkspaceRuntimeJids,
   quiesceWorkspaceRunnersAroundCommit,
   resolveEffectiveAgentProfile,
   withAgentProfileLocks,
@@ -210,11 +211,57 @@ interface ApplyOptions {
    * protocol-level fields (anthropicBaseUrl / anthropicModel) change.
    */
   clearSessionsForProviderId?: string;
+  sessionInvalidation?: {
+    modelChanged: boolean;
+    baseUrlChanged: boolean;
+  };
 }
 
 interface ClaudeMutationResult<T> {
   value?: T;
   applied: ClaudeApplyResultPayload;
+}
+
+class ClaudeConfigPersistedError<T> extends Error {
+  constructor(
+    public readonly persistedValue: T,
+    public readonly cause: unknown,
+  ) {
+    super(
+      cause instanceof Error
+        ? cause.message
+        : 'Provider configuration was persisted but a follow-up action failed',
+    );
+    this.name = 'ClaudeConfigPersistedError';
+  }
+}
+
+function runAfterProviderPersistence<T>(
+  persistedValue: T,
+  followUp: () => void,
+): T {
+  try {
+    followUp();
+    return persistedValue;
+  } catch (error) {
+    throw new ClaudeConfigPersistedError(persistedValue, error);
+  }
+}
+
+function appendClaudeConfigAuditBestEffort(
+  actor: string,
+  action: string,
+  changedFields: string[],
+  metadata?: Record<string, unknown>,
+): void {
+  try {
+    appendClaudeConfigAudit(actor, action, changedFields, metadata);
+  } catch (error) {
+    logger.error(
+      { error, actor, action },
+      'Provider configuration audit append failed after persistence',
+    );
+  }
 }
 
 let claudeConfigMutationTail: Promise<void> = Promise.resolve();
@@ -235,18 +282,33 @@ async function withClaudeConfigMutationLock<T>(
   }
 }
 
-function hasWorkspaceProviderOverride(folder: string): boolean {
+function hasWorkspaceProviderOverride(
+  folder: string,
+  invalidation?: ApplyOptions['sessionInvalidation'],
+): boolean {
   const override = getContainerEnvConfig(folder);
-  return !!(
+  const hasCredentialOrEndpointOverride = !!(
     override.anthropicBaseUrl ||
     override.anthropicAuthToken ||
     override.anthropicApiKey ||
     override.claudeCodeOauthToken ||
     override.claudeOAuthCredentials
   );
+  // A workspace-level model still uses the global provider endpoint. It only
+  // makes a legacy NULL session unattributable for a model-only global change;
+  // a simultaneous Base URL change still affects that workspace.
+  const hasRelevantModelOverride = !!(
+    invalidation?.modelChanged &&
+    !invalidation.baseUrlChanged &&
+    override.anthropicModel
+  );
+  return hasCredentialOrEndpointOverride || hasRelevantModelOverride;
 }
 
-function getSafeLegacyUnboundFolders(providerId: string): string[] {
+function getSafeLegacyUnboundFolders(
+  providerId: string,
+  invalidation?: ApplyOptions['sessionInvalidation'],
+): string[] {
   if (!deps) return [];
   const configuredProviders = getProviders();
   if (
@@ -261,16 +323,26 @@ function getSafeLegacyUnboundFolders(providerId: string): string[] {
         deps.getRegisteredGroups() as Record<string, RegisteredGroup>,
       )
         .map((group) => group.folder)
-        .filter((folder) => !hasWorkspaceProviderOverride(folder)),
+        .filter(
+          (folder) => !hasWorkspaceProviderOverride(folder, invalidation),
+        ),
     ),
   );
 }
 
-function clearProviderSessions(providerId: string): number {
+function clearProviderSessions(
+  providerId: string,
+  invalidation?: ApplyOptions['sessionInvalidation'],
+): number {
   if (!deps) return 0;
   const { deletedCount, affectedFolders } = deleteSessionsByProviderId(
     providerId,
-    { includeUnboundFolders: getSafeLegacyUnboundFolders(providerId) },
+    {
+      includeUnboundFolders: getSafeLegacyUnboundFolders(
+        providerId,
+        invalidation,
+      ),
+    },
   );
   for (const folder of affectedFolders) {
     delete deps.sessions[folder];
@@ -303,19 +375,56 @@ async function mutateClaudeConfigForAllGroups<T>(
   if (!deps) throw new Error('Server not initialized');
 
   const targets = getClaudeRuntimeTargets();
+  const reason = String(metadata?.trigger ?? 'claude_config_apply');
+  const knownRuntimeJids = Array.from(
+    new Set(
+      targets.flatMap((target) =>
+        getWorkspaceRuntimeJids(deps, target.folder, target.primaryJid),
+      ),
+    ),
+  );
   try {
     const result = await quiesceWorkspaceRunnersAroundCommit(
       deps,
       targets,
-      { reason: String(metadata?.trigger ?? 'claude_config_apply') },
+      {
+        reason,
+        onPostCommitFailure: (runtimeJids) =>
+          deps.queue.blockGroupsForRuntimeSafety?.(
+            runtimeJids,
+            `${reason}: post-commit provider runtime cleanup failed`,
+          ),
+      },
       async () => {
-        const value = await commit();
+        // Invalidate attributable resume state before persisting protocol
+        // changes. If cleanup fails the provider file remains unchanged, so a
+        // same-value retry cannot accidentally skip the unfinished cleanup and
+        // release a runtime-safety gate.
         const clearedSessionsCount = options?.clearSessionsForProviderId
-          ? clearProviderSessions(options.clearSessionsForProviderId)
+          ? clearProviderSessions(
+              options.clearSessionsForProviderId,
+              options.sessionInvalidation,
+            )
           : undefined;
+        let value: T;
+        try {
+          value = await commit();
+        } catch (error) {
+          if (error instanceof ClaudeConfigPersistedError) {
+            deps.queue.blockGroupsForRuntimeSafety?.(
+              knownRuntimeJids,
+              `${reason}: provider config persisted but follow-up failed`,
+            );
+          }
+          throw error;
+        }
         return { value, clearedSessionsCount };
       },
     );
+    // A successful retry proves every runtime now observes the persisted
+    // provider config, so it may repair a fail-closed gate left by an earlier
+    // post-commit teardown failure.
+    deps.queue.unblockGroupsForRuntimeSafety?.(result.runtimeJids);
     const applied: ClaudeApplyResultPayload = {
       success: true,
       stoppedCount: result.runtimeJids.length,
@@ -325,12 +434,35 @@ async function mutateClaudeConfigForAllGroups<T>(
         ? { clearedSessionsCount: result.value.clearedSessionsCount }
         : {}),
     };
-    appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
-      ...applied,
-      ...(metadata || {}),
-    });
+    appendClaudeConfigAuditBestEffort(
+      actor,
+      'apply_to_all_flows',
+      ['queue.stopGroup'],
+      {
+        ...applied,
+        ...(metadata || {}),
+      },
+    );
     return { value: result.value.value, applied };
   } catch (err) {
+    if (err instanceof ClaudeConfigPersistedError) {
+      const applied: ClaudeApplyResultPayload = {
+        success: false,
+        stoppedCount: 0,
+        failedCount: 1,
+        persisted: true,
+        phase: 'post_commit',
+        error:
+          'Configuration was saved, but provider runtime cleanup did not complete safely',
+      };
+      appendClaudeConfigAuditBestEffort(
+        actor,
+        'apply_to_all_flows',
+        ['queue.stopGroup'],
+        { ...applied, ...(metadata || {}) },
+      );
+      return { value: err.persistedValue as T, applied };
+    }
     if (!(err instanceof WorkspaceRuntimeQuiesceError)) throw err;
     const committed = err.committedValue as
       | { value: T; clearedSessionsCount?: number }
@@ -349,10 +481,12 @@ async function mutateClaudeConfigForAllGroups<T>(
         ? 'Configuration was saved, but one or more runtimes failed to restart safely'
         : 'Configuration was not updated because one or more runtimes failed to stop safely',
     };
-    appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
-      ...applied,
-      ...(metadata || {}),
-    });
+    appendClaudeConfigAuditBestEffort(
+      actor,
+      'apply_to_all_flows',
+      ['queue.stopGroup'],
+      { ...applied, ...(metadata || {}) },
+    );
     return { value: committed?.value, applied };
   }
 }
@@ -596,7 +730,7 @@ configRoutes.patch(
         };
         const commit = () => {
           const updated = updateProvider(id, validation.data);
-          appendClaudeConfigAudit(actor, 'update_provider', [
+          appendClaudeConfigAuditBestEffort(actor, 'update_provider', [
             `id:${id}`,
             ...changedFields,
             ...(protocolFieldChanged ? ['protocolFieldChanged'] : []),
@@ -611,14 +745,17 @@ configRoutes.patch(
             metadata,
             commit,
             shouldClearSessions
-              ? { clearSessionsForProviderId: id }
+              ? {
+                  clearSessionsForProviderId: id,
+                  sessionInvalidation: { modelChanged, baseUrlChanged },
+                }
               : undefined,
           );
         } else {
-          const updated = commit();
           const clearedSessionsCount = shouldClearSessions
-            ? clearProviderSessions(id)
+            ? clearProviderSessions(id, { modelChanged, baseUrlChanged })
             : undefined;
+          const updated = commit();
           mutation = {
             value: updated,
             applied: {
@@ -701,15 +838,16 @@ configRoutes.put(
 
         const commit = () => {
           const updated = updateProviderSecrets(id, validation.data);
-          appendClaudeConfigAudit(actor, 'update_provider_secrets', [
+          appendClaudeConfigAuditBestEffort(actor, 'update_provider_secrets', [
             `id:${id}`,
             ...changedFields,
           ]);
-          if (validation.data.claudeOAuthCredentials && updated.enabled) {
-            updateAllSessionCredentials(providerToConfig(updated));
-            deps?.queue?.closeAllActiveForCredentialRefresh();
-          }
-          return updated;
+          return runAfterProviderPersistence(updated, () => {
+            if (validation.data.claudeOAuthCredentials && updated.enabled) {
+              updateAllSessionCredentials(providerToConfig(updated));
+              deps?.queue?.closeAllActiveForCredentialRefresh();
+            }
+          });
         };
 
         const mutation = previous.enabled
@@ -795,7 +933,7 @@ configRoutes.post(
           { trigger: 'provider_toggle', providerId: id },
           () => {
             const updated = toggleProvider(id);
-            appendClaudeConfigAudit(actor, 'toggle_provider', [
+            appendClaudeConfigAuditBestEffort(actor, 'toggle_provider', [
               `id:${id}`,
               `enabled:${updated.enabled}`,
             ]);
@@ -911,11 +1049,15 @@ configRoutes.post(
   async (c) => {
     const actor = (c.get('user') as AuthUser).username;
     try {
-      const result = await applyClaudeConfigToAllGroups(actor);
-      if (!result.success) {
-        return c.json(result, 207);
-      }
-      return c.json(result);
+      return await withClaudeConfigMutationLock(async () => {
+        const result = await applyClaudeConfigToAllGroups(actor, {
+          trigger: 'manual_provider_apply',
+        });
+        if (!result.success) {
+          return c.json(result, 207);
+        }
+        return c.json(result);
+      });
     } catch (err) {
       logger.error({ err }, 'Failed to apply Claude config to all groups');
       return c.json({ error: 'Server not initialized' }, 500);

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -87,6 +87,7 @@ import {
   saveAppearanceConfig,
   getSystemSettings,
   getEffectiveExternalDir,
+  getContainerEnvConfig,
   saveSystemSettings,
   getUserFeishuConfig,
   saveUserFeishuConfig,
@@ -196,6 +197,9 @@ interface ClaudeApplyResultPayload {
   stoppedCount: number;
   failedCount: number;
   clearedSessionsCount?: number;
+  /** Whether the config mutation itself was durably written. */
+  persisted?: boolean;
+  phase?: 'pre_commit' | 'post_commit';
   error?: string;
 }
 
@@ -208,72 +212,163 @@ interface ApplyOptions {
   clearSessionsForProviderId?: string;
 }
 
+interface ClaudeMutationResult<T> {
+  value?: T;
+  applied: ClaudeApplyResultPayload;
+}
+
+let claudeConfigMutationTail: Promise<void> = Promise.resolve();
+
+async function withClaudeConfigMutationLock<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = claudeConfigMutationTail;
+  let release!: () => void;
+  claudeConfigMutationTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+function hasWorkspaceProviderOverride(folder: string): boolean {
+  const override = getContainerEnvConfig(folder);
+  return !!(
+    override.anthropicBaseUrl ||
+    override.anthropicAuthToken ||
+    override.anthropicApiKey ||
+    override.claudeCodeOauthToken ||
+    override.claudeOAuthCredentials
+  );
+}
+
+function getSafeLegacyUnboundFolders(providerId: string): string[] {
+  if (!deps) return [];
+  const configuredProviders = getProviders();
+  if (
+    configuredProviders.length !== 1 ||
+    configuredProviders[0]?.id !== providerId
+  ) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      Object.values(
+        deps.getRegisteredGroups() as Record<string, RegisteredGroup>,
+      )
+        .map((group) => group.folder)
+        .filter((folder) => !hasWorkspaceProviderOverride(folder)),
+    ),
+  );
+}
+
+function clearProviderSessions(providerId: string): number {
+  if (!deps) return 0;
+  const { deletedCount, affectedFolders } = deleteSessionsByProviderId(
+    providerId,
+    { includeUnboundFolders: getSafeLegacyUnboundFolders(providerId) },
+  );
+  for (const folder of affectedFolders) {
+    delete deps.sessions[folder];
+  }
+  return deletedCount;
+}
+
+function getClaudeRuntimeTargets(): Array<{
+  folder: string;
+  primaryJid: string;
+}> {
+  if (!deps) return [];
+  const targets = new Map<string, { folder: string; primaryJid: string }>();
+  for (const [jid, group] of Object.entries(
+    deps.getRegisteredGroups() as Record<string, RegisteredGroup>,
+  )) {
+    if (!targets.has(group.folder)) {
+      targets.set(group.folder, { folder: group.folder, primaryJid: jid });
+    }
+  }
+  return [...targets.values()];
+}
+
+async function mutateClaudeConfigForAllGroups<T>(
+  actor: string,
+  metadata: Record<string, unknown> | undefined,
+  commit: () => T | Promise<T>,
+  options?: ApplyOptions,
+): Promise<ClaudeMutationResult<T>> {
+  if (!deps) throw new Error('Server not initialized');
+
+  const targets = getClaudeRuntimeTargets();
+  try {
+    const result = await quiesceWorkspaceRunnersAroundCommit(
+      deps,
+      targets,
+      { reason: String(metadata?.trigger ?? 'claude_config_apply') },
+      async () => {
+        const value = await commit();
+        const clearedSessionsCount = options?.clearSessionsForProviderId
+          ? clearProviderSessions(options.clearSessionsForProviderId)
+          : undefined;
+        return { value, clearedSessionsCount };
+      },
+    );
+    const applied: ClaudeApplyResultPayload = {
+      success: true,
+      stoppedCount: result.runtimeJids.length,
+      failedCount: 0,
+      persisted: true,
+      ...(result.value.clearedSessionsCount !== undefined
+        ? { clearedSessionsCount: result.value.clearedSessionsCount }
+        : {}),
+    };
+    appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
+      ...applied,
+      ...(metadata || {}),
+    });
+    return { value: result.value.value, applied };
+  } catch (err) {
+    if (!(err instanceof WorkspaceRuntimeQuiesceError)) throw err;
+    const committed = err.committedValue as
+      | { value: T; clearedSessionsCount?: number }
+      | undefined;
+    const persisted = err.persisted;
+    const applied: ClaudeApplyResultPayload = {
+      success: false,
+      stoppedCount: 0,
+      failedCount: err.failures.length,
+      persisted,
+      phase: err.phase,
+      ...(committed?.clearedSessionsCount !== undefined
+        ? { clearedSessionsCount: committed.clearedSessionsCount }
+        : {}),
+      error: persisted
+        ? 'Configuration was saved, but one or more runtimes failed to restart safely'
+        : 'Configuration was not updated because one or more runtimes failed to stop safely',
+    };
+    appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
+      ...applied,
+      ...(metadata || {}),
+    });
+    return { value: committed?.value, applied };
+  }
+}
+
 async function applyClaudeConfigToAllGroups(
   actor: string,
   metadata?: Record<string, unknown>,
   options?: ApplyOptions,
 ): Promise<ClaudeApplyResultPayload> {
-  if (!deps) {
-    throw new Error('Server not initialized');
-  }
-
-  const groupJids = Object.keys(deps.getRegisteredGroups());
-  // Also stop descendant runners (agents and scheduled tasks) — they run
-  // under {jid}#agent:{id} or {jid}#task:{id} keys which are not in
-  // registeredGroups and would otherwise keep running with stale
-  // ANTHROPIC_MODEL env vars after a provider config change.
-  const allJidsToStop = groupJids.flatMap((jid) => [
-    jid,
-    ...deps.queue.listDescendantJids(jid),
-  ]);
-  const results = await Promise.allSettled(
-    allJidsToStop.map((jid) => deps.queue.stopGroup(jid)),
+  const result = await mutateClaudeConfigForAllGroups(
+    actor,
+    metadata,
+    () => undefined,
+    options,
   );
-  const failedCount = results.filter((r) => r.status === 'rejected').length;
-  const stoppedCount = allJidsToStop.length - failedCount;
-
-  // Narrowed session cleanup: only drop sticky bindings for the provider whose
-  // protocol-level fields actually changed. Bindings to other providers stay
-  // intact so a routine update doesn't reset the entire pool. See issue #476.
-  let clearedSessionsCount: number | undefined;
-  if (options?.clearSessionsForProviderId) {
-    // In single-provider deployments, unbound (NULL) sessions certainly belong
-    // to the only provider. In multi-provider setups they could belong to any
-    // provider, so only delete exact matches to avoid collateral damage.
-    const isSingleProvider = getEnabledProviders().length <= 1;
-    const { deletedCount, affectedFolders } = deleteSessionsByProviderId(
-      options.clearSessionsForProviderId,
-      { includeUnbound: isSingleProvider },
-    );
-    clearedSessionsCount = deletedCount;
-    for (const folder of affectedFolders) {
-      delete deps.sessions[folder];
-    }
-  }
-
-  appendClaudeConfigAudit(actor, 'apply_to_all_flows', ['queue.stopGroup'], {
-    stoppedCount,
-    failedCount,
-    ...(clearedSessionsCount !== undefined ? { clearedSessionsCount } : {}),
-    ...(metadata || {}),
-  });
-
-  if (failedCount > 0) {
-    return {
-      success: false,
-      stoppedCount,
-      failedCount,
-      ...(clearedSessionsCount !== undefined ? { clearedSessionsCount } : {}),
-      error: `${failedCount} container(s) failed to stop`,
-    };
-  }
-
-  return {
-    success: true,
-    stoppedCount,
-    failedCount: 0,
-    ...(clearedSessionsCount !== undefined ? { clearedSessionsCount } : {}),
-  };
+  return result.applied;
 }
 
 // --- OAuth 常量 ---
@@ -472,52 +567,88 @@ configRoutes.patch(
     const actor = (c.get('user') as AuthUser).username;
 
     try {
-      const previous = getProviders().find((p) => p.id === id);
-      const updated = updateProvider(id, validation.data);
-      const changedFields = Object.keys(validation.data).map(
-        (k) => `${k}:updated`,
-      );
-      // Protocol-level fields are the ones that, if changed, can break
-      // resumption of an existing Claude session (different model framing /
-      // different signing authority for thinking blocks). Other fields
-      // (name, weight, customEnv) only affect routing or environment and are
-      // safe to apply mid-session.
-      const protocolFieldChanged = !!(
-        previous &&
-        ((validation.data.anthropicBaseUrl !== undefined &&
-          validation.data.anthropicBaseUrl !== previous.anthropicBaseUrl) ||
-          (validation.data.anthropicModel !== undefined &&
-            validation.data.anthropicModel !== previous.anthropicModel))
-      );
-      appendClaudeConfigAudit(actor, 'update_provider', [
-        `id:${id}`,
-        ...changedFields,
-        ...(protocolFieldChanged ? ['protocolFieldChanged'] : []),
-      ]);
-
-      // If this provider is enabled, apply to running containers
-      let applied: ClaudeApplyResultPayload | null = null;
-      if (updated.enabled) {
-        // Third-party providers typically don't verify thinking block signatures,
-        // so model changes can be applied without destroying session context.
-        // Only clear sessions for official providers where signature verification
-        // would reject a cross-model resume.
-        const shouldClearSessions =
-          protocolFieldChanged && updated.type === 'official';
-        applied = await applyClaudeConfigToAllGroups(
-          actor,
-          {
-            trigger: 'provider_update',
-            providerId: id,
-            protocolFieldChanged,
-          },
-          shouldClearSessions ? { clearSessionsForProviderId: id } : undefined,
+      return await withClaudeConfigMutationLock(async () => {
+        const previous = getProviders().find((p) => p.id === id);
+        if (!previous) throw new Error('未找到指定供应商');
+        const changedFields = Object.keys(validation.data).map(
+          (k) => `${k}:updated`,
         );
-      }
+        const baseUrlChanged = !!(
+          validation.data.anthropicBaseUrl !== undefined &&
+          validation.data.anthropicBaseUrl !== previous.anthropicBaseUrl
+        );
+        const modelChanged = !!(
+          validation.data.anthropicModel !== undefined &&
+          validation.data.anthropicModel !== previous.anthropicModel
+        );
+        const protocolFieldChanged = baseUrlChanged || modelChanged;
+        // Preserve this PR's model/base-URL resume behavior for third-party
+        // gateways. We do not have a reproducible third-party backend failure
+        // proving that their sessions must be invalidated.
+        const shouldClearSessions =
+          protocolFieldChanged && previous.type === 'official';
+        const metadata = {
+          trigger: 'provider_update',
+          providerId: id,
+          protocolFieldChanged,
+          baseUrlChanged,
+          modelChanged,
+        };
+        const commit = () => {
+          const updated = updateProvider(id, validation.data);
+          appendClaudeConfigAudit(actor, 'update_provider', [
+            `id:${id}`,
+            ...changedFields,
+            ...(protocolFieldChanged ? ['protocolFieldChanged'] : []),
+          ]);
+          return updated;
+        };
 
-      return c.json({
-        provider: toPublicProvider(updated),
-        ...(applied ? { applied } : {}),
+        let mutation: ClaudeMutationResult<ReturnType<typeof updateProvider>>;
+        if (previous.enabled) {
+          mutation = await mutateClaudeConfigForAllGroups(
+            actor,
+            metadata,
+            commit,
+            shouldClearSessions
+              ? { clearSessionsForProviderId: id }
+              : undefined,
+          );
+        } else {
+          const updated = commit();
+          const clearedSessionsCount = shouldClearSessions
+            ? clearProviderSessions(id)
+            : undefined;
+          mutation = {
+            value: updated,
+            applied: {
+              success: true,
+              stoppedCount: 0,
+              failedCount: 0,
+              persisted: true,
+              ...(clearedSessionsCount !== undefined
+                ? { clearedSessionsCount }
+                : {}),
+            },
+          };
+        }
+
+        if (!mutation.applied.success) {
+          return c.json(
+            {
+              error: mutation.applied.error,
+              applied: mutation.applied,
+              ...(mutation.value
+                ? { provider: toPublicProvider(mutation.value) }
+                : {}),
+            },
+            503,
+          );
+        }
+        return c.json({
+          provider: toPublicProvider(mutation.value!),
+          applied: mutation.applied,
+        });
       });
     } catch (err) {
       const message =
@@ -547,49 +678,75 @@ configRoutes.put(
     const actor = (c.get('user') as AuthUser).username;
 
     try {
-      const updated = updateProviderSecrets(id, validation.data);
+      return await withClaudeConfigMutationLock(async () => {
+        const previous = getProviders().find((provider) => provider.id === id);
+        if (!previous) throw new Error('未找到指定供应商');
+        const changedFields: string[] = [];
+        if (validation.data.anthropicAuthToken !== undefined)
+          changedFields.push('anthropicAuthToken:set');
+        if (validation.data.clearAnthropicAuthToken)
+          changedFields.push('anthropicAuthToken:clear');
+        if (validation.data.anthropicApiKey !== undefined)
+          changedFields.push('anthropicApiKey:set');
+        if (validation.data.clearAnthropicApiKey)
+          changedFields.push('anthropicApiKey:clear');
+        if (validation.data.claudeCodeOauthToken !== undefined)
+          changedFields.push('claudeCodeOauthToken:set');
+        if (validation.data.clearClaudeCodeOauthToken)
+          changedFields.push('claudeCodeOauthToken:clear');
+        if (validation.data.claudeOAuthCredentials)
+          changedFields.push('claudeOAuthCredentials:set');
+        if (validation.data.clearClaudeOAuthCredentials)
+          changedFields.push('claudeOAuthCredentials:clear');
 
-      const changedFields: string[] = [];
-      if (validation.data.anthropicAuthToken !== undefined)
-        changedFields.push('anthropicAuthToken:set');
-      if (validation.data.clearAnthropicAuthToken)
-        changedFields.push('anthropicAuthToken:clear');
-      if (validation.data.anthropicApiKey !== undefined)
-        changedFields.push('anthropicApiKey:set');
-      if (validation.data.clearAnthropicApiKey)
-        changedFields.push('anthropicApiKey:clear');
-      if (validation.data.claudeCodeOauthToken !== undefined)
-        changedFields.push('claudeCodeOauthToken:set');
-      if (validation.data.clearClaudeCodeOauthToken)
-        changedFields.push('claudeCodeOauthToken:clear');
-      if (validation.data.claudeOAuthCredentials)
-        changedFields.push('claudeOAuthCredentials:set');
-      if (validation.data.clearClaudeOAuthCredentials)
-        changedFields.push('claudeOAuthCredentials:clear');
+        const commit = () => {
+          const updated = updateProviderSecrets(id, validation.data);
+          appendClaudeConfigAudit(actor, 'update_provider_secrets', [
+            `id:${id}`,
+            ...changedFields,
+          ]);
+          if (validation.data.claudeOAuthCredentials && updated.enabled) {
+            updateAllSessionCredentials(providerToConfig(updated));
+            deps?.queue?.closeAllActiveForCredentialRefresh();
+          }
+          return updated;
+        };
 
-      appendClaudeConfigAudit(actor, 'update_provider_secrets', [
-        `id:${id}`,
-        ...changedFields,
-      ]);
+        const mutation = previous.enabled
+          ? await mutateClaudeConfigForAllGroups(
+              actor,
+              {
+                trigger: 'provider_secrets_update',
+                providerId: id,
+              },
+              commit,
+            )
+          : {
+              value: commit(),
+              applied: {
+                success: true,
+                stoppedCount: 0,
+                failedCount: 0,
+                persisted: true,
+              } satisfies ClaudeApplyResultPayload,
+            };
 
-      // Update .credentials.json if OAuth credentials changed
-      if (validation.data.claudeOAuthCredentials && updated.enabled) {
-        updateAllSessionCredentials(providerToConfig(updated));
-        deps?.queue?.closeAllActiveForCredentialRefresh();
-      }
-
-      // Apply if enabled
-      let applied: ClaudeApplyResultPayload | null = null;
-      if (updated.enabled) {
-        applied = await applyClaudeConfigToAllGroups(actor, {
-          trigger: 'provider_secrets_update',
-          providerId: id,
+        if (!mutation.applied.success) {
+          return c.json(
+            {
+              error: mutation.applied.error,
+              applied: mutation.applied,
+              ...(mutation.value
+                ? { provider: toPublicProvider(mutation.value) }
+                : {}),
+            },
+            503,
+          );
+        }
+        return c.json({
+          provider: toPublicProvider(mutation.value!),
+          applied: mutation.applied,
         });
-      }
-
-      return c.json({
-        provider: toPublicProvider(updated),
-        ...(applied ? { applied } : {}),
       });
     } catch (err) {
       const message =
@@ -632,20 +789,35 @@ configRoutes.post(
     const actor = (c.get('user') as AuthUser).username;
 
     try {
-      const updated = toggleProvider(id);
-      appendClaudeConfigAudit(actor, 'toggle_provider', [
-        `id:${id}`,
-        `enabled:${updated.enabled}`,
-      ]);
-
-      const applied = await applyClaudeConfigToAllGroups(actor, {
-        trigger: 'provider_toggle',
-        providerId: id,
-      });
-
-      return c.json({
-        provider: toPublicProvider(updated),
-        applied,
+      return await withClaudeConfigMutationLock(async () => {
+        const mutation = await mutateClaudeConfigForAllGroups(
+          actor,
+          { trigger: 'provider_toggle', providerId: id },
+          () => {
+            const updated = toggleProvider(id);
+            appendClaudeConfigAudit(actor, 'toggle_provider', [
+              `id:${id}`,
+              `enabled:${updated.enabled}`,
+            ]);
+            return updated;
+          },
+        );
+        if (!mutation.applied.success) {
+          return c.json(
+            {
+              error: mutation.applied.error,
+              applied: mutation.applied,
+              ...(mutation.value
+                ? { provider: toPublicProvider(mutation.value) }
+                : {}),
+            },
+            503,
+          );
+        }
+        return c.json({
+          provider: toPublicProvider(mutation.value!),
+          applied: mutation.applied,
+        });
       });
     } catch (err) {
       const message =

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -29,7 +29,13 @@ import {
   logAuthEvent,
   clearSenderAllowlist,
   deleteWorkspaceSessions,
-  deleteSessionsByProviderId,
+  deleteSessionsByProviderIdAroundCommit,
+  getSession,
+  getRouterState,
+  getRouterStateByPrefix,
+  setRouterState,
+  deleteRouterState,
+  isDatabaseInitialized,
   VALID_ACTIVATION_MODES,
   getDefaultChannelAccount,
   getLegacyChannelAccount,
@@ -69,7 +75,7 @@ import {
   createProvider,
   updateProvider,
   updateProviderSecrets,
-  toggleProvider,
+  setProviderEnabled,
   deleteProvider,
   providerToConfig,
   toPublicProvider,
@@ -177,6 +183,7 @@ function countOtherEnabledImChannels(
 let deps: any = null;
 export function injectConfigDeps(d: any) {
   deps = d;
+  restorePendingProviderRuntimeSafetyBlocks();
 }
 
 function createTelegramApiAgent(proxyUrl?: string): HttpsAgent | ProxyAgent {
@@ -215,6 +222,148 @@ interface ApplyOptions {
     modelChanged: boolean;
     baseUrlChanged: boolean;
   };
+}
+
+interface PendingProviderSessionInvalidation {
+  providerId: string;
+  modelChanged: boolean;
+  baseUrlChanged: boolean;
+}
+
+const PROVIDER_INVALIDATION_STATE_PREFIX =
+  'provider_session_invalidation_pending:';
+const volatilePendingProviderSessionInvalidations = new Map<
+  string,
+  PendingProviderSessionInvalidation
+>();
+
+function providerInvalidationStateKey(providerId: string): string {
+  return `${PROVIDER_INVALIDATION_STATE_PREFIX}${providerId}`;
+}
+
+function getPendingProviderSessionInvalidation(
+  providerId: string,
+): PendingProviderSessionInvalidation | undefined {
+  const raw = getRouterState(providerInvalidationStateKey(providerId));
+  const volatile = volatilePendingProviderSessionInvalidations.get(providerId);
+  let durable: PendingProviderSessionInvalidation | undefined;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(
+        raw,
+      ) as Partial<PendingProviderSessionInvalidation>;
+      if (parsed.providerId === providerId) {
+        durable = {
+          providerId,
+          modelChanged: parsed.modelChanged === true,
+          baseUrlChanged: parsed.baseUrlChanged === true,
+        };
+      } else {
+        durable = {
+          providerId,
+          modelChanged: true,
+          baseUrlChanged: true,
+        };
+      }
+    } catch {
+      // A corrupt marker must remain repairable rather than becoming a
+      // permanent global gate. Conservatively replay both invalidations when
+      // this provider is next PATCHed.
+      durable = {
+        providerId,
+        modelChanged: true,
+        baseUrlChanged: true,
+      };
+    }
+  }
+  if (!durable) return volatile;
+  if (!volatile) return durable;
+  return {
+    providerId,
+    modelChanged: durable.modelChanged || volatile.modelChanged,
+    baseUrlChanged: durable.baseUrlChanged || volatile.baseUrlChanged,
+  };
+}
+
+function setPendingProviderSessionInvalidation(
+  pending: PendingProviderSessionInvalidation,
+): void {
+  const previous = getPendingProviderSessionInvalidation(pending.providerId);
+  const merged = {
+    providerId: pending.providerId,
+    modelChanged: pending.modelChanged || previous?.modelChanged === true,
+    baseUrlChanged: pending.baseUrlChanged || previous?.baseUrlChanged === true,
+  };
+  // Keep an in-process repair path even if durable state persistence fails.
+  volatilePendingProviderSessionInvalidations.set(pending.providerId, merged);
+  setRouterState(
+    providerInvalidationStateKey(pending.providerId),
+    JSON.stringify(merged),
+  );
+}
+
+function clearPendingProviderSessionInvalidation(providerId: string): void {
+  deleteRouterState(providerInvalidationStateKey(providerId));
+  volatilePendingProviderSessionInvalidations.delete(providerId);
+}
+
+function hasPendingProviderSessionInvalidations(): boolean {
+  return (
+    volatilePendingProviderSessionInvalidations.size > 0 ||
+    getRouterStateByPrefix(PROVIDER_INVALIDATION_STATE_PREFIX).length > 0
+  );
+}
+
+/**
+ * Runtime-safety blocks live in memory, while incomplete provider session
+ * invalidations are durable. Rebuild the gate when web dependencies are
+ * injected after a process restart so no stale session can resume before an
+ * exact provider PATCH repairs the pending cleanup.
+ */
+function restorePendingProviderRuntimeSafetyBlocks(): void {
+  if (!deps || !isDatabaseInitialized()) return;
+  const durableRows = getRouterStateByPrefix(
+    PROVIDER_INVALIDATION_STATE_PREFIX,
+  );
+  const configuredProviderIds = new Set(
+    getProviders().map((provider) => provider.id),
+  );
+  const pendingProviderIds = new Set([
+    ...durableRows.map((row) =>
+      row.key.slice(PROVIDER_INVALIDATION_STATE_PREFIX.length),
+    ),
+    ...volatilePendingProviderSessionInvalidations.keys(),
+  ]);
+  for (const providerId of pendingProviderIds) {
+    if (providerId && configuredProviderIds.has(providerId)) continue;
+    if (providerId) {
+      const cleanup = deleteSessionsByProviderIdAroundCommit(
+        providerId,
+        undefined,
+        () => undefined,
+      );
+      syncProviderSessionCaches(cleanup.affectedFolders);
+    }
+    deleteRouterState(providerInvalidationStateKey(providerId));
+    volatilePendingProviderSessionInvalidations.delete(providerId);
+    pendingProviderIds.delete(providerId);
+    logger.warn(
+      { providerId },
+      'Removed orphaned provider session invalidation marker during startup',
+    );
+  }
+  if (pendingProviderIds.size === 0) return;
+  const runtimeJids = Array.from(
+    new Set(
+      getClaudeRuntimeTargets().flatMap((target) =>
+        getWorkspaceRuntimeJids(deps, target.folder, target.primaryJid),
+      ),
+    ),
+  );
+  deps.queue.blockGroupsForRuntimeSafety(
+    runtimeJids,
+    `provider session invalidation pending after restart: ${pendingProviderIds.size}`,
+  );
 }
 
 interface ClaudeMutationResult<T> {
@@ -286,23 +435,17 @@ function hasWorkspaceProviderOverride(
   folder: string,
   invalidation?: ApplyOptions['sessionInvalidation'],
 ): boolean {
+  if (!invalidation) return false;
   const override = getContainerEnvConfig(folder);
-  const hasCredentialOrEndpointOverride = !!(
-    override.anthropicBaseUrl ||
-    override.anthropicAuthToken ||
-    override.anthropicApiKey ||
-    override.claudeCodeOauthToken ||
-    override.claudeOAuthCredentials
-  );
-  // A workspace-level model still uses the global provider endpoint. It only
-  // makes a legacy NULL session unattributable for a model-only global change;
-  // a simultaneous Base URL change still affects that workspace.
-  const hasRelevantModelOverride = !!(
-    invalidation?.modelChanged &&
-    !invalidation.baseUrlChanged &&
-    override.anthropicModel
-  );
-  return hasCredentialOrEndpointOverride || hasRelevantModelOverride;
+  // Shadowing is field-specific. Credentials do not protect a workspace from
+  // inheriting a changed global model or Base URL, and when both fields change
+  // the workspace must override both before its legacy NULL-bound session is
+  // safe to preserve.
+  const modelChangeIsShadowed =
+    !invalidation.modelChanged || !!override.anthropicModel;
+  const baseUrlChangeIsShadowed =
+    !invalidation.baseUrlChanged || !!override.anthropicBaseUrl;
+  return modelChangeIsShadowed && baseUrlChangeIsShadowed;
 }
 
 function getSafeLegacyUnboundFolders(
@@ -330,24 +473,42 @@ function getSafeLegacyUnboundFolders(
   );
 }
 
-function clearProviderSessions(
+function getProviderSessionCleanupOptions(
   providerId: string,
   invalidation?: ApplyOptions['sessionInvalidation'],
-): number {
-  if (!deps) return 0;
-  const { deletedCount, affectedFolders } = deleteSessionsByProviderId(
-    providerId,
-    {
-      includeUnboundFolders: getSafeLegacyUnboundFolders(
-        providerId,
-        invalidation,
-      ),
-    },
-  );
+): { includeUnboundFolders: string[] } {
+  return {
+    includeUnboundFolders: getSafeLegacyUnboundFolders(
+      providerId,
+      invalidation,
+    ),
+  };
+}
+
+function syncProviderSessionCaches(affectedFolders: string[]): void {
+  if (!deps) return;
   for (const folder of affectedFolders) {
-    delete deps.sessions[folder];
+    const remainingMainSession = getSession(folder);
+    if (remainingMainSession !== undefined) {
+      deps.sessions[folder] = remainingMainSession;
+    } else {
+      delete deps.sessions[folder];
+    }
   }
-  return deletedCount;
+}
+
+function commitProviderConfigWithSessionInvalidation<T>(
+  providerId: string,
+  invalidation: ApplyOptions['sessionInvalidation'],
+  commit: () => T,
+): { value: T; clearedSessionsCount: number } {
+  const result = deleteSessionsByProviderIdAroundCommit(
+    providerId,
+    getProviderSessionCleanupOptions(providerId, invalidation),
+    commit,
+  );
+  syncProviderSessionCaches(result.affectedFolders);
+  return { value: result.value, clearedSessionsCount: result.deletedCount };
 }
 
 function getClaudeRuntimeTargets(): Array<{
@@ -369,7 +530,7 @@ function getClaudeRuntimeTargets(): Array<{
 async function mutateClaudeConfigForAllGroups<T>(
   actor: string,
   metadata: Record<string, unknown> | undefined,
-  commit: () => T | Promise<T>,
+  commit: () => T,
   options?: ApplyOptions,
 ): Promise<ClaudeMutationResult<T>> {
   if (!deps) throw new Error('Server not initialized');
@@ -389,26 +550,50 @@ async function mutateClaudeConfigForAllGroups<T>(
       targets,
       {
         reason,
-        onPostCommitFailure: (runtimeJids) =>
+        onPostCommitFailure: (runtimeJids) => {
+          // Establish the in-memory fail-closed gate before any durable marker
+          // I/O. Focused test fixtures may omit the optional method, while the
+          // production WebDeps queue is a concrete GroupQueue that implements
+          // it and startup restoration below requires it when pending exists.
           deps.queue.blockGroupsForRuntimeSafety?.(
             runtimeJids,
             `${reason}: post-commit provider runtime cleanup failed`,
-          ),
+          );
+          if (
+            options?.clearSessionsForProviderId &&
+            options.sessionInvalidation
+          ) {
+            try {
+              setPendingProviderSessionInvalidation({
+                providerId: options.clearSessionsForProviderId,
+                ...options.sessionInvalidation,
+              });
+            } catch (error) {
+              // The volatile marker was set before SQLite persistence, so an
+              // exact retry in this process can still repair and unblock.
+              logger.error(
+                { error, providerId: options.clearSessionsForProviderId },
+                'Failed to persist pending provider session invalidation',
+              );
+            }
+          }
+        },
       },
       async () => {
-        // Invalidate attributable resume state before persisting protocol
-        // changes. If cleanup fails the provider file remains unchanged, so a
-        // same-value retry cannot accidentally skip the unfinished cleanup and
-        // release a runtime-safety gate.
-        const clearedSessionsCount = options?.clearSessionsForProviderId
-          ? clearProviderSessions(
+        let value: T;
+        let clearedSessionsCount: number | undefined;
+        try {
+          if (options?.clearSessionsForProviderId) {
+            const committed = commitProviderConfigWithSessionInvalidation(
               options.clearSessionsForProviderId,
               options.sessionInvalidation,
-            )
-          : undefined;
-        let value: T;
-        try {
-          value = await commit();
+              commit,
+            );
+            value = committed.value;
+            clearedSessionsCount = committed.clearedSessionsCount;
+          } else {
+            value = commit();
+          }
         } catch (error) {
           if (error instanceof ClaudeConfigPersistedError) {
             deps.queue.blockGroupsForRuntimeSafety?.(
@@ -424,7 +609,14 @@ async function mutateClaudeConfigForAllGroups<T>(
     // A successful retry proves every runtime now observes the persisted
     // provider config, so it may repair a fail-closed gate left by an earlier
     // post-commit teardown failure.
-    deps.queue.unblockGroupsForRuntimeSafety?.(result.runtimeJids);
+    if (options?.clearSessionsForProviderId) {
+      clearPendingProviderSessionInvalidation(
+        options.clearSessionsForProviderId,
+      );
+    }
+    if (!hasPendingProviderSessionInvalidations()) {
+      deps.queue.unblockGroupsForRuntimeSafety?.(result.runtimeJids);
+    }
     const applied: ClaudeApplyResultPayload = {
       success: true,
       stoppedCount: result.runtimeJids.length,
@@ -716,11 +908,19 @@ configRoutes.patch(
           validation.data.anthropicModel !== previous.anthropicModel
         );
         const protocolFieldChanged = baseUrlChanged || modelChanged;
+        const pendingInvalidation = getPendingProviderSessionInvalidation(id);
+        const sessionInvalidation = {
+          modelChanged:
+            modelChanged || pendingInvalidation?.modelChanged === true,
+          baseUrlChanged:
+            baseUrlChanged || pendingInvalidation?.baseUrlChanged === true,
+        };
         // Preserve this PR's model/base-URL resume behavior for third-party
         // gateways. We do not have a reproducible third-party backend failure
         // proving that their sessions must be invalidated.
         const shouldClearSessions =
-          protocolFieldChanged && previous.type === 'official';
+          !!pendingInvalidation ||
+          (protocolFieldChanged && previous.type === 'official');
         const metadata = {
           trigger: 'provider_update',
           providerId: id,
@@ -747,15 +947,23 @@ configRoutes.patch(
             shouldClearSessions
               ? {
                   clearSessionsForProviderId: id,
-                  sessionInvalidation: { modelChanged, baseUrlChanged },
+                  sessionInvalidation,
                 }
               : undefined,
           );
         } else {
-          const clearedSessionsCount = shouldClearSessions
-            ? clearProviderSessions(id, { modelChanged, baseUrlChanged })
-            : undefined;
-          const updated = commit();
+          const committed = shouldClearSessions
+            ? commitProviderConfigWithSessionInvalidation(
+                id,
+                sessionInvalidation,
+                commit,
+              )
+            : { value: commit(), clearedSessionsCount: undefined };
+          const updated = committed.value;
+          const clearedSessionsCount = committed.clearedSessionsCount;
+          if (shouldClearSessions) {
+            clearPendingProviderSessionInvalidation(id);
+          }
           mutation = {
             value: updated,
             applied: {
@@ -925,6 +1133,10 @@ configRoutes.post(
   async (c) => {
     const { id } = c.req.param();
     const actor = (c.get('user') as AuthUser).username;
+    const body = await c.req.json().catch(() => ({}));
+    if (typeof body.enabled !== 'boolean') {
+      return c.json({ error: 'enabled must be a boolean' }, 400);
+    }
 
     try {
       return await withClaudeConfigMutationLock(async () => {
@@ -932,7 +1144,7 @@ configRoutes.post(
           actor,
           { trigger: 'provider_toggle', providerId: id },
           () => {
-            const updated = toggleProvider(id);
+            const updated = setProviderEnabled(id, body.enabled);
             appendClaudeConfigAuditBestEffort(actor, 'toggle_provider', [
               `id:${id}`,
               `enabled:${updated.enabled}`,
@@ -1054,7 +1266,7 @@ configRoutes.post(
           trigger: 'manual_provider_apply',
         });
         if (!result.success) {
-          return c.json(result, 207);
+          return c.json(result, 503);
         }
         return c.json(result);
       });

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -218,9 +218,10 @@ async function applyClaudeConfigToAllGroups(
   }
 
   const groupJids = Object.keys(deps.getRegisteredGroups());
-  // Also stop agent sub-processes — they run under {jid}#agent:{id} keys
-  // which are not in registeredGroups and would otherwise keep running with
-  // stale ANTHROPIC_MODEL env vars after a provider config change.
+  // Also stop descendant runners (agents and scheduled tasks) — they run
+  // under {jid}#agent:{id} or {jid}#task:{id} keys which are not in
+  // registeredGroups and would otherwise keep running with stale
+  // ANTHROPIC_MODEL env vars after a provider config change.
   const allJidsToStop = groupJids.flatMap((jid) => [
     jid,
     ...deps.queue.listDescendantJids(jid),

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -232,6 +232,7 @@ interface PendingProviderSessionInvalidation {
 
 const PROVIDER_INVALIDATION_STATE_PREFIX =
   'provider_session_invalidation_pending:';
+const PROVIDER_RUNTIME_SAFETY_SOURCE = 'provider-config-mutation';
 const volatilePendingProviderSessionInvalidations = new Map<
   string,
   PendingProviderSessionInvalidation
@@ -363,6 +364,7 @@ function restorePendingProviderRuntimeSafetyBlocks(): void {
   deps.queue.blockGroupsForRuntimeSafety(
     runtimeJids,
     `provider session invalidation pending after restart: ${pendingProviderIds.size}`,
+    PROVIDER_RUNTIME_SAFETY_SOURCE,
   );
 }
 
@@ -563,6 +565,7 @@ async function mutateClaudeConfigForAllGroups<T>(
           deps.queue.blockGroupsForRuntimeSafety?.(
             runtimeJids,
             `${reason}: post-commit provider runtime cleanup failed`,
+            PROVIDER_RUNTIME_SAFETY_SOURCE,
           );
           if (
             options?.clearSessionsForProviderId &&
@@ -604,6 +607,7 @@ async function mutateClaudeConfigForAllGroups<T>(
             deps.queue.blockGroupsForRuntimeSafety?.(
               knownRuntimeJids,
               `${reason}: provider config persisted but follow-up failed`,
+              PROVIDER_RUNTIME_SAFETY_SOURCE,
             );
           }
           throw error;
@@ -620,7 +624,10 @@ async function mutateClaudeConfigForAllGroups<T>(
       );
     }
     if (!hasPendingProviderSessionInvalidations()) {
-      deps.queue.unblockGroupsForRuntimeSafety?.(result.runtimeJids);
+      deps.queue.unblockGroupsForRuntimeSafety?.(
+        result.runtimeJids,
+        PROVIDER_RUNTIME_SAFETY_SOURCE,
+      );
     }
     const applied: ClaudeApplyResultPayload = {
       success: true,
@@ -971,6 +978,7 @@ configRoutes.patch(
             if (!hasPendingProviderSessionInvalidations()) {
               deps?.queue?.unblockGroupsForRuntimeSafety?.(
                 getKnownClaudeRuntimeJids(),
+                PROVIDER_RUNTIME_SAFETY_SOURCE,
               );
             }
           }

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -218,19 +218,31 @@ async function applyClaudeConfigToAllGroups(
   }
 
   const groupJids = Object.keys(deps.getRegisteredGroups());
+  // Also stop agent sub-processes — they run under {jid}#agent:{id} keys
+  // which are not in registeredGroups and would otherwise keep running with
+  // stale ANTHROPIC_MODEL env vars after a provider config change.
+  const allJidsToStop = groupJids.flatMap((jid) => [
+    jid,
+    ...deps.queue.listDescendantJids(jid),
+  ]);
   const results = await Promise.allSettled(
-    groupJids.map((jid) => deps.queue.stopGroup(jid)),
+    allJidsToStop.map((jid) => deps.queue.stopGroup(jid)),
   );
   const failedCount = results.filter((r) => r.status === 'rejected').length;
-  const stoppedCount = groupJids.length - failedCount;
+  const stoppedCount = allJidsToStop.length - failedCount;
 
   // Narrowed session cleanup: only drop sticky bindings for the provider whose
   // protocol-level fields actually changed. Bindings to other providers stay
   // intact so a routine update doesn't reset the entire pool. See issue #476.
   let clearedSessionsCount: number | undefined;
   if (options?.clearSessionsForProviderId) {
+    // In single-provider deployments, unbound (NULL) sessions certainly belong
+    // to the only provider. In multi-provider setups they could belong to any
+    // provider, so only delete exact matches to avoid collateral damage.
+    const isSingleProvider = getEnabledProviders().length <= 1;
     const { deletedCount, affectedFolders } = deleteSessionsByProviderId(
       options.clearSessionsForProviderId,
+      { includeUnbound: isSingleProvider },
     );
     clearedSessionsCount = deletedCount;
     for (const folder of affectedFolders) {
@@ -485,6 +497,12 @@ configRoutes.patch(
       // If this provider is enabled, apply to running containers
       let applied: ClaudeApplyResultPayload | null = null;
       if (updated.enabled) {
+        // Third-party providers typically don't verify thinking block signatures,
+        // so model changes can be applied without destroying session context.
+        // Only clear sessions for official providers where signature verification
+        // would reject a cross-model resume.
+        const shouldClearSessions =
+          protocolFieldChanged && updated.type === 'official';
         applied = await applyClaudeConfigToAllGroups(
           actor,
           {
@@ -492,7 +510,7 @@ configRoutes.patch(
             providerId: id,
             protocolFieldChanged,
           },
-          protocolFieldChanged ? { clearSessionsForProviderId: id } : undefined,
+          shouldClearSessions ? { clearSessionsForProviderId: id } : undefined,
         );
       }
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1503,7 +1503,10 @@ export function updateProviderSecrets(
   return updated;
 }
 
-export function toggleProvider(id: string): UnifiedProvider {
+export function setProviderEnabled(
+  id: string,
+  enabled: boolean,
+): UnifiedProvider {
   const state = readStoredStateV4();
   if (!state) throw new Error('Claude 配置不存在');
 
@@ -1511,20 +1514,26 @@ export function toggleProvider(id: string): UnifiedProvider {
   if (idx < 0) throw new Error('未找到指定供应商');
 
   const provider = state.providers[idx];
-  const newEnabled = !provider.enabled;
+  if (provider.enabled === enabled) return provider;
 
   // Prevent disabling the last enabled provider
-  if (!newEnabled && state.providers.filter((p) => p.enabled).length <= 1) {
+  if (!enabled && state.providers.filter((p) => p.enabled).length <= 1) {
     throw new Error('至少需要保留一个启用的供应商');
   }
 
   state.providers[idx] = {
     ...provider,
-    enabled: newEnabled,
+    enabled,
     updatedAt: new Date().toISOString(),
   };
   writeStoredStateV4(state.providers, state.balancing);
   return state.providers[idx];
+}
+
+export function toggleProvider(id: string): UnifiedProvider {
+  const provider = getProviders().find((item) => item.id === id);
+  if (!provider) throw new Error('未找到指定供应商');
+  return setProviderEnabled(id, !provider.enabled);
 }
 
 export function deleteProvider(id: string): void {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -950,11 +950,27 @@ export const BugReportSubmitSchema = z.object({
 
 // ─── 统一供应商 (V4) ────────────────────────────────────────
 
+const ProviderBaseUrlSchema = z
+  .string()
+  .max(2000)
+  .refine(
+    (value) => {
+      if (!value.trim()) return true;
+      try {
+        const parsed = new URL(value.trim());
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Base URL must be an HTTP(S) URL' },
+  );
+
 export const UnifiedProviderCreateSchema = z
   .object({
     name: z.string().min(1).max(64),
     type: z.enum(['official', 'third_party']),
-    anthropicBaseUrl: z.string().max(2000).optional(),
+    anthropicBaseUrl: ProviderBaseUrlSchema.optional(),
     anthropicAuthToken: z.string().max(2000).optional(),
     anthropicModel: z.string().max(128).optional(),
     anthropicApiKey: z.string().max(2000).optional(),
@@ -981,7 +997,7 @@ export const UnifiedProviderCreateSchema = z
 export const UnifiedProviderPatchSchema = z
   .object({
     name: z.string().min(1).max(64).optional(),
-    anthropicBaseUrl: z.string().max(2000).optional(),
+    anthropicBaseUrl: ProviderBaseUrlSchema.optional(),
     anthropicModel: z.string().max(128).optional(),
     customEnv: z.record(z.string().max(256), z.string().max(4096)).optional(),
     weight: z.number().int().min(1).max(100).optional(),

--- a/tests/group-queue-mutation-pause.test.ts
+++ b/tests/group-queue-mutation-pause.test.ts
@@ -339,4 +339,37 @@ describe('GroupQueue mutation pause', () => {
     expect(queue.isGroupRuntimeSafetyBlocked(WEB_JID)).toBe(false);
     expect(runs).toBe(1);
   });
+
+  test('runtime safety sources release independently and drain only after the final source', async () => {
+    let runs = 0;
+    queue.setProcessMessagesFn(async () => {
+      runs++;
+      return true;
+    });
+    queue.blockGroupsForRuntimeSafety(
+      [WEB_JID, IM_JID],
+      'capability repair pending',
+    );
+    queue.blockGroupsForRuntimeSafety(
+      [WEB_JID, IM_JID],
+      'provider repair pending',
+      'provider-config-mutation',
+    );
+    queue.enqueueMessageCheck(IM_JID);
+
+    queue.unblockGroupsForRuntimeSafety(
+      [WEB_JID, IM_JID],
+      'provider-config-mutation',
+    );
+    await tick();
+    await tick();
+    expect(queue.isGroupRuntimeSafetyBlocked(WEB_JID)).toBe(true);
+    expect(runs).toBe(0);
+
+    queue.unblockGroupsForRuntimeSafety([WEB_JID, IM_JID]);
+    await tick();
+    await tick();
+    expect(queue.isGroupRuntimeSafetyBlocked(WEB_JID)).toBe(false);
+    expect(runs).toBe(1);
+  });
 });

--- a/tests/routes-provider-runtime-apply.test.ts
+++ b/tests/routes-provider-runtime-apply.test.ts
@@ -360,6 +360,7 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
     expect(blockGroupsForRuntimeSafety).toHaveBeenCalledWith(
       [jid],
       expect.stringContaining('post-commit provider runtime cleanup failed'),
+      'provider-config-mutation',
     );
     expect(unblockGroupsForRuntimeSafety).not.toHaveBeenCalled();
 
@@ -435,7 +436,10 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
       runtimeConfig.getProviders().find((item) => item.id === target.id)
         ?.enabled,
     ).toBe(false);
-    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
+    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith(
+      [jid],
+      'provider-config-mutation',
+    );
   });
 
   test('unblocks a restarted workspace after a disabled provider repairs pending session cleanup', async () => {
@@ -565,7 +569,38 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
     expect(
       db.getRouterState(`provider_session_invalidation_pending:${target.id}`),
     ).toBeUndefined();
-    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
+    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith(
+      [jid],
+      'provider-config-mutation',
+    );
+  });
+
+  test('does not release a runtime safety block owned by another mutation source', async () => {
+    const folder = unique('cross-source-runtime-block');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    const queue = new GroupQueue();
+    liveQueue = queue;
+    bindDeps({ [jid]: group }, queue);
+    queue.blockGroupsForRuntimeSafety(
+      [jid],
+      'capability mutation requires manual repair',
+    );
+    const provider = runtimeConfig.createProvider({
+      name: unique('cross-source-provider'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://same.example.test',
+      anthropicAuthToken: 'test-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(queue.isGroupRuntimeSafetyBlocked(jid)).toBe(true);
   });
 
   test('serializes manual apply with a concurrent provider mutation', async () => {

--- a/tests/routes-provider-runtime-apply.test.ts
+++ b/tests/routes-provider-runtime-apply.test.ts
@@ -1,0 +1,456 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+const tmpDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'happyclaw-provider-runtime-apply-'),
+);
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: tmpDir,
+  STORE_DIR: path.join(tmpDir, 'db'),
+  GROUPS_DIR: path.join(tmpDir, 'groups'),
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../src/middleware/auth.ts', async (importOriginal) => {
+  const real =
+    await importOriginal<typeof import('../src/middleware/auth.ts')>();
+  return {
+    ...real,
+    authMiddleware: async (c: any, next: any) => {
+      c.set('user', {
+        id: 'provider-runtime-admin',
+        username: 'provider-runtime-admin',
+        display_name: 'Provider Runtime Admin',
+        role: 'admin',
+        status: 'active',
+        permissions: [],
+        must_change_password: false,
+      });
+      return next();
+    },
+  };
+});
+
+const web = await import('../src/web.js');
+const db = await import('../src/db.js');
+const runtimeConfig = await import('../src/runtime-config.js');
+const { GroupQueue } = await import('../src/group-queue.js');
+
+const app = web.createAppForTest({
+  queue: {
+    stopGroup: vi.fn(async () => {}),
+    listDescendantJids: () => [],
+    pauseGroupsForMutation: () => ({ id: 0 }),
+    resumeGroupsAfterMutation: vi.fn(),
+  },
+  getRegisteredGroups: () => ({}),
+  sessions: {},
+} as any);
+
+let sequence = 0;
+let liveQueue: InstanceType<typeof GroupQueue> | null = null;
+
+function unique(label: string): string {
+  sequence += 1;
+  return `${label}-${sequence}`;
+}
+
+function registerWorkspace(jid: string, folder: string) {
+  const group = {
+    name: folder,
+    folder,
+    added_at: new Date().toISOString(),
+    executionMode: 'container' as const,
+    created_by: 'provider-runtime-admin',
+  };
+  db.setRegisteredGroup(jid, group);
+  return group;
+}
+
+function bindDeps(
+  groups: Record<string, ReturnType<typeof registerWorkspace>>,
+  queue: unknown,
+  sessions: Record<string, string> = {},
+): void {
+  web.createAppForTest({
+    queue,
+    getRegisteredGroups: () => groups,
+    sessions,
+  } as any);
+}
+
+async function patchProvider(
+  providerId: string,
+  patch: Record<string, unknown>,
+): Promise<Response> {
+  return app.request(`/api/config/claude/providers/${providerId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+}
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'groups'), { recursive: true });
+  db.initDatabase();
+});
+
+beforeEach(() => {
+  fs.rmSync(path.join(tmpDir, 'config'), { recursive: true, force: true });
+  fs.rmSync(path.join(tmpDir, 'container-env'), {
+    recursive: true,
+    force: true,
+  });
+});
+
+afterEach(async () => {
+  if (liveQueue) {
+    await liveQueue.shutdown(0);
+    liveQueue = null;
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('provider runtime apply is a lossless configuration mutation', () => {
+  test('keeps a capacity-queued descendant task instead of dropping it', async () => {
+    const folder = unique('queued-work');
+    const jid = `web:${folder}`;
+    const descendantJid = `${jid}#task:scheduled`;
+    const group = registerWorkspace(jid, folder);
+    const queue = new GroupQueue();
+    liveQueue = queue;
+    queue.setSerializationKeyResolver((candidate) => {
+      const taskSeparator = candidate.indexOf('#task:');
+      if (taskSeparator >= 0) {
+        return `${folder}#task:${candidate.slice(taskSeparator + 6)}`;
+      }
+      return candidate === jid ? folder : candidate;
+    });
+    let capacityAllowed = false;
+    queue.setUserConcurrentLimitChecker(() => ({
+      allowed: capacityAllowed,
+    }));
+
+    let dropped = 0;
+    let runs = 0;
+    expect(
+      queue.enqueueTask(
+        descendantJid,
+        'scheduled',
+        async () => {
+          runs += 1;
+        },
+        {
+          onDropped: () => {
+            dropped += 1;
+          },
+        },
+      ),
+    ).toBe(true);
+    expect(queue.listDescendantJids(jid)).toEqual([descendantJid]);
+
+    bindDeps({ [jid]: group }, queue);
+    const provider = runtimeConfig.createProvider({
+      name: unique('third-party'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://old.example.test',
+      anthropicAuthToken: 'test-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(dropped).toBe(0);
+    expect(queue.listDescendantJids(jid)).toEqual([descendantJid]);
+    capacityAllowed = true;
+    (
+      queue as unknown as {
+        drainWaiting: () => void;
+      }
+    ).drainWaiting();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(runs).toBe(1);
+    expect(dropped).toBe(0);
+  });
+
+  test('never stops the same descendant concurrently when sibling JIDs share a folder', async () => {
+    const folder = unique('sibling-stop');
+    const webJid = `web:${folder}`;
+    const imJid = `feishu:${folder}`;
+    const descendantJid = `${webJid}#agent:researcher`;
+    const webGroup = registerWorkspace(webJid, folder);
+    const imGroup = registerWorkspace(imJid, folder);
+    const inFlight = new Set<string>();
+    let overlappingDuplicateStops = 0;
+    const stopOptions: unknown[] = [];
+    const queue = {
+      listDescendantJids: () => [descendantJid],
+      pauseGroupsForMutation: () => ({ id: 1 }),
+      resumeGroupsAfterMutation: vi.fn(),
+      stopGroup: vi.fn(async (target: string, options?: unknown) => {
+        stopOptions.push(options);
+        if (inFlight.has(target)) overlappingDuplicateStops += 1;
+        inFlight.add(target);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight.delete(target);
+      }),
+    };
+    bindDeps({ [webJid]: webGroup, [imJid]: imGroup }, queue);
+    const provider = runtimeConfig.createProvider({
+      name: unique('dedupe-provider'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://old.example.test',
+      anthropicAuthToken: 'test-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(overlappingDuplicateStops).toBe(0);
+    expect(stopOptions).not.toContain(undefined);
+    expect(stopOptions).toSatisfy((options) =>
+      options.every(
+        (option) =>
+          (option as { force?: boolean }).force === true &&
+          (option as { preserveQueuedWork?: boolean }).preserveQueuedWork ===
+            true,
+      ),
+    );
+  });
+
+  test('does not commit a provider update when pre-commit runtime quiesce fails', async () => {
+    const folder = unique('pre-commit-failure');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    bindDeps(
+      { [jid]: group },
+      {
+        listDescendantJids: () => [],
+        pauseGroupsForMutation: () => ({ id: 2 }),
+        resumeGroupsAfterMutation: vi.fn(),
+        stopGroup: vi.fn(async () => {
+          throw new Error('simulated stop failure');
+        }),
+      },
+    );
+    const provider = runtimeConfig.createProvider({
+      name: unique('failed-provider'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://old.example.test',
+      anthropicAuthToken: 'test-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'must-not-commit',
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      error: expect.stringContaining('not updated'),
+      applied: { success: false, persisted: false },
+    });
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.anthropicModel,
+    ).toBe('old-model');
+  });
+
+  test('reports a persisted update when the post-commit quiesce pass fails', async () => {
+    const folder = unique('post-commit-failure');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    let stopCalls = 0;
+    bindDeps(
+      { [jid]: group },
+      {
+        listDescendantJids: () => [],
+        pauseGroupsForMutation: () => ({ id: 4 }),
+        resumeGroupsAfterMutation: vi.fn(),
+        stopGroup: vi.fn(async () => {
+          stopCalls += 1;
+          if (stopCalls === 2) {
+            throw new Error('simulated post-commit stop failure');
+          }
+        }),
+      },
+    );
+    const provider = runtimeConfig.createProvider({
+      name: unique('partially-applied-provider'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://old.example.test',
+      anthropicAuthToken: 'test-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'persisted-model',
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      error: expect.stringContaining('saved'),
+      provider: { anthropicModel: 'persisted-model' },
+      applied: { success: false, persisted: true, phase: 'post_commit' },
+    });
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.anthropicModel,
+    ).toBe('persisted-model');
+  });
+});
+
+describe('provider session invalidation only removes attributable sessions', () => {
+  function bindIdleWorkspace(jid: string, folder: string, sessionId: string) {
+    const group = registerWorkspace(jid, folder);
+    const sessions = { [folder]: sessionId };
+    bindDeps(
+      { [jid]: group },
+      {
+        listDescendantJids: () => [],
+        pauseGroupsForMutation: () => ({ id: 3 }),
+        resumeGroupsAfterMutation: vi.fn(),
+        stopGroup: vi.fn(async () => {}),
+      },
+      sessions,
+    );
+    return sessions;
+  }
+
+  test('preserves an unbound session owned by a workspace-level env override', async () => {
+    const folder = unique('env-override');
+    const jid = `web:${folder}`;
+    const sessionId = unique('override-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    runtimeConfig.saveContainerEnvConfig(folder, {
+      anthropicBaseUrl: 'https://workspace.example.test',
+      anthropicAuthToken: 'workspace-token',
+      anthropicModel: 'workspace-model',
+    });
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBe(sessionId);
+  });
+
+  test('preserves ambiguous unbound sessions when another provider is configured but disabled', async () => {
+    const folder = unique('ambiguous-unbound');
+    const jid = `web:${folder}`;
+    const sessionId = unique('ambiguous-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+    runtimeConfig.createProvider({
+      name: unique('disabled-third-party'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://disabled.example.test',
+      anthropicAuthToken: 'disabled-token',
+      enabled: false,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBe(sessionId);
+  });
+
+  test('still clears a legacy unbound session in a true single-provider workspace', async () => {
+    const folder = unique('single-provider');
+    const jid = `web:${folder}`;
+    const sessionId = unique('legacy-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBeUndefined();
+  });
+
+  test('keeps a bound third-party session for a model-only change', async () => {
+    const folder = unique('third-party-model');
+    const jid = `web:${folder}`;
+    const sessionId = unique('bound-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    const provider = runtimeConfig.createProvider({
+      name: unique('third-party'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://same.example.test',
+      anthropicAuthToken: 'third-party-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+    db.setSessionProviderId(folder, '', provider.id);
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBe(sessionId);
+    expect(db.getSessionProviderId(folder)).toBe(provider.id);
+  });
+});

--- a/tests/routes-provider-runtime-apply.test.ts
+++ b/tests/routes-provider-runtime-apply.test.ts
@@ -118,6 +118,12 @@ async function setProviderEnabled(
   });
 }
 
+async function deleteProvider(providerId: string): Promise<Response> {
+  return app.request(`/api/config/claude/providers/${providerId}`, {
+    method: 'DELETE',
+  });
+}
+
 beforeAll(() => {
   fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'groups'), { recursive: true });
@@ -429,6 +435,136 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
       runtimeConfig.getProviders().find((item) => item.id === target.id)
         ?.enabled,
     ).toBe(false);
+    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
+  });
+
+  test('unblocks a restarted workspace after a disabled provider repairs pending session cleanup', async () => {
+    const folder = unique('disabled-provider-repair');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    const staleSessionId = unique('disabled-repair-stale-session');
+    let stopCalls = 0;
+    const initialQueue = {
+      listDescendantJids: () => [],
+      pauseGroupsForMutation: () => ({ id: 8 }),
+      resumeGroupsAfterMutation: vi.fn(),
+      blockGroupsForRuntimeSafety: vi.fn(),
+      unblockGroupsForRuntimeSafety: vi.fn(),
+      stopGroup: vi.fn(async () => {
+        stopCalls += 1;
+        if (stopCalls === 2) {
+          db.setSession(folder, staleSessionId);
+          db.setSessionProviderId(folder, '', target.id);
+          throw new Error('simulated post-commit stop failure');
+        }
+      }),
+    };
+    bindDeps({ [jid]: group }, initialQueue);
+    const target = runtimeConfig.createProvider({
+      name: unique('disabled-repair-target'),
+      type: 'official',
+      anthropicApiKey: 'target-key',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+    runtimeConfig.createProvider({
+      name: unique('disabled-repair-fallback'),
+      type: 'official',
+      anthropicApiKey: 'fallback-key',
+      enabled: true,
+    });
+    db.setSession(folder, unique('disabled-repair-initial-session'));
+    db.setSessionProviderId(folder, '', target.id);
+
+    const failedPatch = await patchProvider(target.id, {
+      anthropicModel: 'persisted-model',
+    });
+    expect(failedPatch.status).toBe(503);
+    const disableResponse = await setProviderEnabled(target.id, false);
+    expect(disableResponse.status).toBe(200);
+
+    const restartedQueue = new GroupQueue();
+    liveQueue = restartedQueue;
+    bindDeps({ [jid]: group }, restartedQueue, {
+      [folder]: staleSessionId,
+    });
+    expect(restartedQueue.isGroupRuntimeSafetyBlocked(jid)).toBe(true);
+
+    const repairResponse = await patchProvider(target.id, {
+      anthropicModel: 'persisted-model',
+    });
+    expect(repairResponse.status).toBe(200);
+    expect(db.getSession(folder)).toBeUndefined();
+    expect(restartedQueue.isGroupRuntimeSafetyBlocked(jid)).toBe(false);
+  });
+
+  test('deletes a pending provider through lossless runtime mutation and clears its gate', async () => {
+    const folder = unique('pending-provider-delete');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    const staleSessionId = unique('delete-stale-session');
+    let stopCalls = 0;
+    const stopOptions: unknown[] = [];
+    const unblockGroupsForRuntimeSafety = vi.fn();
+    const queue = {
+      listDescendantJids: () => [],
+      pauseGroupsForMutation: vi.fn(() => ({ id: 9 })),
+      resumeGroupsAfterMutation: vi.fn(),
+      blockGroupsForRuntimeSafety: vi.fn(),
+      unblockGroupsForRuntimeSafety,
+      stopGroup: vi.fn(async (_targetJid: string, options?: unknown) => {
+        stopCalls += 1;
+        stopOptions.push(options);
+        if (stopCalls === 2) {
+          db.setSession(folder, staleSessionId);
+          db.setSessionProviderId(folder, '', target.id);
+          throw new Error('simulated post-commit stop failure');
+        }
+      }),
+    };
+    bindDeps({ [jid]: group }, queue);
+    const target = runtimeConfig.createProvider({
+      name: unique('delete-target'),
+      type: 'official',
+      anthropicApiKey: 'target-key',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+    runtimeConfig.createProvider({
+      name: unique('delete-fallback'),
+      type: 'official',
+      anthropicApiKey: 'fallback-key',
+      enabled: true,
+    });
+    db.setSession(folder, unique('delete-initial-session'));
+    db.setSessionProviderId(folder, '', target.id);
+
+    const failedPatch = await patchProvider(target.id, {
+      anthropicModel: 'persisted-model',
+    });
+    expect(failedPatch.status).toBe(503);
+    expect(db.getSession(folder)).toBe(staleSessionId);
+
+    const deleteResponse = await deleteProvider(target.id);
+    expect(deleteResponse.status).toBe(200);
+    expect(
+      runtimeConfig
+        .getProviders()
+        .some((provider) => provider.id === target.id),
+    ).toBe(false);
+    expect(stopCalls).toBe(4);
+    expect(stopOptions).toSatisfy((options) =>
+      options.every(
+        (option) =>
+          (option as { force?: boolean }).force === true &&
+          (option as { preserveQueuedWork?: boolean }).preserveQueuedWork ===
+            true,
+      ),
+    );
+    expect(db.getSession(folder)).toBeUndefined();
+    expect(
+      db.getRouterState(`provider_session_invalidation_pending:${target.id}`),
+    ).toBeUndefined();
     expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
   });
 

--- a/tests/routes-provider-runtime-apply.test.ts
+++ b/tests/routes-provider-runtime-apply.test.ts
@@ -293,20 +293,22 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
     const jid = `web:${folder}`;
     const group = registerWorkspace(jid, folder);
     let stopCalls = 0;
-    bindDeps(
-      { [jid]: group },
-      {
-        listDescendantJids: () => [],
-        pauseGroupsForMutation: () => ({ id: 4 }),
-        resumeGroupsAfterMutation: vi.fn(),
-        stopGroup: vi.fn(async () => {
-          stopCalls += 1;
-          if (stopCalls === 2) {
-            throw new Error('simulated post-commit stop failure');
-          }
-        }),
-      },
-    );
+    const blockGroupsForRuntimeSafety = vi.fn();
+    const unblockGroupsForRuntimeSafety = vi.fn();
+    const queue = {
+      listDescendantJids: () => [],
+      pauseGroupsForMutation: () => ({ id: 4 }),
+      resumeGroupsAfterMutation: vi.fn(),
+      blockGroupsForRuntimeSafety,
+      unblockGroupsForRuntimeSafety,
+      stopGroup: vi.fn(async () => {
+        stopCalls += 1;
+        if (stopCalls === 2) {
+          throw new Error('simulated post-commit stop failure');
+        }
+      }),
+    };
+    bindDeps({ [jid]: group }, queue);
     const provider = runtimeConfig.createProvider({
       name: unique('partially-applied-provider'),
       type: 'third_party',
@@ -331,6 +333,76 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
       runtimeConfig.getProviders().find((item) => item.id === provider.id)
         ?.anthropicModel,
     ).toBe('persisted-model');
+    expect(blockGroupsForRuntimeSafety).toHaveBeenCalledWith(
+      [jid],
+      expect.stringContaining('post-commit provider runtime cleanup failed'),
+    );
+    expect(unblockGroupsForRuntimeSafety).not.toHaveBeenCalled();
+
+    const retryResponse = await patchProvider(provider.id, {
+      anthropicModel: 'retry-succeeded-model',
+    });
+    expect(retryResponse.status).toBe(200);
+    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.anthropicModel,
+    ).toBe('retry-succeeded-model');
+  });
+
+  test('serializes manual apply with a concurrent provider mutation', async () => {
+    const folder = unique('manual-apply-lock');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    let releaseFirstStop!: () => void;
+    const firstStopGate = new Promise<void>((resolve) => {
+      releaseFirstStop = resolve;
+    });
+    let stopCalls = 0;
+    bindDeps(
+      { [jid]: group },
+      {
+        listDescendantJids: () => [],
+        pauseGroupsForMutation: () => ({ id: 5 }),
+        resumeGroupsAfterMutation: vi.fn(),
+        blockGroupsForRuntimeSafety: vi.fn(),
+        unblockGroupsForRuntimeSafety: vi.fn(),
+        stopGroup: vi.fn(async () => {
+          stopCalls += 1;
+          if (stopCalls === 1) await firstStopGate;
+        }),
+      },
+    );
+    const provider = runtimeConfig.createProvider({
+      name: unique('locked-provider'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://same.example.test',
+      anthropicAuthToken: 'test-token',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+
+    const patchRequest = patchProvider(provider.id, {
+      anthropicModel: 'new-model',
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stopCalls).toBe(1);
+
+    const manualApplyRequest = app.request('/api/config/claude/apply', {
+      method: 'POST',
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stopCalls).toBe(1);
+
+    releaseFirstStop();
+    const [patchResponse, applyResponse] = await Promise.all([
+      patchRequest,
+      manualApplyRequest,
+    ]);
+    expect(patchResponse.status).toBe(200);
+    expect(applyResponse.status).toBe(200);
+    expect(stopCalls).toBe(4);
   });
 });
 
@@ -372,6 +444,31 @@ describe('provider session invalidation only removes attributable sessions', () 
 
     const response = await patchProvider(provider.id, {
       anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBe(sessionId);
+  });
+
+  test('preserves an unbound session with a workspace model-only override during a global model-only update', async () => {
+    const folder = unique('model-only-override');
+    const jid = `web:${folder}`;
+    const sessionId = unique('model-override-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    runtimeConfig.saveContainerEnvConfig(folder, {
+      anthropicModel: 'workspace-model',
+    });
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicModel: 'old-global-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-global-model',
     });
 
     expect(response.status).toBe(200);

--- a/tests/routes-provider-runtime-apply.test.ts
+++ b/tests/routes-provider-runtime-apply.test.ts
@@ -107,6 +107,17 @@ async function patchProvider(
   });
 }
 
+async function setProviderEnabled(
+  providerId: string,
+  enabled: boolean,
+): Promise<Response> {
+  return app.request(`/api/config/claude/providers/${providerId}/toggle`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  });
+}
+
 beforeAll(() => {
   fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'groups'), { recursive: true });
@@ -288,10 +299,11 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
     ).toBe('old-model');
   });
 
-  test('reports a persisted update when the post-commit quiesce pass fails', async () => {
+  test('repairs a stale provider session on an exact retry after post-commit quiesce fails', async () => {
     const folder = unique('post-commit-failure');
     const jid = `web:${folder}`;
     const group = registerWorkspace(jid, folder);
+    const staleSessionId = unique('stale-session');
     let stopCalls = 0;
     const blockGroupsForRuntimeSafety = vi.fn();
     const unblockGroupsForRuntimeSafety = vi.fn();
@@ -304,6 +316,10 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
       stopGroup: vi.fn(async () => {
         stopCalls += 1;
         if (stopCalls === 2) {
+          // Reproduce a runner finishing late after the transactional cleanup
+          // and writing its old provider session back into SQLite.
+          db.setSession(folder, staleSessionId);
+          db.setSessionProviderId(folder, '', provider.id);
           throw new Error('simulated post-commit stop failure');
         }
       }),
@@ -311,12 +327,13 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
     bindDeps({ [jid]: group }, queue);
     const provider = runtimeConfig.createProvider({
       name: unique('partially-applied-provider'),
-      type: 'third_party',
-      anthropicBaseUrl: 'https://old.example.test',
-      anthropicAuthToken: 'test-token',
+      type: 'official',
+      anthropicApiKey: 'official-key',
       anthropicModel: 'old-model',
       enabled: true,
     });
+    db.setSession(folder, unique('initial-session'));
+    db.setSessionProviderId(folder, '', provider.id);
 
     const response = await patchProvider(provider.id, {
       anthropicModel: 'persisted-model',
@@ -333,21 +350,86 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
       runtimeConfig.getProviders().find((item) => item.id === provider.id)
         ?.anthropicModel,
     ).toBe('persisted-model');
+    expect(db.getSession(folder)).toBe(staleSessionId);
     expect(blockGroupsForRuntimeSafety).toHaveBeenCalledWith(
       [jid],
       expect.stringContaining('post-commit provider runtime cleanup failed'),
     );
     expect(unblockGroupsForRuntimeSafety).not.toHaveBeenCalled();
 
+    // A process restart creates a fresh in-memory queue. The durable pending
+    // marker must rebuild its safety block when web dependencies are injected.
+    const restartedQueue = new GroupQueue();
+    liveQueue = restartedQueue;
+    bindDeps({ [jid]: group }, restartedQueue);
+    expect(restartedQueue.isGroupRuntimeSafetyBlocked(jid)).toBe(true);
+
+    // The desired value is already persisted. The retry must still replay the
+    // pending invalidation instead of treating this as a no-op.
     const retryResponse = await patchProvider(provider.id, {
-      anthropicModel: 'retry-succeeded-model',
+      anthropicModel: 'persisted-model',
     });
     expect(retryResponse.status).toBe(200);
-    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
+    expect(restartedQueue.isGroupRuntimeSafetyBlocked(jid)).toBe(false);
+    expect(db.getSession(folder)).toBeUndefined();
     expect(
       runtimeConfig.getProviders().find((item) => item.id === provider.id)
         ?.anthropicModel,
-    ).toBe('retry-succeeded-model');
+    ).toBe('persisted-model');
+  });
+
+  test('retries a persisted provider toggle idempotently instead of reversing it', async () => {
+    const folder = unique('toggle-retry');
+    const jid = `web:${folder}`;
+    const group = registerWorkspace(jid, folder);
+    let stopCalls = 0;
+    const blockGroupsForRuntimeSafety = vi.fn();
+    const unblockGroupsForRuntimeSafety = vi.fn();
+    bindDeps(
+      { [jid]: group },
+      {
+        listDescendantJids: () => [],
+        pauseGroupsForMutation: () => ({ id: 6 }),
+        resumeGroupsAfterMutation: vi.fn(),
+        blockGroupsForRuntimeSafety,
+        unblockGroupsForRuntimeSafety,
+        stopGroup: vi.fn(async () => {
+          stopCalls += 1;
+          if (stopCalls === 2) {
+            throw new Error('simulated post-toggle stop failure');
+          }
+        }),
+      },
+    );
+    const target = runtimeConfig.createProvider({
+      name: unique('toggle-target'),
+      type: 'official',
+      anthropicApiKey: 'target-key',
+      enabled: true,
+    });
+    runtimeConfig.createProvider({
+      name: unique('toggle-fallback'),
+      type: 'official',
+      anthropicApiKey: 'fallback-key',
+      enabled: true,
+    });
+
+    const firstResponse = await setProviderEnabled(target.id, false);
+    expect(firstResponse.status).toBe(503);
+    expect(firstResponse.ok).toBe(false);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === target.id)
+        ?.enabled,
+    ).toBe(false);
+    expect(blockGroupsForRuntimeSafety).toHaveBeenCalled();
+
+    const retryResponse = await setProviderEnabled(target.id, false);
+    expect(retryResponse.status).toBe(200);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === target.id)
+        ?.enabled,
+    ).toBe(false);
+    expect(unblockGroupsForRuntimeSafety).toHaveBeenCalledWith([jid]);
   });
 
   test('serializes manual apply with a concurrent provider mutation', async () => {
@@ -404,6 +486,44 @@ describe('provider runtime apply is a lossless configuration mutation', () => {
     expect(applyResponse.status).toBe(200);
     expect(stopCalls).toBe(4);
   });
+
+  test.each([
+    { label: 'pre-commit', failAt: 1, persisted: false },
+    { label: 'post-commit', failAt: 2, persisted: true },
+  ])(
+    'returns a non-2xx status when manual apply fails in the $label pass',
+    async ({ failAt, persisted }) => {
+      const folder = unique('manual-apply-failure');
+      const jid = `web:${folder}`;
+      const group = registerWorkspace(jid, folder);
+      let stopCalls = 0;
+      bindDeps(
+        { [jid]: group },
+        {
+          listDescendantJids: () => [],
+          pauseGroupsForMutation: () => ({ id: 7 }),
+          resumeGroupsAfterMutation: vi.fn(),
+          blockGroupsForRuntimeSafety: vi.fn(),
+          unblockGroupsForRuntimeSafety: vi.fn(),
+          stopGroup: vi.fn(async () => {
+            stopCalls += 1;
+            if (stopCalls === failAt) {
+              throw new Error('simulated manual apply failure');
+            }
+          }),
+        },
+      );
+
+      const response = await app.request('/api/config/claude/apply', {
+        method: 'POST',
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(response.ok).toBe(false);
+      expect(body).toMatchObject({ success: false, persisted });
+    },
+  );
 });
 
 describe('provider session invalidation only removes attributable sessions', () => {
@@ -473,6 +593,95 @@ describe('provider session invalidation only removes attributable sessions', () 
 
     expect(response.status).toBe(200);
     expect(db.getSession(folder)).toBe(sessionId);
+  });
+
+  test('clears an unbound session when credentials override but the changed model does not', async () => {
+    const folder = unique('credential-only-override');
+    const jid = `web:${folder}`;
+    const sessionId = unique('credential-override-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    runtimeConfig.saveContainerEnvConfig(folder, {
+      anthropicAuthToken: 'workspace-token',
+    });
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicModel: 'old-global-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'new-global-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBeUndefined();
+  });
+
+  test('clears an unbound session unless every changed protocol field is overridden', async () => {
+    const folder = unique('partial-protocol-override');
+    const jid = `web:${folder}`;
+    const sessionId = unique('partial-override-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    runtimeConfig.saveContainerEnvConfig(folder, {
+      anthropicModel: 'workspace-model',
+    });
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicBaseUrl: 'https://old-global.example.test',
+      anthropicModel: 'old-global-model',
+      enabled: true,
+    });
+
+    const response = await patchProvider(provider.id, {
+      anthropicBaseUrl: 'https://new-global.example.test',
+      anthropicModel: 'new-global-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBeUndefined();
+  });
+
+  test('repairs a corrupt durable invalidation marker instead of leaving a permanent gate', async () => {
+    const folder = unique('corrupt-pending-marker');
+    const jid = `web:${folder}`;
+    const sessionId = unique('corrupt-marker-session');
+    const group = registerWorkspace(jid, folder);
+    db.setSession(folder, sessionId);
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicModel: 'unchanged-model',
+      enabled: true,
+    });
+    db.setSessionProviderId(folder, '', provider.id);
+    db.setRouterState(
+      `provider_session_invalidation_pending:${provider.id}`,
+      '{corrupt-json',
+    );
+    const restartedQueue = new GroupQueue();
+    liveQueue = restartedQueue;
+    bindDeps({ [jid]: group }, restartedQueue, {
+      [folder]: sessionId,
+    });
+
+    expect(restartedQueue.isGroupRuntimeSafetyBlocked(jid)).toBe(true);
+    const response = await patchProvider(provider.id, {
+      anthropicModel: 'unchanged-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBeUndefined();
+    expect(restartedQueue.isGroupRuntimeSafetyBlocked(jid)).toBe(false);
+    expect(
+      db.getRouterState(`provider_session_invalidation_pending:${provider.id}`),
+    ).toBeUndefined();
   });
 
   test('preserves ambiguous unbound sessions when another provider is configured but disabled', async () => {
@@ -549,5 +758,69 @@ describe('provider session invalidation only removes attributable sessions', () 
     expect(response.status).toBe(200);
     expect(db.getSession(folder)).toBe(sessionId);
     expect(db.getSessionProviderId(folder)).toBe(provider.id);
+  });
+
+  test('does not clear a provider session when the requested config is invalid', async () => {
+    const folder = unique('invalid-provider-patch');
+    const jid = `web:${folder}`;
+    const sessionId = unique('invalid-patch-session');
+    bindIdleWorkspace(jid, folder, sessionId);
+    db.setSession(folder, sessionId);
+    const provider = runtimeConfig.createProvider({
+      name: unique('official'),
+      type: 'official',
+      anthropicApiKey: 'official-key',
+      anthropicBaseUrl: 'https://valid.example.test',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+    db.setSessionProviderId(folder, '', provider.id);
+
+    const response = await patchProvider(provider.id, {
+      anthropicBaseUrl: 'not-a-url',
+    });
+
+    expect(response.status).toBe(400);
+    expect(db.getSession(folder)).toBe(sessionId);
+    expect(db.getSessionProviderId(folder)).toBe(provider.id);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.anthropicBaseUrl,
+    ).toBe('https://valid.example.test');
+  });
+
+  test('keeps the main-session cache when only a target-provider agent session is invalidated', async () => {
+    const folder = unique('agent-only-invalidation');
+    const jid = `web:${folder}`;
+    const mainSessionId = unique('main-session');
+    const agentSessionId = unique('agent-session');
+    const sessions = bindIdleWorkspace(jid, folder, mainSessionId);
+    db.setSession(folder, mainSessionId);
+    const target = runtimeConfig.createProvider({
+      name: unique('official-target'),
+      type: 'official',
+      anthropicApiKey: 'target-key',
+      anthropicModel: 'old-model',
+      enabled: true,
+    });
+    const other = runtimeConfig.createProvider({
+      name: unique('other-provider'),
+      type: 'third_party',
+      anthropicBaseUrl: 'https://other.example.test',
+      anthropicAuthToken: 'other-token',
+      enabled: false,
+    });
+    db.setSessionProviderId(folder, '', other.id);
+    db.setSession(folder, agentSessionId, 'agent-a');
+    db.setSessionProviderId(folder, 'agent-a', target.id);
+
+    const response = await patchProvider(target.id, {
+      anthropicModel: 'new-model',
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.getSession(folder)).toBe(mainSessionId);
+    expect(db.getSession(folder, 'agent-a')).toBeUndefined();
+    expect(sessions[folder]).toBe(mainSessionId);
   });
 });

--- a/tests/session-provider-binding.test.ts
+++ b/tests/session-provider-binding.test.ts
@@ -20,6 +20,7 @@ vi.mock('../src/config.js', async () => {
 const {
   initDatabase,
   setSession,
+  getSession,
   getSessionProviderId,
   setSessionProviderId,
   deleteSession,
@@ -41,7 +42,9 @@ afterAll(() => {
 describe('session→provider sticky binding', () => {
   test('returns undefined for unknown session', () => {
     expect(getSessionProviderId('unknown-folder')).toBeUndefined();
-    expect(getSessionProviderId('unknown-folder', 'some-agent')).toBeUndefined();
+    expect(
+      getSessionProviderId('unknown-folder', 'some-agent'),
+    ).toBeUndefined();
   });
 
   test('setSessionProviderId creates a row when none exists', () => {
@@ -130,5 +133,21 @@ describe('deleteSessionsByProviderId — narrowed cleanup (issue #476)', () => {
       'folder-narrow-4',
       'folder-narrow-5',
     ]);
+  });
+
+  test('only removes unbound legacy rows from explicitly attributable folders', () => {
+    setSession('folder-unbound-safe', 'sess-safe', '');
+    setSession('folder-unbound-ambiguous', 'sess-ambiguous', '');
+
+    const result = deleteSessionsByProviderId('provider-target', {
+      includeUnboundFolders: ['folder-unbound-safe'],
+    });
+
+    expect(result.deletedCount).toBe(1);
+    expect(result.affectedFolders).toEqual(['folder-unbound-safe']);
+    expect(getSessionProviderId('folder-unbound-safe')).toBeUndefined();
+    expect(getSessionProviderId('folder-unbound-ambiguous')).toBeUndefined();
+    expect(getSession('folder-unbound-safe')).toBeUndefined();
+    expect(getSession('folder-unbound-ambiguous')).toBe('sess-ambiguous');
   });
 });

--- a/web/src/components/settings/ClaudeProviderSection.tsx
+++ b/web/src/components/settings/ClaudeProviderSection.tsx
@@ -106,7 +106,11 @@ export function ClaudeProviderSection({
     async (provider: ProviderWithHealth) => {
       setTogglingId(provider.id);
       try {
-        await api.post(`/api/config/claude/providers/${provider.id}/toggle`);
+        await api.post(
+          `/api/config/claude/providers/${provider.id}/toggle`,
+          { enabled: !provider.enabled },
+          120_000,
+        );
         await loadProviders();
         setNotice(
           provider.enabled
@@ -114,6 +118,10 @@ export function ClaudeProviderSection({
             : `已启用「${provider.name}」`,
         );
       } catch (err) {
+        // A 503 can mean the target state was persisted but runtime teardown
+        // failed afterward. Reload instead of leaving a stale toggle that a
+        // user might click again and accidentally reverse.
+        await loadProviders().catch(() => {});
         setError(getErrorMessage(err, '切换提供商状态失败'));
       } finally {
         setTogglingId(null);


### PR DESCRIPTION
## 问题描述

用户在设置页切换 provider 模型（如 Opus 4.6 → 4.8）后，已运行的 agent/task 子进程仍然调用旧模型，需要再次切换或手动重启才能生效。此外 `third_party` 类型 provider 切换模型时不必要地清除了 session，导致用户丢失对话上下文。

### 复现路径

1. 使用 third_party provider（如第三方 API 网关），模型设为 `Claude-Opus-4.6`
2. 开始对话，建立上下文
3. 在设置页将模型切换为 `Claude-Opus-4.8`
4. **期望**：对话继续，使用新模型，上下文不丢失
5. **实际**（修改前）：
   - 顶层群组进程被停止，但 agent/task 子进程继续用旧模型运行
   - session 被清除，下次对话丢失上下文（仅通过消息历史部分恢复）

### 根因

1. `applyClaudeConfigToAllGroups` 只遍历 `registeredGroups` 停止顶层群组进程，agent/task 子进程运行在独立的 serialization key（`{folder}#agent:{id}` / `{folder}#task:{id}`）下未被覆盖
2. 原代码对所有 provider 类型一视同仁：只要模型变了就清 session。但 third_party 代理不校验 thinking block 签名，清除是不必要的损耗
3. 单 provider 部署下历史会话 `provider_id` 为 NULL（绑定机制上线前创建的），`deleteSessionsByProviderId` 按精确匹配无法清到这些 session

## 修复方案

### 行为变化对比

| 场景 | 修改前 | 修改后 |
|------|--------|--------|
| third_party 切换模型 | 停顶层进程 + 清 session（丢上下文） | 停所有进程（含子进程） + **保留 session**（无损切换） |
| official 切换模型 | 停顶层进程 + 清 session | 停所有进程（含子进程） + 清 session（行为不变） |
| official 单 provider + 历史 NULL session | 清不到 NULL session → 恢复旧 session 报签名错误 | 一并清除 NULL session（修复） |

### `src/routes/config.ts`

- `applyClaudeConfigToAllGroups` 通过 `listDescendantJids` 收集每个群组下活跃的 agent 和 task 子进程 JID，与父 JID 一并停止，确保模型变更覆盖所有运行中进程
- provider 更新时区分类型：仅 `official` 类型在协议字段变更时清除 session——官方 API 校验 thinking block 签名（签名绑定特定 OAuth 账号 + 模型，换模型后旧签名失效报 `"Invalid signature in thinking block"` 400 错误）；`third_party` 类型通常不做签名校验，默认保留 session 实现无损模型切换

### `src/db.ts`

- `deleteSessionsByProviderId` 新增 `includeUnbound` 选项：单 provider 部署时 NULL 绑定的历史会话必然属于唯一的 provider，一并清除；多 provider 部署时 NULL 可能属于任意 provider，只精确匹配避免误伤

## 备注

- **对 official 类型无行为退化**：session 清除逻辑不变，唯一改进是额外停了子进程 + 覆盖了 NULL session
- `stopGroup()` 幂等，descendant JID 结构上不会与父 JID 重复（serialization key 前缀互斥），无需去重
- official 清 session 后通过 `buildRecentConversationHistoryContext` 从 DB 消息历史重建上下文注入新 session，不是完全失忆
- 若未来出现某些 third_party 代理也校验签名的情况，可在 provider 配置中增加 `forceSessionClearOnModelChange` 字段扩展