### PR TITLE
修复: Markdown 图片中文文件名无法加载

### DIFF
--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -31,7 +31,15 @@ function resolveImageSrc(src: string, groupJid?: string): string {
   if (/^(https?:\/\/|data:|\/\/)/.test(src) || src.startsWith('/')) return src;
   // Strip #agent:xxx suffix — file API uses the base group JID
   const baseJid = groupJid.replace(/#agent:.*$/, '');
-  const encoded = toBase64Url(src);
+  // Markdown parser (micromark) percent-encodes non-ASCII characters in URLs;
+  // decode first so toBase64Url encodes the actual UTF-8 filename.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(src);
+  } catch {
+    decoded = src;
+  }
+  const encoded = toBase64Url(decoded);
   return withBasePath(`/api/groups/${encodeURIComponent(baseJid)}/files/download/${encoded}`);
 }
 

--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -40,11 +40,19 @@ function resolveImageSrc(src: string, groupJid?: string): string {
     decoded = src;
   }
   const encoded = toBase64Url(decoded);
-  return withBasePath(`/api/groups/${encodeURIComponent(baseJid)}/files/download/${encoded}`);
+  return withBasePath(
+    `/api/groups/${encodeURIComponent(baseJid)}/files/download/${encoded}`,
+  );
 }
 
 /** Image lightbox for markdown images */
