### PR TITLE
build: refresh agent image tools from latest releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22.22.3
+          node-version: 24
           cache: npm
           cache-dependency-path: |
             package-lock.json

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,6 +59,8 @@ jobs:
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TOOL_REFRESH=${{ github.sha }}
           cache-from: type=gha,scope=happyclaw-agent
           cache-to: type=gha,mode=max,scope=happyclaw-agent
           provenance: mode=max

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ make dev
 | `make restore FILE=happyclaw-backup-xxx.tar.gz` | 停止服务后恢复指定备份                                |
 | `make help`                                     | 查看完整命令列表                                      |
 
+`main` 分支每次推送都会重新构建并发布
+`riba2534/happyclaw-agent:latest`（amd64/arm64）。镜像构建时会解析 Claude Code、
+Claude Agent SDK、agent-browser、feishu-cli、uv 和 Headroom 的最新稳定版；
+实际安装版本记录在镜像内的
+`/usr/local/share/happyclaw-tool-versions.txt`，需要回滚时也可以通过 Docker
+build args 指定精确版本。
+
 ## 配置与数据
 
 HappyClaw 优先通过 Web 设置管理配置，不要求用户维护一组庞大的环境变量。
@@ -440,7 +447,11 @@ happyclaw/
 <details>
 <summary><strong>需要另外安装 Claude Code CLI 吗？</strong></summary>
 
-不需要。HappyClaw 锁定的 Claude Agent SDK 依赖已经包含对应 Claude Code 运行时。固定版本的内置 Skills 会在 `make install`、`make dev` 和 `make start` 时自动物化，并由 Host/Container 共用同一 Manifest；其他 Host 工具可通过 `make install-host-tools` 安装。
+不需要。官方 Agent 镜像会在每次发布时安装最新稳定版 Claude Agent SDK 和
+Claude Code，并把实际版本写入
+`/usr/local/share/happyclaw-tool-versions.txt`。固定版本的内置 Skills 会在
+`make install`、`make dev` 和 `make start` 时自动物化，并由 Host/Container
+共用同一 Manifest；其他 Host 工具可通过 `make install-host-tools` 安装。
 
 </details>
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,14 +1,19 @@
 # HappyClaw Agent Container
 # Runs Claude Agent SDK in isolated Linux VM with full toolchain
 
-FROM node:22.22.3-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
+FROM node:24-slim
+
+# The publish workflow sets this to the main-branch commit SHA. Writing it into
+# the first layer intentionally invalidates all downstream "latest" tool
+# installs on every main push, while still allowing exact-version overrides for
+# local or incident-response builds.
+ARG TOOL_REFRESH=manual
 
 # Install system packages (organized by category)
-# NOTE: Keep this layer before the uv copy so tool updates do not invalidate
-# this ~440MB layer. Debian packages intentionally follow the signed Bookworm
-# repositories for security fixes; their transitive versions are not frozen.
-# See issue #403.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Debian packages intentionally follow the current signed stable repositories,
+# so a refreshed build receives the newest security and bug-fix packages.
+RUN printf '%s\n' "$TOOL_REFRESH" > /etc/happyclaw-tool-refresh \
+    && apt-get update && apt-get install -y --no-install-recommends \
     # --- Browser & fonts ---
     chromium \
     fonts-liberation \
@@ -85,11 +90,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Symlink fd-find → fd (Debian names it fdfind)
     && ln -sf /usr/bin/fdfind /usr/local/bin/fd
 
-# Copy the verified multi-arch uv release from its immutable manifest digest.
-# Keeping it after apt-get avoids invalidating the heavy package layer when uv
-# is deliberately upgraded. See issue #403.
-COPY --from=ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d /uv /usr/local/bin/uv
-COPY --from=ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d /uvx /usr/local/bin/uvx
+# Pull the newest stable multi-arch uv release. The publish workflow uses
+# `pull: true`, and TOOL_REFRESH prevents a stale cached COPY layer.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 
 # Locale environment
 ENV LANG=en_US.UTF-8
@@ -98,6 +102,8 @@ ENV LC_ALL=en_US.UTF-8
 # Set Chromium path for agent-browser
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # Allow pip install without venv (Debian 12+ PEP 668) and add user bin to PATH
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
@@ -106,14 +112,24 @@ ENV PATH="/home/node/.local/bin:${PATH}"
 # Create app directory
 WORKDIR /app
 
