### PR TITLE
fix: 修复热注入路径 externalMessageId 使用随机 deliveryId 导致消息重复处理

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6129,7 +6129,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           chatId: nextAddress.externalChatId,
           rootId: nextAddress.rootMessageId,
           threadId: nextAddress.threadId,
-          externalMessageId: inputTurnId,
+          externalMessageId: inputCursor?.id ?? inputTurnId,
           sessionId: activeSessionId,
         });
         if (nextRuntime.executionDisposition !== 'execute') {
@@ -13480,7 +13480,7 @@ async function processAgentConversation(
   bindAgentTurnOutputCoordinator(lastProcessed.id);
   activeRouteAdmissions.set(
     agentAdmissionKey,
-    (newSourceJid, inputTurnId, _inputCursor, coveredInputs) => {
+    (newSourceJid, inputTurnId, inputCursor, coveredInputs) => {
       if (admittedWarmAgentInputs.has(inputTurnId)) return false;
       const targetSourceJid = resolveStickyChannelOwner(
         replySourceImJid,
@@ -13504,7 +13504,7 @@ async function processAgentConversation(
           chatId: nextAddress.externalChatId,
           rootId: nextAddress.rootMessageId,
           threadId: nextAddress.threadId,
-          externalMessageId: inputTurnId,
+          externalMessageId: inputCursor?.id ?? inputTurnId,
           agentId,
           sessionId: currentAgentSessionId,
         });


### PR DESCRIPTION
## 问题

Fixes #600

飞书私聊热注入路径（IPC 注入到运行中会话）触发的 turn，其 `ChannelTurnRuntime.start()` 的 `externalMessageId` 使用了 `inputTurnId`——而热注入场景下 `inputTurnId` 来自 `invokeActiveRouteAdmission()` 传入的 `receipt.deliveryId`，是每次 IPC 投递生成的随机 UUID（`src/group-queue.ts:1504`）。

冷启动/入站路径的 `externalMessageId` 用的是稳定的飞书原生消息 id（`lastProcessed.id`）。两条路径的幂等键落在不相交的空间里，导致 `turn_runs.UNIQUE(idempotency_key)` 拦不住同一条消息被冷、热两条路径各处理一次，用户端表现为收到两条重复回复。

## 修复

`activeRouteAdmissions` 的 warm-path 回调本身已经拿到 `inputCursor`（原生消息 cursor，含稳定 `id`），只是此前主路径把它算进了准入时序判断、agent 路径干脆忽略（`_inputCursor`）。两处都改为对 `externalMessageId` 使用 `inputCursor?.id ?? inputTurnId`，与冷启动路径共享同一个幂等键空间。

`inputTurnId`（即 `deliveryId`）本身不变，因为它仍然是 `admittedWarmMainInputs` / `admittedWarmAgentInputs` / `channelTurnRuntimes` 等内存 Map 以及 IPC ack 追踪使用的 key——解耦而非替换，改动面很小。

## 改动文件

- `src/index.ts`：主会话与 Agent 会话两处 warm-path admission 回调

## 测试

- `make typecheck` 通过
- `make test`：2557 passed / 2 pre-existing failures（`backup-restore-safety` 硬链接环境相关、`feishu-card` 超时相关），均可在改动前的 `upstream/main` 上独立复现，与本次改动无关