### PR TITLE
feat(container): start managed Chromium on CDP 9222

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -99,8 +99,14 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-# Set Chromium path for agent-browser
+# Set Chromium path for agent-browser. The entrypoint starts a managed
+# headless Chromium instance on this container-local CDP port, and
+# agent-browser attaches to it instead of launching a second browser with a
+# random debugging port.
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV HAPPYCLAW_CHROMIUM_CDP_HOST=127.0.0.1
+ENV HAPPYCLAW_CHROMIUM_CDP_PORT=9222
+ENV AGENT_BROWSER_CDP=9222
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV PUPPETEER_SKIP_DOWNLOAD=true

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -85,18 +85,79 @@ ln -s /app/node_modules /tmp/dist/node_modules
 ln -s /app/prompts /tmp/prompts
 chmod -R a-w /tmp/dist
 
-# Buffer stdin to file (container requires EOF to flush stdin pipe)
-cat > /tmp/input.json
-chmod 644 /tmp/input.json
-
 # Fix permissions on exit: Claude Code creates some files with mode 0600
 # (e.g. settings.json), which the host backend (agent user) cannot read.
-# The trap runs as root after the node process exits.
+# The trap runs as root after the node process exits. It also stops the managed
+# Chromium process so no browser child survives a cancelled run.
+CHROMIUM_PID=
 cleanup() {
+  if [ -n "$CHROMIUM_PID" ] && kill -0 "$CHROMIUM_PID" 2>/dev/null; then
+    kill "$CHROMIUM_PID" 2>/dev/null || true
+    for ((attempt = 0; attempt < 20; attempt++)); do
+      kill -0 "$CHROMIUM_PID" 2>/dev/null || break
+      sleep 0.1
+    done
+    if kill -0 "$CHROMIUM_PID" 2>/dev/null; then
+      kill -KILL "$CHROMIUM_PID" 2>/dev/null || true
+    fi
+    wait "$CHROMIUM_PID" 2>/dev/null || true
+  fi
   chmod -R a+rwX /home/node/.claude 2>/dev/null || true
   chmod -R a+rwX /workspace/group 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Start one deterministic browser for this task container. Binding to loopback
+# keeps the raw Chrome DevTools Protocol private to the container; a future Web
+# browser panel must proxy the authenticated agent-browser dashboard/stream,
+# never publish this port directly.
+HAPPYCLAW_CHROMIUM_CDP_HOST="${HAPPYCLAW_CHROMIUM_CDP_HOST:-127.0.0.1}"
+HAPPYCLAW_CHROMIUM_CDP_PORT="${HAPPYCLAW_CHROMIUM_CDP_PORT:-9222}"
+CHROMIUM_PROFILE_DIR=/tmp/happyclaw-chromium-profile
+CHROMIUM_LOG=/tmp/happyclaw-chromium.log
+mkdir -p "$CHROMIUM_PROFILE_DIR"
+chown -R node:node "$CHROMIUM_PROFILE_DIR"
+
+# agent-browser reads this value when its daemon starts, so it attaches to the
+# managed browser instead of creating another Chromium with a random CDP port.
+export AGENT_BROWSER_CDP="$HAPPYCLAW_CHROMIUM_CDP_PORT"
+
+HOME=/home/node setpriv --reuid=node --regid=node --init-groups -- \
+  "${AGENT_BROWSER_EXECUTABLE_PATH:-/usr/bin/chromium}" \
+  --headless=new \
+  --no-sandbox \
+  --disable-dev-shm-usage \
+  --no-first-run \
+  --no-default-browser-check \
+  --remote-debugging-address="$HAPPYCLAW_CHROMIUM_CDP_HOST" \
+  --remote-debugging-port="$HAPPYCLAW_CHROMIUM_CDP_PORT" \
+  --user-data-dir="$CHROMIUM_PROFILE_DIR" \
+  about:blank >"$CHROMIUM_LOG" 2>&1 &
+CHROMIUM_PID=$!
+
+CHROMIUM_READY=false
+for ((attempt = 0; attempt < 100; attempt++)); do
+  if curl --noproxy '*' -fsS \
+    "http://127.0.0.1:${HAPPYCLAW_CHROMIUM_CDP_PORT}/json/version" \
+    >/dev/null 2>&1; then
+    CHROMIUM_READY=true
+    break
+  fi
+  if ! kill -0 "$CHROMIUM_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [ "$CHROMIUM_READY" != true ]; then
+  echo "Chromium failed to listen on container-local CDP port ${HAPPYCLAW_CHROMIUM_CDP_PORT}" >&2
+  cat "$CHROMIUM_LOG" >&2 2>/dev/null || true
+  exit 1
+fi
+
+# Buffer stdin to file (container requires EOF to flush stdin pipe)
+cat > /tmp/input.json
+chmod 644 /tmp/input.json
 
 # Drop privileges and execute agent-runner as node user
 runuser -u node -- node /tmp/dist/index.js < /tmp/input.json

--- a/tests/chromium-cdp-entrypoint-contract.test.ts
+++ b/tests/chromium-cdp-entrypoint-contract.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const dockerfile = fs.readFileSync(
+  path.join(repoRoot, 'container', 'Dockerfile'),
+  'utf8',
+);
+const entrypoint = fs.readFileSync(
+  path.join(repoRoot, 'container', 'entrypoint.sh'),
+  'utf8',
+);
+const containerRunner = fs.readFileSync(
+  path.join(repoRoot, 'src', 'container-runner.ts'),
+  'utf8',
+);
+
+describe('managed Chromium CDP contract', () => {
+  test('defaults Chromium and agent-browser to container-local port 9222', () => {
+    expect(dockerfile).toContain('ENV HAPPYCLAW_CHROMIUM_CDP_HOST=127.0.0.1');
+    expect(dockerfile).toContain('ENV HAPPYCLAW_CHROMIUM_CDP_PORT=9222');
+    expect(dockerfile).toContain('ENV AGENT_BROWSER_CDP=9222');
+
+    expect(entrypoint).toContain(
+      '--remote-debugging-address="$HAPPYCLAW_CHROMIUM_CDP_HOST"',
+    );
+    expect(entrypoint).toContain(
+      '--remote-debugging-port="$HAPPYCLAW_CHROMIUM_CDP_PORT"',
+    );
+    expect(entrypoint).toContain(
+      'export AGENT_BROWSER_CDP="$HAPPYCLAW_CHROMIUM_CDP_PORT"',
+    );
+  });
+
+  test('waits for the real HTTP endpoint and cleans up the managed browser', () => {
+    expect(entrypoint).toContain('/json/version');
+    expect(entrypoint).toContain('kill "$CHROMIUM_PID"');
+    expect(entrypoint).toContain('wait "$CHROMIUM_PID"');
+  });
+
+  test('does not expose the privileged raw CDP port to the host', () => {
+    expect(dockerfile).not.toMatch(/^EXPOSE\s+9222$/m);
+    expect(containerRunner).not.toMatch(
+      /(?:--publish|-p)\s*(?:["'`])?9222:9222/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- start one headless Chromium instance per task container on container-local CDP port 9222
- make agent-browser attach to that managed browser via AGENT_BROWSER_CDP
- wait for the real /json/version endpoint and clean up Chromium on exit
- keep raw CDP private: no EXPOSE and no host port publish

## Validation
- bash -n container/entrypoint.sh
- npm test -- --run tests/chromium-cdp-entrypoint-contract.test.ts tests/docker-publish-workflow-contract.test.ts
- real HTTP GET http://127.0.0.1:19222/json/version against an equivalent local launch
- agent-browser attached over CDP, opened https://example.com, and returned the expected title/URL
- agent-browser Dashboard returned HTTP 200 on a test port