-# Reproducible agent runtime: the verified SDK/CLI graph is locked and npm ci
-# refuses to build if package.json and package-lock.json ever drift.
+# Start with the committed dependency graph so application dependencies stay
+# deterministic and package.json/package-lock.json drift still fails fast.
 COPY agent-runner/package.json agent-runner/package-lock.json ./
 
-# agent-browser is part of the committed dependency graph, so npm ci locks its
-# full transitive tree. Expose the package-local CLI on the container PATH.
+# Runtime tools default to their newest npm releases at image-build time. Exact
+# versions remain available as build args for rollback/reproduction. These are
+# deliberately installed without rewriting the committed lockfile.
+ARG CLAUDE_AGENT_SDK_VERSION=latest
+ARG CLAUDE_CODE_VERSION=latest
+ARG AGENT_BROWSER_VERSION=latest
 RUN npm ci \
-    && ln -s /app/node_modules/.bin/agent-browser /usr/local/bin/agent-browser
+    && npm install --no-save --package-lock=false \
+      "@anthropic-ai/claude-agent-sdk@${CLAUDE_AGENT_SDK_VERSION}" \
+      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+      "agent-browser@${AGENT_BROWSER_VERSION}" \
+    && npm cache clean --force \
+    && ln -s /app/node_modules/.bin/agent-browser /usr/local/bin/agent-browser \
+    && node -e "const fs=require('node:fs'); for (const p of ['@anthropic-ai/claude-agent-sdk','@anthropic-ai/claude-code','agent-browser']) { const j=JSON.parse(fs.readFileSync('/app/node_modules/'+p+'/package.json','utf8')); console.log(p+' '+j.version); }"
 
 # Headroom (https://github.com/chopratejas/headroom) - 工具输出/RAG/日志压缩.
 # 装上 binary 但默认不启用——用户在 /mcp-servers 自行添加才生效, 配置:
@@ -124,36 +140,58 @@ RUN npm ci \
 # embedding 类 retrieve. 用户如真需要 headroom 的 memory 能力, 可在容器内
 # 单独 `pip install --index-url https://download.pytorch.org/whl/cpu torch`
 # 再 `pip install "headroom-ai[memory]"` 走 CPU 路径. PIP_BREAK_SYSTEM_PACKAGES
-# 已在 line 103 设置, 这里无需再传 --break-system-packages.
-# Pin 到已验证的 0.27.0：headroom-ai 仍是 PyPI Beta, 且 extras 解析
-# 曾因 [memory]→torch 把镜像撑爆; `headroom --version` 自检只挡『装不上』挡不住
-# 体积/行为漂移, 故锁定已验证的 ~550MB footprint, 仅允许 0.27.x 补丁更新.
-RUN pip install "headroom-ai[code,mcp]==0.27.0" \
-    && headroom --version
+# 已在上方设置, 这里无需再传 --break-system-packages.
+# 默认安装 PyPI 最新稳定版；可用 HEADROOM_VERSION 精确回退。继续只安装
+# [code,mcp]，避免 [memory] 的 GPU/torch 依赖把镜像额外撑大数 GB。
+ARG HEADROOM_VERSION=latest
+RUN set -eu; \
+    if [ "$HEADROOM_VERSION" = latest ]; then \
+      HEADROOM_SPEC='headroom-ai[code,mcp]'; \
+    else \
+      HEADROOM_SPEC="headroom-ai[code,mcp]==${HEADROOM_VERSION}"; \
+    fi; \
+    pip install --no-cache-dir --upgrade "$HEADROOM_SPEC"; \
+    headroom --version
 
-# Install the verified feishu-cli release. Its matching Skills are materialized
-# on the host by scripts/install-host-tools.sh and then governed by the same
-# EffectiveSkillManifest as every other runtime Skill.
-# Checksums prevent a replaced or truncated download from entering the image.
+# Resolve the newest stable feishu-cli GitHub release by default, then verify
+# the selected archive against the checksums file published with that release.
+# An exact vX.Y.Z tag can be supplied through FEISHU_CLI_VERSION for rollback.
 ARG TARGETARCH
