### PR TITLE
修复: outbox 测试租约校验漏传 now 参数导致 CI 时间性失败

### DIFF
--- a/tests/channel-reliability-store.test.ts
+++ b/tests/channel-reliability-store.test.ts
@@ -966,7 +966,12 @@ describe('durable streaming card state and cleanup', () => {
       60_000,
       '2026-07-23T03:59:00.600Z',
     )!;
-    expect(reliability.markChannelOutboxSending(outboxClaim)).toBe(true);
+    expect(
+      reliability.markChannelOutboxSending(
+        outboxClaim,
+        '2026-07-23T03:59:00.650Z',
+      ),
+    ).toBe(true);
     expect(
       reliability.rollbackUnpublishedStreamingCardReservation(
         claim,


### PR DESCRIPTION
## 问题描述

76e6ed9 引入的 `tests/channel-reliability-store.test.ts` 中，`reservation rollback requires the exact lease and rejects visible Outbox state` 用例是一颗时间炸弹：2026-07-23T04:00:00.600Z（UTC）之后所有 CI 运行必然失败，包括 main 分支和所有 PR。

该用例用硬编码时间戳 `2026-07-23T03:59:00.600Z` 创建了 60 秒租约，但第 969 行调用 `markChannelOutboxSending(outboxClaim)` 时漏传了 `now` 参数。实现里 `transitionClaimedOutbox` 的 `isoNow(input.now)` 会 fallback 到真实系统时间，参与 `lease_expires_at > ?` 校验——真实时间一旦越过租约过期点，断言就从 true 变为 false。

今天早上 main 的 CI 全绿只是因为跑得早；之后触发的运行（如 CI run 29979856579）已开始失败。

## 修复方案

### `tests/channel-reliability-store.test.ts`

- 给第 969 行的 `markChannelOutboxSending` 补传租约有效期内的固定时间戳 `2026-07-23T03:59:00.650Z`，与该文件其余 100+ 处显式传时间戳的写法保持一致（全文件仅此一处漏传）
- 本地验证：该文件 17/17 用例通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)