### PR TITLE
fix(tasks): persist workspace results and harden image release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,42 +12,170 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  IMAGE_NAME: riba2534/happyclaw-agent
+
 jobs:
-  publish:
-    name: Build and publish on native runners
-    uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7 # v1
+  build-and-smoke:
+    name: Build and smoke (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # docker/github-builder finalizes image tags in its reusable workflow.
+      # Build by digest here so no user-facing tag can move before both native
+      # runners have started their image and passed the real CDP HTTP probe.
+      - name: Build and push untagged candidate
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: ./container
+          file: ./container/Dockerfile
+          platforms: ${{ matrix.platform }}
+          pull: true
+          build-args: |
+            TOOL_REFRESH=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=happyclaw-agent-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=happyclaw-agent-${{ matrix.arch }}
+          sbom: true
+          provenance: mode=max
+          labels: |
+            org.opencontainers.image.title=HappyClaw Agent
+            org.opencontainers.image.description=Isolated multi-platform agent runtime for HappyClaw
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Start candidate and probe Chromium over HTTP
+        env:
+          IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: ./scripts/smoke-agent-image.sh "$IMAGE_REF" "${{ matrix.arch }}"
+
+      - name: Record verified digest
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]
+          mkdir -p /tmp/happyclaw-digests
+          touch "/tmp/happyclaw-digests/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload verified digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/happyclaw-digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  promote:
+    name: Promote verified multi-platform image
+    needs: build-and-smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
-    with:
-      output: image
-      push: true
-      platforms: linux/amd64,linux/arm64
-      distribute: true
-      setup-qemu: false
-      runner: |
-        default=ubuntu-24.04
-        linux/amd64=ubuntu-24.04
-        linux/arm64=ubuntu-24.04-arm
-      context: ./container
-      file: ./Dockerfile
-      build-args: |
-        TOOL_REFRESH=${{ github.sha }}
-      cache: true
-      cache-scope: happyclaw-agent
-      cache-mode: max
-      sbom: true
-      sign: auto
-      set-meta-labels: true
-      meta-images: riba2534/happyclaw-agent
-      meta-tags: |
-        type=raw,value=latest
-        type=sha,format=long,prefix=git-
-      meta-labels: |
-        org.opencontainers.image.title=HappyClaw Agent
-        org.opencontainers.image.description=Isolated multi-platform agent runtime for HappyClaw
-    secrets:
-      registry-auths: |
-        - registry: docker.io
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download verified digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: digests-*
+          path: /tmp/happyclaw-digests
+          merge-multiple: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
+
+      - name: Create and sign verified commit manifest
+        id: manifest
+        run: |
+          set -euo pipefail
+          mapfile -t digest_files < <(find /tmp/happyclaw-digests -maxdepth 1 -type f -printf '%f\n' | sort)
+          if [ "${#digest_files[@]}" -ne 2 ]; then
+            echo "Expected two verified platform digests, found ${#digest_files[@]}" >&2
+            exit 1
+          fi
+
+          sources=()
+          for digest in "${digest_files[@]}"; do
+            if [[ ! "$digest" =~ ^[a-f0-9]{64}$ ]]; then
+              echo "Invalid digest artifact: $digest" >&2
+              exit 1
+            fi
+            sources+=("${IMAGE_NAME}@sha256:${digest}")
+          done
+
+          commit_tag="${IMAGE_NAME}:git-${GITHUB_SHA}"
+          docker buildx imagetools create --tag "$commit_tag" "${sources[@]}"
+          inspection="$(docker buildx imagetools inspect "$commit_tag")"
+          printf '%s\n' "$inspection"
+
+          raw_manifest="$(docker buildx imagetools inspect --raw "$commit_tag")"
+          jq -e '
+            [
+              .manifests[] |
+              select(
+                (.platform.os // "unknown") != "unknown" and
+                (.platform.architecture // "unknown") != "unknown"
+              ) |
+              "\(.platform.os)/\(.platform.architecture)"
+            ] as $platforms |
+            ($platforms | length) == 2 and
+            (($platforms | sort) == ["linux/amd64", "linux/arm64"])
+          ' <<<"$raw_manifest" >/dev/null
+
+          manifest_digest="$(awk '$1 == "Digest:" { print $2; exit }' <<<"$inspection")"
+          [[ "$manifest_digest" =~ ^sha256:[a-f0-9]{64}$ ]]
+          cosign sign --yes "${IMAGE_NAME}@${manifest_digest}"
+          certificate_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/docker-publish.yml@${GITHUB_REF}"
+          cosign verify \
+            --certificate-identity "$certificate_identity" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${IMAGE_NAME}@${manifest_digest}" >/dev/null
+          echo "digest=$manifest_digest" >>"$GITHUB_OUTPUT"
+
+      - name: Promote signed manifest to latest
+        env:
+          MANIFEST_DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:latest" \
+            "${IMAGE_NAME}@${MANIFEST_DIGEST}"
+          latest_digest="$(
+            docker buildx imagetools inspect "${IMAGE_NAME}:latest" |
+              awk '$1 == "Digest:" { print $2; exit }'
+          )"
+          test "$latest_digest" = "$MANIFEST_DIGEST"
+          echo "Published ${IMAGE_NAME}:latest at ${MANIFEST_DIGEST}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-backend dev-web build build-backend build-web start \
+.PHONY: dev dev-local dev-backend dev-web build build-backend build-web start start-local \
        typecheck typecheck-backend typecheck-web typecheck-agent-runner \
        format format-check install install-host-tools clean reset-init update-sdk ensure-latest-sdk sync-types \
        backup restore help _ensure-docker-image docker-build-local logs status stop \
@@ -17,6 +17,8 @@ RUNNER  := npx tsx src/index.ts
 RUNTIME_DATA_DIR ?= data
 BACKUP_DIR ?= .
 CONTAINER_IMAGE ?= riba2534/happyclaw-agent:latest
+LOCAL_CONTAINER_IMAGE ?= happyclaw-agent:local
+CONTAINER_IMAGE_PULL ?= always
 export CONTAINER_IMAGE
 
 # ─── Development ─────────────────────────────────────────────
@@ -28,6 +30,11 @@ dev: ## 启动前后端（首次自动安装依赖并拉取容器镜像）
 	@$(PKG) --prefix container/agent-runner run build --silent 2>/dev/null || $(PKG) --prefix container/agent-runner run build
 	@echo "🚀 使用 $(PKG) 启动..."
 	$(PKG) run dev:all
+
+dev-local: ## 使用本机构建的 Agent 镜像启动开发环境（不拉取远端镜像）
+	@$(MAKE) dev \
+	  CONTAINER_IMAGE="$(LOCAL_CONTAINER_IMAGE)" \
+	  CONTAINER_IMAGE_PULL=never
 
 dev-backend: ## 仅启动后端（tsx 直跑 TS）
 	$(RUNNER)
@@ -67,6 +74,11 @@ start: ## 一键启动生产环境（前台阻塞运行）
 	@$(MAKE) _build-ar-if-stale
 	@echo "🟢 Node 模式：运行编译后的 dist/index.js（本项目不使用 bun，WebSocket 需要 node）"
 	node dist/index.js
+
+start-local: ## 使用本机构建的 Agent 镜像启动生产环境（不拉取远端镜像）
+	@$(MAKE) start \
+	  CONTAINER_IMAGE="$(LOCAL_CONTAINER_IMAGE)" \
+	  CONTAINER_IMAGE_PULL=never
 
 # ─── Internal build checks ────────────────────────────────────
 
@@ -172,21 +184,38 @@ format-check: ## 检查代码格式
 
 # ─── Docker Image ─────────────────────────────────────────────
 
-_ensure-docker-image: ## (内部) 拉取远端镜像；网络不可用时回退到本地缓存
+_ensure-docker-image: ## (内部) 按 CONTAINER_IMAGE_PULL 策略准备容器镜像
 	@if command -v docker >/dev/null 2>&1; then \
-	  echo "🐳 拉取 Docker 镜像 $(CONTAINER_IMAGE)..."; \
-	  if docker pull "$(CONTAINER_IMAGE)"; then \
-	    echo "✅ Docker 镜像已就绪：$(CONTAINER_IMAGE)"; \
-	  elif docker image inspect "$(CONTAINER_IMAGE)" >/dev/null 2>&1; then \
-	    echo "⚠️  无法拉取远端镜像，继续使用本地缓存：$(CONTAINER_IMAGE)"; \
-	  else \
-	    echo "❌ 无法拉取且本地没有镜像：$(CONTAINER_IMAGE)"; \
-	    exit 1; \
-	  fi; \
+	  case "$(CONTAINER_IMAGE_PULL)" in \
+	    always) \
+	      echo "🐳 拉取 Docker 镜像 $(CONTAINER_IMAGE)..."; \
+	      if docker pull "$(CONTAINER_IMAGE)"; then \
+	        echo "✅ Docker 镜像已就绪：$(CONTAINER_IMAGE)"; \
+	      elif docker image inspect "$(CONTAINER_IMAGE)" >/dev/null 2>&1; then \
+	        echo "⚠️  无法拉取远端镜像，继续使用本地缓存：$(CONTAINER_IMAGE)"; \
+	      else \
+	        echo "❌ 无法拉取且本地没有镜像：$(CONTAINER_IMAGE)"; \
+	        exit 1; \
+	      fi \
+	      ;; \
+	    never) \
+	      if docker image inspect "$(CONTAINER_IMAGE)" >/dev/null 2>&1; then \
+	        echo "✅ 使用本地 Docker 镜像（不拉取）：$(CONTAINER_IMAGE)"; \
+	      else \
+	        echo "❌ 本地镜像不存在：$(CONTAINER_IMAGE)"; \
+	        echo "   请先运行 make docker-build-local，或改用 make dev / make start。"; \
+	        exit 1; \
+	      fi \
+	      ;; \
+	    *) \
+	      echo "❌ CONTAINER_IMAGE_PULL 仅支持 always 或 never，当前值：$(CONTAINER_IMAGE_PULL)"; \
+	      exit 1 \
+	      ;; \
+	  esac; \
 	fi
 
-docker-build-local: ## 显式在本机为 CONTAINER_IMAGE 构建 Agent 镜像
-	./container/build.sh "$(CONTAINER_IMAGE)"
+docker-build-local: ## 构建独立的本地 Agent 镜像（默认 happyclaw-agent:local）
+	./container/build.sh "$(LOCAL_CONTAINER_IMAGE)"
 
 # ─── Shared Types ────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ REST 接口和状态字段见 [API 文档](docs/API.md#任务)。
 ### 环境要求
 
 - macOS 或 Linux；Windows 推荐使用 WSL2。
-- [Node.js](https://nodejs.org/) 20 或更高版本，推荐使用 CI 同款 Node.js 22。
+- [Node.js](https://nodejs.org/) 20 或更高版本，推荐使用 CI 同款 Node.js 24。
 - npm 与 GNU Make。
 - [Docker](https://www.docker.com/)：普通成员和 Container 工作区需要；仅使用管理员 Host 工作区时可不安装。
 
@@ -256,20 +256,30 @@ make dev
 | 命令                                            | 说明                                                  |
 | ----------------------------------------------- | ----------------------------------------------------- |
 | `make start`                                    | 构建必要产物并以前台生产模式启动                      |
+| `make start-local`                              | 使用本地 Agent 镜像启动生产环境且不拉取远端镜像       |
 | `WEB_PORT=8080 make start`                      | 使用自定义端口启动                                    |
 | `make status`                                   | 查看端口、健康状态、日志文件和 Docker 容器            |
 | `make stop`                                     | 停止当前端口上的 HappyClaw 服务                       |
 | `make docker-build-local`                       | 开发时显式在本机重新构建 Agent 镜像                   |
+| `make dev-local`                                | 使用本地 Agent 镜像启动开发环境且不拉取远端镜像       |
 | `make install-host-tools`                       | 安装 Host 工具并刷新 Host/Container 共用的内置 Skills |
 | `make backup`                                   | 创建一致性运行数据备份                                |
 | `make restore FILE=happyclaw-backup-xxx.tar.gz` | 停止服务后恢复指定备份                                |
 | `make help`                                     | 查看完整命令列表                                      |
 
-`main` 分支每次推送都会重新构建并发布
-`riba2534/happyclaw-agent:latest`（amd64/arm64）。两个架构会分别在 GitHub
-原生 x64 与 ARM64 Hosted Runner 上并行构建，不使用 QEMU 模拟。镜像构建时会解析
-Claude Code、Claude Agent SDK、agent-browser、feishu-cli、uv 和 Headroom 的最新稳定版；
-实际安装版本记录在镜像内的
+`make docker-build-local` 默认构建独立标签 `happyclaw-agent:local`；随后使用
+`make dev-local` 或 `make start-local`，启动过程不会拉取远端镜像。普通的
+`make dev` 和 `make start` 仍会拉取 DockerHub 上的 `latest`，因此本地开发镜像
+不会被同名远端标签覆盖。可以通过 `LOCAL_CONTAINER_IMAGE=example:local`
+覆盖本地标签。
+
+`main` 分支每次推送都会重新构建
+`riba2534/happyclaw-agent`（amd64/arm64）。两个架构会分别在 GitHub 原生 x64
+与 ARM64 Hosted Runner 上并行构建，不使用 QEMU 模拟。每个 runner 先推送没有
+用户标签的 digest candidate，使用真实容器入口启动 Chromium，并通过 HTTP 请求
+`/json/version`；两边都验证通过后才合并、签名并提升 `git-<sha>` 和 `latest`
+manifest。镜像构建时会解析 Claude Code、Claude Agent SDK、agent-browser、
+feishu-cli、uv 和 Headroom 的最新稳定版；实际安装版本记录在镜像内的
 `/usr/local/share/happyclaw-tool-versions.txt`，需要回滚时也可以通过 Docker
 build args 指定精确版本。
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -90,8 +90,8 @@ RUN printf '%s\n' "$TOOL_REFRESH" > /etc/happyclaw-tool-refresh \
     # Symlink fd-find → fd (Debian names it fdfind)
     && ln -sf /usr/bin/fdfind /usr/local/bin/fd
 
-# Pull the newest stable multi-arch uv release. The publish workflow uses
-# `pull: true`, and TOOL_REFRESH prevents a stale cached COPY layer.
+# Pull the newest stable multi-arch uv release. CI and the local build helper
+# enable base-image pulling, and TOOL_REFRESH prevents a stale cached COPY layer.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 

--- a/container/build.sh
+++ b/container/build.sh
@@ -6,25 +6,28 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-IMAGE_REF="${1:-${CONTAINER_IMAGE:-riba2534/happyclaw-agent:latest}}"
+IMAGE_REF="${1:-${LOCAL_CONTAINER_IMAGE:-happyclaw-agent:local}}"
 
 echo "Building HappyClaw agent container image..."
 echo "Image: ${IMAGE_REF}"
 
-# Build with Docker. SDK/Claude Code and container tools are version-pinned;
-# do not inject a time-based cache bust because that defeats reproducibility.
+# Build with Docker. The committed application dependency graph remains
+# deterministic, while externally sourced runtime tools intentionally resolve
+# their newest stable versions unless exact build args are supplied.
+# --pull refreshes mutable base/tool stages without adding a time-based cache
+# bust to deterministic application layers.
 # --network=host: the build container otherwise gets Docker's default bridge DNS
 # (8.8.8.8), which is unreliable inside VPN/tunnel environments and breaks the
 # GitHub fetch in the feishu-cli step. Host networking reuses the host's working
 # DNS resolver. Override with BUILD_NETWORK=default if your environment differs.
 BUILD_NETWORK="${BUILD_NETWORK:-host}"
-if ! docker build --network="${BUILD_NETWORK}" -t "${IMAGE_REF}" .; then
+if ! docker build --pull --network="${BUILD_NETWORK}" -t "${IMAGE_REF}" .; then
   # Restricted/rootless BuildKit builders reject host networking (it's a gated
   # entitlement) instead of falling back. Retry once on the default bridge so
   # those environments still build — bridge DNS may need a working resolver.
   if [ "${BUILD_NETWORK}" = "host" ]; then
     echo "host-network build failed (restricted builder?); retrying with default bridge network..." >&2
-    docker build -t "${IMAGE_REF}" .
+    docker build --pull -t "${IMAGE_REF}" .
   else
     exit 1
   fi

--- a/scripts/smoke-agent-image.sh
+++ b/scripts/smoke-agent-image.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <image-reference> [expected-architecture]" >&2
+  exit 2
+fi
+
+IMAGE_REF="$1"
+EXPECTED_ARCHITECTURE="${2:-}"
+SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-120}"
+SMOKE_CONTAINER_NAME="${SMOKE_CONTAINER_NAME:-happyclaw-image-smoke-${GITHUB_RUN_ID:-local}-${RANDOM}}"
+
+# shellcheck disable=SC2317 # invoked indirectly by trap
+cleanup() {
+  docker rm -f "$SMOKE_CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# A digest reference is immutable. Prefer an already loaded local image for
+# developer use; CI's digest candidate is not loaded, so this performs a real
+# registry pull before the runtime probe.
+if ! docker image inspect "$IMAGE_REF" >/dev/null 2>&1; then
+  docker pull "$IMAGE_REF"
+fi
+
+if [ -n "$EXPECTED_ARCHITECTURE" ]; then
+  actual_architecture="$(
+    docker image inspect --format '{{.Architecture}}' "$IMAGE_REF"
+  )"
+  if [ "$actual_architecture" != "$EXPECTED_ARCHITECTURE" ]; then
+    echo "Expected $EXPECTED_ARCHITECTURE image, pulled $actual_architecture" >&2
+    exit 1
+  fi
+fi
+
+# -i keeps stdin open while detached. The production entrypoint starts Chromium
+# first and then waits for the task JSON on stdin, giving the probe a stable
+# window without bypassing any real startup behavior.
+docker run --detach --interactive \
+  --name "$SMOKE_CONTAINER_NAME" \
+  "$IMAGE_REF" >/dev/null
+
+for ((attempt = 1; attempt <= SMOKE_TIMEOUT_SECONDS; attempt++)); do
+  if ! docker inspect --format '{{.State.Running}}' "$SMOKE_CONTAINER_NAME" |
+    grep -qx true; then
+    echo "Container exited before Chromium became ready" >&2
+    docker logs "$SMOKE_CONTAINER_NAME" >&2 || true
+    exit 1
+  fi
+
+  if response="$(
+    docker exec "$SMOKE_CONTAINER_NAME" \
+      curl --noproxy '*' -fsS http://127.0.0.1:9222/json/version 2>/dev/null
+  )"; then
+    if jq -e '
+      type == "object" and
+      (.Browser | type == "string" and length > 0) and
+      (.webSocketDebuggerUrl | type == "string" and startswith("ws://"))
+    ' <<<"$response" >/dev/null; then
+      printf '%s\n' "$response" | jq .
+      echo "Chromium CDP HTTP smoke test passed for $IMAGE_REF"
+      exit 0
+    fi
+  fi
+
+  sleep 1
+done
+
+echo "Timed out waiting for Chromium CDP HTTP endpoint" >&2
+docker logs "$SMOKE_CONTAINER_NAME" >&2 || true
+exit 1

--- a/src/db.ts
+++ b/src/db.ts
@@ -5581,6 +5581,416 @@ export function completeTaskRun(
   })();
 }
 