-ARG FEISHU_CLI_VERSION=v1.35.0
-ARG FEISHU_CLI_SHA256_AMD64=2bfd4e973add5674be92ec67c2f4948b656537a58ba6d04630c1ecda35121695
-ARG FEISHU_CLI_SHA256_ARM64=9d7214916815242b9ea65984984b82f6ad215a52328968e4e799bcf136b795d6
+ARG FEISHU_CLI_VERSION=latest
 RUN set -eu && \
     ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     case "$ARCH" in \
-      amd64) BINARY_SHA256="$FEISHU_CLI_SHA256_AMD64" ;; \
-      arm64) BINARY_SHA256="$FEISHU_CLI_SHA256_ARM64" ;; \
+      amd64|arm64) ;; \
       *) echo "ERROR: unsupported feishu-cli architecture: $ARCH" >&2; exit 1 ;; \
     esac && \
-    echo "Installing feishu-cli $FEISHU_CLI_VERSION for $ARCH" && \
-    DOWNLOAD_TMP=$(mktemp -d) && \
+    DOWNLOAD_TMP="$(mktemp -d)" && \
+    if [ "$FEISHU_CLI_VERSION" = latest ]; then \
+      RELEASE_URL='https://github.com/riba2534/feishu-cli/releases/latest/download'; \
+    else \
+      RELEASE_URL="https://github.com/riba2534/feishu-cli/releases/download/${FEISHU_CLI_VERSION}"; \
+    fi && \
     curl -fsSL --retry 3 \
-      -o "$DOWNLOAD_TMP/feishu-cli.tar.gz" \
-      "https://github.com/riba2534/feishu-cli/releases/download/${FEISHU_CLI_VERSION}/feishu-cli_${FEISHU_CLI_VERSION}_linux-${ARCH}.tar.gz" && \
-    echo "$BINARY_SHA256  $DOWNLOAD_TMP/feishu-cli.tar.gz" | sha256sum -c - && \
-    tar -xzf "$DOWNLOAD_TMP/feishu-cli.tar.gz" --strip-components=1 -C /usr/local/bin && \
+      -o "$DOWNLOAD_TMP/checksums.txt" "$RELEASE_URL/checksums.txt" && \
+    if [ "$FEISHU_CLI_VERSION" = latest ]; then \
+      ARCHIVE="$(awk -v arch="$ARCH" \
+        '$2 ~ ("^feishu-cli_v[0-9.]+_linux-" arch "\\.tar\\.gz$") { print $2; exit }' \
+        "$DOWNLOAD_TMP/checksums.txt")"; \
+      test -n "$ARCHIVE"; \
+      RELEASE_TAG="${ARCHIVE#feishu-cli_}"; \
+      RELEASE_TAG="${RELEASE_TAG%_linux-*}"; \
+    else \
+      RELEASE_TAG="$FEISHU_CLI_VERSION"; \
+      ARCHIVE="feishu-cli_${RELEASE_TAG}_linux-${ARCH}.tar.gz"; \
+    fi && \
+    echo "Installing feishu-cli $RELEASE_TAG for $ARCH" && \
+    curl -fsSL --retry 3 \
+      -o "$DOWNLOAD_TMP/$ARCHIVE" "$RELEASE_URL/$ARCHIVE" && \
+    grep -F "  $ARCHIVE" "$DOWNLOAD_TMP/checksums.txt" \
+      > "$DOWNLOAD_TMP/checksum.txt" && \
+    (cd "$DOWNLOAD_TMP" && sha256sum -c checksum.txt) && \
+    tar -xzf "$DOWNLOAD_TMP/$ARCHIVE" --strip-components=1 -C /usr/local/bin && \
     feishu-cli --version && \
+    printf '%s\n' "$RELEASE_TAG" > /usr/local/share/feishu-cli-version && \
     rm -rf "$DOWNLOAD_TMP"
 
 # Copy source code
@@ -173,23 +211,40 @@ RUN chmod +x /app/entrypoint.sh
 # Set ownership to node user (non-root) for writable directories
 RUN chown -R node:node /workspace
 
