### PR TITLE
feat(provider): add first-class MiniMax provider preset

### DIFF
--- a/web/src/components/settings/ProviderEditor.tsx
+++ b/web/src/components/settings/ProviderEditor.tsx
@@ -27,11 +27,20 @@ import {
   buildProviderModel,
   parseProviderModel,
 } from '../../utils/provider-model';
+import {
+  PROVIDER_PRESETS,
+  getPresetEndpoint,
+  getPresetModel,
+  providerPresetRegionLabel,
+  type ProviderPreset,
+  type ProviderPresetRegion,
+} from '../../utils/provider-presets';
 import type { ProviderWithHealth, EnvRow } from './types';
 import { getErrorMessage } from './types';
 
 type ProviderType = 'official' | 'third_party';
 type OfficialAuthTab = 'oauth' | 'setup_token' | 'api_key';
+type PresetSelection = ProviderPreset | 'custom';
 
 const RESERVED_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
@@ -124,6 +133,13 @@ export function ProviderEditor({
   const [oneMillionContext, setOneMillionContext] = useState(false);
   const [weight, setWeight] = useState(1);
 
+  // 预设选择（仅第三方创建模式）
+  const [presetSelection, setPresetSelection] =
+    useState<PresetSelection>('custom');
+  const [presetRegion, setPresetRegion] = useState<ProviderPresetRegion | null>(
+    null,
+  );
+
   // 官方认证
   const [authTab, setAuthTab] = useState<OfficialAuthTab>('oauth');
   const [setupToken, setSetupToken] = useState('');
@@ -166,6 +182,8 @@ export function ProviderEditor({
       setModel('');
       setOneMillionContext(false);
       setWeight(1);
+      setPresetSelection('custom');
+      setPresetRegion(null);
       setAuthTab('oauth');
       setSetupToken('');
       setApiKey('');
@@ -184,6 +202,8 @@ export function ProviderEditor({
       setModel(modelSelection.model);
       setOneMillionContext(modelSelection.oneMillionContext);
       setWeight(provider.weight);
+      setPresetSelection('custom');
+      setPresetRegion(null);
       setAuthTab('oauth');
       setSetupToken('');
       setApiKey('');
@@ -231,6 +251,44 @@ export function ProviderEditor({
     setCustomEnvRows((prev) =>
       prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)),
     );
+
+  // Apply a preset's default region, endpoint, and model to the editable
+  // fields. Every filled value remains editable, so a preset is only a
+  // convenience for the manually typed endpoint + single model flow.
+  const applyPreset = useCallback(
+    (preset: ProviderPreset) => {
+      const region = presetRegion ?? preset.defaultRegion;
+      const endpoint = getPresetEndpoint(preset, region);
+      setBaseUrl(endpoint.anthropicBaseUrl);
+      const presetModel = getPresetModel(preset, preset.defaultModelId);
+      setModel(presetModel.modelId);
+      setOneMillionContext(presetModel.oneMillionContext);
+      setName((current) => current.trim() || preset.name);
+      setPresetRegion(region);
+    },
+    [presetRegion],
+  );
+
+  const handlePresetChange = useCallback(
+    (selection: PresetSelection) => {
+      setPresetSelection(selection);
+      if (selection !== 'custom') {
+        applyPreset(selection);
+      }
+    },
+    [applyPreset],
+  );
+
+  const handlePresetRegionChange = useCallback(
+    (region: ProviderPresetRegion) => {
+      setPresetRegion(region);
+      if (presetSelection !== 'custom') {
+        const endpoint = getPresetEndpoint(presetSelection, region);
+        setBaseUrl(endpoint.anthropicBaseUrl);
+      }
+    },
+    [presetSelection],
+  );
 
   const updateProviderEnv = (
     key: string,
@@ -305,6 +363,12 @@ export function ProviderEditor({
 
   // ─── 保存 ──────────────────────────────────────────────────
   const handleSave = async () => {
+    // Switching the provider type away from a preset resets the preset
+    // selection so the create-time preset UI does not leak into official mode.
+    if (providerType !== 'third_party' && presetSelection !== 'custom') {
+      setPresetSelection('custom');
+      setPresetRegion(null);
+    }
     const normalizedModel =
       providerType === 'third_party'
         ? buildProviderModel(model, oneMillionContext)
@@ -563,6 +627,86 @@ export function ProviderEditor({
                   第三方
                 </button>
               </div>
+            </div>
+          )}
+
+          {/* ─── 第三方预设选择（仅创建模式） ─── */}
+          {isCreate && providerType === 'third_party' && (
+            <div className="space-y-3 rounded-xl border border-border/80 bg-muted/30 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <label className="text-xs font-medium text-foreground">
+                  预设提供商
+                </label>
+                <span className="text-[11px] text-muted-foreground">
+                  选择后自动填充端点与模型
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  aria-pressed={presetSelection === 'custom'}
+                  onClick={() => handlePresetChange('custom')}
+                  className={`min-h-8 rounded-md px-3 py-1 text-xs transition-colors cursor-pointer ${
+                    presetSelection === 'custom'
+                      ? 'bg-background text-primary shadow-sm'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  自定义
+                </button>
+                {PROVIDER_PRESETS.map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    aria-pressed={presetSelection === preset}
+                    onClick={() => handlePresetChange(preset)}
+                    className={`min-h-8 rounded-md px-3 py-1 text-xs transition-colors cursor-pointer ${
+                      presetSelection === preset
+                        ? 'bg-background text-primary shadow-sm'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {preset.name}
+                  </button>
+                ))}
+              </div>
+              {presetSelection !== 'custom' && (
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-[11px] text-muted-foreground">
+                    区域：
+                  </span>
+                  {presetSelection.endpoints.map((endpoint) => (
+                    <button
+                      key={endpoint.region}
+                      type="button"
+                      aria-pressed={presetRegion === endpoint.region}
+                      onClick={() => handlePresetRegionChange(endpoint.region)}
+                      className={`min-h-7 rounded-md px-2.5 py-0.5 text-[11px] transition-colors cursor-pointer ${
+                        (presetRegion ?? presetSelection.defaultRegion) ===
+                        endpoint.region
+                          ? 'bg-background text-primary shadow-sm'
+                          : 'text-muted-foreground'
+                      }`}
+                    >
+                      {providerPresetRegionLabel(endpoint.region)}
+                    </button>
+                  ))}
+                  <a
+                    href={
+                      getPresetEndpoint(
+                        presetSelection,
+                        presetRegion ?? presetSelection.defaultRegion,
+                      ).docsRoot
+                    }
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-1 inline-flex items-center gap-0.5 text-[11px] text-teal-600 underline"
+                  >
+                    <ExternalLink className="size-3" />
+                    文档
+                  </a>
+                </div>
+              )}
             </div>
           )}
 
@@ -857,14 +1001,40 @@ export function ProviderEditor({
                       ANTHROPIC_MODEL
                     </span>
                   </label>
-                  <Input
-                    type="text"
-                    value={model}
-                    onChange={(e) => setModel(e.target.value)}
-                    disabled={saving}
-                    placeholder="例如 glm-5.2、k3、qwen3.7-max"
-                    autoComplete="off"
-                  />
+                  {presetSelection !== 'custom' ? (
+                    <select
+                      value={model}
+                      onChange={(e) => {
+                        setModel(e.target.value);
+                        const presetModel = getPresetModel(
+                          presetSelection,
+                          e.target.value,
+                        );
+                        setOneMillionContext(presetModel.oneMillionContext);
+                      }}
+                      disabled={saving}
+                      className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    >
+                      {presetSelection.models.map((presetModel) => (
+                        <option
+                          key={presetModel.modelId}
+                          value={presetModel.modelId}
+                        >
+                          {presetModel.modelId}
+                          {presetModel.oneMillionContext ? ' (1M)' : ''}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <Input
+                      type="text"
+                      value={model}
+                      onChange={(e) => setModel(e.target.value)}
+                      disabled={saving}
+                      placeholder="例如 glm-5.2、k3、qwen3.7-max"
+                      autoComplete="off"
+                    />
+                  )}
                 </div>
 
                 <div className="flex min-h-16 items-center justify-between gap-3 rounded-xl border border-border/80 bg-muted/35 px-3.5 py-2.5">

--- a/web/src/utils/provider-presets.test.ts
+++ b/web/src/utils/provider-presets.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  PROVIDER_PRESETS,
+  findProviderPreset,
+  getPresetEndpoint,
+  getPresetModel,
+  providerPresetRegionLabel,
+} from './provider-presets';
+
+describe('provider presets', () => {
+  test('exposes a first-class MiniMax preset', () => {
+    const minimax = findProviderPreset('minimax');
+    expect(minimax).toBeDefined();
+    expect(minimax!.name).toBe('MiniMax');
+  });
+
+  test('covers both current models', () => {
+    const minimax = findProviderPreset('minimax')!;
+    expect(minimax.models.map((m) => m.modelId)).toEqual([
+      'MiniMax-M3',
+      'MiniMax-M2.7',
+    ]);
+    expect(
+      minimax.models.find((m) => m.modelId === 'MiniMax-M3')!.oneMillionContext,
+    ).toBe(true);
+    expect(
+      minimax.models.find((m) => m.modelId === 'MiniMax-M2.7')!
+        .oneMillionContext,
+    ).toBe(false);
+  });
+
+  test('covers the global and China endpoint families', () => {
+    const minimax = findProviderPreset('minimax')!;
+    const regions = minimax.endpoints.map((e) => e.region);
+    expect(regions).toEqual(['global_en', 'cn_zh']);
+
+    const globalEn = getPresetEndpoint(minimax, 'global_en');
+    expect(globalEn.anthropicBaseUrl).toBe('https://api.minimax.io/anthropic');
+    expect(globalEn.openaiBaseUrl).toBe('https://api.minimax.io/v1');
+
+    const cnZh = getPresetEndpoint(minimax, 'cn_zh');
+    expect(cnZh.anthropicBaseUrl).toBe('https://api.minimaxi.com/anthropic');
+    expect(cnZh.openaiBaseUrl).toBe('https://api.minimaxi.com/v1');
+  });
+
+  test('resolves the default model and falls back when unknown', () => {
+    const minimax = findProviderPreset('minimax')!;
+    expect(getPresetModel(minimax, 'MiniMax-M2.7').modelId).toBe(
+      'MiniMax-M2.7',
+    );
+    expect(getPresetModel(minimax, 'unknown').modelId).toBe(
+      minimax.defaultModelId,
+    );
+  });
+
+  test('labels regions readably', () => {
+    expect(providerPresetRegionLabel('global_en')).toBe('Global');
+    expect(providerPresetRegionLabel('cn_zh')).toBe('China');
+  });
+
+  test('every preset exposes the Anthropic-compatible base URL it injects at runtime', () => {
+    for (const preset of PROVIDER_PRESETS) {
+      for (const endpoint of preset.endpoints) {
+        expect(endpoint.anthropicBaseUrl).toMatch(/^https?:\/\//);
+      }
+    }
+  });
+});

--- a/web/src/utils/provider-presets.ts
+++ b/web/src/utils/provider-presets.ts
@@ -1,0 +1,108 @@
+/**
+ * Provider presets — first-class configuration templates for known
+ * Anthropic-compatible providers.
+ *
+ * A preset captures a provider's current models and regional endpoint
+ * families so the provider editor can prefill a provider instead of
+ * requiring a manually typed endpoint and model name. Selecting a preset
+ * only fills in the editable fields; every value stays user-editable.
+ *
+ * The agent runtime speaks the Anthropic-compatible protocol
+ * (ANTHROPIC_BASE_URL), so the Anthropic-compatible base URL is the value
+ * injected at runtime. The OpenAI-compatible base URL is recorded per
+ * region for reference so the full endpoint family is documented in one
+ * place.
+ */
+
+export type ProviderPresetRegion = 'global_en' | 'cn_zh';
+
+export interface ProviderPresetEndpoint {
+  region: ProviderPresetRegion;
+  /** Anthropic-compatible base URL (ANTHROPIC_BASE_URL), used at runtime. */
+  anthropicBaseUrl: string;
+  /** OpenAI-compatible base URL, recorded for reference. */
+  openaiBaseUrl: string;
+  /** Documentation root for this region. */
+  docsRoot: string;
+}
+
+export interface ProviderPresetModel {
+  modelId: string;
+  /** Whether the model ships a one-million-token context window. */
+  oneMillionContext: boolean;
+}
+
+export interface ProviderPreset {
+  id: string;
+  name: string;
+  /** Models currently offered by the provider. */
+  models: ProviderPresetModel[];
+  /** Regional endpoint families. */
+  endpoints: ProviderPresetEndpoint[];
+  /** Region selected by default. */
+  defaultRegion: ProviderPresetRegion;
+  /** Model selected by default. */
+  defaultModelId: string;
+}
+
+export const PROVIDER_PRESETS: ProviderPreset[] = [
+  {
+    id: 'minimax',
+    name: 'MiniMax',
+    models: [
+      { modelId: 'MiniMax-M3', oneMillionContext: true },
+      { modelId: 'MiniMax-M2.7', oneMillionContext: false },
+    ],
+    endpoints: [
+      {
+        region: 'global_en',
+        anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+        openaiBaseUrl: 'https://api.minimax.io/v1',
+        docsRoot: 'https://platform.minimax.io/docs',
+      },
+      {
+        region: 'cn_zh',
+        anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+        openaiBaseUrl: 'https://api.minimaxi.com/v1',
+        docsRoot: 'https://platform.minimaxi.com/docs',
+      },
+    ],
+    defaultRegion: 'global_en',
+    defaultModelId: 'MiniMax-M3',
+  },
+];
+
+/** Human-readable label for a preset region. */
+export function providerPresetRegionLabel(
+  region: ProviderPresetRegion,
+): string {
+  return region === 'global_en' ? 'Global' : 'China';
+}
+
+/** Look up a preset by id. */
+export function findProviderPreset(id: string): ProviderPreset | undefined {
+  return PROVIDER_PRESETS.find((preset) => preset.id === id);
+}
+
+/** Resolve the endpoint for a region, falling back to the first endpoint. */
+export function getPresetEndpoint(
+  preset: ProviderPreset,
+  region: ProviderPresetRegion,
+): ProviderPresetEndpoint {
+  return (
+    preset.endpoints.find((endpoint) => endpoint.region === region) ??
+    preset.endpoints[0]
+  );
+}
+
+/** Resolve a model by id, falling back to the default model. */
+export function getPresetModel(
+  preset: ProviderPreset,
+  modelId: string,
+): ProviderPresetModel {
+  return (
+    preset.models.find((model) => model.modelId === modelId) ??
+    preset.models.find((model) => model.modelId === preset.defaultModelId) ??
+    preset.models[0]
+  );
+}


### PR DESCRIPTION
Reason: Add first-class MiniMax provider configuration for both current models and both regional endpoint families.

## Changes

- Add `web/src/utils/provider-presets.ts`, a small preset registry describing known Anthropic-compatible providers. Each preset records the provider's current models (with their one-million-token context flag) and the regional endpoint families it serves. The Anthropic-compatible base URL is the value injected at runtime via `ANTHROPIC_BASE_URL`; the OpenAI-compatible base URL is recorded per region for reference.
- The first preset is **MiniMax**, covering both current models (`MiniMax-M3` with a one-million-token context, `MiniMax-M2.7`) and both regional endpoint families (Global: `https://api.minimax.io/anthropic`, China: `https://api.minimaxi.com/anthropic`).
- Extend the third-party provider editor (`web/src/components/settings/ProviderEditor.tsx`) with a preset selector shown only in create mode. Selecting a preset prefills the endpoint, model, 1M-context flag, and name; switching the region updates the endpoint. Every prefilled value stays editable, so the existing manual third-party flow is preserved. Selecting a preset also renders the model field as a dropdown of the preset's current models.
- Add `web/src/utils/provider-presets.test.ts` covering the MiniMax preset's models, both regional endpoints, default-model resolution, and region labels.

## Checks

- `node scripts/check-format-changed.mjs` (Prettier) — clean.
- `node scripts/check-docs.mjs` — passed.
- `tsc --noEmit -p web/tsconfig.json` — no type errors.
- `vitest run tests/provider-model-settings.test.ts web/src/utils/provider-presets.test.ts web/src/utils/chat-route-preload.test.ts` — 27 passed.