-function MarkdownImageLightbox({ src, onClose }: { src: string; onClose: () => void }) {
+function MarkdownImageLightbox({
+  src,
+  onClose,
+}: {
+  src: string;
+  onClose: () => void;
+}) {
   return createPortal(
     <div
       className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center cursor-pointer"
@@ -57,12 +65,20 @@ function MarkdownImageLightbox({ src, onClose }: { src: string; onClose: () => v
         onClick={(e) => e.stopPropagation()}
       />
     </div>,
-    document.body
+    document.body,
   );
 }
 
 /** Inline image component with lightbox support */
-function MarkdownImage({ src, alt, loading }: { src?: string; alt?: string; loading?: 'lazy' | 'eager' }) {
+function MarkdownImage({
+  src,
+  alt,
+  loading,
+}: {
+  src?: string;
+  alt?: string;
+  loading?: 'lazy' | 'eager';
+}) {
   const [expanded, setExpanded] = useState(false);
   const [error, setError] = useState(false);
 
@@ -71,8 +87,18 @@ function MarkdownImage({ src, alt, loading }: { src?: string; alt?: string; load
   if (error) {
     return (
       <span className="inline-flex items-center gap-1 px-2 py-1 bg-muted text-muted-foreground rounded text-sm">
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
-          <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z" />
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
+          />
         </svg>
         {alt || '图片加载失败'}
       </span>
@@ -90,7 +116,9 @@ function MarkdownImage({ src, alt, loading }: { src?: string; alt?: string; load
         onClick={() => setExpanded(true)}
         onError={() => setError(true)}
       />
-      {expanded && <MarkdownImageLightbox src={src} onClose={() => setExpanded(false)} />}
+      {expanded && (
+        <MarkdownImageLightbox src={src} onClose={() => setExpanded(false)} />
+      )}
     </>
   );
 }
@@ -101,8 +129,19 @@ const sanitizeSchema = {
   attributes: {
     ...defaultSchema.attributes,
     code: [...(defaultSchema.attributes?.code || []), 'class', 'className'],
-    span: [...(defaultSchema.attributes?.span || []), 'class', 'className', 'style', 'aria-hidden'],
-    div: [...(defaultSchema.attributes?.div || []), 'class', 'className', 'style'],
+    span: [
+      ...(defaultSchema.attributes?.span || []),
+      'class',
+      'className',
+      'style',
+      'aria-hidden',
+    ],
+    div: [
+      ...(defaultSchema.attributes?.div || []),
+      'class',
+      'className',
+      'style',
+    ],
     img: ['src', 'alt', 'width', 'height', 'loading', 'longDesc', 'title'],
     math: ['xmlns', 'display'],
     annotation: ['encoding'],
@@ -110,10 +149,31 @@ const sanitizeSchema = {
   tagNames: [
     ...(defaultSchema.tagNames || []),
     // MathML tags for KaTeX accessibility layer
-    'math', 'semantics', 'mrow', 'mi', 'mn', 'mo', 'msup', 'msub',
-    'mfrac', 'mover', 'munder', 'msqrt', 'mroot', 'mtable', 'mtr', 'mtd',
-    'mtext', 'mspace', 'mstyle', 'menclose', 'annotation',
-    'msubsup', 'munderover', 'mpadded', 'mphantom',
+    'math',
+    'semantics',
+    'mrow',
+    'mi',
+    'mn',
+    'mo',
+    'msup',
+    'msub',
+    'mfrac',
+    'mover',
+    'munder',
+    'msqrt',
+    'mroot',
+    'mtable',
+    'mtr',
+    'mtd',
+    'mtext',
+    'mspace',
+    'mstyle',
+    'menclose',
+    'annotation',
+    'msubsup',
+    'munderover',
+    'mpadded',
+    'mphantom',
   ],
   protocols: {
     ...defaultSchema.protocols,
@@ -124,7 +184,8 @@ const sanitizeSchema = {
 function extractText(node: React.ReactNode): string {
   if (typeof node === 'string' || typeof node === 'number') return String(node);
   if (Array.isArray(node)) return node.map(extractText).join('');
-  if (React.isValidElement(node)) return extractText((node.props as { children?: React.ReactNode }).children);
+  if (React.isValidElement(node))
+    return extractText((node.props as { children?: React.ReactNode }).children);
   return '';
 }
 
@@ -134,7 +195,10 @@ function CodeBlock({
   children,
   variant = 'chat',
   ...props
-}: React.ComponentPropsWithoutRef<'code'> & { className?: string; variant?: 'chat' | 'docs' }) {
+}: React.ComponentPropsWithoutRef<'code'> & {
+  className?: string;
+  variant?: 'chat' | 'docs';
+}) {
   const [copied, setCopied] = useState(false);
   const match = /language-(\w+)/.exec(className || '');
   const lang = match?.[1];
@@ -195,36 +259,45 @@ function CodeBlock({
   );
 }
 
-export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJid, variant = 'chat', streaming = false, eagerImages = false }: MarkdownRendererProps) {
-  const textSizeClass = variant === 'chat'
-    ? 'text-base leading-[1.65] text-foreground'
-    : 'text-sm leading-6 text-foreground';
+export const MarkdownRenderer = memo(function MarkdownRenderer({
+  content,
+  groupJid,
+  variant = 'chat',
+  streaming = false,
+  eagerImages = false,
+}: MarkdownRendererProps) {
+  const textSizeClass =
+    variant === 'chat'
+      ? 'text-base leading-[1.65] text-foreground'
+      : 'text-sm leading-6 text-foreground';
   const tableTextClass = variant === 'chat' ? 'text-[0.95em]' : 'text-sm';
 
   // Streaming mode: skip expensive KaTeX + sanitize for faster renders.
   // singleDollarTextMath: false — disables `$...$` inline math so dollar-sign
   // amounts ($113, $5.51) in everyday text aren't parsed as LaTeX. Block math
   // ($$...$$) still works for the rare case real formulas are needed.
-  const remarkPluginsList = useMemo(() =>
-    streaming
-      ? [remarkGfm, remarkBreaks]
-      : [
-          remarkGfm,
-          remarkBreaks,
-          [remarkMath, { singleDollarTextMath: false }] as const,
-        ],
-    [streaming]
+  const remarkPluginsList = useMemo(
+    () =>
+      streaming
+        ? [remarkGfm, remarkBreaks]
+        : [
+            remarkGfm,
+            remarkBreaks,
+            [remarkMath, { singleDollarTextMath: false }] as const,
+          ],
+    [streaming],
   );
-  const rehypePluginsList = useMemo(() =>
-    streaming
-      ? [[rehypeHighlight, { plainText: ['mermaid'] }] as const]
-      : [
-          rehypeRaw,
-          [rehypeHighlight, { plainText: ['mermaid'] }] as const,
-          [rehypeKatex, { throwOnError: false, strict: false }] as const,
-          [rehypeSanitize, sanitizeSchema] as const,
-        ],
-    [streaming]
+  const rehypePluginsList = useMemo(
+    () =>
+      streaming
+        ? [[rehypeHighlight, { plainText: ['mermaid'] }] as const]
+        : [
+            rehypeRaw,
+            [rehypeHighlight, { plainText: ['mermaid'] }] as const,
+            [rehypeKatex, { throwOnError: false, strict: false }] as const,
+            [rehypeSanitize, sanitizeSchema] as const,
+          ],
+    [streaming],
   );
 
   return (
@@ -234,7 +307,13 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
         rehypePlugins={rehypePluginsList as any}
         components={{
           code: (props) => <CodeBlock {...props} variant={variant} />,
-          img: ({ src, alt }) => <MarkdownImage src={src ? resolveImageSrc(src, groupJid) : undefined} alt={alt} loading={eagerImages ? 'eager' : 'lazy'} />,
+          img: ({ src, alt }) => (
+            <MarkdownImage
+              src={src ? resolveImageSrc(src, groupJid) : undefined}
+              alt={alt}
+              loading={eagerImages ? 'eager' : 'lazy'}
+            />
+          ),
           a: ({ href, children }) => (
             <a
               href={href}
@@ -258,19 +337,23 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
           thead: ({ children }) => (
             <thead className="bg-muted">{children}</thead>
           ),
-          tbody: ({ children }) => <tbody className="divide-y divide-border">{children}</tbody>,
+          tbody: ({ children }) => (
+            <tbody className="divide-y divide-border">{children}</tbody>
+          ),
           tr: ({ children }) => (
-            <tr className="even:bg-surface odd:bg-muted/30">
-              {children}
-            </tr>
+            <tr className="even:bg-surface odd:bg-muted/30">{children}</tr>
           ),
           th: ({ children }) => (
-            <th className={`px-4 py-2 text-left font-semibold text-foreground border border-border whitespace-nowrap align-top ${tableTextClass}`}>
+            <th
+              className={`px-4 py-2 text-left font-semibold text-foreground border border-border whitespace-nowrap align-top ${tableTextClass}`}
+            >
               {children}
             </th>
           ),
           td: ({ children }) => (
-            <td className={`px-4 py-2 text-foreground border border-border whitespace-nowrap align-top ${tableTextClass}`}>
+            <td
+              className={`px-4 py-2 text-foreground border border-border whitespace-nowrap align-top ${tableTextClass}`}
+            >
               {children}
             </td>
           ),
@@ -285,13 +368,19 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({ content, groupJ
           ),
           p: ({ children }) => <p className="my-2">{children}</p>,
           h1: ({ children }) => (
-            <h1 className="text-2xl font-bold mt-6 mb-4 leading-tight">{children}</h1>
+            <h1 className="text-2xl font-bold mt-6 mb-4 leading-tight">
+              {children}
+            </h1>
           ),
           h2: ({ children }) => (
-            <h2 className="text-xl font-bold mt-5 mb-3 leading-tight">{children}</h2>
+            <h2 className="text-xl font-bold mt-5 mb-3 leading-tight">
+              {children}
+            </h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-lg font-semibold mt-4 mb-2 leading-snug">{children}</h3>
+            <h3 className="text-lg font-semibold mt-4 mb-2 leading-snug">
+              {children}
+            </h3>
           ),
           blockquote: ({ children }) => (
             <blockquote className="border-l-4 border-border pl-4 my-4 text-muted-foreground italic">

--- a/web/src/components/chat/MarkdownRenderer.tsx
+++ b/web/src/components/chat/MarkdownRenderer.tsx
@@ -10,8 +10,7 @@ import React, { useState, useMemo, memo } from 'react';
 import { createPortal } from 'react-dom';
 import { Copy, Check } from 'lucide-react';
 import { MermaidDiagram } from './MermaidDiagram';
-import { toBase64Url } from '../../stores/files';
-import { withBasePath } from '../../utils/url';
+import { resolveMarkdownImageSrc } from '../../utils/markdownImageSrc';
 import 'highlight.js/styles/github.css';
 import 'katex/dist/katex.min.css';
 
@@ -23,26 +22,6 @@ interface MarkdownRendererProps {
   streaming?: boolean;
   /** When true, force images to load eagerly. Required for offscreen render contexts (e.g. share-image export) where lazy-loaded images would otherwise never start fetching. */
   eagerImages?: boolean;
-}
-
-/** Resolve relative image paths to the file download API */
-function resolveImageSrc(src: string, groupJid?: string): string {
-  if (!groupJid || !src) return src;
-  if (/^(https?:\/\/|data:|\/\/)/.test(src) || src.startsWith('/')) return src;
-  // Strip #agent:xxx suffix — file API uses the base group JID
-  const baseJid = groupJid.replace(/#agent:.*$/, '');
-  // Markdown parser (micromark) percent-encodes non-ASCII characters in URLs;
-  // decode first so toBase64Url encodes the actual UTF-8 filename.
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(src);
-  } catch {
-    decoded = src;
-  }
-  const encoded = toBase64Url(decoded);
-  return withBasePath(
-    `/api/groups/${encodeURIComponent(baseJid)}/files/download/${encoded}`,
-  );
 }
 
 /** Image lightbox for markdown images */
@@ -309,7 +288,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
           code: (props) => <CodeBlock {...props} variant={variant} />,
           img: ({ src, alt }) => (
             <MarkdownImage
-              src={src ? resolveImageSrc(src, groupJid) : undefined}
+              src={src ? resolveMarkdownImageSrc(src, groupJid) : undefined}
               alt={alt}
               loading={eagerImages ? 'eager' : 'lazy'}
             />

--- a/web/src/utils/markdownImageSrc.ts
+++ b/web/src/utils/markdownImageSrc.ts
@@ -1,0 +1,67 @@
+import { toBase64Url } from '../stores/files';
+import { withBasePath } from './url';
+
+const ENCODED_BYTE_RUN = /(?:%[0-9a-f]{2})+/gi;
+// decodeURI preserves most URI-reserved escapes, but not these seven.
+const DECODE_URI_UNESCAPED_RESERVED = /(%(?:21|27|28|29|2a|5b|5d))/gi;
+const DECODE_URI_UNESCAPED_RESERVED_EXACT = /^%(?:21|27|28|29|2a|5b|5d)$/i;
+
+function decodeValidPrefixes(value: string): string {
+  let decoded = '';
+  let remaining = value;
+
+  while (remaining) {
+    let decodedLength = 0;
+    for (let length = remaining.length; length > 0; length -= 3) {
+      try {
+        decoded += decodeURI(remaining.slice(0, length));
+        decodedLength = length;
+        break;
+      } catch {
+        // Try a shorter prefix so one malformed UTF-8 byte stays literal while
+        // later valid UTF-8 in the same run can still be decoded.
+      }
+    }
+
+    if (decodedLength === 0) {
+      decoded += remaining.slice(0, 3);
+      decodedLength = 3;
+    }
+    remaining = remaining.slice(decodedLength);
+  }
+
+  return decoded;
+}
+
+/**
+ * Decode the percent-encoded UTF-8 produced by micromark without changing URI
+ * reserved escapes or letting one malformed escape prevent later text from
+ * being decoded.
+ */
+export function decodeMarkdownImagePath(value: string): string {
+  return value.replace(ENCODED_BYTE_RUN, (run) =>
+    run
+      .split(DECODE_URI_UNESCAPED_RESERVED)
+      .map((part) =>
+        DECODE_URI_UNESCAPED_RESERVED_EXACT.test(part)
+          ? part
+          : decodeValidPrefixes(part),
+      )
+      .join(''),
+  );
+}
+
+/** Resolve a markdown image source to the local file download API. */
+export function resolveMarkdownImageSrc(
+  src: string,
+  groupJid?: string,
+): string {
+  if (!groupJid || !src) return src;
+  if (/^(https?:\/\/|data:|\/\/)/.test(src) || src.startsWith('/')) return src;
+
+  const baseJid = groupJid.replace(/#agent:.*$/, '');
+  const encoded = toBase64Url(decodeMarkdownImagePath(src));
+  return withBasePath(
+    `/api/groups/${encodeURIComponent(baseJid)}/files/download/${encoded}`,
+  );
+}

--- a/web/tests/MarkdownRenderer.test.tsx
+++ b/web/tests/MarkdownRenderer.test.tsx
@@ -1,0 +1,122 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  decodeMarkdownImagePath,
+  resolveMarkdownImageSrc,
+} from '../src/utils/markdownImageSrc';
+import { MarkdownRenderer } from '../src/components/chat/MarkdownRenderer';
+
+function renderedImageSrc(markdown: string): string {
+  const html = renderToStaticMarkup(
+    <MarkdownRenderer content={markdown} groupJid="test-group#agent:worker" />,
+  );
+  const src = html.match(/<img[^>]+src="([^"]+)"/)?.[1];
+  if (!src) throw new Error(`Rendered image src not found in: ${html}`);
+  return src;
+}
+
+function renderedDownloadPath(markdown: string): string {
+  const src = renderedImageSrc(markdown);
+  const encoded = src.split('/').at(-1);
+  if (!encoded) throw new Error(`Encoded path not found in: ${src}`);
+  return Buffer.from(encoded, 'base64url').toString('utf8');
+}
+
+describe('decodeMarkdownImagePath', () => {
+  it.each([
+    ['images/photo.png', 'images/photo.png'],
+    ['images/%E5%9B%BE%E7%89%87.png', 'images/图片.png'],
+    ['images/my%20photo.png', 'images/my photo.png'],
+    ['images/100%25-ready.png', 'images/100%-ready.png'],
+    ['images/%ZZ-%E5%9B%BE%E7%89%87.png', 'images/%ZZ-图片.png'],
+    ['images/%FF-%E5%9B%BE%E7%89%87.png', 'images/%FF-图片.png'],
+    ['images/%FF%E5%9B%BE.png', 'images/%FF图.png'],
+    ['images/%E5%9B%BE%FF.png', 'images/图%FF.png'],
+  ])('decodes %s as %s', (input, expected) => {
+    expect(decodeMarkdownImagePath(input)).toBe(expected);
+  });
+
+  it.each([
+    '%21',
+    '%23',
+    '%24',
+    '%26',
+    '%27',
+    '%28',
+    '%29',
+    '%2A',
+    '%2B',
+    '%2C',
+    '%2F',
+    '%3A',
+    '%3B',
+    '%3D',
+    '%3F',
+    '%40',
+    '%5B',
+    '%5D',
+  ])('preserves the reserved escape %s', (escape) => {
+    expect(decodeMarkdownImagePath(`before${escape}after.png`)).toBe(
+      `before${escape}after.png`,
+    );
+  });
+});
+
+describe('resolveMarkdownImageSrc', () => {
+  it.each([
+    'https://example.com/image.png',
+    'http://example.com/image.png',
+    '//example.com/image.png',
+    'data:image/png;base64,AAAA',
+    '/absolute/image.png',
+  ])('leaves the non-local source unchanged: %s', (src) => {
+    expect(resolveMarkdownImageSrc(src, 'test-group')).toBe(src);
+  });
+
+  it('leaves a relative source unchanged without a group', () => {
+    expect(resolveMarkdownImageSrc('images/photo.png')).toBe(
+      'images/photo.png',
+    );
+  });
+
+  it('uses the base group JID for an agent conversation', () => {
+    const src = resolveMarkdownImageSrc(
+      'images/photo.png',
+      'group@example#agent:researcher',
+    );
+    expect(src).toContain('/api/groups/group%40example/files/download/');
+    expect(src).not.toContain('agent');
+  });
+});
+
+describe('MarkdownRenderer local image paths through react-markdown/micromark', () => {
+  it('resolves a plain Chinese filename to its real UTF-8 path', () => {
+    expect(renderedDownloadPath('![截图](images/图片.png)')).toBe(
+      'images/图片.png',
+    );
+  });
+
+  it('resolves spaces and literal percent signs after micromark encoding', () => {
+    expect(renderedDownloadPath('![截图](images/100%-完成%20截图.png)')).toBe(
+      'images/100%-完成 截图.png',
+    );
+  });
+
+  it('keeps a literal invalid percent escape while decoding Chinese text', () => {
+    expect(renderedDownloadPath('![截图](images/%ZZ-图片.png)')).toBe(
+      'images/%ZZ-图片.png',
+    );
+  });
+
+  it('does not turn a percent-encoded reserved slash into a path separator', () => {
+    expect(renderedDownloadPath('![截图](dir%2F图片.png)')).toBe(
+      'dir%2F图片.png',
+    );
+  });
+
+  it('strips the agent suffix from the download route', () => {
+    expect(renderedImageSrc('![截图](images/photo.png)')).toContain(
+      '/api/groups/test-group/files/download/',
+    );
+  });
+});


### PR DESCRIPTION
## 问题描述

Markdown 消息中引用中文文件名的图片（如 `![百度PaddleBox-三级存储](ctr-images/04-百度PaddleBox-三级存储.png)`）无法正常加载，显示为 broken image placeholder。

**修复前：**

<img width="1638" height="1066" alt="image" src="https://github.com/user-attachments/assets/aa40286b-5055-4be2-a208-ebf585fd13a5" />

**复现 Markdown：**

```markdown
![HET-DLRM结构图](ctr-images/01-HET-DLRM结构图.png)
![HET-混合通信架构](ctr-images/02-HET-混合通信架构.png)
![HET-细粒度Embedding时钟](ctr-images/03-HET-细粒度Embedding时钟.png)
![百度PaddleBox-三级存储](ctr-images/04-百度PaddleBox-三级存储.png)
```

## 修复方案

### `web/src/components/chat/MarkdownRenderer.tsx`

**根因**：Markdown 解析器（micromark 的 `normalizeUri`）会对非 ASCII 字符做 percent-encoding（`图片.png` → `%E5%9B%BE%E7%89%87.png`）。`resolveImageSrc` 中的 `toBase64Url(src)` 编码的是 percent-encoded 字符串，后端 base64url 解码后拿到带 `%XX` 字面字符的路径，磁盘上找不到对应文件。

**修复**：在 `toBase64Url` 之前先 `decodeURIComponent(src)` 还原原始 UTF-8 文件名，使后端能正确定位磁盘文件。纯英文文件名经过 `decodeURIComponent` 不变，无回归风险。

## Test plan

- [x] 中文文件名图片（`ctr-images/04-百度PaddleBox-三级存储.png`）正常渲染
- [x] 纯英文文件名图片不受影响
- [x] 绝对路径（`/tmp/xxx.png`）、HTTP URL、data URL 不受影响
- [x] TypeScript 类型检查通过
- [x] Prettier 格式检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)