### PR TITLE
fix(ci): resolve Dockerfile within native build context

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
         linux/amd64=ubuntu-24.04
         linux/arm64=ubuntu-24.04-arm
       context: ./container
-      file: ./container/Dockerfile
+      file: ./Dockerfile
       build-args: |
         TOOL_REFRESH=${{ github.sha }}
       cache: true

--- a/tests/docker-publish-workflow-contract.test.ts
+++ b/tests/docker-publish-workflow-contract.test.ts
@@ -21,6 +21,9 @@ describe('Docker image distribution contract', () => {
     expect(workflow).toContain('setup-qemu: false');
     expect(workflow).toContain('linux/amd64=ubuntu-24.04');
     expect(workflow).toContain('linux/arm64=ubuntu-24.04-arm');
+    expect(workflow).toContain('context: ./container');
+    expect(workflow).toContain('file: ./Dockerfile');
+    expect(workflow).not.toContain('file: ./container/Dockerfile');
     expect(workflow).toContain('TOOL_REFRESH=${{ github.sha }}');
     expect(workflow).toContain('username: ${{ secrets.DOCKERHUB_USERNAME }}');
     expect(workflow).toContain('password: ${{ secrets.DOCKERHUB_TOKEN }}');


### PR DESCRIPTION
## Summary
- resolve the Dockerfile relative to the reusable builder's `./container` Git context
- add a workflow contract assertion so the duplicated `container/container` path cannot regress

## Root cause
The native jobs were scheduled correctly, but BuildKit received a Git context with `subdir=./container` and then tried to open `./container/Dockerfile` inside that context.

## Validation
- `pnpm exec vitest run tests/docker-publish-workflow-contract.test.ts`
- Prettier check
- workflow YAML parse
- `git diff --check`