### PR TITLE
ci: build images on native architecture runners

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,56 +12,42 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  IMAGE_NAME: riba2534/happyclaw-agent
-  DOCKER_METADATA_SHORT_SHA_LENGTH: 40
-
 jobs:
   publish:
-    name: Build and publish multi-platform image
-    runs-on: ubuntu-24.04
-    timeout-minutes: 180
-    steps:
-      - name: Check out source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
+    name: Build and publish on native runners
+    uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7 # v1
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      distribute: true
+      setup-qemu: false
+      runner: |
+        default=ubuntu-24.04
+        linux/amd64=ubuntu-24.04
+        linux/arm64=ubuntu-24.04-arm
+      context: ./container
+      file: ./container/Dockerfile
+      build-args: |
+        TOOL_REFRESH=${{ github.sha }}
+      cache: true
+      cache-scope: happyclaw-agent
+      cache-mode: max
+      sbom: true
+      sign: auto
+      set-meta-labels: true
+      meta-images: riba2534/happyclaw-agent
+      meta-tags: |
+        type=raw,value=latest
+        type=sha,format=long,prefix=git-
+      meta-labels: |
+        org.opencontainers.image.title=HappyClaw Agent
+        org.opencontainers.image.description=Isolated multi-platform agent runtime for HappyClaw
+    secrets:
+      registry-auths: |
+        - registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Generate image metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha,format=long,prefix=git-
-          labels: |
-            org.opencontainers.image.title=HappyClaw Agent
-            org.opencontainers.image.description=Isolated multi-platform agent runtime for HappyClaw
-
-      - name: Build and push image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: ./container
-          file: ./container/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          pull: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            TOOL_REFRESH=${{ github.sha }}
-          cache-from: type=gha,scope=happyclaw-agent
-          cache-to: type=gha,mode=max,scope=happyclaw-agent
-          provenance: mode=max
-          sbom: true

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ make dev
 | `make help`                                     | 查看完整命令列表                                      |
 
 `main` 分支每次推送都会重新构建并发布
-`riba2534/happyclaw-agent:latest`（amd64/arm64）。镜像构建时会解析 Claude Code、
-Claude Agent SDK、agent-browser、feishu-cli、uv 和 Headroom 的最新稳定版；
+`riba2534/happyclaw-agent:latest`（amd64/arm64）。两个架构会分别在 GitHub
+原生 x64 与 ARM64 Hosted Runner 上并行构建，不使用 QEMU 模拟。镜像构建时会解析
+Claude Code、Claude Agent SDK、agent-browser、feishu-cli、uv 和 Headroom 的最新稳定版；
 实际安装版本记录在镜像内的
 `/usr/local/share/happyclaw-tool-versions.txt`，需要回滚时也可以通过 Docker
 build args 指定精确版本。

--- a/tests/docker-publish-workflow-contract.test.ts
+++ b/tests/docker-publish-workflow-contract.test.ts
@@ -6,31 +6,29 @@ const root = process.cwd();
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 
 describe('Docker image distribution contract', () => {
-  test('main pushes publish a pinned multi-platform latest image', () => {
+  test('main pushes publish from pinned native multi-platform runners', () => {
     const workflow = read('.github/workflows/docker-publish.yml');
 
     expect(workflow).toContain('branches: [main]');
-    expect(workflow).toContain('IMAGE_NAME: riba2534/happyclaw-agent');
+    expect(workflow).toContain(
+      'uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7',
+    );
+    expect(workflow).toContain('meta-images: riba2534/happyclaw-agent');
     expect(workflow).toContain('type=raw,value=latest');
     expect(workflow).toContain('type=sha,format=long,prefix=git-');
     expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
+    expect(workflow).toContain('distribute: true');
+    expect(workflow).toContain('setup-qemu: false');
+    expect(workflow).toContain('linux/amd64=ubuntu-24.04');
+    expect(workflow).toContain('linux/arm64=ubuntu-24.04-arm');
     expect(workflow).toContain('TOOL_REFRESH=${{ github.sha }}');
     expect(workflow).toContain('username: ${{ secrets.DOCKERHUB_USERNAME }}');
     expect(workflow).toContain('password: ${{ secrets.DOCKERHUB_TOKEN }}');
     expect(workflow).not.toContain(`${['dckr', 'pat'].join('_')}_`);
-
-    for (const action of [
-      'actions/checkout',
-      'docker/setup-qemu-action',
-      'docker/setup-buildx-action',
-      'docker/login-action',
-      'docker/metadata-action',
-      'docker/build-push-action',
-    ]) {
-      expect(workflow).toMatch(
-        new RegExp(`uses: ${action.replace('/', '\\/')}@[a-f0-9]{40}(?:\\s|$)`),
-      );
-    }
+    expect(workflow).not.toContain('docker/setup-qemu-action');
+    expect(workflow).toMatch(
+      /uses: docker\/github-builder\/\.github\/workflows\/build\.yml@[a-f0-9]{40}(?:\s|$)/,
+    );
   });
 
   test('runtime defaults to the remotely published image', () => {


### PR DESCRIPTION
## What changed

- replaced the single amd64 + QEMU multi-platform job with Docker's official GitHub Builder reusable workflow
- pinned the reusable workflow to commit `27ade872c1e2296e62ef15ab3b10d37665e57cf7`
- route `linux/amd64` to `ubuntu-24.04` and `linux/arm64` to the native `ubuntu-24.04-arm` hosted runner
- build both architectures concurrently, then publish one `latest` and one full-SHA multi-platform manifest
- preserve SBOM generation, signed provenance, Docker Hub authentication, and architecture-scoped GitHub Actions cache

## Why

The previous ARM64 build ran through QEMU on an amd64 runner. In the last production run, ARM64 apt installation took 446.6 seconds versus 58.7 seconds on amd64; Headroom installation took 206.2 seconds versus 26.7 seconds. Native ARM64 removes that emulation bottleneck.

## User impact

`main` continues publishing `riba2534/happyclaw-agent:latest` for amd64 and arm64, but the two images are now built on their native architectures in parallel.

## Validation

- parsed `.github/workflows/docker-publish.yml` with the repository's YAML dependency
- `npm test -- --run tests/docker-publish-workflow-contract.test.ts tests/reproducible-build-contract.test.ts`
- `npm run format:check -- --base=origin/main`
- `git diff --check`