-# Install a checksum-verified oh-my-zsh snapshot for node (ys theme). Failure is
-# fatal: a successful image must never vary based on optional network timing.
-ARG OH_MY_ZSH_COMMIT=677a4592b18c08ddea737f8aca70bac0e9fc9313
-ARG OH_MY_ZSH_SHA256=f8c4c980bf28c77db703e083b5d395a2c42403abddbd36467c41a50a476fd841
-RUN timeout -k 5 90 sh -c 'set -eu; \
-      DOWNLOAD_TMP=$(mktemp -d); \
-      curl -fsSL --retry 3 \
-        -o "$DOWNLOAD_TMP/oh-my-zsh.tar.gz" \
-        "https://github.com/ohmyzsh/ohmyzsh/archive/${OH_MY_ZSH_COMMIT}.tar.gz"; \
-      echo "$OH_MY_ZSH_SHA256  $DOWNLOAD_TMP/oh-my-zsh.tar.gz" | sha256sum -c -; \
-      tar -xzf "$DOWNLOAD_TMP/oh-my-zsh.tar.gz" -C "$DOWNLOAD_TMP"; \
-      mv "$DOWNLOAD_TMP"/ohmyzsh-* /home/node/.oh-my-zsh; \
-      cp /home/node/.oh-my-zsh/templates/zshrc.zsh-template /home/node/.zshrc; \
-      sed -i '\''s/ZSH_THEME="robbyrussell"/ZSH_THEME="ys"/'\'' /home/node/.zshrc; \
-      chown -R node:node /home/node/.oh-my-zsh /home/node/.zshrc; \
-      chsh -s /bin/zsh node; \
-      rm -rf "$DOWNLOAD_TMP"'
+# Install the newest oh-my-zsh master snapshot by default. An exact tag or
+# commit can be passed through OH_MY_ZSH_REF when reproducing an older image.
+ARG OH_MY_ZSH_REF=master
+RUN set -eu; \
+    mkdir -p /home/node/.oh-my-zsh; \
+    git -C /home/node/.oh-my-zsh init; \
+    git -C /home/node/.oh-my-zsh remote add origin \
+      https://github.com/ohmyzsh/ohmyzsh.git; \
+    git -C /home/node/.oh-my-zsh fetch --depth 1 origin "$OH_MY_ZSH_REF"; \
+    git -C /home/node/.oh-my-zsh checkout --detach FETCH_HEAD; \
+    git -C /home/node/.oh-my-zsh rev-parse HEAD \
+      > /usr/local/share/oh-my-zsh-version; \
+    rm -rf /home/node/.oh-my-zsh/.git; \
+    cp /home/node/.oh-my-zsh/templates/zshrc.zsh-template /home/node/.zshrc; \
+    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="ys"/' /home/node/.zshrc; \
+    chown -R node:node /home/node/.oh-my-zsh /home/node/.zshrc; \
+    chsh -s /bin/zsh node
+
+# Keep an in-image audit record of every dynamically resolved tool version.
+# This can be inspected without relying on transient GitHub Actions logs:
+#   cat /usr/local/share/happyclaw-tool-versions.txt
+RUN set -eu; \
+    { \
+      printf 'tool_refresh=%s\n' "$TOOL_REFRESH"; \
+      printf 'node=%s\n' "$(node --version)"; \
+      printf 'npm=%s\n' "$(npm --version)"; \
+      printf 'uv=%s\n' "$(uv --version | awk '{print $2}')"; \
+      node -e "const fs=require('node:fs'); for (const p of ['@anthropic-ai/claude-agent-sdk','@anthropic-ai/claude-code','agent-browser']) { const j=JSON.parse(fs.readFileSync('/app/node_modules/'+p+'/package.json','utf8')); console.log(p+'='+j.version); }"; \
+      printf 'feishu-cli=%s\n' "$(cat /usr/local/share/feishu-cli-version)"; \
+      printf 'headroom=%s\n' "$(headroom --version | awk '{print $NF}')"; \
+      printf 'chromium=%s\n' "$(chromium --version | awk '{print $2}')"; \
+      printf 'oh-my-zsh=%s\n' "$(cat /usr/local/share/oh-my-zsh-version)"; \
+    } > /usr/local/share/happyclaw-tool-versions.txt; \
+    cat /usr/local/share/happyclaw-tool-versions.txt
 
 # Entrypoint runs as root to fix volume permissions, then drops to node user.
 # Do NOT add USER node here — entrypoint handles the privilege drop.

--- a/container/agent-runner/package-lock.json
+++ b/container/agent-runner/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.205",
-        "@anthropic-ai/claude-code": "2.1.205",
-        "agent-browser": "0.27.0",
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
+        "@anthropic-ai/claude-code": "2.1.220",
+        "agent-browser": "0.33.1",
         "cron-parser": "^5.0.0",
         "zod": "^4.0.0"
       },
