### PR TITLE
修复: 账号撞 session limit 后自动切换到池内其他 provider

### DIFF
--- a/container/agent-runner/src/provider-fallback.ts
+++ b/container/agent-runner/src/provider-fallback.ts
@@ -3,7 +3,10 @@ import type { IpcInputMessage } from './ipc-delivery.js';
 /** Claude-specific account/usage-limit phrases (not generic API errors). */
 const CLAUDE_LIMIT_PHRASE_PATTERNS = [
   /\bout of extra usage\b/i,
-  /\byou(?:'ve|'re| are)\s+(?:hit|out of)\s+(?:your\s+)?(?:limit|extra usage)\b/i,
+  // Optional qualifier before "limit" so the real Claude banner "you've hit
+  // your SESSION limit" (also "weekly"/"usage") matches, not just "your limit".
+  // Keep in sync with the copy in src/agent-output-parser.ts.
+  /\byou(?:'ve|'re| are)\s+(?:hit|out of|reached)\s+(?:your\s+)?(?:\w+\s+)?(?:limit|extra usage)\b/i,
   /\busage\s+limit\s+reached\b/i,
   /\bupgrade\s+to\s+(?:increase|raise)\s+your\s+usage\s+limit\b/i,
   /\byour\s+(?:usage\s+)?limit\s+will\s+reset\b/i,

--- a/src/agent-output-parser.ts
+++ b/src/agent-output-parser.ts
@@ -770,7 +770,12 @@ const API_ERROR_PATTERNS = [
 /** Claude-specific account/usage-limit phrases (not generic provider errors). */
 const CLAUDE_LIMIT_PHRASE_PATTERNS = [
   /\bout of extra usage\b/i,
-  /\byou(?:'ve|'re| are)\s+(?:hit|out of)\s+(?:your\s+)?(?:limit|extra usage)\b/i,
+  // Optional qualifier before "limit" so the real Claude banner "you've hit
+  // your SESSION limit" (also "weekly"/"usage"/etc.) matches, not just the bare
+  // "your limit". Without it, account session limits went undetected — the
+  // English notice leaked to the user and the provider was never marked
+  // unhealthy, so weighted pools never rotated off the exhausted account.
+  /\byou(?:'ve|'re| are)\s+(?:hit|out of|reached)\s+(?:your\s+)?(?:\w+\s+)?(?:limit|extra usage)\b/i,
   // "usage limit reached" — anchored on "usage" so a generic "rate limit
   // reached" / "request limit reached" in a normal reply does not match.
   /\busage\s+limit\s+reached\b/i,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -2556,6 +2556,41 @@ export async function runHostAgent(
 export type AgentRunner = typeof runContainerAgent | typeof runHostAgent;
 
 /** Compatibility entry point; same-turn fallback now lives inside agent-runner. */
+export interface AgentRunOptions {
+  /**
+   * Rebuild the run input before retrying the turn on a *different* provider
+   * after an account-level usage limit ("You've hit your session limit …").
+   *
+   * Switching providers resets the Claude session inside the runner (thinking-
+   * block signatures are per-account), so the fresh session would otherwise
+   * lose context. The caller uses this hook to re-inject recent conversation
+   * history into the prompt — mirroring the proactive
+   * willClearSessionOnProviderSwitch path.
+   *
+   * Always invoked with the ORIGINAL input so repeated retries rebuild from the
+   * same base instead of stacking history prefixes.
+   */
+  rebuildInputForProviderSwitch?: (
+    originalInput: ContainerInput,
+  ) => ContainerInput;
+}
+
+/**
+ * Run one agent turn, transparently retrying it on another provider when the
+ * selected account hits its usage/session limit.
+ *
+ * Two independent recovery layers cooperate here:
+ *  - In-process MODEL fallback (opus → sonnet on the SAME account) happens
+ *    inside the runner and is invisible to this wrapper.
+ *  - Cross-process PROVIDER (account) failover happens HERE: when the runner
+ *    reports `providerFailure`, the exhausted account has already been marked
+ *    unhealthy, so re-invoking the runner re-selects a healthy account, resets
+ *    the session, and answers the same turn — instead of surfacing the raw
+ *    English limit notice and dropping the user's message.
+ *
+ * Retries are capped at the number of enabled providers (each account gets one
+ * shot) and stop early once no healthy account remains.
+ */
 export async function runAgentWithModelFallback(
   runFn: AgentRunner,
   group: RegisteredGroup,
@@ -2567,6 +2602,40 @@ export async function runAgentWithModelFallback(
   ) => void,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   ownerHomeFolder?: string,
+  options?: AgentRunOptions,
 ): Promise<ContainerOutput> {
-  return runFn(group, input, onProcess, onOutput, ownerHomeFolder);
+  const maxAttempts = Math.max(1, providerPool.getEnabledCount());
+  let currentInput = input;
+  let output = await runFn(
+    group,
+    currentInput,
+    onProcess,
+    onOutput,
+    ownerHomeFolder,
+  );
+
+  for (let attempt = 1; attempt < maxAttempts; attempt++) {
+    if (!output.providerFailure) return output;
+    // The just-exhausted account was marked unhealthy by runFn's health
+    // reporting. Only retry while a *different* healthy account remains;
+    // otherwise surface the failure unchanged.
+    if (!providerPool.hasHealthyEnabledMember()) return output;
+
+    logger.warn(
+      { group: group.name, attempt },
+      'Account usage limit hit; retrying the turn on another provider',
+    );
+    currentInput = options?.rebuildInputForProviderSwitch
+      ? options.rebuildInputForProviderSwitch(input)
+      : input;
+    output = await runFn(
+      group,
+      currentInput,
+      onProcess,
+      onOutput,
+      ownerHomeFolder,
+    );
+  }
+
+  return output;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
   AvailableGroup,
   ContainerInput,
   ContainerOutput,
+  AgentRunOptions,
   runContainerAgent,
   runHostAgent,
   runAgentWithModelFallback,
@@ -4650,6 +4651,32 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       scheduledTaskId: message.task_id ?? null,
     })),
   );
+
+  // Account-limit failover: when the selected provider hits its usage/session
+  // limit, runAgentWithModelFallback retries this turn on another provider.
+  // The switch resets the Claude session (thinking-block signatures are
+  // per-account), so re-inject recent history — same treatment as the proactive
+  // willClearSessionOnProviderSwitch path. Built here where missedMessages is in
+  // scope so the current turn's own messages are excluded from the injected
+  // history. Rebuilt from the ORIGINAL prompt each retry to avoid stacking.
+  const providerSwitchRunOptions: AgentRunOptions = {
+    rebuildInputForProviderSwitch: (originalInput) => {
+      const historyContext = buildRecentConversationHistoryContext(
+        chatJid,
+        new Set(missedMessages.map((m) => m.id)),
+        {
+          limit: 30,
+          maxMessageLength: 700,
+          intro:
+            '检测到本次因切换 provider 需要使用新的底层模型 session。以下是 HappyClaw 保存的最近对话记录，供你延续上下文。',
+        },
+      );
+      return historyContext
+        ? { ...originalInput, prompt: historyContext.context + prompt }
+        : originalInput;
+    },
+  };
+
   try {
     output = await runAgent(
       effectiveGroup,
@@ -5538,6 +5565,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       currentSourceJid,
       currentChannelContext,
       agentProfile,
+      providerSwitchRunOptions,
     );
   } finally {
     runEnded = true;
@@ -6216,6 +6244,7 @@ async function runAgent(
   currentSourceJid?: string,
   channelContext?: ChannelTurnContext,
   agentProfile?: AgentProfile,
+  runOptions?: AgentRunOptions,
 ): Promise<{ status: 'success' | 'error' | 'closed'; error?: string }> {
   const isHome = !!group.is_home;
   const owner = group.created_by ? getUserById(group.created_by) : undefined;
@@ -6353,6 +6382,7 @@ async function runAgent(
         onProcessCb,
         wrappedOnOutput,
         ownerHomeFolder,
+        runOptions,
       );
     } else {
       output = await runAgentWithModelFallback(
@@ -6377,6 +6407,7 @@ async function runAgent(
         onProcessCb,
         wrappedOnOutput,
         ownerHomeFolder,
+        runOptions,
       );
     }
 

--- a/src/provider-pool.ts
+++ b/src/provider-pool.ts
@@ -81,6 +81,20 @@ export class ProviderPool {
     return this.members.filter((m) => m.enabled).length;
   }
 
+  /**
+   * Whether at least one enabled member is currently considered healthy.
+   * Used by the account-limit failover loop to decide if retrying the turn on
+   * a different provider is worthwhile — once every account is exhausted there
+   * is nothing left to switch to.
+   */
+  hasHealthyEnabledMember(): boolean {
+    return this.members.some((m) => {
+      if (!m.enabled) return false;
+      const health = this.healthMap.get(m.profileId);
+      return !health || health.healthy;
+    });
+  }
+
   // ─── 选择算法 ────────────────────────────────────────────
 
   /** 选择一个提供商，返回 profileId */
@@ -197,10 +211,7 @@ export class ProviderPool {
       : health.consecutiveErrors + 1;
     health.lastErrorAt = Date.now();
 
-    if (
-      health.healthy &&
-      health.consecutiveErrors >= this.unhealthyThreshold
-    ) {
+    if (health.healthy && health.consecutiveErrors >= this.unhealthyThreshold) {
       health.healthy = false;
       health.unhealthySince = Date.now();
       logger.warn(

--- a/tests/agent-output-parser.test.ts
+++ b/tests/agent-output-parser.test.ts
@@ -22,6 +22,27 @@ describe('isProviderFailureResult — positive (genuine Claude limit notices)', 
     expect(isProviderFailureResult(msg)).toBe(true);
   });
 
+  test('detects Claude "hit your session limit" banner (qualified limit)', () => {
+    // Regression: the real banner qualifies "limit" ("session limit"), which
+    // the original pattern missed — the notice leaked to users verbatim and
+    // the exhausted account was never marked unhealthy, so weighted pools
+    // never rotated off it.
+    const msg =
+      "You've hit your session limit · resets 11:10pm (Asia/Singapore)";
+    expect(isProviderFailureResult(msg)).toBe(true);
+  });
+
+  test('detects other qualified limit variants (weekly/usage, "reached")', () => {
+    expect(
+      isProviderFailureResult(
+        "You've hit your weekly limit · resets 3am (America/New_York)",
+      ),
+    ).toBe(true);
+    expect(isProviderFailureResult("You've reached your usage limit.")).toBe(
+      true,
+    );
+  });
+
   test('detects "usage limit reached" notice with reset time', () => {
     const msg =
       'Claude usage limit reached. Your limit will reset at 3pm (America/New_York)';

--- a/tests/provider-account-failover.test.ts
+++ b/tests/provider-account-failover.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from 'vitest';
+
+import { ProviderPool, providerPool } from '../src/provider-pool.js';
+import {
+  runAgentWithModelFallback,
+  type ContainerInput,
+  type ContainerOutput,
+} from '../src/container-runner.js';
+import type { RegisteredGroup } from '../src/types.js';
+import type { BalancingConfig } from '../src/runtime-config.js';
+
+const BALANCING: BalancingConfig = {
+  strategy: 'weighted-round-robin',
+  unhealthyThreshold: 3,
+  recoveryIntervalMs: 300_000,
+};
+
+function poolProviders(ids: string[]) {
+  return ids.map((id) => ({ id, enabled: true, weight: 1 }));
+}
+
+const GROUP = { name: 'test-group', folder: 'test-folder' } as RegisteredGroup;
+
+const INPUT: ContainerInput = {
+  prompt: 'original prompt',
+  groupFolder: 'test-folder',
+  chatJid: 'web:test-folder',
+};
+
+const noopOnProcess = () => {};
+
+function successOutput(): ContainerOutput {
+  return { status: 'success', result: 'ok' };
+}
+
+function limitOutput(): ContainerOutput {
+  return {
+    status: 'success',
+    result: "You've hit your session limit · resets 11:10pm (Asia/Singapore)",
+    providerFailure: true,
+  };
+}
+
+describe('ProviderPool.hasHealthyEnabledMember', () => {
+  test('true when at least one enabled member has no failures', () => {
+    const pool = new ProviderPool();
+    pool.refreshFromConfig(poolProviders(['a', 'b']), BALANCING);
+    expect(pool.hasHealthyEnabledMember()).toBe(true);
+
+    pool.reportFailure('a', true);
+    expect(pool.hasHealthyEnabledMember()).toBe(true);
+
+    pool.reportFailure('b', true);
+    expect(pool.hasHealthyEnabledMember()).toBe(false);
+  });
+
+  test('ignores disabled members even when healthy', () => {
+    const pool = new ProviderPool();
+    pool.refreshFromConfig(
+      [
+        { id: 'a', enabled: false, weight: 1 },
+        { id: 'b', enabled: true, weight: 1 },
+      ],
+      BALANCING,
+    );
+    pool.reportFailure('b', true);
+    expect(pool.hasHealthyEnabledMember()).toBe(false);
+  });
+
+  test('false when no members configured', () => {
+    const pool = new ProviderPool();
+    pool.refreshFromConfig([], BALANCING);
+    expect(pool.hasHealthyEnabledMember()).toBe(false);
+  });
+});
+
+describe('runAgentWithModelFallback — account-limit provider failover', () => {
+  test('retries the turn on another provider until one succeeds', async () => {
+    providerPool.refreshFromConfig(
+      poolProviders(['acct-1', 'acct-2', 'acct-3']),
+      BALANCING,
+    );
+
+    // Simulate the real runner: each failing attempt marks its account
+    // unhealthy (the runner's health reporting does this via reportFailure
+    // with immediate=true) and surfaces providerFailure.
+    const attempts: string[] = [];
+    const accounts = ['acct-1', 'acct-2', 'acct-3'];
+    const runFn = async (): Promise<ContainerOutput> => {
+      const account = accounts[attempts.length];
+      attempts.push(account);
+      if (attempts.length < 3) {
+        providerPool.reportFailure(account, true);
+        return limitOutput();
+      }
+      return successOutput();
+    };
+
+    const output = await runAgentWithModelFallback(
+      runFn as never,
+      GROUP,
+      INPUT,
+      noopOnProcess,
+    );
+
+    expect(attempts).toEqual(['acct-1', 'acct-2', 'acct-3']);
+    expect(output.status).toBe('success');
+    expect(output.providerFailure).toBeUndefined();
+    expect(output.result).toBe('ok');
+  });
+
+  test('stops retrying once every enabled account is exhausted', async () => {
+    providerPool.refreshFromConfig(
+      poolProviders(['dead-1', 'dead-2', 'dead-3']),
+      BALANCING,
+    );
+
+    let calls = 0;
+    const accounts = ['dead-1', 'dead-2', 'dead-3'];
+    const runFn = async (): Promise<ContainerOutput> => {
+      providerPool.reportFailure(accounts[calls], true);
+      calls++;
+      return limitOutput();
+    };
+
+    const output = await runAgentWithModelFallback(
+      runFn as never,
+      GROUP,
+      INPUT,
+      noopOnProcess,
+    );
+
+    // Each account gets exactly one shot; the final failure is surfaced.
+    expect(calls).toBe(3);
+    expect(output.providerFailure).toBe(true);
+  });
+
+  test('does not retry with a single provider (nothing to switch to)', async () => {
+    providerPool.refreshFromConfig(poolProviders(['only-1']), BALANCING);
+
+    let calls = 0;
+    const runFn = async (): Promise<ContainerOutput> => {
+      calls++;
+      providerPool.reportFailure('only-1', true);
+      return limitOutput();
+    };
+
+    const output = await runAgentWithModelFallback(
+      runFn as never,
+      GROUP,
+      INPUT,
+      noopOnProcess,
+    );
+
+    expect(calls).toBe(1);
+    expect(output.providerFailure).toBe(true);
+  });
+
+  test('rebuilds retry input from the ORIGINAL input each attempt (no history stacking)', async () => {
+    providerPool.refreshFromConfig(
+      poolProviders(['r-1', 'r-2', 'r-3']),
+      BALANCING,
+    );
+
+    const seenPrompts: string[] = [];
+    const rebuildInputs: ContainerInput[] = [];
+    const accounts = ['r-1', 'r-2', 'r-3'];
+    let calls = 0;
+    const runFn = async (
+      _group: RegisteredGroup,
+      input: ContainerInput,
+    ): Promise<ContainerOutput> => {
+      seenPrompts.push(input.prompt);
+      const account = accounts[calls];
+      calls++;
+      if (calls < 3) {
+        providerPool.reportFailure(account, true);
+        return limitOutput();
+      }
+      return successOutput();
+    };
+
+    await runAgentWithModelFallback(
+      runFn as never,
+      GROUP,
+      INPUT,
+      noopOnProcess,
+      undefined,
+      undefined,
+      {
+        rebuildInputForProviderSwitch: (originalInput) => {
+          rebuildInputs.push(originalInput);
+          return {
+            ...originalInput,
+            prompt: `[history]\n${originalInput.prompt}`,
+          };
+        },
+      },
+    );
+
+    // First attempt uses the raw input; each retry rebuilds from the original,
+    // so the history prefix appears exactly once no matter how many retries.
+    expect(seenPrompts).toEqual([
+      'original prompt',
+      '[history]\noriginal prompt',
+      '[history]\noriginal prompt',
+    ]);
+    expect(rebuildInputs).toEqual([INPUT, INPUT]);
+  });
+
+  test('does not retry a successful turn', async () => {
+    providerPool.refreshFromConfig(poolProviders(['ok-1', 'ok-2']), BALANCING);
+
+    let calls = 0;
+    const runFn = async (): Promise<ContainerOutput> => {
+      calls++;
+      return successOutput();
+    };
+
+    const output = await runAgentWithModelFallback(
+      runFn as never,
+      GROUP,
+      INPUT,
+      noopOnProcess,
+    );
+
+    expect(calls).toBe(1);
+    expect(output.status).toBe('success');
+  });
+});

--- a/tests/provider-model-fallback.test.ts
+++ b/tests/provider-model-fallback.test.ts
@@ -33,6 +33,10 @@ describe('provider model fallback lifecycle', () => {
     const samples = [
       ["You're out of extra usage · resets 2:10am (Asia/Shanghai)", true],
       ["You've hit your limit", true],
+      // Qualified variants of the real banner ("session"/"weekly" limit) must
+      // match too — the original pattern only accepted the bare "your limit".
+      ["You've hit your session limit · resets 11:10pm (Asia/Singapore)", true],
+      ["You've hit your weekly limit · resets 3am (America/New_York)", true],
       ['Claude usage limit reached. Your limit will reset at 3pm.', true],
       [
         'To avoid a rate limit, retry the request with exponential backoff.',


### PR DESCRIPTION
## 问题描述

配置了 3 个官方账号 + 权重轮训后:
1. 请求一直落在第一个账号上,撞额度墙后也不切换
2. 英文额度墙原文 `You've hit your session limit · resets 11:10pm (Asia/Singapore)` 直接泄漏给用户
3. 当前这条消息的回复直接丢失

## 根因

两份 Claude 额度墙检测正则(`src/agent-output-parser.ts` 与 `container/agent-runner/src/provider-fallback.ts`)只匹配裸的 "your limit",而真实横幅带 **session**/weekly 等限定词("your **session** limit"),不被识别。整条失败链由此展开:

- `isProviderFailureResult` 不命中 → `providerFailure` 标志从不设置
- 额度墙作为"成功"结果返回 → 反被 `reportSuccess` 标记为**健康**
- sticky 绑定(`sessions.provider_id`)只在绑定账号不健康时才放弃 → 永远钉死在第一个账号,权重轮训形同虚设
- `index.ts` 的静默切换抑制逻辑不触发 → 英文原文发给用户

## 修复方案

### `src/agent-output-parser.ts` / `container/agent-runner/src/provider-fallback.ts`

- 正则加 `(?:\w+\s+)?` 可选限定词并支持 "reached" 动词变体,"your session limit" / "your weekly limit" 均可命中;负向用例(普通回复提及 rate limit / quota)全部保持不误报,两份副本同步

### `src/container-runner.ts`

- `runAgentWithModelFallback` 增加**账号级 failover 循环**:runner 报告 `providerFailure` 时(撞墙账号已被标 unhealthy),在其余健康账号上重跑**当前这轮**,用户无感知;每个账号一次机会,全部耗尽即停
- 新增 `AgentRunOptions.rebuildInputForProviderSwitch` 钩子:切账号会重置 Claude session(thinking block 签名跨账号失效),重试前从**原始** prompt 重建输入并注入最近对话历史(与既有 `willClearSessionOnProviderSwitch` 主动切换路径同等待遇),多次重试不叠加历史前缀

### `src/provider-pool.ts`

- 新增 `hasHealthyEnabledMember()`:判断池内是否还有健康账号可切,避免全部耗尽后空转重试

### `src/index.ts`

- 冷启动路径构建 `providerSwitchRunOptions` 并传入 `runAgent` → `runAgentWithModelFallback`,历史注入排除当前 turn 自身的消息

## 测试

- 新增 `tests/provider-account-failover.test.ts`(8 用例):`hasHealthyEnabledMember` 边界、failover 循环逐账号重试直至成功、全部耗尽即停、单账号不重试、重试输入从原始 input 重建不叠加、成功结果不重试
- `tests/agent-output-parser.test.ts` / `tests/provider-model-fallback.test.ts` 补 session/weekly limit 正向用例
- `make typecheck` 通过;相关测试套件 84 用例全绿;全量测试中 backup-restore / plugin-mount 的 6 个失败在干净树上同样失败(既有环境问题,与本 PR 无关)