+/**
+ * Atomically terminalize one fenced isolated execution and enqueue its
+ * canonical Web workspace result.
+ *
+ * The Agent may already have performed arbitrary tool side effects by this
+ * point, so persisting the execution terminal separately from the Web repair
+ * intent would create an avoidable replay window. The notification worker
+ * performs only the idempotent workspace projection; it never reruns Agent
+ * work or interprets Agent-owned tools such as feishu-cli.
+ */
+export function completeIsolatedTaskRunWithWorkspaceResultIntent(input: {
+  runId: string;
+  taskId: string;
+  leaseOwner: string;
+  leaseToken: number;
+  status: 'success' | 'failed';
+  result?: string | null;
+  error?: string | null;
+  payload: TaskRunTextNotificationPayload;
+}): boolean {
+  if (
+    input.payload.kind !== 'workspace_result' ||
+    input.payload.groupRunId ||
+    input.payload.groupTaskId ||
+    input.payload.options?.sourceKind !== 'scheduled_task_result' ||
+    input.payload.options.messageId !== `scheduled-task-result:${input.runId}`
+  ) {
+    return false;
+  }
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+  return db.transaction(() => {
+    const current = db
+      .prepare('SELECT * FROM task_runs WHERE id = ?')
+      .get(input.runId) as TaskRunRow | undefined;
+    if (
+      !current ||
+      current.task_id !== input.taskId ||
+      current.status !== 'running' ||
+      current.lease_owner !== input.leaseOwner ||
+      current.lease_token !== input.leaseToken
+    ) {
+      return false;
+    }
+
+    let currentPayload: TaskRunNotificationPayload | null = null;
+    let currentSummary: TaskRunNotificationSummary = {
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      failed_channels: [],
+    };
+    try {
+      currentPayload = current.notification_payload
+        ? (JSON.parse(
+            current.notification_payload,
+          ) as TaskRunNotificationPayload)
+        : null;
+      currentSummary = current.notification_summary
+        ? (JSON.parse(
+            current.notification_summary,
+          ) as TaskRunNotificationSummary)
+        : currentSummary;
+    } catch {
+      return false;
+    }
+
+    const mergedPayload = mergeTaskRunNotificationPayloads(
+      currentPayload,
+      input.payload,
+    );
+    if (!mergedPayload) return false;
+    const notificationStatus: TaskRunNotificationStatus =
+      current.notification_status === 'failed' ||
+      current.notification_status === 'partial_failed'
+        ? current.notification_status
+        : 'pending';
+    const startedAt = current.started_at
+      ? new Date(current.started_at).getTime()
+      : new Date(current.created_at).getTime();
+    const durationMs = Math.max(0, now.getTime() - startedAt);
+    const availableAt =
+      current.notification_available_at &&
+      current.notification_available_at < nowIso
+        ? current.notification_available_at
+        : nowIso;
+    const changed = db
+      .prepare(
+        `UPDATE task_runs
+         SET status = ?, result = ?, error = ?,
+             notification_status = ?, notification_error = ?,
+             notification_summary = ?, notification_payload = ?,
+             notification_attempt = CASE
+               WHEN notification_lease_owner IS NULL THEN 0
+               ELSE notification_attempt
+             END,
+             notification_available_at = ?,
+             notification_generation = notification_generation + 1,
+             duration_ms = ?, completed_at = ?,
+             lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+         WHERE id = ? AND task_id = ? AND status = 'running'
+           AND lease_owner = ? AND lease_token = ?`,
+      )
+      .run(
+        input.status,
+        input.result ?? null,
+        input.error ?? null,
+        notificationStatus,
+        current.notification_error,
+        JSON.stringify(currentSummary),
+        JSON.stringify(mergedPayload),
+        availableAt,
+        durationMs,
+        nowIso,
+        nowIso,
+        input.runId,
+        input.taskId,
+        input.leaseOwner,
+        input.leaseToken,
+      );
+    if (changed.changes !== 1) return false;
+
+    const summary = input.error
+      ? `Error: ${input.error}`
+      : input.result?.slice(0, 200) || 'Completed';
+    db.prepare(
+      `UPDATE scheduled_tasks
+       SET last_run = ?, last_result = ?,
+           status = CASE
+             WHEN schedule_type = 'once' AND next_run IS NULL THEN 'completed'
+             ELSE status
+           END,
+           updated_at = ?
+       WHERE id = ?`,
+    ).run(nowIso, summary, nowIso, input.taskId);
+    return true;
+  })();
+}
+
+export interface StoreScheduledGroupPromptInput {
+  runId: string;
+  taskId: string;
+  leaseOwner: string;
+  leaseToken: number;
+  messageId: string;
+  chatJid: string;
+  senderId: string;
+  senderName: string;
+  text: string;
+  queuedResult: string;
+}
+
+/**
+ * Atomically cross the group-mode execution boundary.
+ *
+ * Persisting the prompt and releasing the run lease in separate transactions
+ * leaves a crash window where the workspace later executes the prompt while
+ * lease recovery marks its run failed. Keeping both writes under one SQLite
+ * transaction makes either the prompt+delivered hand-off visible together or
+ * neither visible.
+ */
+export function storeScheduledGroupPromptAndCompleteRun(
+  input: StoreScheduledGroupPromptInput,
+): string {
+  return db.transaction(() => {
+    const run = db
+      .prepare(
+        `SELECT task_id, status, lease_owner, lease_token, started_at, created_at
+         FROM task_runs WHERE id = ?`,
+      )
+      .get(input.runId) as
+      | Pick<
+          TaskRunRow,
+          | 'task_id'
+          | 'status'
+          | 'lease_owner'
+          | 'lease_token'
+          | 'started_at'
+          | 'created_at'
+        >
+      | undefined;
+    if (!run || run.task_id !== input.taskId) {
+      throw new Error(
+        `Group task run ${input.runId} does not belong to task ${input.taskId}`,
+      );
+    }
+
+    ensureChatExists(input.chatJid);
+    const messageId = storeMessageDirect(
+      input.messageId,
+      input.chatJid,
+      input.senderId,
+      input.senderName,
+      input.text,
+      new Date().toISOString(),
+      false,
+      {
+        meta: {
+          sourceKind: 'scheduled_task_prompt',
+          taskId: input.taskId,
+        },
+      },
+    );
+
+    const now = new Date().toISOString();
+    const startedAt = run.started_at
+      ? new Date(run.started_at).getTime()
+      : new Date(run.created_at).getTime();
+    const durationMs = Math.max(0, Date.now() - startedAt);
+    const changed = db
+      .prepare(
+        `UPDATE task_runs
+         SET status = 'delivered', result = ?, error = NULL,
+             notification_status = 'skipped', notification_error = NULL,
+             duration_ms = ?, completed_at = ?,
+             lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+         WHERE id = ? AND task_id = ? AND status = 'running'
+           AND lease_owner = ? AND lease_token = ?`,
+      )
+      .run(
+        input.queuedResult,
+        durationMs,
+        now,
+        now,
+        input.runId,
+        input.taskId,
+        input.leaseOwner,
+        input.leaseToken,
+      );
+    if (changed.changes !== 1) {
+      throw new Error(
+        `Group task run ${input.runId} lost its execution fence during prompt delivery`,
+      );
+    }
+    db.prepare(
+      `UPDATE scheduled_tasks
+       SET last_run = ?, last_result = ?,
+           status = CASE
+             WHEN schedule_type = 'once' AND next_run IS NULL THEN 'completed'
+             ELSE status
+           END,
+           updated_at = ?
+       WHERE id = ?`,
+    ).run(now, input.queuedResult.slice(0, 200), now, input.taskId);
+    return messageId;
+  })();
+}
+
+/**
+ * Replace a group-mode run's queue acknowledgement with the exact Assistant
+ * outcome produced by that scheduler-owned prompt.
+ *
+ * Group execution crosses an asynchronous workspace queue boundary, so its
+ * lease is intentionally released as `delivered` after prompt injection. The
+ * stable prompt message id later identifies this exact run. Only that terminal
+ * hand-off state may be upgraded; ordinary conversations and another
+ * occurrence of the same task cannot overwrite it.
+ */
+export function finalizeDeliveredGroupTaskRun(
+  id: string,
+  taskId: string,
+  input: {
+    status?: 'success' | 'failed' | 'cancelled';
+    result?: string | null;
+    error?: string | null;
+  },
+): boolean {
+  return db.transaction(() =>
+    finalizeDeliveredGroupTaskRunInTransaction(id, taskId, input),
+  )();
+}
+
+function finalizeDeliveredGroupTaskRunInTransaction(
+  id: string,
+  taskId: string,
+  input: {
+    status?: 'success' | 'failed' | 'cancelled';
+    result?: string | null;
+    error?: string | null;
+  },
+): boolean {
+  const resultText = input.result?.trim() || null;
+  const errorText = input.error?.trim() || null;
+  const status = input.status ?? (errorText ? 'failed' : 'success');
+  const now = new Date().toISOString();
+  const current = db
+    .prepare(
+      `SELECT task_id, status, result, error, completed_at
+         FROM task_runs WHERE id = ?`,
+    )
+    .get(id) as
+    | Pick<
+        TaskRunRow,
+        'task_id' | 'status' | 'result' | 'error' | 'completed_at'
+      >
+    | undefined;
+  if (!current || current.task_id !== taskId) return false;
+
+  // Duplicate SDK terminal frames and replay-safe Web writes are no-ops.
+  if (
+    current.status === status &&
+    current.result === resultText &&
+    current.error === errorText
+  ) {
+    return true;
+  }
+  if (current.status !== 'delivered') return false;
+
+  const changed = db
+    .prepare(
+      `UPDATE task_runs
+         SET status = ?, result = ?, error = ?, completed_at = ?,
+             duration_ms = CASE
+               WHEN started_at IS NULL THEN duration_ms
+               ELSE MAX(0, CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER))
+             END,
+             updated_at = ?
+         WHERE id = ? AND task_id = ? AND status = 'delivered'`,
+    )
+    .run(status, resultText, errorText, now, now, now, id, taskId);
+  if (changed.changes !== 1) return false;
+
+  const summary = errorText
+    ? `Error: ${errorText}`
+    : resultText?.slice(0, 200) || 'Completed';
+  // Do not let a late result from an older group occurrence overwrite a
+  // newer run's task-list summary.
+  db.prepare(
+    `UPDATE scheduled_tasks
+       SET last_run = ?, last_result = ?, updated_at = ?
+       WHERE id = ?
+         AND (last_run = ? OR last_run IS NULL)`,
+  ).run(now, summary, now, taskId, current.completed_at);
+  return true;
+}
+
+export interface ScheduledGroupWorkspaceFinalization {
+  runId: string;
+  taskId: string;
+  status?: 'success' | 'failed' | 'cancelled';
+  result?: string | null;
+  error?: string | null;
+}
+
+export interface StoreScheduledGroupWorkspaceResultInput {
+  messageId: string;
+  chatJid: string;
+  senderId: string;
+  senderName: string;
+  text: string;
+  timestamp: string;
+  messageMeta?: {
+    turnId?: string;
+    sessionId?: string;
+    sdkMessageUuid?: string;
+    sourceKind?: MessageSourceKind;
+    finalizationReason?: MessageFinalizationReason;
+  };
+  finalizations: ScheduledGroupWorkspaceFinalization[];
+}
+
+/**
+ * Atomically persist one canonical group result and terminalize every exact
+ * scheduler occurrence represented by that result.
+ *
+ * The WebSocket broadcast deliberately happens at the caller after this
+ * transaction commits. A crash before commit leaves both message and runs
+ * untouched; a crash after commit leaves a durable message that polling can
+ * recover while the stable scheduler prompts are already terminal.
+ */
+export function storeScheduledGroupWorkspaceResultAndFinalize(
+  input: StoreScheduledGroupWorkspaceResultInput,
+): string {
+  if (input.finalizations.length === 0) {
+    throw new Error('Scheduled group workspace result has no run finalization');
+  }
+  return db.transaction(() => {
+    ensureChatExists(input.chatJid);
+    const messageId = storeMessageDirect(
+      input.messageId,
+      input.chatJid,
+      input.senderId,
+      input.senderName,
+      input.text,
+      input.timestamp,
+      true,
+      { meta: input.messageMeta },
+    );
+    for (const finalization of input.finalizations) {
+      if (
+        !finalizeDeliveredGroupTaskRunInTransaction(
+          finalization.runId,
+          finalization.taskId,
+          {
+            status: finalization.status,
+            result: finalization.result,
+            error: finalization.error,
+          },
+        )
+      ) {
+        throw new Error(
+          `Group task run ${finalization.runId} could not atomically accept its workspace result`,
+        );
+      }
+    }
+    return messageId;
+  })();
+}
+
 /** Cancellation increments the fencing token so a late worker cannot commit. */
 export function cancelTaskRun(
   id: string,
@@ -5689,9 +6099,15 @@ export function updateTaskRunNotification(
 }
 
 export interface TaskRunTextNotificationPayload {
-  kind: 'store_result_and_notify' | 'send_message';
+  kind: 'store_result_and_notify' | 'send_message' | 'workspace_result';
   chatJid: string;
   text: string;
+  /** Optional group-mode terminal transition completed after Web persistence. */
+  groupRunId?: string;
+  groupTaskId?: string;
+  groupStatus?: 'success' | 'failed' | 'cancelled';
+  groupResult?: string | null;
+  groupError?: string | null;
   options?: {
     ownerId?: string;
     notifyChannels?: string[] | null;
@@ -5763,6 +6179,8 @@ export interface ClaimedTaskRunNotification {
 const MAX_TASK_NOTIFICATION_ATTEMPTS = 5;
 const FINAL_NOTIFICATION_UNKNOWN_ERROR =
   'Final notification attempt expired; delivery outcome is unknown';
+const PENDING_NOTIFICATION_RETRY_ERROR =
+  'Notification retry work remains pending delivery';
 
 function mergeTaskRunNotificationPayloads(
   current: TaskRunNotificationPayload | null,
@@ -5806,6 +6224,69 @@ function taskRunNotificationPayloadItems(
 ): TaskRunAtomicNotificationPayload[] {
   if (!payload) return [];
   return payload.kind === 'batch' ? payload.items : [payload];
+}
+
+function notificationPayloadOwnsCancelledGroupWorkspaceRun(
+  payload: TaskRunNotificationPayload | null | undefined,
+  runId: string,
+): boolean {
+  return taskRunNotificationPayloadItems(payload).some(
+    (item) =>
+      item.kind === 'workspace_result' &&
+      item.groupRunId === runId &&
+      Boolean(item.groupTaskId) &&
+      item.groupStatus === 'cancelled',
+  );
+}
+
+function cancelledGroupWorkspaceRetryPayload(
+  payload: TaskRunNotificationPayload | null | undefined,
+  runId: string,
+): TaskRunNotificationPayload | null {
+  const items = taskRunNotificationPayloadItems(payload).filter(
+    (item) =>
+      item.kind === 'workspace_result' &&
+      item.groupRunId === runId &&
+      Boolean(item.groupTaskId) &&
+      item.groupStatus === 'cancelled',
+  );
+  return items.length === 0
+    ? null
+    : items.length === 1
+      ? items[0]
+      : { kind: 'batch', items };
+}
+
+/**
+ * Notification exhaustion must not leave the asynchronous group execution in
+ * `delivered` forever. Execution and projection status remain independent:
+ * settle the exact business outcome carried by the payload while the
+ * notification row keeps its failed/unknown delivery audit.
+ */
+function settleDiscardedGroupWorkspaceResults(
+  runId: string,
+  payload: TaskRunNotificationPayload | null | undefined,
+): number {
+  let settled = 0;
+  for (const item of taskRunNotificationPayloadItems(payload)) {
+    if (
+      item.kind !== 'workspace_result' ||
+      item.groupRunId !== runId ||
+      !item.groupTaskId
+    ) {
+      continue;
+    }
+    if (
+      finalizeDeliveredGroupTaskRunInTransaction(runId, item.groupTaskId, {
+        status: item.groupStatus,
+        result: item.groupResult,
+        error: item.groupError,
+      })
+    ) {
+      settled++;
+    }
+  }
+  return settled;
 }
 
 /** Remove exactly the atomic work owned by one claim from the latest queue. */
@@ -5964,7 +6445,7 @@ function keepRetryWorkNonSuccessful(
   return {
     ...receipt,
     status: 'failed',
-    error: receipt.error || 'Notification retry work remains pending delivery',
+    error: receipt.error || PENDING_NOTIFICATION_RETRY_ERROR,
   };
 }
 
@@ -5974,67 +6455,93 @@ export function recordTaskRunNotificationReceipt(
   receipt: TaskRunNotificationReceipt,
   retryPayload?: TaskRunNotificationPayload,
 ): boolean {
+  return db.transaction(() =>
+    recordTaskRunNotificationReceiptInTransaction(runId, receipt, retryPayload),
+  )();
+}
+
+function recordTaskRunNotificationReceiptInTransaction(
+  runId: string,
+  receipt: TaskRunNotificationReceipt,
+  retryPayload?: TaskRunNotificationPayload,
+  allowCancelledWorkspaceRun = false,
+): boolean {
   const now = new Date();
-  return db.transaction(() => {
-    const row = db
-      .prepare(
-        `SELECT status, notification_status, notification_error,
+  const row = db
+    .prepare(
+      `SELECT status, notification_status, notification_error,
                 notification_summary, notification_payload,
+                notification_available_at,
+                notification_lease_owner,
                 notification_generation
          FROM task_runs WHERE id = ?`,
-      )
-      .get(runId) as
-      | Pick<
-          TaskRunRow,
-          | 'status'
-          | 'notification_status'
-          | 'notification_error'
-          | 'notification_summary'
-          | 'notification_payload'
-          | 'notification_generation'
-        >
-      | undefined;
-    // Cancellation/misfire is authoritative. Late IPC files must not notify
-    // the user or resurrect notification-only retry work.
-    if (!row || row.status === 'cancelled' || row.status === 'missed') {
-      return false;
-    }
-    let currentSummary: TaskRunNotificationSummary | null = null;
-    let currentPayload: TaskRunNotificationPayload | null = null;
-    try {
-      currentSummary = row.notification_summary
-        ? (JSON.parse(row.notification_summary) as TaskRunNotificationSummary)
-        : null;
-      currentPayload = row.notification_payload
-        ? (JSON.parse(row.notification_payload) as TaskRunNotificationPayload)
-        : null;
-    } catch {
-      // A new valid receipt repairs malformed legacy/internal JSON.
-    }
-    let mergedReceipt = mergeTaskRunNotificationReceipts(
-      row.notification_status,
-      currentSummary,
-      row.notification_error,
-      receipt,
-    );
-    const shouldRetry =
-      (receipt.status === 'failed' || receipt.status === 'partial_failed') &&
-      !!retryPayload;
-    const mergedPayload = mergeTaskRunNotificationPayloads(
-      currentPayload,
-      shouldRetry ? retryPayload : undefined,
-    );
-    mergedReceipt = keepRetryWorkNonSuccessful(mergedReceipt, mergedPayload);
-    const addedNewRetryWork = notificationPayloadAddsNewWork(
-      currentPayload,
-      shouldRetry ? retryPayload : undefined,
-    );
-    const availableAt = mergedPayload
-      ? new Date(now.getTime() + 1_000).toISOString()
+    )
+    .get(runId) as
+    | Pick<
+        TaskRunRow,
+        | 'status'
+        | 'notification_status'
+        | 'notification_error'
+        | 'notification_summary'
+        | 'notification_payload'
+        | 'notification_available_at'
+        | 'notification_lease_owner'
+        | 'notification_generation'
+      >
+    | undefined;
+  // Cancellation/misfire is authoritative. Late IPC files must not notify
+  // the user or resurrect notification-only retry work.
+  if (
+    !row ||
+    (row.status === 'cancelled' && !allowCancelledWorkspaceRun) ||
+    row.status === 'missed'
+  ) {
+    return false;
+  }
+  let currentSummary: TaskRunNotificationSummary | null = null;
+  let currentPayload: TaskRunNotificationPayload | null = null;
+  try {
+    currentSummary = row.notification_summary
+      ? (JSON.parse(row.notification_summary) as TaskRunNotificationSummary)
       : null;
-    const result = db
-      .prepare(
-        `UPDATE task_runs
+    currentPayload = row.notification_payload
+      ? (JSON.parse(row.notification_payload) as TaskRunNotificationPayload)
+      : null;
+  } catch {
+    // A new valid receipt repairs malformed legacy/internal JSON.
+  }
+  let mergedReceipt = mergeTaskRunNotificationReceipts(
+    row.notification_status,
+    currentSummary,
+    row.notification_error,
+    receipt,
+  );
+  const shouldRetry =
+    (receipt.status === 'failed' || receipt.status === 'partial_failed') &&
+    !!retryPayload;
+  const mergedPayload = mergeTaskRunNotificationPayloads(
+    currentPayload,
+    shouldRetry ? retryPayload : undefined,
+  );
+  mergedReceipt = keepRetryWorkNonSuccessful(mergedReceipt, mergedPayload);
+  const addedNewRetryWork = notificationPayloadAddsNewWork(
+    currentPayload,
+    shouldRetry ? retryPayload : undefined,
+  );
+  const retryAt = new Date(now.getTime() + 1_000).toISOString();
+  const availableAt = mergedPayload
+    ? [
+        currentPayload && !row.notification_lease_owner
+          ? row.notification_available_at
+          : null,
+        shouldRetry ? retryAt : null,
+      ]
+        .filter((value): value is string => !!value)
+        .sort()[0] || retryAt
+    : null;
+  const result = db
+    .prepare(
+      `UPDATE task_runs
          SET notification_status = ?, notification_error = ?,
              notification_summary = ?, notification_payload = ?,
              notification_attempt = CASE WHEN ? AND notification_lease_owner IS NULL THEN 0
@@ -6042,20 +6549,75 @@ export function recordTaskRunNotificationReceipt(
              notification_available_at = ?,
              notification_generation = notification_generation + 1,
              updated_at = ?
-         WHERE id = ? AND status NOT IN ('cancelled','missed')`,
-      )
-      .run(
-        mergedReceipt.status,
-        mergedReceipt.error ?? null,
-        JSON.stringify(mergedReceipt.summary),
-        mergedPayload ? JSON.stringify(mergedPayload) : null,
-        addedNewRetryWork ? 1 : 0,
-        availableAt,
-        now.toISOString(),
-        runId,
-      );
-    return result.changes === 1;
-  })();
+         WHERE id = ?
+           AND (
+             status NOT IN ('cancelled','missed')
+             OR (? = 1 AND status = 'cancelled')
+           )`,
+    )
+    .run(
+      mergedReceipt.status,
+      mergedReceipt.error ?? null,
+      JSON.stringify(mergedReceipt.summary),
+      mergedPayload ? JSON.stringify(mergedPayload) : null,
+      addedNewRetryWork ? 1 : 0,
+      availableAt,
+      now.toISOString(),
+      runId,
+      allowCancelledWorkspaceRun ? 1 : 0,
+    );
+  return result.changes === 1;
+}
+
+/**
+ * Atomically persist canonical Web projection repair work and settle the exact
+ * group execution outcome. Neither the notification repair nor the business
+ * terminal is allowed to become visible alone across a crash.
+ */
+export function recordGroupWorkspaceProjectionFailureAndFinalize(input: {
+  runId: string;
+  taskId: string;
+  receipt: TaskRunNotificationReceipt;
+  payload: TaskRunTextNotificationPayload;
+  status?: 'success' | 'failed' | 'cancelled';
+  result?: string | null;
+  error?: string | null;
+}): boolean {
+  if (
+    input.payload.kind !== 'workspace_result' ||
+    input.payload.groupRunId !== input.runId ||
+    input.payload.groupTaskId !== input.taskId
+  ) {
+    return false;
+  }
+  try {
+    return db.transaction(() => {
+      if (
+        !recordTaskRunNotificationReceiptInTransaction(
+          input.runId,
+          input.receipt,
+          input.payload,
+          input.status === 'cancelled',
+        )
+      ) {
+        return false;
+      }
+      if (
+        !finalizeDeliveredGroupTaskRunInTransaction(input.runId, input.taskId, {
+          status: input.status,
+          result: input.result,
+          error: input.error,
+        })
+      ) {
+        throw new Error(
+          `Group task run ${input.runId} could not atomically settle its workspace projection failure`,
+        );
+      }
+      return true;
+    })();
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -6276,16 +6838,43 @@ function claimTaskRunNotification(
   const nowIso = now.toISOString();
   const expiresAt = new Date(now.getTime() + leaseMs).toISOString();
   return db.transaction(() => {
-    const row = db
+    const rows = db
       .prepare(
-        `SELECT id, notification_payload, notification_attempt,
+        `SELECT id, status, notification_payload, notification_attempt,
                 notification_lease_token, notification_generation,
                 notification_status, notification_summary,
                 notification_error
          FROM task_runs
          WHERE notification_payload IS NOT NULL
            AND (? IS NULL OR id = ?)
-           AND status IN ('success','failed','delivered')
+           AND (
+             status IN ('success','failed','delivered')
+             OR (
+               status = 'cancelled'
+               AND CASE
+                 WHEN json_valid(notification_payload) THEN (
+                   (
+                     json_extract(notification_payload, '$.kind') = 'workspace_result'
+                     AND json_extract(notification_payload, '$.groupRunId') = id
+                     AND json_extract(notification_payload, '$.groupTaskId') IS NOT NULL
+                     AND json_extract(notification_payload, '$.groupStatus') = 'cancelled'
+                   )
+                   OR (
+                     json_extract(notification_payload, '$.kind') = 'batch'
+                     AND EXISTS (
+                       SELECT 1
+                       FROM json_each(notification_payload, '$.items') AS item
+                       WHERE json_extract(item.value, '$.kind') = 'workspace_result'
+                         AND json_extract(item.value, '$.groupRunId') = id
+                         AND json_extract(item.value, '$.groupTaskId') IS NOT NULL
+                         AND json_extract(item.value, '$.groupStatus') = 'cancelled'
+                     )
+                   )
+                 )
+                 ELSE 0
+               END
+             )
+           )
            AND notification_attempt < ?
            AND (
              (notification_status IN ('failed','partial_failed','pending')
@@ -6295,76 +6884,103 @@ function claimTaskRunNotification(
              OR (notification_lease_expires_at IS NOT NULL
                  AND notification_lease_expires_at <= ?)
            )
-         ORDER BY notification_available_at, completed_at, created_at LIMIT 1`,
+         ORDER BY CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END,
+                  notification_available_at, completed_at, created_at
+         LIMIT 32`,
       )
-      .get(
+      .all(
         runId ?? null,
         runId ?? null,
         MAX_TASK_NOTIFICATION_ATTEMPTS,
         nowIso,
         nowIso,
-      ) as
-      | {
-          id: string;
-          notification_payload: string;
-          notification_attempt: number;
-          notification_lease_token: number;
-          notification_generation: number;
-          notification_status: TaskRunNotificationStatus;
-          notification_summary: string | null;
-          notification_error: string | null;
-        }
-      | undefined;
-    if (!row) return undefined;
-    const token = row.notification_lease_token + 1;
-    const changed = db
-      .prepare(
-        `UPDATE task_runs
+      ) as Array<{
+      id: string;
+      status: TaskRunStatus;
+      notification_payload: string;
+      notification_attempt: number;
+      notification_lease_token: number;
+      notification_generation: number;
+      notification_status: TaskRunNotificationStatus;
+      notification_summary: string | null;
+      notification_error: string | null;
+    }>;
+    for (const row of rows) {
+      let payload: TaskRunNotificationPayload;
+      try {
+        payload = JSON.parse(
+          row.notification_payload,
+        ) as TaskRunNotificationPayload;
+      } catch {
+        db.prepare(
+          `UPDATE task_runs SET notification_status='failed',
+             notification_error='Invalid persisted notification payload',
+             notification_payload=NULL, notification_available_at=NULL,
+             notification_lease_owner=NULL,
+             notification_lease_expires_at=NULL,
+             notification_lease_payload=NULL, updated_at=?
+           WHERE id=? AND notification_lease_token=?`,
+        ).run(nowIso, row.id, row.notification_lease_token);
+        continue;
+      }
+      if (
+        row.status === 'cancelled' &&
+        !notificationPayloadOwnsCancelledGroupWorkspaceRun(payload, row.id)
+      ) {
+        continue;
+      }
+
+      const token = row.notification_lease_token + 1;
+      const changed = db
+        .prepare(
+          `UPDATE task_runs
          SET notification_lease_owner = ?, notification_lease_token = ?,
              notification_lease_expires_at = ?,
              notification_lease_payload = notification_payload,
              notification_attempt = notification_attempt + 1,
              updated_at = ?
          WHERE id = ? AND notification_lease_token = ?`,
-      )
-      .run(
-        owner,
-        token,
-        expiresAt,
-        nowIso,
-        row.id,
-        row.notification_lease_token,
-      );
-    if (changed.changes !== 1) return undefined;
-    try {
-      return {
-        runId: row.id,
-        payload: JSON.parse(
-          row.notification_payload,
-        ) as TaskRunNotificationPayload,
-        attempt: row.notification_attempt + 1,
-        owner,
-        token,
-        expiresAt,
-        generation: row.notification_generation,
-        notificationStatus: row.notification_status,
-        notificationSummary: row.notification_summary
-          ? (JSON.parse(row.notification_summary) as TaskRunNotificationSummary)
-          : null,
-        notificationError: row.notification_error,
-      };
-    } catch {
-      db.prepare(
-        `UPDATE task_runs SET notification_status='failed',
-           notification_error='Invalid persisted notification payload',
-           notification_payload=NULL, notification_available_at=NULL,
-           notification_lease_owner=NULL, notification_lease_expires_at=NULL,
-           notification_lease_payload=NULL,
-           updated_at=? WHERE id=? AND notification_lease_owner=?
+        )
+        .run(
+          owner,
+          token,
+          expiresAt,
+          nowIso,
+          row.id,
+          row.notification_lease_token,
+        );
+      if (changed.changes !== 1) continue;
+      try {
+        return {
+          runId: row.id,
+          payload,
+          attempt: row.notification_attempt + 1,
+          owner,
+          token,
+          expiresAt,
+          generation: row.notification_generation,
+          notificationStatus: row.notification_status,
+          notificationSummary: row.notification_summary
+            ? (JSON.parse(
+                row.notification_summary,
+              ) as TaskRunNotificationSummary)
+            : null,
+          notificationError: row.notification_error,
+        };
+      } catch {
+        db.prepare(
+          `UPDATE task_runs SET notification_status='failed',
+             notification_error='Invalid persisted notification payload',
+             notification_payload=NULL, notification_available_at=NULL,
+             notification_lease_owner=NULL,
+             notification_lease_expires_at=NULL,
+             notification_lease_payload=NULL, updated_at=?
+           WHERE id=? AND notification_lease_owner=?
              AND notification_lease_token=?`,
-      ).run(nowIso, row.id, owner, token);
-      return undefined;
+        ).run(nowIso, row.id, owner, token);
+      }
     }
+    return undefined;
   })();
 }
 
@@ -6435,10 +7051,22 @@ export function finalizeExpiredTaskRunNotificationAttempts(): number {
       } catch {
         currentSummary = null;
       }
-      const remainingPayload = subtractTaskRunNotificationPayload(
+      let remainingPayload = subtractTaskRunNotificationPayload(
         currentPayload,
         claimedPayload,
       );
+      const ownsCancelledGroupWorkspaceRun =
+        row.status === 'cancelled' &&
+        notificationPayloadOwnsCancelledGroupWorkspaceRun(
+          claimedPayload,
+          row.id,
+        );
+      if (ownsCancelledGroupWorkspaceRun) {
+        // Cancellation is authoritative. Late notification-only work appended
+        // before the cancellation became visible must not keep a cancelled
+        // run reclaimable forever.
+        remainingPayload = null;
+      }
       const summary: TaskRunNotificationSummary = {
         attempted: (currentSummary?.attempted ?? 0) + 1,
         succeeded: currentSummary?.succeeded ?? 0,
@@ -6468,7 +7096,10 @@ export function finalizeExpiredTaskRunNotificationAttempts(): number {
              AND notification_lease_token = ?
              AND notification_lease_expires_at <= ?
              AND notification_generation = ?
-             AND status NOT IN ('cancelled','missed')`,
+             AND (
+               status NOT IN ('cancelled','missed')
+               OR (? = 1 AND status = 'cancelled')
+             )`,
         )
         .run(
           notificationStatusForSummary(summary),
@@ -6486,7 +7117,11 @@ export function finalizeExpiredTaskRunNotificationAttempts(): number {
           row.notification_lease_token,
           now,
           row.notification_generation,
+          ownsCancelledGroupWorkspaceRun ? 1 : 0,
         );
+      if (result.changes === 1) {
+        settleDiscardedGroupWorkspaceResults(row.id, claimedPayload);
+      }
       changed += result.changes;
     }
     return changed;
@@ -6528,6 +7163,11 @@ export function completeTaskRunNotificationAttempt(
   const workerAvailableAt = workerRetryable
     ? new Date(now.getTime() + delayMs).toISOString()
     : null;
+  const ownsCancelledGroupWorkspaceRun =
+    notificationPayloadOwnsCancelledGroupWorkspaceRun(
+      claim.payload,
+      claim.runId,
+    );
   return db.transaction(() => {
     const row = db
       .prepare(
@@ -6556,7 +7196,7 @@ export function completeTaskRunNotificationAttempt(
       | undefined;
     if (
       !row ||
-      row.status === 'cancelled' ||
+      (row.status === 'cancelled' && !ownsCancelledGroupWorkspaceRun) ||
       row.status === 'missed' ||
       row.notification_lease_owner !== claim.owner ||
       row.notification_lease_token !== claim.token ||
@@ -6583,14 +7223,25 @@ export function completeTaskRunNotificationAttempt(
     const latePayload = concurrentWrite
       ? subtractTaskRunNotificationPayload(currentPayload, claim.payload)
       : null;
-    const nextPayload = mergeTaskRunNotificationPayloads(
-      latePayload,
-      workerRetryable ? retryPayload : undefined,
-    );
+    const cancelledAuthoritative =
+      row.status === 'cancelled' && ownsCancelledGroupWorkspaceRun;
+    const nextPayload = cancelledAuthoritative
+      ? workerRetryable
+        ? cancelledGroupWorkspaceRetryPayload(retryPayload, claim.runId)
+        : null
+      : mergeTaskRunNotificationPayloads(
+          latePayload,
+          workerRetryable ? retryPayload : undefined,
+        );
 
     // A final-attempt crash is terminal historical evidence: later work may
     // succeed, but it cannot retroactively prove that unknown delivery A did
     // not happen. Preserve that audit receipt while settling fresh batch B.
+    const claimedSummaryIsHistoricalSuccess =
+      !!claim.notificationSummary &&
+      claim.notificationSummary.failed === 0 &&
+      (claim.notificationStatus === 'pending' ||
+        claim.notificationError === PENDING_NOTIFICATION_RETRY_ERROR);
     let nextReceipt =
       currentSummary &&
       row.notification_error?.includes(FINAL_NOTIFICATION_UNKNOWN_ERROR)
@@ -6600,7 +7251,14 @@ export function completeTaskRunNotificationAttempt(
             row.notification_error,
             receipt,
           )
-        : receipt;
+        : claimedSummaryIsHistoricalSuccess && claim.notificationSummary
+          ? mergeTaskRunNotificationReceipts(
+              notificationStatusForSummary(claim.notificationSummary),
+              claim.notificationSummary,
+              null,
+              receipt,
+            )
+          : receipt;
     if (concurrentWrite) {
       const lateSummary = subtractNotificationSummary(
         currentSummary,
@@ -6613,9 +7271,9 @@ export function completeTaskRunNotificationAttempt(
         lateSummary.failed > 0
       ) {
         nextReceipt = mergeTaskRunNotificationReceipts(
-          receipt.status,
-          receipt.summary,
-          receipt.error ?? null,
+          nextReceipt.status,
+          nextReceipt.summary,
+          nextReceipt.error ?? null,
           {
             status:
               lateSummary.failed === 0
@@ -6647,7 +7305,8 @@ export function completeTaskRunNotificationAttempt(
     // The late payload was appended after this claim began and has not itself
     // consumed an attempt. Reset the shared batch counter so its next claim is
     // attempt 1 (and the merged batch receives a complete retry budget).
-    const nextAttempt = latePayload ? 0 : row.notification_attempt;
+    const nextAttempt =
+      latePayload && !cancelledAuthoritative ? 0 : row.notification_attempt;
     const result = db
       .prepare(
         `UPDATE task_runs
@@ -6663,7 +7322,10 @@ export function completeTaskRunNotificationAttempt(
            AND notification_lease_token = ?
            AND notification_lease_expires_at > ?
            AND notification_generation = ?
-           AND status NOT IN ('cancelled','missed')`,
+           AND (
+             status NOT IN ('cancelled','missed')
+             OR (? = 1 AND status = 'cancelled')
+           )`,
       )
       .run(
         nextReceipt.status,
@@ -6678,7 +7340,16 @@ export function completeTaskRunNotificationAttempt(
         claim.token,
         nowIso,
         row.notification_generation,
+        ownsCancelledGroupWorkspaceRun ? 1 : 0,
       );
+    const discardedPayload =
+      !workerRetryable &&
+      (receipt.status === 'failed' || receipt.status === 'partial_failed')
+        ? (retryPayload ?? claim.payload)
+        : null;
+    if (result.changes === 1 && discardedPayload) {
+      settleDiscardedGroupWorkspaceResults(claim.runId, discardedPayload);
+    }
     return result.changes === 1;
   })();
 }
@@ -6710,7 +7381,51 @@ export function getNextTaskRunWakeAt(): string | null {
        )`,
     )
     .get(now) as { wake_at: string | null };
-  return row.wake_at ?? null;
+  const cancelledWorkspaceRows = db
+    .prepare(
+      `SELECT id, notification_payload, notification_available_at
+       FROM task_runs
+       WHERE status = 'cancelled'
+         AND notification_payload IS NOT NULL
+         AND notification_attempt < ?
+         AND notification_available_at IS NOT NULL
+         AND notification_lease_owner IS NULL
+         AND notification_status IN ('failed','partial_failed','pending')`,
+    )
+    .all(MAX_TASK_NOTIFICATION_ATTEMPTS) as Array<{
+    id: string;
+    notification_payload: string;
+    notification_available_at: string;
+  }>;
+  let cancelledWakeAt: string | null = null;
+  for (const candidate of cancelledWorkspaceRows) {
+    try {
+      const payload = JSON.parse(
+        candidate.notification_payload,
+      ) as TaskRunNotificationPayload;
+      if (
+        !notificationPayloadOwnsCancelledGroupWorkspaceRun(
+          payload,
+          candidate.id,
+        )
+      ) {
+        continue;
+      }
+      if (
+        !cancelledWakeAt ||
+        candidate.notification_available_at < cancelledWakeAt
+      ) {
+        cancelledWakeAt = candidate.notification_available_at;
+      }
+    } catch {
+      // Invalid cancelled payloads are not scheduler-owned repair work.
+    }
+  }
+  return (
+    [row.wake_at, cancelledWakeAt]
+      .filter((value): value is string => !!value)
+      .sort()[0] ?? null
+  );
 }
 
 export function getNextScheduledTaskWakeAt(): string | null {

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -31,6 +31,11 @@ export interface IpcDeliveryTarget {
   coveredCursors: IpcMessageCursor[];
   cursor: IpcMessageCursor;
 }
+/** Immutable DB-message batch owned by one concrete message-lane attempt. */
+export interface MessageRetrySnapshot {
+  coveredCursors: IpcMessageCursor[];
+  cursor: IpcMessageCursor;
+}
 export interface IpcPrePublishAdmission {
   /** Undo host-side Turn/Card/Outbox reservations if disk publish fails. */
   rollback?: () => void;
@@ -150,6 +155,8 @@ interface GroupState {
   retryTimer: ReturnType<typeof setTimeout> | null;
   /** Exact task captured by a retry timer; null means a message-lane retry. */
   retryTask: QueuedTask | null;
+  /** Exact message batch captured by the current message-lane attempt. */
+  messageRetrySnapshot: MessageRetrySnapshot | null;
   restarting: boolean;
   /** Provider profile ID selected for the current active runner (null = default/override). */
   selectedProviderId: string | null;
@@ -208,7 +215,12 @@ export class GroupQueue {
   private hostModeChecker: ((groupJid: string) => boolean) | null = null;
   private serializationKeyResolver: ((groupJid: string) => string) | null =
     null;
-  private onMaxRetriesExceededFn: ((groupJid: string) => void) | null = null;
+  private onMaxRetriesExceededFn:
+    | ((
+        groupJid: string,
+        snapshot: MessageRetrySnapshot | null,
+      ) => void | Promise<void>)
+    | null = null;
   private onContainerExitFn: ((groupJid: string) => void) | null = null;
   private onRunnerStateChangeFn:
     | ((chatJid: string, state: 'idle' | 'running') => void)
@@ -269,6 +281,7 @@ export class GroupQueue {
         retryCount: 0,
         retryTimer: null,
         retryTask: null,
+        messageRetrySnapshot: null,
         restarting: false,
         selectedProviderId: null,
         feishuCliAccountId: null,
@@ -578,8 +591,35 @@ export class GroupQueue {
     this.serializationKeyResolver = fn;
   }
 
-  setOnMaxRetriesExceeded(fn: (groupJid: string) => void): void {
+  setOnMaxRetriesExceeded(
+    fn: (
+      groupJid: string,
+      snapshot: MessageRetrySnapshot | null,
+    ) => void | Promise<void>,
+  ): void {
     this.onMaxRetriesExceededFn = fn;
+  }
+
+  /**
+   * Fence retry exhaustion to the immutable DB batch read by the current
+   * message-lane attempt. Messages arriving after this snapshot must remain
+   * pending work and cannot be attributed to the failed attempt.
+   */
+  setMessageRetrySnapshot(
+    groupJid: string,
+    snapshot: MessageRetrySnapshot,
+  ): boolean {
+    const state = this.groups.get(groupJid);
+    if (!state?.active || state.activeRunnerIsTask) return false;
+    const coveredCursors = [...snapshot.coveredCursors]
+      .map((cursor) => ({ ...cursor }))
+      .sort(compareIpcMessageCursors);
+    if (coveredCursors.length === 0) return false;
+    state.messageRetrySnapshot = {
+      coveredCursors,
+      cursor: { ...coveredCursors[coveredCursors.length - 1] },
+    };
+    return true;
   }
 
   setOnContainerExit(fn: (groupJid: string) => void): void {
@@ -732,6 +772,7 @@ export class GroupQueue {
     }
     state.retryTask = null;
     state.retryCount = 0;
+    state.messageRetrySnapshot = null;
   }
 
   /**
@@ -2206,6 +2247,7 @@ export class GroupQueue {
     state.queryStartedAt = Date.now();
     state.announcedQueryId = null;
     state.pendingMessages = false;
+    state.messageRetrySnapshot = null;
     this.waitingGroups.delete(groupJid);
     this.activeCount++;
     if (isHostMode) {
@@ -2236,11 +2278,12 @@ export class GroupQueue {
         const success = await this.processMessagesFn(groupJid);
         if (success) {
           state.retryCount = 0;
+          state.messageRetrySnapshot = null;
           // Defensive: clear any lingering retry timer from a previous failed
           // run that was superseded by a successful drain-triggered run.
           this.clearRetryTimer(state);
         } else if (this.canScheduleRetry(state)) {
-          this.scheduleRetry(groupJid, state);
+          await this.scheduleRetry(groupJid, state);
         } else {
           logger.info(
             {
@@ -2255,7 +2298,7 @@ export class GroupQueue {
     } catch (err) {
       logger.error({ groupJid, err }, 'Error processing messages for group');
       if (this.canScheduleRetry(state)) {
-        this.scheduleRetry(groupJid, state);
+        await this.scheduleRetry(groupJid, state);
       } else {
         logger.info(
           {
@@ -2428,7 +2471,7 @@ export class GroupQueue {
       const success = await task.fn();
       if (success === false) {
         if (this.canScheduleRetry(state)) {
-          this.scheduleRetry(groupJid, state, task);
+          await this.scheduleRetry(groupJid, state, task);
         } else {
           logger.info(
             {
@@ -2514,11 +2557,11 @@ export class GroupQueue {
     return !this.shuttingDown && !state.stopRequested && !state.restarting;
   }
 
-  private scheduleRetry(
+  private async scheduleRetry(
     groupJid: string,
     state: GroupState,
     retryTask: QueuedTask | null = null,
-  ): void {
+  ): Promise<void> {
     if (!this.canScheduleRetry(state)) {
       logger.info(
         {
@@ -2560,10 +2603,14 @@ export class GroupQueue {
       state.retryCount = 0;
       state.retryTask = null;
       try {
-        this.onMaxRetriesExceededFn?.(groupJid);
+        await this.onMaxRetriesExceededFn?.(
+          groupJid,
+          retryTask ? null : state.messageRetrySnapshot,
+        );
       } catch (err) {
         logger.error({ groupJid, err }, 'onMaxRetriesExceeded callback failed');
       }
+      state.messageRetrySnapshot = null;
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,8 @@ import {
   getTaskRunById,
   getActiveTaskRunForTask,
   getTaskRunsForTask,
+  finalizeDeliveredGroupTaskRun,
+  recordGroupWorkspaceProjectionFailureAndFinalize,
   recordTaskRunNotificationReceipt,
   finalizeTaskRunNotificationIfPending,
   type TaskRunAtomicNotificationPayload,
@@ -127,6 +129,8 @@ import {
   deleteSession,
   deleteMessagesForChatJid,
   storeMessageDirect,
+  storeScheduledGroupPromptAndCompleteRun,
+  storeScheduledGroupWorkspaceResultAndFinalize,
   updateLatestMessageTokenUsage,
   rebuildMessageTokenUsageFromLedger,
   updateChatName,
@@ -421,6 +425,7 @@ import {
   GroupQueue,
   type IpcDeliveryReceipt,
   type IpcDeliveryTarget,
+  type MessageRetrySnapshot,
   type IpcPrePublishAdmission,
 } from './group-queue.js';
 import {
@@ -433,6 +438,10 @@ import {
   computeNextRunForSchedule,
   computeNextRunForTaskResume,
   getRunningTaskIds,
+  formatScheduledTaskWorkspaceResult,
+  resolveScheduledGroupRunsForOutput,
+  resolveTerminalScheduledGroupPromptRun,
+  scheduledGroupPromptMessageId,
 } from './task-scheduler.js';
 import { getMergedTaskRunHistory } from './task-run-history.js';
 import { findDuplicateActiveAgentTask } from './task-definition-fingerprint.js';
@@ -466,6 +475,7 @@ import {
   FollowUpActionResult,
   MessageSourceKind,
   MessageFinalizationReason,
+  TaskRun,
   TaskRunStatus,
 } from './types.js';
 import {
@@ -4757,6 +4767,17 @@ interface SendMessageOptions {
     sourceKind?: MessageSourceKind;
     finalizationReason?: MessageFinalizationReason;
   };
+  /**
+   * Exact scheduler occurrences represented by this canonical group result.
+   * The DB row and these transitions commit atomically before Web broadcast.
+   */
+  scheduledGroupFinalizations?: Array<{
+    runId: string;
+    taskId: string;
+    status?: 'success' | 'failed' | 'cancelled';
+    result?: string | null;
+    error?: string | null;
+  }>;
 }
 
 /**
@@ -5330,6 +5351,162 @@ function learnDirectMessageOwners(
   }
 }
 
+function settleScheduledGroupWorkspaceProjection(input: {
+  runs: TaskRun[];
+  chatJid: string;
+  workspaceFolder: string;
+  text: string;
+  messageId: string;
+  projected: boolean;
+  projectionError?: string;
+  runStatus?: 'success' | 'failed' | 'cancelled';
+  runResult?: string | null;
+  runError?: string | null;
+}): boolean {
+  if (input.runs.length === 0) return false;
+  let allDurable = true;
+  for (const run of input.runs) {
+    if (input.projected) {
+      const finalized = finalizeDeliveredGroupTaskRun(run.id, run.task_id, {
+        status: input.runStatus,
+        result: input.runResult === undefined ? input.text : input.runResult,
+        error: input.runError,
+      });
+      allDurable &&= finalized;
+      if (!finalized) {
+        logger.error(
+          { runId: run.id, taskId: run.task_id, chatJid: input.chatJid },
+          'Failed to finalize group scheduled-task workspace result',
+        );
+      }
+      continue;
+    }
+
+    const error =
+      input.projectionError ||
+      `Scheduled-task workspace result was not persisted and broadcast: ${input.chatJid}`;
+    const payload = {
+      kind: 'workspace_result',
+      chatJid: input.chatJid,
+      text: input.text,
+      groupRunId: run.id,
+      groupTaskId: run.task_id,
+      groupStatus: input.runStatus,
+      groupResult: input.runResult === undefined ? input.text : input.runResult,
+      groupError: input.runError,
+      options: {
+        sourceKind: 'scheduled_task_result',
+        messageId: input.messageId,
+        skipStore: false,
+        workspaceFolder: input.workspaceFolder,
+      },
+    } as const;
+    const recorded = recordGroupWorkspaceProjectionFailureAndFinalize({
+      runId: run.id,
+      taskId: run.task_id,
+      receipt: {
+        status: 'failed',
+        summary: {
+          attempted: 1,
+          succeeded: 0,
+          failed: 1,
+          failed_channels: [`workspace:${input.chatJid}`],
+        },
+        error,
+      },
+      payload,
+      status: input.runStatus,
+      result: input.runResult === undefined ? input.text : input.runResult,
+      error: input.runError,
+    });
+    allDurable &&= recorded;
+    if (!recorded) {
+      logger.error(
+        { runId: run.id, taskId: run.task_id, chatJid: input.chatJid },
+        'Failed to persist group scheduled-task workspace projection retry',
+      );
+    }
+  }
+  return allDurable;
+}
+
+async function projectTerminalScheduledGroupRuns(input: {
+  runs: Iterable<TaskRun>;
+  chatJid: string;
+  workspaceFolder: string;
+  status: 'failed' | 'cancelled';
+  error: string;
+}): Promise<boolean> {
+  let allDurable = true;
+  let sawDeliveredRun = false;
+  for (const staleRun of input.runs) {
+    const run = getTaskRunById(staleRun.id);
+    if (!run) continue;
+    if (run.status === input.status && run.error === input.error) {
+      sawDeliveredRun = true;
+      continue;
+    }
+    if (run.status !== 'delivered') continue;
+    sawDeliveredRun = true;
+    const task = getTaskById(run.task_id);
+    const text = task
+      ? formatScheduledTaskWorkspaceResult({
+          task,
+          runId: run.id,
+          result: null,
+          error: input.error,
+        })
+      : `## ❌ 定时任务执行失败\n\n**任务 ID**：\`${run.task_id}\`\n**运行 ID**：\`${run.id}\`\n**错误**：${input.error}`;
+    const messageId = `scheduled-group-terminal:${run.id}`;
+    const outcome = await sendMessageWithOutcome(input.chatJid, text, {
+      messageId,
+      sendToIM: false,
+      source: 'scheduled_task',
+      messageMeta: {
+        sourceKind: 'scheduled_task_result',
+        finalizationReason:
+          input.status === 'cancelled' ? 'interrupted' : 'error',
+      },
+      scheduledGroupFinalizations: [
+        {
+          runId: run.id,
+          taskId: run.task_id,
+          status: input.status,
+          result: null,
+          error: input.error,
+        },
+      ],
+    });
+    const durable = settleScheduledGroupWorkspaceProjection({
+      runs: [run],
+      chatJid: input.chatJid,
+      workspaceFolder: input.workspaceFolder,
+      text,
+      messageId,
+      projected: outcome.webProjected && !!outcome.messageId,
+      projectionError: outcome.webProjected
+        ? undefined
+        : `Scheduled-task terminal workspace result was not persisted and broadcast: ${input.chatJid}`,
+      runStatus: input.status,
+      runResult: null,
+      runError: input.error,
+    });
+    allDurable &&= durable;
+    if (!durable) {
+      logger.error(
+        {
+          runId: run.id,
+          taskId: run.task_id,
+          chatJid: input.chatJid,
+          status: input.status,
+        },
+        'Failed to durably project terminal group scheduled-task result',
+      );
+    }
+  }
+  return sawDeliveredRun && allDurable;
+}
+
 /**
  * Process all pending messages for a group.
  * Called by the GroupQueue when it's this group's turn.
@@ -5371,6 +5548,29 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let missedMessages = getMessagesSince(chatJid, sinceCursor);
 
   if (missedMessages.length === 0) return true;
+
+  // Bounded-retry exhaustion may intentionally leave ordinary messages
+  // behind the committed cursor. Consume only scheduler prompts whose exact
+  // durable occurrence is already terminal, so a later user message cannot
+  // execute that old occurrence again.
+  const terminalScheduledPrompts = missedMessages.filter((message) =>
+    resolveTerminalScheduledGroupPromptRun(message, getTaskRunById),
+  );
+  if (terminalScheduledPrompts.length > 0) {
+    for (const message of terminalScheduledPrompts) {
+      completeOutOfBandMessage(chatJid, {
+        timestamp: message.timestamp,
+        id: message.id,
+      });
+    }
+    const terminalIds = new Set(
+      terminalScheduledPrompts.map((message) => message.id),
+    );
+    missedMessages = missedMessages.filter(
+      (message) => !terminalIds.has(message.id),
+    );
+    if (missedMessages.length === 0) return true;
+  }
 
   // Direct IM chats reply to themselves. Routed IM messages keep their original
   // source_jid so workspace-bound conversations can reply back to the sender
@@ -5486,6 +5686,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   if (effectiveGroup.created_by) {
     learnDirectMessageOwners(effectiveGroup.created_by, missedMessages);
+  }
+
+  const retrySnapshot = createIpcDeliveryTarget(chatJid, missedMessages);
+  if (retrySnapshot) {
+    queue.setMessageRetrySnapshot(chatJid, retrySnapshot);
   }
 
   const agentProfile = resolveEffectiveAgentProfile(
@@ -5759,6 +5964,53 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     inputTurnId: lastProcessed.id,
     delivered: false,
   };
+  const scheduledGroupRunsByInput = new Map<string, Map<string, TaskRun>>();
+  const terminalScheduledGroupInputs = new Set<string>();
+  const rememberScheduledGroupRuns = (
+    containerOutput: Pick<ContainerOutput, 'inputTurnId' | 'ipcReceipts'>,
+  ): TaskRun[] => {
+    const runs = resolveScheduledGroupRunsForOutput({
+      chatJid,
+      fallbackInputTurnId: lastProcessed.id,
+      coldMessages: missedMessages,
+      output: containerOutput,
+      getMessage: (targetJid, messageId) =>
+        getAgentBuilderInputMessage(targetJid, messageId),
+      getRun: getTaskRunById,
+    });
+    const inputTurnId =
+      containerOutput.inputTurnId ??
+      containerOutput.ipcReceipts?.[containerOutput.ipcReceipts.length - 1]
+        ?.deliveryId ??
+      ipcReplyTurnTracker.inputTurnId;
+    if (runs.length > 0 && inputTurnId) {
+      const remembered =
+        scheduledGroupRunsByInput.get(inputTurnId) ??
+        new Map<string, TaskRun>();
+      for (const run of runs) remembered.set(run.id, run);
+      scheduledGroupRunsByInput.set(inputTurnId, remembered);
+    }
+    return runs;
+  };
+  const projectCurrentScheduledGroupTerminal = (
+    status: 'failed' | 'cancelled',
+    error: string,
+  ): Promise<boolean> => {
+    const inputTurnId = ipcReplyTurnTracker.inputTurnId;
+    return projectTerminalScheduledGroupRuns({
+      runs: scheduledGroupRunsByInput.get(inputTurnId)?.values() ?? [],
+      chatJid,
+      workspaceFolder: effectiveGroup.folder,
+      status,
+      error,
+    }).then((durable) => {
+      if (durable) terminalScheduledGroupInputs.add(inputTurnId);
+      return durable;
+    });
+  };
+  // A cold run owns the whole initial durable batch. Warm turns are remembered
+  // later from each IPC receipt's covered cursor set.
+  rememberScheduledGroupRuns({ inputTurnId: lastProcessed.id });
   let currentInputCursor: MessageCursor = {
     timestamp: lastProcessed.timestamp,
     id: lastProcessed.id,
@@ -6786,6 +7038,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             );
             return;
           }
+          // Warm runners may report the exact covered scheduled prompt only on
+          // an earlier IPC receipt. Remember it before lifecycle/provider
+          // callbacks return so the later genuine final can settle the same
+          // durable run without guessing from ordinary conversation history.
+          rememberScheduledGroupRuns(result);
           await activateMainProjectionForInput(result.inputTurnId);
           if (result.inputTurnCompleted) {
             const completedInputTurnIds = result.ipcReceipts?.length
@@ -7347,10 +7604,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               resetIdleTimer();
               return;
             }
-            result.result = PROVIDER_FAILURE_USER_NOTICE;
+            const terminalGroupFailureDurable =
+              await projectCurrentScheduledGroupTerminal(
+                'failed',
+                PROVIDER_FAILURE_USER_NOTICE,
+              );
+            // The dedicated scheduled-task failure projection is richer and
+            // stable across replay. Suppress the generic provider notice only
+            // when that exact run has been durably projected or queued for
+            // workspace retry.
+            result.result = terminalGroupFailureDurable
+              ? null
+              : PROVIDER_FAILURE_USER_NOTICE;
             logger.warn(
               {
                 group: group.name,
+                terminalGroupFailureDurable,
               },
               'Provider failure surfaced to user',
             );
@@ -7364,7 +7633,69 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               result,
               lastProcessed.id,
             );
-            if (result.proactiveFinalCandidate?.trim()) {
+            const scheduledRuns = [
+              ...(scheduledGroupRunsByInput.get(proactiveInputId)?.values() ??
+                []),
+            ];
+            const completedScheduledCandidate =
+              result.status === 'success' &&
+              result.inputTurnCompleted === true &&
+              result.proactiveFinalCandidate?.trim()
+                ? stripAgentInternalTags(result.proactiveFinalCandidate).trim()
+                : '';
+            if (
+              scheduledRuns.length > 0 &&
+              result.inputTurnCompleted === true
+            ) {
+              if (completedScheduledCandidate) {
+                const messageId = `scheduled-group-result:${crypto
+                  .createHash('sha256')
+                  .update(
+                    [
+                      chatJid,
+                      proactiveInputId,
+                      ...scheduledRuns.map((run) => run.id).sort(),
+                    ].join('\0'),
+                  )
+                  .digest('hex')
+                  .slice(0, 32)}`;
+                const outcome = await sendMessageWithOutcome(
+                  chatJid,
+                  completedScheduledCandidate,
+                  {
+                    messageId,
+                    sendToIM: false,
+                    source: 'scheduled_task',
+                    messageMeta: {
+                      turnId: proactiveInputId,
+                      sessionId: result.sessionId || activeSessionId,
+                      sourceKind: 'scheduled_task_result',
+                      finalizationReason: 'completed',
+                    },
+                    scheduledGroupFinalizations: scheduledRuns.map((run) => ({
+                      runId: run.id,
+                      taskId: run.task_id,
+                      status: 'success',
+                      result: completedScheduledCandidate,
+                      error: null,
+                    })),
+                  },
+                );
+                settleScheduledGroupWorkspaceProjection({
+                  runs: scheduledRuns,
+                  chatJid,
+                  workspaceFolder: effectiveGroup.folder,
+                  text: completedScheduledCandidate,
+                  messageId,
+                  projected: outcome.webProjected && !!outcome.messageId,
+                });
+              } else {
+                await projectCurrentScheduledGroupTerminal(
+                  'failed',
+                  '定时任务已结束，但 Agent 没有返回可展示的完整业务结果。',
+                );
+              }
+            } else if (result.proactiveFinalCandidate?.trim()) {
               const outputScope =
                 channelOutboxScopesByInput.get(proactiveInputId);
               const recovery = await recoverProactiveFinalCandidate({
@@ -7754,6 +8085,37 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               } else {
                 turnIdForDb = effectiveTurnId;
               }
+              const isGenuineCompletedGroupResult =
+                result.status === 'success' &&
+                !result.providerFailure &&
+                !holdReason &&
+                result.inputTurnCompleted === true &&
+                isGenuineReplyResult({
+                  holdReason,
+                  sourceKind: result.sourceKind,
+                  finalizationReason: result.finalizationReason,
+                });
+              const scheduledGroupRuns = isGenuineCompletedGroupResult
+                ? [
+                    ...(scheduledGroupRunsByInput
+                      .get(effectiveTurnId)
+                      ?.values() ?? []),
+                  ]
+                : [];
+              const scheduledGroupResultMessageId =
+                scheduledGroupRuns.length > 0
+                  ? `scheduled-group-result:${crypto
+                      .createHash('sha256')
+                      .update(
+                        [
+                          chatJid,
+                          effectiveTurnId,
+                          ...scheduledGroupRuns.map((run) => run.id).sort(),
+                        ].join('\0'),
+                      )
+                      .digest('hex')
+                      .slice(0, 32)}`
+                  : undefined;
               const durableOutputIdentity =
                 result.sdkMessageUuid ||
                 crypto
@@ -7766,6 +8128,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 chatJid,
                 dbText,
                 {
+                  messageId: scheduledGroupResultMessageId,
                   sendToIM: directImReply && !skipImSend,
                   imTextOverride: dbText !== text ? text : undefined,
                   localImagePaths,
@@ -7787,9 +8150,31 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                     finalizationReason:
                       result.finalizationReason || 'completed',
                   },
+                  scheduledGroupFinalizations: scheduledGroupRuns.map(
+                    (run) => ({
+                      runId: run.id,
+                      taskId: run.task_id,
+                      status: 'success',
+                      result: dbText,
+                      error: null,
+                    }),
+                  ),
                 },
               );
               lastReplyMsgId = replySendOutcome.messageId;
+              const scheduledGroupProjectionDurable =
+                scheduledGroupRuns.length > 0
+                  ? settleScheduledGroupWorkspaceProjection({
+                      runs: scheduledGroupRuns,
+                      chatJid,
+                      workspaceFolder: effectiveGroup.folder,
+                      text: dbText,
+                      messageId: scheduledGroupResultMessageId!,
+                      projected:
+                        replySendOutcome.webProjected &&
+                        !!replySendOutcome.messageId,
+                    })
+                  : false;
               // A final provider-card ACK is the irreversible user-visible
               // side effect for this turn.  Do it only after the Web/DB row is
               // durable, and only after every local attachment has reached
@@ -7891,6 +8276,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               let replyDeliveryAcknowledged = streamingCardHandledIM
                 ? streamingCardAttachmentsDelivered
                 : replySendOutcome.targetDelivered;
+              // A Web-only group-mode task must not replay Agent work after
+              // its canonical projection failure has been persisted for
+              // idempotent notification-worker repair.
+              if (
+                scheduledGroupRuns.length > 0 &&
+                !directImReply &&
+                !outputReplySourceJid &&
+                scheduledGroupProjectionDurable
+              ) {
+                replyDeliveryAcknowledged = true;
+              }
               if (!holdReason) {
                 activeWorkflowRuns = [];
                 completedWorkflowRuns = [];
@@ -7974,6 +8370,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 mirrorDeliveryAcknowledged &&= delivered;
               }
               replyDeliveryAcknowledged &&= mirrorDeliveryAcknowledged;
+              // An IM/card ACK proves only a channel side effect. Every
+              // scheduled group occurrence must also have durably committed
+              // its canonical Web result and business terminal before its
+              // input cursor may advance; otherwise a DB failure can consume
+              // the prompt while leaving the run stranded in `delivered`.
+              if (scheduledGroupRuns.length > 0) {
+                replyDeliveryAcknowledged &&= scheduledGroupProjectionDurable;
+              }
 
               sentReply = true;
               sentReplyByInput.set(outputChannelScope.inputId, true);
@@ -8334,6 +8738,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   }
   if (!output) {
     if (queue.getRecentStopDisposition(effectiveGroup.folder) === 'discard') {
+      await projectCurrentScheduledGroupTerminal(
+        'cancelled',
+        '定时任务已被用户停止，未继续执行。',
+      );
       commitCursor();
       await clearProcessingIndicatorForInput(ipcReplyTurnTracker.inputTurnId);
       return true;
@@ -8343,6 +8751,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     // narrow delivery signals complete the turn; DB-only interrupt partials
     // deliberately do not set either signal and therefore remain retryable.
     if (activeGenuineReplyDelivered || ipcReplyTurnTracker.delivered) {
+      if (!activeGenuineReplyDelivered && ipcReplyTurnTracker.delivered) {
+        await projectCurrentScheduledGroupTerminal(
+          'failed',
+          'Agent 在发送旁路消息后退出，但没有返回定时任务的完整业务结果。',
+        );
+      }
       await notifyProactiveTailInterruption(ipcReplyTurnTracker.inputTurnId);
       commitCursor();
       await clearProcessingIndicatorForInput(ipcReplyTurnTracker.inputTurnId);
@@ -8353,6 +8767,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   const stopDisposition = queue.getRecentStopDisposition(effectiveGroup.folder);
   if (stopDisposition === 'discard') {
+    await projectCurrentScheduledGroupTerminal(
+      'cancelled',
+      '定时任务已被用户停止，未继续执行。',
+    );
     const activeInputHealthy = healthyCompletedInputTurns.has(
       ipcReplyTurnTracker.inputTurnId,
     );
@@ -8403,6 +8821,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     }
 
     sendSystemMessage(chatJid, 'context_reset', `会话已自动重置：${detail}`);
+    await projectCurrentScheduledGroupTerminal(
+      'failed',
+      `无法恢复的会话记录错误：${detail}`,
+    );
     commitCursor();
     await clearProcessingIndicatorForInput(ipcReplyTurnTracker.inputTurnId);
     return true;
@@ -8445,6 +8867,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       return false;
     }
 
+    await projectCurrentScheduledGroupTerminal(
+      'failed',
+      output.error || lastError || 'Agent 连接在定时任务产生完整结果前关闭。',
+    );
     logger.info(
       { group: group.name, chatJid, turnOutcome },
       'Container close resolved without replay',
@@ -8548,6 +8974,15 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   if (
     isErrorExit &&
+    terminalScheduledGroupInputs.has(ipcReplyTurnTracker.inputTurnId)
+  ) {
+    commitCursor();
+    await clearProcessingIndicatorForInput(ipcReplyTurnTracker.inputTurnId);
+    return true;
+  }
+
+  if (
+    isErrorExit &&
     !healthyCompletedInputTurns.has(ipcReplyTurnTracker.inputTurnId)
   ) {
     // Partial/interrupted text is useful to persist, but it is not a delivery
@@ -8578,6 +9013,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         ipcReplyDeliveredForInputTurn: ipcReplyTurnTracker.delivered,
       })
     ) {
+      await projectCurrentScheduledGroupTerminal(
+        'failed',
+        output.error || lastError || 'Agent 在发送旁路消息后异常退出。',
+      );
       commitCursor();
       await clearProcessingIndicatorForInput(ipcReplyTurnTracker.inputTurnId);
       return true;
@@ -8606,6 +9045,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         deterministicFailure: true,
       });
       sendSystemMessage(chatJid, 'context_overflow', budgetMsg);
+      await projectCurrentScheduledGroupTerminal('failed', budgetMsg);
       logger.warn(
         { group: group.name, error: budgetMsg, turnOutcome },
         'Static prompt/context budget is invalid; skipping retry',
@@ -8619,6 +9059,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (errorDetail.startsWith('context_overflow:')) {
       const overflowMsg = errorDetail.replace(/^context_overflow:\s*/, '');
       sendSystemMessage(chatJid, 'context_overflow', overflowMsg);
+      await projectCurrentScheduledGroupTerminal('failed', overflowMsg);
       logger.warn(
         { group: group.name, error: overflowMsg },
         'Context overflow detected, skipping retry',
@@ -8636,6 +9077,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         '',
       );
       sendSystemMessage(chatJid, 'system_error', profileMsg);
+      await projectCurrentScheduledGroupTerminal('failed', profileMsg);
       logger.warn(
         { group: group.name, error: profileMsg },
         'AgentProfile references unavailable skill/MCP, skipping retry',
@@ -8704,6 +9146,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           chatJid,
           'context_reset',
           '会话文件过大导致内存溢出（OOM），已自动重置会话。之前的对话上下文已清除，请重新描述您的需求。',
+        );
+        await projectCurrentScheduledGroupTerminal(
+          'failed',
+          '会话文件过大导致内存溢出（OOM），已自动重置会话。',
         );
         commitCursor();
         await clearProcessingIndicatorForInput(ipcReplyTurnTracker.inputTurnId);
@@ -9147,6 +9593,9 @@ async function runAgent(
 
 interface SendMessageOutcome {
   messageId?: string;
+  /** True only after the canonical DB row and its WebSocket broadcast both
+   * complete. Kept separate from an IM connector ACK. */
+  webProjected: boolean;
   /** True only when the logical target actually received the message. For an
    * IM JID this requires connector success; for a Web/virtual JID it requires
    * successful persistence+broadcast. */
@@ -9161,6 +9610,7 @@ async function sendMessageWithOutcome(
   const isIMChannel = getChannelType(jid) !== null;
   const sendToIM = options.sendToIM ?? isIMChannel;
   let targetDelivered = false;
+  let webProjected = false;
   try {
     if (sendToIM && isIMChannel) {
       try {
@@ -9182,17 +9632,32 @@ async function sendMessageWithOutcome(
     // Persist assistant reply so Web polling can render it and clear waiting state.
     const msgId = options.messageId ?? crypto.randomUUID();
     const timestamp = new Date().toISOString();
-    ensureChatExists(jid);
-    const persistedMsgId = storeMessageDirect(
-      msgId,
-      jid,
-      'happyclaw-agent',
-      ASSISTANT_NAME,
-      text,
-      timestamp,
-      true,
-      { meta: options.messageMeta },
-    );
+    const persistedMsgId =
+      options.scheduledGroupFinalizations &&
+      options.scheduledGroupFinalizations.length > 0
+        ? storeScheduledGroupWorkspaceResultAndFinalize({
+            messageId: msgId,
+            chatJid: jid,
+            senderId: 'happyclaw-agent',
+            senderName: ASSISTANT_NAME,
+            text,
+            timestamp,
+            messageMeta: options.messageMeta,
+            finalizations: options.scheduledGroupFinalizations,
+          })
+        : (() => {
+            ensureChatExists(jid);
+            return storeMessageDirect(
+              msgId,
+              jid,
+              'happyclaw-agent',
+              ASSISTANT_NAME,
+              text,
+              timestamp,
+              true,
+              { meta: options.messageMeta },
+            );
+          })();
     if (!sendToIM || !isIMChannel) targetDelivered = true;
 
     broadcastNewMessage(
@@ -9215,6 +9680,7 @@ async function sendMessageWithOutcome(
       undefined,
       options.source,
     );
+    webProjected = true;
     logger.info({ jid, length: text.length, sendToIM }, 'Message sent');
     // Skip agent_reply broadcast for scheduled tasks to avoid clearing
     // streaming state of a concurrently running main agent.
@@ -9223,10 +9689,10 @@ async function sendMessageWithOutcome(
     if (!options.source) {
       broadcastToWebClients(jid, text);
     }
-    return { messageId: persistedMsgId, targetDelivered };
+    return { messageId: persistedMsgId, targetDelivered, webProjected };
   } catch (err) {
     logger.error({ jid, err }, 'Failed to send message');
-    return { targetDelivered };
+    return { targetDelivered, webProjected };
   }
 }
 
@@ -19965,16 +20431,55 @@ async function main(): Promise<void> {
     const group = registeredGroups[groupJid];
     return group?.folder || groupJid;
   });
-  queue.setOnMaxRetriesExceeded((groupJid: string) => {
-    const group = registeredGroups[groupJid];
-    const name = group?.name || groupJid;
-    sendSystemMessage(
-      groupJid,
-      'agent_max_retries',
-      `${name} 处理失败，已达最大重试次数`,
-    );
-    void clearTrackedProcessingIndicators(groupJid);
-  });
+  queue.setOnMaxRetriesExceeded(
+    async (groupJid: string, snapshot: MessageRetrySnapshot | null) => {
+      try {
+        const group =
+          registeredGroups[groupJid] ?? getRegisteredGroup(groupJid);
+        const name = group?.name || groupJid;
+        const error = `${name} 处理失败，已达最大重试次数`;
+        if (group && snapshot?.coveredCursors.length) {
+          // Use only the immutable batch read by the final failed attempt.
+          // A prompt arriving while this callback runs belongs to a future
+          // attempt and must not be marked failed or consumed here.
+          const exactMessages: Array<
+            NonNullable<ReturnType<typeof getAgentBuilderInputMessage>>
+          > = [];
+          for (const cursor of snapshot.coveredCursors) {
+            const message = getAgentBuilderInputMessage(groupJid, cursor.id);
+            if (message) exactMessages.push(message);
+          }
+          const runs = resolveScheduledGroupRunsForOutput({
+            chatJid: groupJid,
+            fallbackInputTurnId: snapshot.cursor.id,
+            coldMessages: exactMessages,
+            output: { inputTurnId: snapshot.cursor.id },
+            getMessage: (targetJid, messageId) =>
+              getAgentBuilderInputMessage(targetJid, messageId),
+            getRun: getTaskRunById,
+          });
+          const durable = await projectTerminalScheduledGroupRuns({
+            runs,
+            chatJid: groupJid,
+            workspaceFolder: resolveEffectiveGroup(group).effectiveGroup.folder,
+            status: 'failed',
+            error,
+          });
+          if (durable) {
+            // Retry exhaustion terminates this immutable final-attempt batch,
+            // including any ordinary inputs coalesced before its upper bound.
+            // Commit the whole bounded snapshot so crash recovery cannot
+            // replay the old scheduler prompt; later messages sort after this
+            // cursor and remain pending.
+            advanceCursors(groupJid, snapshot.cursor);
+          }
+        }
+        sendSystemMessage(groupJid, 'agent_max_retries', error);
+      } finally {
+        await clearTrackedProcessingIndicators(groupJid);
+      }
+    },
+  );
   // Billing: user-level concurrent container limit
   queue.setUserConcurrentLimitChecker((groupJid: string) => {
     if (!isBillingEnabled()) return { allowed: true };
@@ -20088,8 +20593,17 @@ async function main(): Promise<void> {
     },
     broadcastStreamEvent,
     onWorkspaceCreated: broadcastGroupCreated,
-    storePromptMessage: (chatJid, senderId, senderName, text, taskId) => {
-      const msgId = crypto.randomUUID();
+    storePromptMessage: (
+      chatJid,
+      senderId,
+      senderName,
+      text,
+      taskId,
+      taskRunId,
+    ) => {
+      const msgId = taskRunId
+        ? scheduledGroupPromptMessageId(taskRunId)
+        : crypto.randomUUID();
       const now = new Date().toISOString();
       ensureChatExists(chatJid);
       storeMessageDirect(
@@ -20113,10 +20627,36 @@ async function main(): Promise<void> {
         timestamp: now,
         is_from_me: false,
       });
+      return msgId;
+    },
+    storeGroupPromptAndDeliverRun: (input) => {
+      const msgId = storeScheduledGroupPromptAndCompleteRun({
+        runId: input.run.id,
+        taskId: input.taskId,
+        leaseOwner: input.run.lease_owner,
+        leaseToken: input.run.lease_token,
+        messageId: input.messageId,
+        chatJid: input.chatJid,
+        senderId: input.senderId,
+        senderName: input.senderName,
+        text: input.text,
+        queuedResult: input.queuedResult,
+      });
+      const now = new Date().toISOString();
+      broadcastNewMessage(input.chatJid, {
+        id: msgId,
+        chat_jid: input.chatJid,
+        sender: input.senderId,
+        sender_name: input.senderName,
+        content: input.text,
+        timestamp: now,
+        is_from_me: false,
+      });
+      return msgId;
     },
     storeResultAndNotify: async (chatJid, text, options) => {
       if (!options.skipStore) {
-        await sendMessage(chatJid, text, {
+        const outcome = await sendMessageWithOutcome(chatJid, text, {
           messageId: options.messageId,
           sendToIM: false,
           source: 'scheduled_task',
@@ -20124,6 +20664,11 @@ async function main(): Promise<void> {
             sourceKind: options.sourceKind || 'sdk_final',
           },
         });
+        if (!outcome.webProjected || !outcome.messageId) {
+          throw new Error(
+            `Scheduled-task workspace result was not persisted and broadcast: ${chatJid}`,
+          );
+        }
       }
 
       if (!options.ownerId) return;

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -27,10 +27,12 @@ import {
   claimNextTaskRunNotification,
   ClaimedTaskRunNotification,
   claimNextTaskRun,
+  completeIsolatedTaskRunWithWorkspaceResultIntent,
   completeTaskRunNotificationAttempt,
   completeTaskRun,
   createTaskRun,
   failExpiredStartedTaskRuns,
+  finalizeDeliveredGroupTaskRun,
   finalizeExpiredTaskRunNotificationAttempts,
   finalizeTaskRunNotificationIfPending,
   getAllTasks,
@@ -452,7 +454,22 @@ export interface SchedulerDependencies {
     senderName: string,
     text: string,
     taskId?: string,
-  ) => void;
+    taskRunId?: string,
+  ) => string | void;
+  /**
+   * Atomically persist a group-mode prompt and fence the durable run into its
+   * delivered hand-off state. Required for V2 group occurrences.
+   */
+  storeGroupPromptAndDeliverRun?: (input: {
+    run: ClaimedTaskRun;
+    messageId: string;
+    chatJid: string;
+    senderId: string;
+    senderName: string;
+    text: string;
+    taskId: string;
+    queuedResult: string;
+  }) => string;
   /** Store task result in workspace chat and push to owner's IM channels */
   storeResultAndNotify?: (
     chatJid: string,
@@ -531,6 +548,12 @@ export interface RunTaskOptions {
   sourceWorkspaceFolder?: string;
   /** V2 occurrence already owns a fenced task_runs lease. */
   durableRun?: ClaimedTaskRun;
+  /**
+   * Exposes the exact isolated terminal hand-off to the owning queue callback
+   * so it can retry one synchronous DB failure without falling back to a
+   * non-atomic legacy completion.
+   */
+  onDurableTerminalHandoffPrepared?: (commit: () => boolean) => void;
 }
 
 const runningTaskIds = new Set<string>();
@@ -1082,6 +1105,75 @@ async function runTaskInner(
   // duration_ms should measure actual work time, not include idle wait.
   let lastOutputTime = startTime;
   let runLogFinalized = false;
+  let durableWorkspaceIntentStored = false;
+  let preparedDurableWorkspaceCommit: (() => boolean) | null = null;
+
+  const commitDurableWorkspaceIntent = (): boolean => {
+    if (durableWorkspaceIntentStored) return true;
+    if (
+      !deps.storeResultAndNotify ||
+      !options?.durableRun ||
+      !options.taskRunId ||
+      effectiveJid === workspace.jid
+    ) {
+      return false;
+    }
+    if (!preparedDurableWorkspaceCommit) {
+      const durableRun = options.durableRun;
+      const runId = durableRun.id;
+      const cleanedResult = result ? stripAgentInternalTags(result) : null;
+      const durableOutcomeError =
+        error ||
+        (cleanedResult?.trim()
+          ? null
+          : '定时任务已结束，但 Agent 没有返回可展示的完整业务结果。');
+      const workspaceResult = formatScheduledTaskWorkspaceResult({
+        task,
+        runId,
+        result: cleanedResult,
+        error: durableOutcomeError,
+      });
+      preparedDurableWorkspaceCommit = () =>
+        completeIsolatedTaskRunWithWorkspaceResultIntent({
+          runId,
+          taskId: task.id,
+          leaseOwner: durableRun.lease_owner,
+          leaseToken: durableRun.lease_token,
+          status: durableOutcomeError ? 'failed' : 'success',
+          result: cleanedResult,
+          error: durableOutcomeError,
+          payload: {
+            kind: 'workspace_result',
+            chatJid: workspace.jid,
+            text: workspaceResult,
+            options: {
+              sourceKind: 'scheduled_task_result',
+              messageId: `scheduled-task-result:${runId}`,
+              skipStore: false,
+              workspaceFolder: workspace.folder || undefined,
+            },
+          },
+        });
+      options.onDurableTerminalHandoffPrepared?.(
+        preparedDurableWorkspaceCommit,
+      );
+    }
+    try {
+      durableWorkspaceIntentStored = preparedDurableWorkspaceCommit();
+    } catch (err) {
+      logger.error(
+        { taskId: task.id, runId: options.durableRun.id, err },
+        'Isolated task workspace-result hand-off transaction failed',
+      );
+    }
+    if (!durableWorkspaceIntentStored) {
+      logger.error(
+        { taskId: task.id, runId: options.durableRun.id },
+        'Failed to atomically terminalize isolated task with its workspace result intent',
+      );
+    }
+    return durableWorkspaceIntentStored;
+  };
 
   const finalizeRunLog = () => {
     if (runLogFinalized) return;
@@ -1252,6 +1344,11 @@ async function runTaskInner(
             scheduledInputCompleted,
           )
         ) {
+          // Cross the durable business/workspace boundary as soon as the SDK
+          // emits the genuine terminal frame. Waiting for the runner promise,
+          // recurrence bookkeeping, or session cleanup would reopen a window
+          // where a host crash replays already-completed Agent/tool work.
+          commitDurableWorkspaceIntent();
           finalizeRunLog();
         }
       },
@@ -1297,6 +1394,7 @@ async function runTaskInner(
     }
 
     // Finalize if not already done by onOutput callback
+    commitDurableWorkspaceIntent();
     finalizeRunLog();
 
     logger.info(
@@ -1307,9 +1405,13 @@ async function runTaskInner(
     if (idleTimer) clearTimeout(idleTimer);
     error = err instanceof Error ? err.message : String(err);
     lastOutputTime = Date.now();
+    commitDurableWorkspaceIntent();
     logger.error({ taskId: task.id, error }, 'Task failed');
   } finally {
     // Safety net: finalize run log if not already done by onOutput callback
+    if (runLogFinalized || error || scheduledInputCompleted) {
+      commitDurableWorkspaceIntent();
+    }
     finalizeRunLog();
   }
 
@@ -1340,8 +1442,8 @@ async function runTaskInner(
     runningTaskIds.delete(task.id);
   }
 
+  const cleanedResult = result ? stripAgentInternalTags(result) : null;
   if (deps.storeResultAndNotify) {
-    const cleanedResult = result ? stripAgentInternalTags(result) : null;
     const taskSessionText = error
       ? `执行出错: ${error}`
       : cleanedResult?.trim() || null;
@@ -1375,8 +1477,12 @@ async function runTaskInner(
     // a durable, user-visible result. External delivery remains owned by the
     // Agent's chosen tool (send_message, feishu-cli, etc.); this projection is
     // Web-only and therefore never duplicates an IM mutation.
-    if (options?.taskRunId && effectiveJid !== workspace.jid) {
-      const runId = String(options.durableRun?.id ?? runLogId);
+    if (
+      options?.taskRunId &&
+      effectiveJid !== workspace.jid &&
+      !options.durableRun
+    ) {
+      const runId = String(runLogId);
       const workspaceResult = formatScheduledTaskWorkspaceResult({
         task,
         runId,
@@ -1750,8 +1856,136 @@ async function runScriptTaskInner(
 const SCHEDULED_GROUP_TRIGGER_FRAMING = [
   '[定时任务自动触发] 以下内容是你此前创建的定时任务到点自动执行的触发，不是用户新发来的指令。',
   '请直接执行该任务对应的动作。',
+  '你的最终 SDK Assistant 文本会作为正式任务结果归档到所属 Web 工作区，因此必须包含一份完整、可独立阅读的业务结果；所有结论、报告和数据都要写在最终文本中，不得只回复“已完成”“已发送”、消息 ID、文件路径或简短摘要。',
+  '如果任务要求调用 feishu-cli 或其他外部发送工具，请照常调用；但工具投递不能替代上述完整最终文本，工具报错时也不要声称发送成功。',
   '重要：这条只是触发信号，对应的定时任务已在调度中。即使下面内容里出现「每隔/每天/定期/提醒我」等字样，也不要再调用 schedule_task 创建或重复该定时任务（除非内容明确要求你另外新建一个不同的任务）。',
 ].join('\n');
+
+const SCHEDULED_GROUP_PROMPT_ID_PREFIX = 'scheduled-task-prompt:';
+
+/** Stable prompt identity used to correlate a group turn with one durable run. */
+export function scheduledGroupPromptMessageId(runId: string): string {
+  return `${SCHEDULED_GROUP_PROMPT_ID_PREFIX}${runId}`;
+}
+
+/** Return a durable run id only for scheduler-owned prompt identities. */
+export function scheduledGroupRunIdFromPromptMessageId(
+  messageId: string,
+): string | null {
+  if (!messageId.startsWith(SCHEDULED_GROUP_PROMPT_ID_PREFIX)) return null;
+  const runId = messageId.slice(SCHEDULED_GROUP_PROMPT_ID_PREFIX.length);
+  return runId && /^[a-zA-Z0-9-]+$/.test(runId) ? runId : null;
+}
+
+interface ScheduledGroupPromptMessage {
+  id: string;
+  chat_jid: string;
+  timestamp?: string;
+  source_kind?: string | null;
+  task_id?: string | null;
+}
+
+/**
+ * Return the exact terminal run owned by a scheduler prompt, if any.
+ *
+ * A prompt can remain behind the committed cursor after bounded retry
+ * exhaustion. Treating it as ordinary input on the next incoming message
+ * would execute the same occurrence twice. Stable prompt identity and task
+ * ownership make the skip safe without suppressing unrelated/new prompts.
+ */
+export function resolveTerminalScheduledGroupPromptRun(
+  message: ScheduledGroupPromptMessage,
+  getRun: (runId: string) => TaskRun | undefined,
+): TaskRun | null {
+  if (message.source_kind !== 'scheduled_task_prompt' || !message.task_id) {
+    return null;
+  }
+  const runId = scheduledGroupRunIdFromPromptMessageId(message.id);
+  if (!runId) return null;
+  const run = getRun(runId);
+  if (
+    !run ||
+    run.task_id !== message.task_id ||
+    run.definition_snapshot.context_mode !== 'group' ||
+    !['success', 'failed', 'cancelled', 'missed'].includes(run.status)
+  ) {
+    return null;
+  }
+  return run;
+}
+
+/**
+ * Resolve every durable group run covered by one genuine Assistant output.
+ *
+ * Cold starts correlate through the stable prompt id(s) in the initial batch;
+ * warm-runner turns correlate through IPC covered cursors. No lookup by
+ * definition task id or "latest run" is allowed, so ordinary conversation
+ * outputs and a later occurrence cannot be attached to the wrong run.
+ */
+export function resolveScheduledGroupRunsForOutput(input: {
+  chatJid: string;
+  fallbackInputTurnId: string;
+  coldMessages: ReadonlyArray<ScheduledGroupPromptMessage>;
+  output: Pick<ContainerOutput, 'inputTurnId' | 'ipcReceipts'>;
+  getMessage: (
+    chatJid: string,
+    messageId: string,
+  ) => ScheduledGroupPromptMessage | null;
+  getRun: (runId: string) => TaskRun | undefined;
+}): TaskRun[] {
+  const refs: Array<{ chatJid: string; messageId: string }> = [];
+  if (input.output.ipcReceipts?.length) {
+    for (const receipt of input.output.ipcReceipts) {
+      for (const cursor of receipt.coveredCursors ?? [receipt.cursor]) {
+        refs.push({ chatJid: receipt.chatJid, messageId: cursor.id });
+      }
+    }
+  } else if (
+    (input.output.inputTurnId ?? input.fallbackInputTurnId) ===
+    input.fallbackInputTurnId
+  ) {
+    for (const message of input.coldMessages) {
+      refs.push({ chatJid: message.chat_jid, messageId: message.id });
+    }
+  } else if (input.output.inputTurnId) {
+    refs.push({
+      chatJid: input.chatJid,
+      messageId: input.output.inputTurnId,
+    });
+  }
+
+  const runIds = new Set<string>();
+  const runs: TaskRun[] = [];
+  for (const ref of refs) {
+    if (ref.chatJid !== input.chatJid) continue;
+    const message =
+      input.coldMessages.find(
+        (candidate) =>
+          candidate.chat_jid === ref.chatJid && candidate.id === ref.messageId,
+      ) ?? input.getMessage(ref.chatJid, ref.messageId);
+    if (
+      !message ||
+      message.source_kind !== 'scheduled_task_prompt' ||
+      !message.task_id
+    ) {
+      continue;
+    }
+    const runId = scheduledGroupRunIdFromPromptMessageId(message.id);
+    if (!runId || runIds.has(runId)) continue;
+    const run = input.getRun(runId);
+    if (
+      !run ||
+      run.task_id !== message.task_id ||
+      run.definition_snapshot.context_mode !== 'group' ||
+      !['delivered', 'success', 'failed'].includes(run.status)
+    ) {
+      continue;
+    }
+    runIds.add(runId);
+    runs.push(run);
+  }
+  return runs;
+}
 
 /**
  * Group context mode: inject task prompt as a regular message into the source workspace.
@@ -1779,19 +2013,36 @@ async function runGroupModeTask(
     const owner = task.created_by ? getUserById(task.created_by) : null;
     const senderName = owner?.display_name || owner?.username || '定时任务';
 
-    if (!deps.storePromptMessage) {
-      throw new Error('storePromptMessage dependency not available');
+    const promptText = `${SCHEDULED_GROUP_TRIGGER_FRAMING}\n\n${task.prompt}`;
+    if (durableRun) {
+      if (!deps.storeGroupPromptAndDeliverRun) {
+        throw new Error(
+          'storeGroupPromptAndDeliverRun dependency not available',
+        );
+      }
+      deps.storeGroupPromptAndDeliverRun({
+        run: durableRun,
+        messageId: scheduledGroupPromptMessageId(durableRun.id),
+        chatJid: targetGroupJid,
+        senderId: owner?.id || 'system',
+        senderName,
+        text: promptText,
+        taskId: task.id,
+        queuedResult: resultSummary,
+      });
+    } else {
+      if (!deps.storePromptMessage) {
+        throw new Error('storePromptMessage dependency not available');
+      }
+      // Legacy, non-durable callers retain the ordinary prompt write.
+      deps.storePromptMessage(
+        targetGroupJid,
+        owner?.id || 'system',
+        senderName,
+        promptText,
+        task.id,
+      );
     }
-
-    // Store prompt as a user message in the source workspace chat.
-    // 前置触发框定，避免被当成用户新指令而递归创建任务（#564）。
-    deps.storePromptMessage(
-      targetGroupJid,
-      owner?.id || 'system',
-      senderName,
-      `${SCHEDULED_GROUP_TRIGGER_FRAMING}\n\n${task.prompt}`,
-      task.id,
-    );
 
     // Trigger normal message processing for the source workspace
     deps.queue.enqueueMessageCheck(targetGroupJid);
@@ -2157,7 +2408,43 @@ function trackTaskRunNotifications(
     storeResultAndNotify: deps.storeResultAndNotify
       ? async (chatJid, text, options) => {
           // ownerId is the signal that this call performs external task
-          // notification. Calls without it only persist the Web audit message.
+          // notification. The scheduled_task_result call is the canonical Web
+          // projection: it is still a durable side effect, but it must never
+          // trigger or validate an Agent-owned external tool such as
+          // feishu-cli. Other ownerless writes are ephemeral task-session
+          // audit rows and are cleaned with that isolated session.
+          if (
+            !options.ownerId &&
+            options.sourceKind === 'scheduled_task_result'
+          ) {
+            const payload: TaskRunNotificationPayload = {
+              kind: 'workspace_result',
+              chatJid,
+              text,
+              options: {
+                ...options,
+                sourceKind: options.sourceKind,
+                // Unlike an IM-only retry, a workspace projection retry must
+                // replay the idempotent DB/Web write.
+                skipStore: false,
+              },
+            };
+            try {
+              await deps.storeResultAndNotify!(chatJid, text, options);
+              // A normal Web projection is not an external notification, so
+              // keep the notification ledger's usual `skipped` semantics.
+              // Only failures enter the ledger because they carry durable
+              // repair work that operators must be able to observe.
+              return undefined;
+            } catch (err) {
+              const receipt = failedNotificationReceipt(
+                `workspace:${chatJid}`,
+                err,
+              );
+              record(receipt, payload);
+              throw err;
+            }
+          }
           if (!options.ownerId) {
             return deps.storeResultAndNotify!(chatJid, text, options);
           }
@@ -2268,7 +2555,26 @@ function finishDurableRunFromLegacyLog(
   deferredReceipt: TaskRunNotificationReceipt | null,
   hasUnconfirmedAttempt: boolean,
   executionStartedAtMs: number,
+  atomicHandoffAttempted = false,
 ): void {
+  const current = getTaskRunById(claim.id);
+  if (current && current.status !== 'running') {
+    // Group prompt hand-off and isolated workspace-result intent both cross
+    // their durable occurrence boundary before this outer queue callback.
+    // Merge only deferred delivery receipts; never perform a second legacy
+    // completion after that boundary.
+    if (deferredReceipt) {
+      recordTaskRunNotificationReceipt(claim.id, deferredReceipt);
+    }
+    return;
+  }
+  if (atomicHandoffAttempted) {
+    logger.error(
+      { runId: claim.id, taskId: claim.task_id },
+      'Leaving isolated run fenced after atomic terminal hand-off failed; refusing non-atomic legacy completion',
+    );
+    return;
+  }
   const log = latestLegacyRunOutcome(claim.task_id, executionStartedAtMs);
   const delivered = mode === 'group' && log?.status === 'queued';
   const failed = !log || log.status === 'error';
@@ -2333,6 +2639,7 @@ function executeClaimedTaskRun(
   const notificationTracker = trackTaskRunNotifications(claim, deps);
   const executionDeps = notificationTracker.deps;
   let executionStartedAtMs = Date.now();
+  let isolatedTerminalHandoff: (() => boolean) | null = null;
 
   const finish = (
     heartbeat: ReturnType<typeof setInterval>,
@@ -2341,6 +2648,22 @@ function executeClaimedTaskRun(
     clearInterval(heartbeat);
     activeDurableTaskIds.delete(task.id);
     clearActiveDurableExecution(claim.id, claim.attempt);
+    let atomicHandoffAttempted = false;
+    if (
+      mode === 'isolated' &&
+      isolatedTerminalHandoff &&
+      getTaskRunById(claim.id)?.status === 'running'
+    ) {
+      atomicHandoffAttempted = true;
+      try {
+        isolatedTerminalHandoff();
+      } catch (err) {
+        logger.error(
+          { runId: claim.id, taskId: task.id, err },
+          'Retrying isolated atomic terminal hand-off failed',
+        );
+      }
+    }
     finishDurableRunFromLegacyLog(
       claim,
       mode,
@@ -2348,6 +2671,7 @@ function executeClaimedTaskRun(
       notificationTracker.deferredReceipt(),
       notificationTracker.hasUnconfirmedAttempt(),
       executionStartedAtMs,
+      atomicHandoffAttempted,
     );
     armScheduler(0);
   };
@@ -2547,6 +2871,9 @@ function executeClaimedTaskRun(
           await runTask(task, executionDeps, {
             ...prepared.options,
             durableRun: claim,
+            onDurableTerminalHandoffPrepared: (commit) => {
+              isolatedTerminalHandoff = commit;
+            },
           });
         } finally {
           if (!settled) {
@@ -2679,6 +3006,40 @@ export async function deliverPersistedNotificationPayload(
             },
           };
         }
+      } else if (
+        item.kind === 'workspace_result' &&
+        deps.storeResultAndNotify &&
+        item.options
+      ) {
+        await deps.storeResultAndNotify(item.chatJid, item.text, {
+          ...item.options,
+          sourceKind: item.options.sourceKind as ContainerOutput['sourceKind'],
+          // messageId is stable, so the canonical workspace write is safe to
+          // replay after either a DB failure or a post-commit broadcast error.
+          skipStore: false,
+        });
+        if (
+          item.groupRunId &&
+          item.groupTaskId &&
+          !finalizeDeliveredGroupTaskRun(item.groupRunId, item.groupTaskId, {
+            status: item.groupStatus,
+            result: item.groupResult,
+            error: item.groupError,
+          })
+        ) {
+          throw new Error(
+            `Group task run ${item.groupRunId} no longer accepts its workspace result`,
+          );
+        }
+        receipt = {
+          status: 'success',
+          summary: {
+            attempted: 1,
+            succeeded: 1,
+            failed: 0,
+            failed_channels: [],
+          },
+        };
       } else if (
         item.kind === 'store_result_and_notify' &&
         deps.storeResultAndNotify &&

--- a/tests/docker-publish-workflow-contract.test.ts
+++ b/tests/docker-publish-workflow-contract.test.ts
@@ -6,35 +6,60 @@ const root = process.cwd();
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 
 describe('Docker image distribution contract', () => {
-  test('main pushes publish from pinned native multi-platform runners', () => {
+  test('builds and smokes on pinned native runners before promoting latest', () => {
     const workflow = read('.github/workflows/docker-publish.yml');
 
     expect(workflow).toContain('branches: [main]');
-    expect(workflow).toContain(
-      'uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7',
-    );
-    expect(workflow).toContain('meta-images: riba2534/happyclaw-agent');
-    expect(workflow).toContain('type=raw,value=latest');
-    expect(workflow).toContain('type=sha,format=long,prefix=git-');
-    expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
-    expect(workflow).toContain('distribute: true');
-    expect(workflow).toContain('setup-qemu: false');
-    expect(workflow).toContain('linux/amd64=ubuntu-24.04');
-    expect(workflow).toContain('linux/arm64=ubuntu-24.04-arm');
+    expect(workflow).toContain('platform: linux/amd64');
+    expect(workflow).toContain('platform: linux/arm64');
+    expect(workflow).toContain('runner: ubuntu-24.04');
+    expect(workflow).toContain('runner: ubuntu-24.04-arm');
+    expect(workflow).toContain('uses: docker/build-push-action@');
     expect(workflow).toContain('context: ./container');
-    expect(workflow).toContain('file: ./Dockerfile');
-    expect(workflow).not.toContain('file: ./container/Dockerfile');
+    expect(workflow).toContain('file: ./container/Dockerfile');
+    expect(workflow).toContain('pull: true');
+    expect(workflow).toContain(
+      'push-by-digest=true,name-canonical=true,push=true',
+    );
     expect(workflow).toContain('TOOL_REFRESH=${{ github.sha }}');
+    expect(workflow).toContain(
+      './scripts/smoke-agent-image.sh "$IMAGE_REF" "${{ matrix.arch }}"',
+    );
+    expect(workflow).toContain(
+      '[[ "$IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]',
+    );
+    expect(workflow).toContain('needs: build-and-smoke');
+    expect(workflow).toContain(
+      'docker buildx imagetools create --tag "$commit_tag"',
+    );
+    expect(workflow).toContain(
+      '(($platforms | sort) == ["linux/amd64", "linux/arm64"])',
+    );
+    expect(workflow).toContain('cosign sign --yes');
+    expect(workflow).toContain('cosign verify');
+    expect(workflow).toContain('--tag "${IMAGE_NAME}:latest"');
     expect(workflow).toContain('username: ${{ secrets.DOCKERHUB_USERNAME }}');
     expect(workflow).toContain('password: ${{ secrets.DOCKERHUB_TOKEN }}');
     expect(workflow).not.toContain(`${['dckr', 'pat'].join('_')}_`);
     expect(workflow).not.toContain('docker/setup-qemu-action');
-    expect(workflow).toMatch(
-      /uses: docker\/github-builder\/\.github\/workflows\/build\.yml@[a-f0-9]{40}(?:\s|$)/,
+
+    const actionUses = [
+      ...workflow.matchAll(/^\s*uses:\s+(\S+)(?:\s+#.*)?$/gm),
+    ].map(([, value]) => value);
+    expect(actionUses.length).toBeGreaterThan(0);
+    for (const action of actionUses) {
+      expect(action).toMatch(/^[^@\s]+@[a-f0-9]{40}$/);
+    }
+
+    const smokeIndex = workflow.indexOf(
+      './scripts/smoke-agent-image.sh "$IMAGE_REF" "${{ matrix.arch }}"',
     );
+    const latestIndex = workflow.indexOf('--tag "${IMAGE_NAME}:latest"');
+    expect(smokeIndex).toBeGreaterThan(-1);
+    expect(latestIndex).toBeGreaterThan(smokeIndex);
   });
 
-  test('runtime defaults to the remotely published image', () => {
+  test('keeps remote and local image lifecycles separate', () => {
     expect(read('src/config.ts')).toContain(
       "'riba2534/happyclaw-agent:latest'",
     );
@@ -42,7 +67,39 @@ describe('Docker image distribution contract', () => {
     expect(makefile).toContain(
       'CONTAINER_IMAGE ?= riba2534/happyclaw-agent:latest',
     );
+    expect(makefile).toContain(
+      'LOCAL_CONTAINER_IMAGE ?= happyclaw-agent:local',
+    );
+    expect(makefile).toContain('CONTAINER_IMAGE_PULL ?= always');
     expect(makefile).toContain('docker pull "$(CONTAINER_IMAGE)"');
     expect(makefile).toContain('docker-build-local:');
+    expect(makefile).toContain(
+      './container/build.sh "$(LOCAL_CONTAINER_IMAGE)"',
+    );
+    expect(makefile).toContain('dev-local:');
+    expect(makefile).toContain('start-local:');
+    expect(makefile).toContain('CONTAINER_IMAGE_PULL=never');
+
+    const buildScript = read('container/build.sh');
+    expect(buildScript).toContain(
+      '${LOCAL_CONTAINER_IMAGE:-happyclaw-agent:local}',
+    );
+    expect(buildScript).toContain('docker build --pull');
+  });
+
+  test('smoke helper exercises the production entrypoint and real HTTP endpoint', () => {
+    const smoke = read('scripts/smoke-agent-image.sh');
+
+    expect(smoke).toContain('docker run --detach --interactive');
+    expect(smoke).not.toContain('--entrypoint');
+    expect(smoke).toContain(
+      "docker image inspect --format '{{.Architecture}}'",
+    );
+    expect(smoke).toContain(
+      '[ "$actual_architecture" != "$EXPECTED_ARCHITECTURE" ]',
+    );
+    expect(smoke).toContain('curl --noproxy');
+    expect(smoke).toContain('http://127.0.0.1:9222/json/version');
+    expect(smoke).toContain('docker rm -f "$SMOKE_CONTAINER_NAME"');
   });
 });

--- a/tests/group-queue-close-retry.test.ts
+++ b/tests/group-queue-close-retry.test.ts
@@ -188,12 +188,73 @@ describe('GroupQueue close outcome retry lifecycle', () => {
     await flushPromises();
     expect(runs).toBe(6);
     expect(onMaxRetriesExceeded).toHaveBeenCalledOnce();
-    expect(onMaxRetriesExceeded).toHaveBeenCalledWith(JID);
+    expect(onMaxRetriesExceeded).toHaveBeenCalledWith(JID, null);
     expect(queue.getRetryCount(JID)).toBe(0);
 
     await vi.advanceTimersByTimeAsync(60_000);
     await flushPromises();
     expect(runs).toBe(6);
+  });
+
+  test('max retry awaits the exact final-attempt snapshot and excludes later work', async () => {
+    const ordinaryCursor = {
+      timestamp: '2026-07-30T00:00:00.000Z',
+      id: 'ordinary-before-scheduled',
+    };
+    const failedCursor = {
+      timestamp: '2026-07-30T00:00:01.000Z',
+      id: 'scheduled-task-prompt:failed-run',
+    };
+    const laterCursor = {
+      timestamp: '2026-07-30T00:00:02.000Z',
+      id: 'scheduled-task-prompt:later-run',
+    };
+    let runs = 0;
+    let releaseTerminal!: () => void;
+    const terminalReleased = new Promise<void>((resolve) => {
+      releaseTerminal = resolve;
+    });
+    const observedSnapshots: unknown[] = [];
+
+    queue.setProcessMessagesFn(async () => {
+      runs += 1;
+      queue.setMessageRetrySnapshot(JID, {
+        coveredCursors:
+          runs <= 6 ? [ordinaryCursor, failedCursor] : [laterCursor],
+        cursor: runs <= 6 ? failedCursor : laterCursor,
+      });
+      return runs > 6;
+    });
+    queue.setOnMaxRetriesExceeded(async (_jid, snapshot) => {
+      observedSnapshots.push(snapshot);
+      await terminalReleased;
+    });
+
+    queue.enqueueMessageCheck(JID);
+    await flushPromises();
+    for (const delay of [5_000, 10_000, 20_000, 40_000, 80_000]) {
+      await vi.advanceTimersByTimeAsync(delay);
+      await flushPromises();
+    }
+    expect(runs).toBe(6);
+    expect(observedSnapshots).toEqual([
+      {
+        coveredCursors: [ordinaryCursor, failedCursor],
+        cursor: failedCursor,
+      },
+    ]);
+
+    // This models a new prompt arriving after the final attempt snapshot.
+    // The active max-retry callback must finish its exact terminal work before
+    // the queue starts the new batch, and the old callback never sees B.
+    queue.enqueueMessageCheck(JID);
+    await flushPromises();
+    expect(runs).toBe(6);
+
+    releaseTerminal();
+    await flushPromises();
+    expect(runs).toBe(7);
+    expect(observedSnapshots).toHaveLength(1);
   });
 
   test('conversation task retries on its task lane without invoking message processing', async () => {

--- a/tests/task-notification-wake.test.ts
+++ b/tests/task-notification-wake.test.ts
@@ -24,6 +24,599 @@ afterAll(() => {
 });
 
 describe('notification retry wake scheduling', () => {
+  test('workspace projection exhaustion settles the exact group business result', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T12:00:00.000Z'));
+    try {
+      const createdAt = new Date().toISOString();
+      db.createTask({
+        id: 'group-workspace-exhausted-success',
+        group_folder: 'workspace',
+        chat_jid: 'web:workspace',
+        prompt: 'build report',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'group',
+        execution_type: 'agent',
+        execution_mode: 'container',
+        script_command: null,
+        next_run: new Date(Date.now() + 3_600_000).toISOString(),
+        status: 'active',
+        created_at: createdAt,
+        notify_channels: null,
+      });
+      const task = db.getTaskById('group-workspace-exhausted-success')!;
+      const created = db.createTaskRun({ task, triggerType: 'manual' });
+      const execution = db.claimNextTaskRun('group-exhaust-worker', 60_000)!;
+      db.markTaskRunExecutionStarted(
+        execution.id,
+        execution.lease_owner,
+        execution.lease_token,
+      );
+      db.completeTaskRun(
+        execution.id,
+        execution.lease_owner,
+        execution.lease_token,
+        {
+          status: 'delivered',
+          result: '已排队',
+          notificationStatus: 'skipped',
+        },
+      );
+      const payload: db.TaskRunNotificationPayload = {
+        kind: 'workspace_result',
+        chatJid: task.chat_jid,
+        text: '完整业务结果',
+        groupRunId: created.run.id,
+        groupTaskId: task.id,
+        groupStatus: 'success',
+        groupResult: '完整业务结果',
+        groupError: null,
+        options: {
+          sourceKind: 'scheduled_task_result',
+          messageId: `scheduled-group-result:${created.run.id}`,
+          skipStore: false,
+          workspaceFolder: task.group_folder,
+        },
+      };
+      db.recordTaskRunNotificationReceipt(
+        created.run.id,
+        {
+          status: 'failed',
+          summary: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            failed_channels: ['workspace'],
+          },
+          error: 'workspace unavailable',
+        },
+        payload,
+      );
+
+      vi.advanceTimersByTime(1_000);
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        const claim = db.claimTaskRunNotificationById(
+          created.run.id,
+          `workspace-exhaust-worker-${attempt}`,
+          60_000,
+        )!;
+        expect(claim.attempt).toBe(attempt);
+        expect(
+          db.completeTaskRunNotificationAttempt(
+            claim,
+            {
+              status: 'failed',
+              summary: {
+                attempted: 1,
+                succeeded: 0,
+                failed: 1,
+                failed_channels: ['workspace'],
+              },
+              error: 'workspace unavailable',
+            },
+            payload,
+          ),
+        ).toBe(true);
+        vi.advanceTimersByTime(1_000 * 2 ** Math.max(0, attempt - 1));
+      }
+
+      expect(db.getTaskRunById(created.run.id)).toMatchObject({
+        status: 'success',
+        result: '完整业务结果',
+        error: null,
+        notification_status: 'failed',
+        notification_attempt: 5,
+      });
+      const raw = db.getTaskRunById(created.run.id) as unknown as {
+        notification_payload: string | null;
+      };
+      expect(raw.notification_payload).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('expired final workspace lease settles terminal group outcome without replay', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T13:00:00.000Z'));
+    try {
+      const createdAt = new Date().toISOString();
+      db.createTask({
+        id: 'group-workspace-expired-failure',
+        group_folder: 'workspace',
+        chat_jid: 'web:workspace',
+        prompt: 'build failing report',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'group',
+        execution_type: 'agent',
+        execution_mode: 'container',
+        script_command: null,
+        next_run: new Date(Date.now() + 3_600_000).toISOString(),
+        status: 'active',
+        created_at: createdAt,
+        notify_channels: null,
+      });
+      const task = db.getTaskById('group-workspace-expired-failure')!;
+      const created = db.createTaskRun({ task, triggerType: 'manual' });
+      const execution = db.claimNextTaskRun('group-expiry-worker', 60_000)!;
+      db.markTaskRunExecutionStarted(
+        execution.id,
+        execution.lease_owner,
+        execution.lease_token,
+      );
+      db.completeTaskRun(
+        execution.id,
+        execution.lease_owner,
+        execution.lease_token,
+        {
+          status: 'delivered',
+          result: '已排队',
+          notificationStatus: 'skipped',
+        },
+      );
+      const payload: db.TaskRunNotificationPayload = {
+        kind: 'workspace_result',
+        chatJid: task.chat_jid,
+        text: '执行失败',
+        groupRunId: created.run.id,
+        groupTaskId: task.id,
+        groupStatus: 'failed',
+        groupResult: null,
+        groupError: 'business failed',
+        options: {
+          sourceKind: 'scheduled_task_result',
+          messageId: `scheduled-group-terminal:${created.run.id}`,
+          skipStore: false,
+          workspaceFolder: task.group_folder,
+        },
+      };
+      db.recordTaskRunNotificationReceipt(
+        created.run.id,
+        {
+          status: 'failed',
+          summary: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            failed_channels: ['workspace'],
+          },
+          error: 'workspace unavailable',
+        },
+        payload,
+      );
+      vi.advanceTimersByTime(1_000);
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        const claim = db.claimTaskRunNotificationById(
+          created.run.id,
+          `workspace-expiry-worker-${attempt}`,
+          2,
+        )!;
+        expect(claim.attempt).toBe(attempt);
+        vi.advanceTimersByTime(5);
+      }
+
+      expect(db.finalizeExpiredTaskRunNotificationAttempts()).toBe(1);
+      expect(db.getTaskRunById(created.run.id)).toMatchObject({
+        status: 'failed',
+        result: null,
+        error: 'business failed',
+        notification_status: 'failed',
+        notification_error: expect.stringContaining(
+          'delivery outcome is unknown',
+        ),
+        notification_attempt: 5,
+      });
+      expect(
+        db.claimTaskRunNotificationById(
+          created.run.id,
+          'must-not-replay-workspace',
+          60_000,
+        ),
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('expired exact cancelled workspace lease clears its payload without reopening the run', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T14:00:00.000Z'));
+    try {
+      const createdAt = new Date().toISOString();
+      db.createTask({
+        id: 'group-workspace-expired-cancelled',
+        group_folder: 'workspace',
+        chat_jid: 'web:workspace',
+        prompt: 'cancel report',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'group',
+        execution_type: 'agent',
+        execution_mode: 'container',
+        script_command: null,
+        next_run: new Date(Date.now() + 3_600_000).toISOString(),
+        status: 'active',
+        created_at: createdAt,
+        notify_channels: null,
+      });
+      const task = db.getTaskById('group-workspace-expired-cancelled')!;
+      const created = db.createTaskRun({ task, triggerType: 'manual' });
+      const execution = db.claimNextTaskRun('group-cancel-worker', 60_000)!;
+      db.markTaskRunExecutionStarted(
+        execution.id,
+        execution.lease_owner,
+        execution.lease_token,
+      );
+      db.completeTaskRun(
+        execution.id,
+        execution.lease_owner,
+        execution.lease_token,
+        {
+          status: 'delivered',
+          result: '已排队',
+          notificationStatus: 'skipped',
+        },
+      );
+      const payload: db.TaskRunNotificationPayload = {
+        kind: 'workspace_result',
+        chatJid: task.chat_jid,
+        text: '任务已取消',
+        groupRunId: created.run.id,
+        groupTaskId: task.id,
+        groupStatus: 'cancelled',
+        groupResult: null,
+        groupError: 'cancelled by user',
+        options: {
+          sourceKind: 'scheduled_task_result',
+          messageId: `scheduled-group-terminal:${created.run.id}`,
+          skipStore: false,
+          workspaceFolder: task.group_folder,
+        },
+      };
+      db.recordTaskRunNotificationReceipt(
+        created.run.id,
+        {
+          status: 'failed',
+          summary: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            failed_channels: ['workspace'],
+          },
+          error: 'workspace unavailable',
+        },
+        payload,
+      );
+      vi.advanceTimersByTime(1_000);
+      for (let attempt = 1; attempt < 5; attempt++) {
+        const claim = db.claimTaskRunNotificationById(
+          created.run.id,
+          `workspace-cancel-worker-${attempt}`,
+          60_000,
+        )!;
+        db.completeTaskRunNotificationAttempt(
+          claim,
+          {
+            status: 'failed',
+            summary: {
+              attempted: 1,
+              succeeded: 0,
+              failed: 1,
+              failed_channels: ['workspace'],
+            },
+            error: 'workspace unavailable',
+          },
+          payload,
+        );
+        vi.advanceTimersByTime(1_000 * 2 ** Math.max(0, attempt - 1));
+      }
+      const finalClaim = db.claimTaskRunNotificationById(
+        created.run.id,
+        'workspace-cancel-worker-5',
+        2,
+      )!;
+      expect(finalClaim.attempt).toBe(5);
+
+      // Simulate the crash window after Web projection finalized the business
+      // run but before the notification lease completion write.
+      expect(
+        db.finalizeDeliveredGroupTaskRun(created.run.id, task.id, {
+          status: 'cancelled',
+          error: 'cancelled by user',
+        }),
+      ).toBe(true);
+      vi.advanceTimersByTime(5);
+      expect(db.finalizeExpiredTaskRunNotificationAttempts()).toBe(1);
+      expect(db.getTaskRunById(created.run.id)).toMatchObject({
+        status: 'cancelled',
+        error: 'cancelled by user',
+        notification_status: 'failed',
+        notification_error: expect.stringContaining(
+          'delivery outcome is unknown',
+        ),
+      });
+      const raw = db.getTaskRunById(created.run.id) as unknown as {
+        notification_payload: string | null;
+        notification_lease_owner: string | null;
+      };
+      expect(raw.notification_payload).toBeNull();
+      expect(raw.notification_lease_owner).toBeNull();
+
+      const completed = db.createTaskRun({ task, triggerType: 'manual' });
+      const completedExecution = db.claimNextTaskRun(
+        'group-cancel-complete-worker',
+        60_000,
+      )!;
+      db.markTaskRunExecutionStarted(
+        completedExecution.id,
+        completedExecution.lease_owner,
+        completedExecution.lease_token,
+      );
+      db.completeTaskRun(
+        completedExecution.id,
+        completedExecution.lease_owner,
+        completedExecution.lease_token,
+        {
+          status: 'delivered',
+          result: '已排队',
+          notificationStatus: 'skipped',
+        },
+      );
+      const completedPayload: db.TaskRunNotificationPayload = {
+        ...payload,
+        groupRunId: completed.run.id,
+        options: {
+          ...payload.options!,
+          messageId: `scheduled-group-terminal:${completed.run.id}`,
+        },
+      };
+      db.recordTaskRunNotificationReceipt(
+        completed.run.id,
+        {
+          status: 'failed',
+          summary: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            failed_channels: ['workspace'],
+          },
+          error: 'temporary workspace outage',
+        },
+        completedPayload,
+      );
+      vi.advanceTimersByTime(1_000);
+      const completedClaim = db.claimTaskRunNotificationById(
+        completed.run.id,
+        'group-cancel-completion-notifier',
+        60_000,
+      )!;
+      db.finalizeDeliveredGroupTaskRun(completed.run.id, task.id, {
+        status: 'cancelled',
+        error: 'cancelled by user',
+      });
+      expect(
+        db.completeTaskRunNotificationAttempt(completedClaim, {
+          status: 'success',
+          summary: {
+            attempted: 1,
+            succeeded: 1,
+            failed: 0,
+            failed_channels: [],
+          },
+        }),
+      ).toBe(true);
+      expect(db.getTaskRunById(completed.run.id)).toMatchObject({
+        status: 'cancelled',
+        notification_status: 'success',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('exact cancelled workspace repair survives a normal failure and an early worker crash', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T14:30:00.000Z'));
+    try {
+      const createdAt = new Date().toISOString();
+      db.createTask({
+        id: 'group-workspace-cancelled-retry',
+        group_folder: 'workspace',
+        chat_jid: 'web:workspace',
+        prompt: 'cancelled retry report',
+        schedule_type: 'cron',
+        schedule_value: '0 * * * *',
+        context_mode: 'group',
+        execution_type: 'agent',
+        execution_mode: 'container',
+        script_command: null,
+        next_run: new Date(Date.now() + 3_600_000).toISOString(),
+        status: 'active',
+        created_at: createdAt,
+        notify_channels: null,
+      });
+      const task = db.getTaskById('group-workspace-cancelled-retry')!;
+      const prepare = (suffix: string) => {
+        const created = db.createTaskRun({
+          task,
+          triggerType: 'manual',
+          idempotencyKey: `cancelled-retry-${suffix}`,
+        });
+        const execution = db.claimNextTaskRun(
+          `cancelled-retry-execution-${suffix}`,
+          60_000,
+        )!;
+        db.markTaskRunExecutionStarted(
+          execution.id,
+          execution.lease_owner,
+          execution.lease_token,
+        );
+        db.completeTaskRun(
+          execution.id,
+          execution.lease_owner,
+          execution.lease_token,
+          {
+            status: 'delivered',
+            result: '已排队',
+            notificationStatus: 'skipped',
+          },
+        );
+        const payload: db.TaskRunNotificationPayload = {
+          kind: 'workspace_result',
+          chatJid: task.chat_jid,
+          text: '任务已取消',
+          groupRunId: created.run.id,
+          groupTaskId: task.id,
+          groupStatus: 'cancelled',
+          groupResult: null,
+          groupError: 'cancelled by user',
+          options: {
+            sourceKind: 'scheduled_task_result',
+            messageId: `scheduled-group-terminal:${created.run.id}`,
+            skipStore: false,
+            workspaceFolder: task.group_folder,
+          },
+        };
+        db.recordTaskRunNotificationReceipt(
+          created.run.id,
+          {
+            status: 'failed',
+            summary: {
+              attempted: 1,
+              succeeded: 0,
+              failed: 1,
+              failed_channels: ['workspace'],
+            },
+            error: 'workspace unavailable',
+          },
+          payload,
+        );
+        return { created, payload };
+      };
+
+      const normal = prepare('normal-failure');
+      vi.advanceTimersByTime(1_000);
+      const first = db.claimTaskRunNotificationById(
+        normal.created.run.id,
+        'cancelled-normal-attempt-1',
+        60_000,
+      )!;
+      expect(
+        db.finalizeDeliveredGroupTaskRun(normal.created.run.id, task.id, {
+          status: 'cancelled',
+          error: 'cancelled by user',
+        }),
+      ).toBe(true);
+      expect(
+        db.completeTaskRunNotificationAttempt(
+          first,
+          {
+            status: 'failed',
+            summary: {
+              attempted: 1,
+              succeeded: 0,
+              failed: 1,
+              failed_channels: ['workspace'],
+            },
+            error: 'workspace still unavailable',
+          },
+          normal.payload,
+        ),
+      ).toBe(true);
+      const retryWake = db.getNextTaskRunWakeAt();
+      expect(retryWake).not.toBeNull();
+      expect(new Date(retryWake!).getTime()).toBeGreaterThan(Date.now());
+      vi.advanceTimersByTime(1_000);
+      const second = db.claimTaskRunNotificationById(
+        normal.created.run.id,
+        'cancelled-normal-attempt-2',
+        60_000,
+      )!;
+      expect(second.attempt).toBe(2);
+      expect(
+        db.completeTaskRunNotificationAttempt(second, {
+          status: 'success',
+          summary: {
+            attempted: 1,
+            succeeded: 1,
+            failed: 0,
+            failed_channels: [],
+          },
+        }),
+      ).toBe(true);
+      expect(db.getTaskRunById(normal.created.run.id)).toMatchObject({
+        status: 'cancelled',
+        notification_status: 'success',
+        notification_payload: null,
+        notification_lease_owner: null,
+      });
+
+      const crashed = prepare('early-crash');
+      vi.advanceTimersByTime(1_000);
+      const crashedFirst = db.claimTaskRunNotificationById(
+        crashed.created.run.id,
+        'cancelled-crash-attempt-1',
+        2,
+      )!;
+      expect(crashedFirst.attempt).toBe(1);
+      expect(
+        db.finalizeDeliveredGroupTaskRun(crashed.created.run.id, task.id, {
+          status: 'cancelled',
+          error: 'cancelled by user',
+        }),
+      ).toBe(true);
+      vi.advanceTimersByTime(5);
+      expect(db.getNextTaskRunWakeAt()).not.toBeNull();
+      const crashedSecond = db.claimTaskRunNotificationById(
+        crashed.created.run.id,
+        'cancelled-crash-attempt-2',
+        60_000,
+      )!;
+      expect(crashedSecond.attempt).toBe(2);
+      expect(
+        db.completeTaskRunNotificationAttempt(crashedSecond, {
+          status: 'success',
+          summary: {
+            attempted: 1,
+            succeeded: 1,
+            failed: 0,
+            failed_channels: [],
+          },
+        }),
+      ).toBe(true);
+      expect(db.getTaskRunById(crashed.created.run.id)).toMatchObject({
+        status: 'cancelled',
+        notification_status: 'success',
+        notification_payload: null,
+        notification_lease_owner: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test('an active slow-delivery lease wakes at lease expiry, not stale available_at', async () => {
     const createdAt = new Date().toISOString();
     db.createTask({

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -129,6 +129,9 @@ const {
   enqueueIsolatedScheduledTask,
   getRunningTaskIds,
   processClaimedTaskRunNotification,
+  resolveScheduledGroupRunsForOutput,
+  resolveTerminalScheduledGroupPromptRun,
+  scheduledGroupPromptMessageId,
   shouldFinalizeScheduledRunOutput,
   triggerTaskNow,
 } = await import('../src/task-scheduler.js');
@@ -136,7 +139,10 @@ const {
 const GROUP_JID = 'web:task-contract';
 const GROUP_FOLDER = 'task-contract';
 
-function makeDeps(groups: Record<string, any>) {
+function makeDeps(
+  groups: Record<string, any>,
+  options: { autoDrainNotifications?: boolean } = {},
+) {
   let runPromise: Promise<void> | null = null;
   const queue = {
     enqueueTask: vi.fn(
@@ -151,21 +157,45 @@ function makeDeps(groups: Record<string, any>) {
     isGroupMutationPaused: vi.fn(() => false),
   };
 
+  const deps = {
+    registeredGroups: () => groups,
+    getSessions: () => ({}),
+    queue,
+    onProcess: vi.fn(),
+    sendMessage: vi.fn(),
+    broadcastStreamEvent: vi.fn(),
+    storePromptMessage: vi.fn(),
+    storeGroupPromptAndDeliverRun: vi.fn((input: any) =>
+      db.storeScheduledGroupPromptAndCompleteRun({
+        runId: input.run.id,
+        taskId: input.taskId,
+        leaseOwner: input.run.lease_owner,
+        leaseToken: input.run.lease_token,
+        messageId: input.messageId,
+        chatJid: input.chatJid,
+        senderId: input.senderId,
+        senderName: input.senderName,
+        text: input.text,
+        queuedResult: input.queuedResult,
+      }),
+    ),
+    storeResultAndNotify: vi.fn(),
+    assistantName: 'HappyClaw',
+  } as any;
   return {
-    deps: {
-      registeredGroups: () => groups,
-      getSessions: () => ({}),
-      queue,
-      onProcess: vi.fn(),
-      sendMessage: vi.fn(),
-      broadcastStreamEvent: vi.fn(),
-      storePromptMessage: vi.fn(),
-      storeResultAndNotify: vi.fn(),
-      assistantName: 'HappyClaw',
-    } as any,
+    deps,
     queue,
     waitForRun: async () => {
       await runPromise;
+      if (options.autoDrainNotifications === false) return;
+      for (let index = 0; index < 8; index++) {
+        const claim = db.claimNextTaskRunNotification(
+          `task-contract-auto-notifier-${index}`,
+          60_000,
+        );
+        if (!claim) break;
+        await processClaimedTaskRunNotification(claim, deps, 60_000);
+      }
     },
   };
 }
@@ -283,6 +313,43 @@ describe('scheduled task workspace/session contract', () => {
       result: 'partial only',
       error: expect.stringContaining('before completing'),
     });
+  });
+
+  test('fails an isolated occurrence whose completed Agent turn has no full business result', async () => {
+    const taskId = createTask({ id: 'task-empty-isolated-result' });
+    const groups = {
+      [GROUP_JID]: db.getRegisteredGroup(GROUP_JID)!,
+    };
+    runContainerAgentMock.mockImplementationOnce(
+      async (_group, input, onProcess) => {
+        onProcess?.({} as never, `container-${input.taskRunId}`, null);
+        return {
+          status: 'success',
+          result: null,
+          inputTurnCompleted: true,
+        };
+      },
+    );
+    const { deps, waitForRun } = makeDeps(groups);
+
+    const trigger = triggerTaskNow(taskId, deps);
+    await waitForRun();
+
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'failed',
+      result: null,
+      error: expect.stringContaining('没有返回可展示的完整业务结果'),
+      notification_status: 'success',
+    });
+    expect(deps.storeResultAndNotify).toHaveBeenCalledWith(
+      GROUP_JID,
+      expect.stringContaining('没有返回可展示的完整业务结果'),
+      expect.objectContaining({
+        sourceKind: 'scheduled_task_result',
+        messageId: `scheduled-task-result:${trigger.runId}`,
+        skipStore: false,
+      }),
+    );
   });
 
   test('resume accepts only future one-shot schedules', () => {
@@ -458,6 +525,108 @@ describe('scheduled task workspace/session contract', () => {
     expect(storedTask.workspace_folder).toBeNull();
   });
 
+  test('commits the isolated terminal and workspace intent inside the SDK terminal callback', async () => {
+    const taskId = createTask({ id: 'task-terminal-callback-handoff' });
+    const groups = {
+      [GROUP_JID]: db.getRegisteredGroup(GROUP_JID)!,
+    };
+    let observedTerminalInsideRunner = false;
+    runContainerAgentMock.mockImplementationOnce(
+      async (_group, input, onProcess, onOutput) => {
+        onProcess?.({} as never, `container-${input.taskRunId}`, null);
+        await onOutput?.({
+          status: 'success',
+          result: 'callback terminal result',
+          inputTurnCompleted: true,
+        });
+        const durableRunId = input.taskRunId
+          .replace(/^task-run-/, '')
+          .replace(/-attempt-1$/, '');
+        const duringCallbackReturn = db.getTaskRunById(durableRunId)!;
+        observedTerminalInsideRunner =
+          duringCallbackReturn.status === 'success' &&
+          duringCallbackReturn.result === 'callback terminal result' &&
+          JSON.parse(
+            (
+              duringCallbackReturn as unknown as {
+                notification_payload: string;
+              }
+            ).notification_payload,
+          ).options.messageId === `scheduled-task-result:${durableRunId}`;
+        return {
+          status: 'success',
+          result: 'callback terminal result',
+          inputTurnCompleted: true,
+        };
+      },
+    );
+    const { deps, waitForRun } = makeDeps(groups);
+
+    const trigger = triggerTaskNow(taskId, deps);
+    await waitForRun();
+
+    expect(observedTerminalInsideRunner).toBe(true);
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'success',
+      result: 'callback terminal result',
+      notification_status: 'success',
+    });
+    expect(runContainerAgentMock).toHaveBeenCalledOnce();
+  });
+
+  test('persists and retries a failed canonical workspace result without rerunning isolated Agent work', async () => {
+    const taskId = createTask({ id: 'task-workspace-projection-retry' });
+    const groups = {
+      [GROUP_JID]: db.getRegisteredGroup(GROUP_JID)!,
+    };
+    const { deps, waitForRun } = makeDeps(groups);
+    deps.storeResultAndNotify.mockImplementation(
+      async (_chatJid: string, _text: string, options: any) => {
+        if (options.sourceKind === 'scheduled_task_result') {
+          throw new Error('workspace broadcast unavailable');
+        }
+      },
+    );
+
+    const trigger = triggerTaskNow(taskId, deps);
+    await waitForRun();
+    await vi.waitFor(() => {
+      expect(db.getTaskRunById(trigger.runId!)?.status).not.toBe('running');
+    });
+    const finished = db.getTaskRunById(trigger.runId!)!;
+    expect(finished).toMatchObject({
+      status: 'success',
+      result: 'task result',
+      notification_status: 'failed',
+    });
+    expect(finished.notification_error).toContain(
+      'workspace broadcast unavailable',
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 1_050));
+    const retry = db.claimNextTaskRunNotification(
+      'workspace-projection-retry-worker',
+      60_000,
+    )!;
+    expect(retry.payload).toMatchObject({
+      kind: 'workspace_result',
+      chatJid: GROUP_JID,
+      options: {
+        messageId: `scheduled-task-result:${trigger.runId}`,
+        skipStore: false,
+      },
+    });
+
+    deps.storeResultAndNotify.mockResolvedValueOnce(undefined);
+    expect(await processClaimedTaskRunNotification(retry, deps, 60_000)).toBe(
+      true,
+    );
+    expect(db.getTaskRunById(trigger.runId!)?.notification_status).toBe(
+      'success',
+    );
+    expect(runContainerAgentMock).toHaveBeenCalledOnce();
+  });
+
   test('isolated manual runs get distinct Claude session namespaces', async () => {
     const taskId = createTask({ id: 'task-per-run-session' });
     const groups = {
@@ -499,6 +668,761 @@ describe('scheduled task workspace/session contract', () => {
       result: '已排队到源工作区，等待智能体执行',
       error: null,
     });
+    expect(deps.storeGroupPromptAndDeliverRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatJid: GROUP_JID,
+        senderId: 'system',
+        senderName: '定时任务',
+        text: expect.stringContaining('write a short status'),
+        taskId,
+        messageId: expect.stringMatching(/^scheduled-task-prompt:/),
+      }),
+    );
+    const storedPrompt = (deps.storeGroupPromptAndDeliverRun as any).mock
+      .calls[0][0].text as string;
+    expect(storedPrompt).toContain('完整、可独立阅读的业务结果');
+    expect(storedPrompt).toContain('所有结论、报告和数据都要写在最终文本中');
+    expect(storedPrompt).toContain('不得只回复“已完成”“已发送”');
+    expect(storedPrompt).toContain('feishu-cli');
+    expect(storedPrompt).toContain('工具投递不能替代上述完整最终文本');
+  });
+
+  test('resolves exact cold and warm group runs, including multi-prompt batches, without guessing from ordinary messages', () => {
+    const run = (id: string, taskId: string) =>
+      ({
+        id,
+        task_id: taskId,
+        status: 'delivered',
+        definition_snapshot: { context_mode: 'group' },
+      }) as any;
+    const runA = run('11111111-1111-4111-8111-111111111111', 'group-task-a');
+    const runB = run('22222222-2222-4222-8222-222222222222', 'group-task-b');
+    const promptA = {
+      id: scheduledGroupPromptMessageId(runA.id),
+      chat_jid: GROUP_JID,
+      source_kind: 'scheduled_task_prompt',
+      task_id: runA.task_id,
+    };
+    const promptB = {
+      id: scheduledGroupPromptMessageId(runB.id),
+      chat_jid: GROUP_JID,
+      source_kind: 'scheduled_task_prompt',
+      task_id: runB.task_id,
+    };
+    const ordinary = {
+      id: 'ordinary-user-input',
+      chat_jid: GROUP_JID,
+      source_kind: 'legacy',
+      task_id: null,
+    };
+    const messages = new Map(
+      [promptA, ordinary, promptB].map((message) => [message.id, message]),
+    );
+    const runs = new Map([
+      [runA.id, runA],
+      [runB.id, runB],
+    ]);
+    const common = {
+      chatJid: GROUP_JID,
+      getMessage: (_chatJid: string, messageId: string) =>
+        messages.get(messageId) ?? null,
+      getRun: (runId: string) => runs.get(runId),
+    };
+
+    const cold = resolveScheduledGroupRunsForOutput({
+      ...common,
+      fallbackInputTurnId: promptB.id,
+      coldMessages: [promptA, ordinary, promptB],
+      output: { inputTurnId: promptB.id },
+    });
+    expect(cold.map((item) => item.id)).toEqual([runA.id, runB.id]);
+
+    const warm = resolveScheduledGroupRunsForOutput({
+      ...common,
+      fallbackInputTurnId: 'unrelated-cold-input',
+      coldMessages: [],
+      output: {
+        inputTurnId: 'ipc-delivery-turn',
+        ipcReceipts: [
+          {
+            chatJid: GROUP_JID,
+            deliveryId: 'ipc-delivery-turn',
+            cursor: { timestamp: '2026-07-30T00:00:00.000Z', id: promptB.id },
+            coveredCursors: [
+              {
+                timestamp: '2026-07-30T00:00:00.000Z',
+                id: promptA.id,
+              },
+              {
+                timestamp: '2026-07-30T00:00:01.000Z',
+                id: ordinary.id,
+              },
+              {
+                timestamp: '2026-07-30T00:00:02.000Z',
+                id: promptB.id,
+              },
+            ],
+          } as any,
+        ],
+      },
+    });
+    expect(warm.map((item) => item.id)).toEqual([runA.id, runB.id]);
+
+    const ordinaryOnly = resolveScheduledGroupRunsForOutput({
+      ...common,
+      fallbackInputTurnId: ordinary.id,
+      coldMessages: [ordinary],
+      output: { inputTurnId: ordinary.id },
+    });
+    expect(ordinaryOnly).toEqual([]);
+  });
+
+  test('upgrades a delivered group run with the full result exactly once', () => {
+    const taskId = createTask({
+      id: 'task-group-result-idempotency',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'group-result-idempotency',
+    });
+    const claim = db.claimNextTaskRun('group-result-worker', 60_000)!;
+    expect(claim.id).toBe(created.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      ),
+    ).toBe(true);
+    expect(
+      db.completeTaskRun(claim.id, claim.lease_owner, claim.lease_token, {
+        status: 'delivered',
+        result: '已排队到源工作区，等待智能体执行',
+        notificationStatus: 'skipped',
+      }),
+    ).toBe(true);
+
+    expect(
+      db.finalizeDeliveredGroupTaskRun(claim.id, taskId, {
+        result: '完整业务结果',
+      }),
+    ).toBe(true);
+    expect(
+      db.finalizeDeliveredGroupTaskRun(claim.id, taskId, {
+        result: '完整业务结果',
+      }),
+    ).toBe(true);
+    expect(
+      db.finalizeDeliveredGroupTaskRun(claim.id, taskId, {
+        result: '迟到的不同回调',
+      }),
+    ).toBe(false);
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'success',
+      result: '完整业务结果',
+      error: null,
+    });
+  });
+
+  test('atomically rolls back the group prompt when the run fence cannot enter delivered state', () => {
+    const taskId = createTask({
+      id: 'task-group-prompt-atomicity',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'group-prompt-atomicity',
+    });
+    const claim = db.claimNextTaskRun('group-atomic-worker', 60_000)!;
+    expect(claim.id).toBe(created.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      ),
+    ).toBe(true);
+    const messageId = scheduledGroupPromptMessageId(claim.id);
+
+    expect(() =>
+      db.storeScheduledGroupPromptAndCompleteRun({
+        runId: claim.id,
+        taskId,
+        leaseOwner: claim.lease_owner,
+        leaseToken: claim.lease_token + 1,
+        messageId,
+        chatJid: GROUP_JID,
+        senderId: 'system',
+        senderName: '定时任务',
+        text: 'atomic prompt',
+        queuedResult: '已排队',
+      }),
+    ).toThrow(/lost its execution fence/);
+    expect(db.getMessage(GROUP_JID, messageId)).toBeNull();
+    expect(db.getTaskRunById(claim.id)?.status).toBe('running');
+
+    expect(
+      db.storeScheduledGroupPromptAndCompleteRun({
+        runId: claim.id,
+        taskId,
+        leaseOwner: claim.lease_owner,
+        leaseToken: claim.lease_token,
+        messageId,
+        chatJid: GROUP_JID,
+        senderId: 'system',
+        senderName: '定时任务',
+        text: 'atomic prompt',
+        queuedResult: '已排队',
+      }),
+    ).toBe(messageId);
+    expect(db.getMessage(GROUP_JID, messageId)).toMatchObject({
+      id: messageId,
+      is_from_me: 0,
+    });
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'delivered',
+      result: '已排队',
+      notification_status: 'skipped',
+    });
+  });
+
+  test('atomically stores one canonical group result and terminalizes every represented run', () => {
+    const taskA = createTask({
+      id: 'task-group-result-atomic-a',
+      context_mode: 'group',
+    });
+    const taskB = createTask({
+      id: 'task-group-result-atomic-b',
+      context_mode: 'group',
+    });
+    const deliveredRuns = [taskA, taskB].map((taskId, index) => {
+      const task = db.getTaskById(taskId)!;
+      const created = db.createTaskRun({
+        task,
+        triggerType: 'manual',
+        idempotencyKey: `group-result-atomic-${index}`,
+      });
+      const claim = db.claimNextTaskRun(
+        `group-result-atomic-worker-${index}`,
+        60_000,
+      )!;
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      );
+      db.completeTaskRun(claim.id, claim.lease_owner, claim.lease_token, {
+        status: 'delivered',
+        result: '已排队',
+        notificationStatus: 'skipped',
+      });
+      return { runId: created.run.id, taskId };
+    });
+    const messageId = 'scheduled-group-result:atomic-two-runs';
+
+    expect(
+      db.storeScheduledGroupWorkspaceResultAndFinalize({
+        messageId,
+        chatJid: GROUP_JID,
+        senderId: 'happyclaw-agent',
+        senderName: 'HappyClaw',
+        text: '两个任务共享的完整结果',
+        timestamp: new Date().toISOString(),
+        messageMeta: { sourceKind: 'scheduled_task_result' },
+        finalizations: deliveredRuns.map((run) => ({
+          ...run,
+          status: 'success',
+          result: '两个任务共享的完整结果',
+          error: null,
+        })),
+      }),
+    ).toBe(messageId);
+    expect(db.getMessagesPage(GROUP_JID)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: messageId,
+          content: '两个任务共享的完整结果',
+          source_kind: 'scheduled_task_result',
+        }),
+      ]),
+    );
+    for (const run of deliveredRuns) {
+      expect(db.getTaskRunById(run.runId)).toMatchObject({
+        status: 'success',
+        result: '两个任务共享的完整结果',
+      });
+    }
+  });
+
+  test('rolls back the canonical group message and earlier run transitions when any represented run rejects', () => {
+    const taskA = createTask({
+      id: 'task-group-result-rollback-a',
+      context_mode: 'group',
+    });
+    const taskB = createTask({
+      id: 'task-group-result-rollback-b',
+      context_mode: 'group',
+    });
+    const deliveredRuns = [taskA, taskB].map((taskId, index) => {
+      const task = db.getTaskById(taskId)!;
+      const created = db.createTaskRun({
+        task,
+        triggerType: 'manual',
+        idempotencyKey: `group-result-rollback-${index}`,
+      });
+      const claim = db.claimNextTaskRun(
+        `group-result-rollback-worker-${index}`,
+        60_000,
+      )!;
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      );
+      db.completeTaskRun(claim.id, claim.lease_owner, claim.lease_token, {
+        status: 'delivered',
+        result: '已排队',
+        notificationStatus: 'skipped',
+      });
+      return { runId: created.run.id, taskId };
+    });
+    const messageId = 'scheduled-group-result:must-rollback';
+
+    expect(() =>
+      db.storeScheduledGroupWorkspaceResultAndFinalize({
+        messageId,
+        chatJid: GROUP_JID,
+        senderId: 'happyclaw-agent',
+        senderName: 'HappyClaw',
+        text: '不得留下的结果',
+        timestamp: new Date().toISOString(),
+        messageMeta: { sourceKind: 'scheduled_task_result' },
+        finalizations: [
+          {
+            ...deliveredRuns[0],
+            status: 'success',
+            result: '不得留下的结果',
+          },
+          {
+            ...deliveredRuns[1],
+            taskId: `${deliveredRuns[1].taskId}-wrong-fence`,
+            status: 'success',
+            result: '不得留下的结果',
+          },
+        ],
+      }),
+    ).toThrow(/could not atomically accept/);
+    expect(db.getMessage(GROUP_JID, messageId)).toBeNull();
+    for (const run of deliveredRuns) {
+      expect(db.getTaskRunById(run.runId)).toMatchObject({
+        status: 'delivered',
+        result: '已排队',
+      });
+    }
+  });
+
+  test('atomically terminalizes an isolated run with a pending canonical workspace intent', () => {
+    const taskId = createTask({ id: 'task-isolated-result-atomic' });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'isolated-result-atomic',
+    });
+    const claim = db.claimNextTaskRun('isolated-result-atomic-worker', 60_000)!;
+    db.markTaskRunExecutionStarted(
+      claim.id,
+      claim.lease_owner,
+      claim.lease_token,
+    );
+    const payload: db.TaskRunTextNotificationPayload = {
+      kind: 'workspace_result',
+      chatJid: GROUP_JID,
+      text: '完整隔离任务结果',
+      options: {
+        sourceKind: 'scheduled_task_result',
+        messageId: `scheduled-task-result:${created.run.id}`,
+        skipStore: false,
+        workspaceFolder: GROUP_FOLDER,
+      },
+    };
+
+    expect(
+      db.completeIsolatedTaskRunWithWorkspaceResultIntent({
+        runId: created.run.id,
+        taskId,
+        leaseOwner: claim.lease_owner,
+        leaseToken: claim.lease_token + 1,
+        status: 'success',
+        result: '完整隔离任务结果',
+        error: null,
+        payload,
+      }),
+    ).toBe(false);
+    expect(db.getTaskRunById(created.run.id)).toMatchObject({
+      status: 'running',
+      notification_payload: null,
+    });
+
+    expect(
+      db.completeIsolatedTaskRunWithWorkspaceResultIntent({
+        runId: created.run.id,
+        taskId,
+        leaseOwner: claim.lease_owner,
+        leaseToken: claim.lease_token,
+        status: 'success',
+        result: '完整隔离任务结果',
+        error: null,
+        payload,
+      }),
+    ).toBe(true);
+    const stored = db.getTaskRunById(created.run.id)!;
+    expect(stored).toMatchObject({
+      status: 'success',
+      result: '完整隔离任务结果',
+      notification_status: 'pending',
+      lease_owner: null,
+    });
+    expect(
+      JSON.parse(
+        (stored as unknown as { notification_payload: string })
+          .notification_payload,
+      ),
+    ).toEqual(payload);
+    expect(
+      db.recordTaskRunNotificationReceipt(created.run.id, {
+        status: 'success',
+        summary: {
+          attempted: 1,
+          succeeded: 1,
+          failed: 0,
+          failed_channels: [],
+        },
+      }),
+    ).toBe(true);
+    const projectionClaim = db.claimTaskRunNotificationById(
+      created.run.id,
+      'isolated-result-projector',
+      60_000,
+    )!;
+    expect(projectionClaim).toMatchObject({ payload, attempt: 1 });
+    expect(
+      db.recordTaskRunNotificationReceipt(created.run.id, {
+        status: 'success',
+        summary: {
+          attempted: 1,
+          succeeded: 1,
+          failed: 0,
+          failed_channels: [],
+        },
+      }),
+    ).toBe(true);
+    expect(
+      db.completeTaskRunNotificationAttempt(projectionClaim, {
+        status: 'success',
+        summary: {
+          attempted: 1,
+          succeeded: 1,
+          failed: 0,
+          failed_channels: [],
+        },
+      }),
+    ).toBe(true);
+    expect(db.getTaskRunById(created.run.id)).toMatchObject({
+      notification_status: 'success',
+      notification_error: null,
+      notification_summary: {
+        attempted: 3,
+        succeeded: 3,
+        failed: 0,
+        failed_channels: [],
+      },
+    });
+  });
+
+  test('retries a failed group workspace projection before upgrading delivered to success', async () => {
+    const taskId = createTask({
+      id: 'task-group-workspace-retry',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'group-workspace-retry',
+    });
+    const claim = db.claimNextTaskRun('group-workspace-worker', 60_000)!;
+    expect(claim.id).toBe(created.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      ),
+    ).toBe(true);
+    const promptId = scheduledGroupPromptMessageId(claim.id);
+    db.storeScheduledGroupPromptAndCompleteRun({
+      runId: claim.id,
+      taskId,
+      leaseOwner: claim.lease_owner,
+      leaseToken: claim.lease_token,
+      messageId: promptId,
+      chatJid: GROUP_JID,
+      senderId: 'system',
+      senderName: '定时任务',
+      text: 'run the report',
+      queuedResult: '已排队',
+    });
+    const resultMessageId = `scheduled-group-result:${claim.id}`;
+    const retryPayload: db.TaskRunNotificationPayload = {
+      kind: 'workspace_result',
+      chatJid: GROUP_JID,
+      text: '完整调研结果',
+      groupRunId: claim.id,
+      groupTaskId: taskId,
+      groupResult: '完整调研结果',
+      options: {
+        sourceKind: 'scheduled_task_result',
+        messageId: resultMessageId,
+        skipStore: false,
+        workspaceFolder: GROUP_FOLDER,
+      },
+    };
+    expect(
+      db.recordTaskRunNotificationReceipt(
+        claim.id,
+        {
+          status: 'failed',
+          summary: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            failed_channels: [`workspace:${GROUP_JID}`],
+          },
+          error: 'broadcast unavailable',
+        },
+        retryPayload,
+      ),
+    ).toBe(true);
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'delivered',
+      notification_status: 'failed',
+      result: '已排队',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1_050));
+    const retry = db.claimNextTaskRunNotification(
+      'group-workspace-retry-worker',
+      60_000,
+    )!;
+    const storeResultAndNotify = vi.fn(async () => undefined);
+    expect(
+      await processClaimedTaskRunNotification(
+        retry,
+        {
+          storeResultAndNotify,
+          sendMessage: vi.fn(),
+        } as never,
+        60_000,
+      ),
+    ).toBe(true);
+    expect(storeResultAndNotify).toHaveBeenCalledWith(
+      GROUP_JID,
+      '完整调研结果',
+      expect.objectContaining({
+        messageId: resultMessageId,
+        skipStore: false,
+      }),
+    );
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'success',
+      result: '完整调研结果',
+      notification_status: 'success',
+    });
+  });
+
+  test('keeps a group run delivered during retry and durably settles a terminal workspace failure', async () => {
+    const taskId = createTask({
+      id: 'task-group-terminal-workspace-retry',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'group-terminal-workspace-retry',
+    });
+    const claim = db.claimNextTaskRun('group-terminal-worker', 60_000)!;
+    db.markTaskRunExecutionStarted(
+      claim.id,
+      claim.lease_owner,
+      claim.lease_token,
+    );
+    db.storeScheduledGroupPromptAndCompleteRun({
+      runId: claim.id,
+      taskId,
+      leaseOwner: claim.lease_owner,
+      leaseToken: claim.lease_token,
+      messageId: scheduledGroupPromptMessageId(claim.id),
+      chatJid: GROUP_JID,
+      senderId: 'system',
+      senderName: '定时任务',
+      text: 'run terminal report',
+      queuedResult: '已排队',
+    });
+    const error = '处理失败，已达最大重试次数';
+    const messageId = `scheduled-group-terminal:${claim.id}`;
+    expect(
+      db.recordTaskRunNotificationReceipt(
+        claim.id,
+        {
+          status: 'failed',
+          summary: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            failed_channels: [`workspace:${GROUP_JID}`],
+          },
+          error: 'workspace unavailable',
+        },
+        {
+          kind: 'workspace_result',
+          chatJid: GROUP_JID,
+          text: `## ❌ 定时任务执行失败\n\n${error}`,
+          groupRunId: claim.id,
+          groupTaskId: taskId,
+          groupStatus: 'failed',
+          groupResult: null,
+          groupError: error,
+          options: {
+            sourceKind: 'scheduled_task_result',
+            messageId,
+            skipStore: false,
+            workspaceFolder: GROUP_FOLDER,
+          },
+        },
+      ),
+    ).toBe(true);
+
+    // A retryable/intermediate failure must not falsely terminate the run
+    // before the visible workspace result is durable.
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'delivered',
+      notification_status: 'failed',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1_050));
+    const retry = db.claimNextTaskRunNotification(
+      'group-terminal-retry-worker',
+      60_000,
+    )!;
+    const storeResultAndNotify = vi.fn(async () => undefined);
+    expect(
+      await processClaimedTaskRunNotification(
+        retry,
+        {
+          storeResultAndNotify,
+          sendMessage: vi.fn(),
+        } as never,
+        60_000,
+      ),
+    ).toBe(true);
+    expect(storeResultAndNotify).toHaveBeenCalledWith(
+      GROUP_JID,
+      expect.stringContaining(error),
+      expect.objectContaining({ messageId, skipStore: false }),
+    );
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'failed',
+      result: null,
+      error,
+      notification_status: 'success',
+    });
+  });
+
+  test('skips only exact terminal group prompts after max retry', () => {
+    const taskId = createTask({
+      id: 'task-group-terminal-prompt-skip',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const oldCreated = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'old-terminal-prompt',
+    });
+    const oldClaim = db.claimNextTaskRun('old-terminal-worker', 60_000)!;
+    db.markTaskRunExecutionStarted(
+      oldClaim.id,
+      oldClaim.lease_owner,
+      oldClaim.lease_token,
+    );
+    db.completeTaskRun(
+      oldClaim.id,
+      oldClaim.lease_owner,
+      oldClaim.lease_token,
+      {
+        status: 'delivered',
+        result: '已排队',
+        notificationStatus: 'skipped',
+      },
+    );
+    db.finalizeDeliveredGroupTaskRun(oldCreated.run.id, taskId, {
+      status: 'failed',
+      error: 'max retries',
+    });
+
+    const laterCreated = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'later-live-prompt',
+    });
+    const laterClaim = db.claimNextTaskRun('later-live-worker', 60_000)!;
+    db.markTaskRunExecutionStarted(
+      laterClaim.id,
+      laterClaim.lease_owner,
+      laterClaim.lease_token,
+    );
+    db.completeTaskRun(
+      laterClaim.id,
+      laterClaim.lease_owner,
+      laterClaim.lease_token,
+      {
+        status: 'delivered',
+        result: '已排队',
+        notificationStatus: 'skipped',
+      },
+    );
+
+    const oldPrompt = {
+      id: scheduledGroupPromptMessageId(oldCreated.run.id),
+      chat_jid: GROUP_JID,
+      source_kind: 'scheduled_task_prompt',
+      task_id: taskId,
+    };
+    const laterPrompt = {
+      id: scheduledGroupPromptMessageId(laterCreated.run.id),
+      chat_jid: GROUP_JID,
+      source_kind: 'scheduled_task_prompt',
+      task_id: taskId,
+    };
+    expect(
+      resolveTerminalScheduledGroupPromptRun(oldPrompt, db.getTaskRunById),
+    ).toMatchObject({ id: oldCreated.run.id, status: 'failed' });
+    expect(
+      resolveTerminalScheduledGroupPromptRun(laterPrompt, db.getTaskRunById),
+    ).toBeNull();
+    expect(
+      resolveTerminalScheduledGroupPromptRun(
+        { ...oldPrompt, id: laterPrompt.id },
+        db.getTaskRunById,
+      ),
+    ).toBeNull();
   });
 
   test('host task cannot use an admin creator to bypass a downgraded workspace owner', async () => {
@@ -1069,7 +1993,10 @@ describe('scheduled task workspace/session contract', () => {
         return { status: 'error', error: 'Agent failed after IPC output' };
       },
     );
-    const { deps, waitForRun } = makeDeps({ [GROUP_JID]: group });
+    const { deps, waitForRun } = makeDeps(
+      { [GROUP_JID]: group },
+      { autoDrainNotifications: false },
+    );
     deps.storeResultAndNotify.mockResolvedValue({
       status: 'success',
       summary: {
@@ -1104,7 +2031,18 @@ describe('scheduled task workspace/session contract', () => {
           }
         ).notification_payload,
       ),
-    ).toEqual(ipcPayload);
+    ).toMatchObject({
+      kind: 'batch',
+      items: expect.arrayContaining([
+        ipcPayload,
+        expect.objectContaining({
+          kind: 'workspace_result',
+          options: expect.objectContaining({
+            messageId: `scheduled-task-result:${trigger.runId}`,
+          }),
+        }),
+      ]),
+    });
     expect(deps.storeResultAndNotify).toHaveBeenCalledWith(
       expect.any(String),
       expect.stringContaining('Agent failed after IPC output'),


### PR DESCRIPTION
## Summary
- atomically persist complete scheduled-task business results and project them into the originating Web workspace
- keep Agent tool calls such as feishu-cli independent from host delivery verification while preserving honest final output and notification audit state
- harden cancellation, retry, fencing, and multi-run group result semantics
- build amd64/arm64 agent images on native runners, smoke-test real Chromium CDP HTTP startup, sign the verified manifest, then promote latest
- separate local image workflows from the DockerHub latest image

## Validation
- 321 test files / 2714 tests passed
- TypeScript, production builds, docs, formatting, and git diff checks passed
- shellcheck/actionlint and local image CDP smoke passed during multi-agent review