@@ -21,22 +21,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.205.tgz",
-      "integrity": "sha512-ft6iBw9kXudsusiXNpeybIPBJ07Z3tqp1ROSg5cEJqgA+9i+JJj2sRfQth+QD+lyenbbAU8yPieLxIimvfBhtw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.205",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.205"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.205.tgz",
-      "integrity": "sha512-lrfJ4eVtzfPkCpbSkBOGSMQCBbvmW6nbPzgHE4IwMN3scZlpuFMUFqh2aaJa/X2SAcWD9H2S0t2WWvSRgM7BjA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -58,9 +58,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.205.tgz",
-      "integrity": "sha512-G6ETPmL5mNzJ2DFsWxG3jmsmrXgZX1N2ZCJvxaGUUpjTsKZJ4Tup1cWYvcd/m7o5fYZmx9REmgzTwsAIc1fdPQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -71,9 +71,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.205.tgz",
-      "integrity": "sha512-CXzySK3PV3EizCRPXnxPqeaAtgrBFDnMFOVpMe36oC3U16yDb1b1tAJGqZi/7uFrVvAiaXvnSFxhUWnDDSaO+A==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -84,9 +84,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.205.tgz",
-      "integrity": "sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -97,9 +97,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.205.tgz",
-      "integrity": "sha512-siS+1iNqBSlGFZZvJY6+mhzZ/6/ec/TbX9GMuwmTF0E6fxGhIIp797jJxR1q8r6FAq7d39mEoRNhC0Ffo60uNQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -110,9 +110,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.205.tgz",
-      "integrity": "sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -123,9 +123,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.205.tgz",
-      "integrity": "sha512-SpP5zF68weFez/6pKrGzq/UVAJDMDNphWqmkLfOpWTDBL5xy6XlIZw5Bl4EXoVnfi2VLFkwuffNeFe+9SdX7kw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -136,9 +136,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.205.tgz",
-      "integrity": "sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.205.tgz",
-      "integrity": "sha512-riShT8jUKjYFupfYtFJF8JelKmJzAm+fHDvqUadfEAjzRAJ3AatZm5gtzWT3pEBmSXPIjoIjOHOXBGzo5wpuCw==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.220.tgz",
+      "integrity": "sha512-ogBrvwkqF9f8okmnXKxmRNHuvtFxFEffe5pWdqOV3iQDxlUOKirFqnyWC7NGXXnDA4WkkbPH8pvSbwyCR2Auyw==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
@@ -161,20 +161,20 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.205",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.205",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.205",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.205",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.205",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.205",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.205",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.205"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.220",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.220",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.220",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.220",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.220",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.220",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.220",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.220"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.205.tgz",
-      "integrity": "sha512-M0thQil5v7ubgIR+3FCbUf+OfdFw+I9vnQVuMSsiVvDNYSKOs4CK6njYbVCWJRokMXTwCJ5fbzO6HUdLUk1edA==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.220.tgz",
+      "integrity": "sha512-rmtd41Bf+n+YnhjSjtQ8WG5qy8KKogUp3YRfQrkLsTgPUD0H3j869rBInBJT3SHrKQ0hLghQLGM73CC1C+USLQ==",
       "cpu": [
         "arm64"
       ],
@@ -185,9 +185,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.205.tgz",
-      "integrity": "sha512-RgYUkU9+x2L/6IIR4iugc16FGlzMC9d2vUNApF88yDUt6NuCnRxEEOQd6rG48AEwbbkxJ4jpTcZgmFHgKIgwrA==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.220.tgz",
+      "integrity": "sha512-hbuoG+YCo37VzSKzKJ47ymRmt/YjASc3dRcsZtCcftLYdopv8KL889x/IbCl3cfp/VqV2rRDZ0f3aUDpHUFweQ==",
       "cpu": [
         "x64"
       ],
@@ -198,9 +198,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.205.tgz",
-      "integrity": "sha512-6xZPQQjQjWIAp3AsCfUBAPMTfD/GdVaNfBOQ/BVfEZN4H6h/dQN1lmctMcfEXXBstul4VoOYzuzALFKlPRzukg==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.220.tgz",
+      "integrity": "sha512-VHFI8mKruIntKn7eq81sbyS19/KWmQcmJQsS/C+j9M/E+w0s4UytgsL7DADPjBE/GByNiKoRtLYDMntCjRlOdA==",
       "cpu": [
         "arm64"
       ],
