### PR TITLE
fix: report resolved Headroom image version

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -151,7 +151,7 @@ RUN set -eu; \
       HEADROOM_SPEC="headroom-ai[code,mcp]==${HEADROOM_VERSION}"; \
     fi; \
     pip install --no-cache-dir --upgrade "$HEADROOM_SPEC"; \
-    headroom --version
+    python3 -c "from importlib.metadata import version; print('headroom-ai', version('headroom-ai'))"
 
 # Resolve the newest stable feishu-cli GitHub release by default, then verify
 # the selected archive against the checksums file published with that release.
@@ -240,7 +240,7 @@ RUN set -eu; \
       printf 'uv=%s\n' "$(uv --version | awk '{print $2}')"; \
       node -e "const fs=require('node:fs'); for (const p of ['@anthropic-ai/claude-agent-sdk','@anthropic-ai/claude-code','agent-browser']) { const j=JSON.parse(fs.readFileSync('/app/node_modules/'+p+'/package.json','utf8')); console.log(p+'='+j.version); }"; \
       printf 'feishu-cli=%s\n' "$(cat /usr/local/share/feishu-cli-version)"; \
-      printf 'headroom=%s\n' "$(headroom --version | awk '{print $NF}')"; \
+      printf 'headroom=%s\n' "$(python3 -c "from importlib.metadata import version; print(version('headroom-ai'))")"; \
       printf 'chromium=%s\n' "$(chromium --version | awk '{print $2}')"; \
       printf 'oh-my-zsh=%s\n' "$(cat /usr/local/share/oh-my-zsh-version)"; \
     } > /usr/local/share/happyclaw-tool-versions.txt; \

--- a/tests/reproducible-build-contract.test.ts
+++ b/tests/reproducible-build-contract.test.ts
@@ -90,6 +90,7 @@ describe('reproducible build contract', () => {
     );
     expect(dockerfile).toContain('sha256sum -c checksum.txt');
     expect(dockerfile).toContain('happyclaw-tool-versions.txt');
+    expect(dockerfile).toContain("version('headroom-ai')");
     expect(dockerfile).toContain('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1');
     expect(dockerfile).not.toContain('npm install -g');
     expect(buildScript).not.toContain('CACHEBUST');


### PR DESCRIPTION
## Summary
- read Headroom's installed distribution version from Python package metadata
- avoid the upstream CLI's misleading literal `latest` version output in the image audit manifest

## Validation
- targeted reproducible-build contract passed
- Dockerfile build check passed with no warnings
- previous full multi-platform build confirmed headroom-ai 0.33.0 was installed on amd64 and arm64