@@ -211,9 +211,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.205.tgz",
-      "integrity": "sha512-I5FmTXbiUZgsBVq5lLRQcOM9bWFcsvS9vD211K2XA7Dz9F1PzHoex3M4gq679Fc5ceRfrx0bAG9nlbf1+EzP8A==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.220.tgz",
+      "integrity": "sha512-m37ALw8jcbSknuyG7xDQjGPY7Gth3eX8iFY1XFEWABVq1iUMVAUn96WC9eqwi8/JSqyG2t3oNRiqHdi2ZNKFGQ==",
       "cpu": [
         "arm64"
       ],
@@ -224,9 +224,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.205.tgz",
-      "integrity": "sha512-VkmVjAIW28gZ0ef+uEBJxEkzQbKVulRY789mbMALJ8Zvb6nG0pl+ykGOdF1CQnRR7wmm+rR+EoiuhnFWu59D/Q==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.220.tgz",
+      "integrity": "sha512-3CGFCnI0gpgsqNeJruFALBDGJaKXOuok3alQEg56ty2yOPpIrOx/r2Y0+T4uhJl7kP5Hzw4IFkxo4DZKWvzQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -237,9 +237,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.205.tgz",
-      "integrity": "sha512-icqsHjQ2qVYzYKYl/7IVVlLIn3CtqgzcMnMICI8sIAw1cRMCQTsVNtvrAThIPpuGtc5DHDAgZtf+an15BQeZ7Q==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.220.tgz",
+      "integrity": "sha512-+QyT1KikOdMRKReWFaBYGsroYx2vEjjx54DwhMoC24oE1DxjC+SlKjeOTRXAKiu0fr0O549Lkhg2tuT5xtQpAQ==",
       "cpu": [
         "x64"
       ],
@@ -250,9 +250,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.205.tgz",
-      "integrity": "sha512-4Bl1LRZcFNJuSccArH3JT82ADq/ozHDSEdmFPSvr8ie2evyW0fDmPUCyjF4zNFDofYsaNdfvhj04wVJs5uDLZw==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.220.tgz",
+      "integrity": "sha512-APqZwFBn38DBUwB65uUTetW7lbtUqFfAfOWKvkmOyqFDswDEsInaINuIwqMCl44WYcch10SaHhEZdXJU9MG3aQ==",
       "cpu": [
         "arm64"
       ],
@@ -263,9 +263,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.205",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.205.tgz",
-      "integrity": "sha512-V/DAwv/jDC6cvH/0qVjri97qTDKKUXMLUKVCz4kv+fMYxfG/Mx5SlBvby8vjEIHhmJ7RaxktFTvwW/zNLEJt0w==",
+      "version": "2.1.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.220.tgz",
+      "integrity": "sha512-UGrjH8cGhC6PzhTyZSdgf/RpKxpfk9XJZ/RT/wsG2AJg9yEJLjLg6/TrnlL8RFbEv6Zahu0Quytc02UOpA/GiA==",
       "cpu": [
         "x64"
       ],
@@ -393,13 +393,17 @@
       }
     },
     "node_modules/agent-browser": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.27.0.tgz",
-      "integrity": "sha512-mmHzVsYFVA6nshNNGJzg83aVMgKpf4h98ytY3pvtJB1Cot0ZyA2bfnkbSngGD56Azkj+GlhVH6qx9DfKOVE0yg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.33.1.tgz",
+      "integrity": "sha512-lS0KbU9QdkD0I2n+uzrmNXKNGRjsd6GcB7bR6Wm1eyLcaxTCSf2zuxbWzf76fHCrDA4YoY3TikoOMSA8qA+wFA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
         "agent-browser": "bin/agent-browser.js"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "pnpm": ">=11.0.0"
       }
     },
     "node_modules/ajv": {

--- a/container/agent-runner/package.json
+++ b/container/agent-runner/package.json
@@ -9,9 +9,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.205",
-    "@anthropic-ai/claude-code": "2.1.205",
-    "agent-browser": "0.27.0",
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
+    "@anthropic-ai/claude-code": "2.1.220",
+    "agent-browser": "0.33.1",
     "cron-parser": "^5.0.0",
     "zod": "^4.0.0"
   },

--- a/tests/docker-publish-workflow-contract.test.ts
+++ b/tests/docker-publish-workflow-contract.test.ts
@@ -14,6 +14,7 @@ describe('Docker image distribution contract', () => {
     expect(workflow).toContain('type=raw,value=latest');
     expect(workflow).toContain('type=sha,format=long,prefix=git-');
     expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
+    expect(workflow).toContain('TOOL_REFRESH=${{ github.sha }}');
     expect(workflow).toContain('username: ${{ secrets.DOCKERHUB_USERNAME }}');
     expect(workflow).toContain('password: ${{ secrets.DOCKERHUB_TOKEN }}');
     expect(workflow).not.toContain(`${['dckr', 'pat'].join('_')}_`);

--- a/tests/reproducible-build-contract.test.ts
+++ b/tests/reproducible-build-contract.test.ts
@@ -72,23 +72,27 @@ describe('reproducible build contract', () => {
     }
   });
 
-  test('container downloads use pinned versions and integrity checks', () => {
+  test('container tools refresh to latest with rollback and audit controls', () => {
     const dockerfile = read('container/Dockerfile');
     const buildScript = read('container/build.sh');
+    const publishWorkflow = read('.github/workflows/docker-publish.yml');
 
-    expect(dockerfile).toMatch(
-      /^FROM node:\d+\.\d+\.\d+-slim@sha256:[a-f0-9]{64}$/m,
+    expect(dockerfile).toMatch(/^FROM node:24-slim$/m);
+    expect(dockerfile).toContain('COPY --from=ghcr.io/astral-sh/uv:latest');
+    expect(dockerfile).toContain('ARG CLAUDE_AGENT_SDK_VERSION=latest');
+    expect(dockerfile).toContain('ARG CLAUDE_CODE_VERSION=latest');
+    expect(dockerfile).toContain('ARG AGENT_BROWSER_VERSION=latest');
+    expect(dockerfile).toContain('ARG HEADROOM_VERSION=latest');
+    expect(dockerfile).toContain('ARG FEISHU_CLI_VERSION=latest');
+    expect(dockerfile).toContain('ARG OH_MY_ZSH_REF=master');
+    expect(dockerfile).toContain(
+      'github.com/riba2534/feishu-cli/releases/latest/download',
     );
-    expect(dockerfile).toMatch(
-      /COPY --from=ghcr\.io\/astral-sh\/uv:\d+\.\d+\.\d+@sha256:[a-f0-9]{64}/,
-    );
-    expect(dockerfile).toMatch(/ARG FEISHU_CLI_VERSION=v\d+\.\d+\.\d+/);
-    expect(dockerfile).toMatch(/ARG OH_MY_ZSH_COMMIT=[a-f0-9]{40}/);
-    expect(dockerfile).toContain('headroom-ai[code,mcp]==0.27.0');
-    expect(dockerfile).toContain('sha256sum -c -');
-    expect(dockerfile).not.toContain('releases/latest');
-    expect(dockerfile).not.toMatch(/(?:^|[/:])latest(?:\s|$)/m);
+    expect(dockerfile).toContain('sha256sum -c checksum.txt');
+    expect(dockerfile).toContain('happyclaw-tool-versions.txt');
+    expect(dockerfile).toContain('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1');
     expect(dockerfile).not.toContain('npm install -g');
     expect(buildScript).not.toContain('CACHEBUST');
+    expect(publishWorkflow).toContain('TOOL_REFRESH=${{ github.sha }}');
   });
 });


### PR DESCRIPTION
## Summary
- resolve latest stable Claude Code, Claude Agent SDK, agent-browser, feishu-cli, uv, Headroom, and oh-my-zsh when the agent image is built
- refresh dynamic tool layers on every main push while retaining exact-version build arguments for rollback
- verify feishu-cli release assets against upstream checksums and record resolved versions inside the image
- move the build/runtime baseline to Node 24 and avoid duplicate browser downloads

## Validation
- Dockerfile build check: no warnings
- feishu-cli v1.37.1 amd64 and arm64 assets downloaded over HTTP and checksum verified
- 320 test files / 2693 tests passed
- typecheck, all builds, format check, and docs check passed