### PR TITLE
fix(tasks): make delivered group runs cancellable

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4419,7 +4419,17 @@ export function pauseWorkspaceTasksForRebuild(
              FROM task_runs tr
              JOIN scheduled_tasks st ON st.id = tr.task_id
              WHERE st.group_folder = ?
-               AND tr.status IN ('queued','running','retry_wait')
+               AND (
+                 tr.status IN ('queued','running','retry_wait')
+                 OR (
+                   tr.status = 'delivered'
+                   AND json_valid(tr.definition_snapshot)
+                   AND json_extract(
+                     tr.definition_snapshot,
+                     '$.context_mode'
+                   ) = 'group'
+                 )
+               )
              ORDER BY tr.created_at, tr.id`,
           )
           .all(groupFolder) as Array<{ id: string }>
@@ -5263,8 +5273,19 @@ export function getActiveTaskRunForTask(taskId: string): TaskRun | undefined {
   const row = db
     .prepare(
       `SELECT * FROM task_runs
-       WHERE task_id = ? AND status IN ('queued','running','retry_wait')
-       ORDER BY created_at LIMIT 1`,
+       WHERE task_id = ?
+         AND (
+           status IN ('queued','running','retry_wait')
+           OR (
+             status = 'delivered'
+             AND json_valid(definition_snapshot)
+             AND json_extract(definition_snapshot, '$.context_mode') = 'group'
+           )
+         )
+       ORDER BY
+         CASE WHEN status IN ('queued','running','retry_wait') THEN 0 ELSE 1 END,
+         created_at
+       LIMIT 1`,
     )
     .get(taskId) as TaskRunRow | undefined;
   return row ? mapTaskRunRow(row) : undefined;
@@ -6025,6 +6046,117 @@ export function cancelTaskRun(
        WHERE id = ? AND schedule_type = 'once' AND next_run IS NULL
          AND status IN ('active','paused')`,
     ).run(now, current.task_id);
+    return true;
+  })();
+}
+
+/**
+ * Cancel a group occurrence after its prompt crossed the workspace queue
+ * boundary. `delivered` is terminal only for the scheduler worker; the Agent
+ * still owes a business result, so user cancellation must remain available.
+ *
+ * The cancelled business terminal and its canonical Web projection intent are
+ * committed together. The notification worker may then idempotently store and
+ * broadcast the cancellation result without replaying Agent work.
+ */
+export function cancelDeliveredGroupTaskRunWithWorkspaceIntent(input: {
+  runId: string;
+  taskId: string;
+  reason: string;
+  payload: TaskRunTextNotificationPayload;
+}): boolean {
+  if (
+    input.payload.kind !== 'workspace_result' ||
+    input.payload.groupRunId !== input.runId ||
+    input.payload.groupTaskId !== input.taskId ||
+    input.payload.groupStatus !== 'cancelled' ||
+    input.payload.groupResult !== null ||
+    input.payload.groupError !== input.reason ||
+    input.payload.options?.sourceKind !== 'scheduled_task_result' ||
+    input.payload.options.messageId !==
+      `scheduled-group-terminal:${input.runId}`
+  ) {
+    return false;
+  }
+  const payloadOptions = input.payload.options;
+
+  const now = new Date().toISOString();
+  return db.transaction(() => {
+    const current = db
+      .prepare(
+        `SELECT task_id, definition_snapshot
+           FROM task_runs
+          WHERE id = ? AND task_id = ? AND status = 'delivered'`,
+      )
+      .get(input.runId, input.taskId) as
+      | Pick<TaskRunRow, 'task_id' | 'definition_snapshot'>
+      | undefined;
+    if (!current) return false;
+
+    let snapshot: TaskRunDefinitionSnapshot;
+    try {
+      snapshot = JSON.parse(
+        current.definition_snapshot,
+      ) as TaskRunDefinitionSnapshot;
+    } catch {
+      return false;
+    }
+    const deliveryRouteJid = snapshot.delivery_route_jid || snapshot.chat_jid;
+    if (
+      snapshot.context_mode !== 'group' ||
+      input.payload.chatJid !== deliveryRouteJid ||
+      payloadOptions.workspaceFolder !== snapshot.group_folder
+    ) {
+      return false;
+    }
+
+    const summary: TaskRunNotificationSummary = {
+      attempted: 0,
+      succeeded: 0,
+      failed: 0,
+      failed_channels: [],
+    };
+    const changed = db
+      .prepare(
+        `UPDATE task_runs
+            SET status = 'cancelled', result = NULL, error = ?,
+                completed_at = ?, updated_at = ?,
+                duration_ms = CASE
+                  WHEN started_at IS NULL THEN duration_ms
+                  ELSE MAX(0, CAST((julianday(?) - julianday(started_at)) * 86400000 AS INTEGER))
+                END,
+                notification_status = 'pending',
+                notification_error = NULL,
+                notification_summary = ?,
+                notification_payload = ?,
+                notification_attempt = 0,
+                notification_available_at = ?,
+                notification_lease_owner = NULL,
+                notification_lease_expires_at = NULL,
+                notification_lease_payload = NULL,
+                notification_generation = notification_generation + 1,
+                lease_owner = NULL, lease_expires_at = NULL,
+                lease_token = lease_token + 1
+          WHERE id = ? AND task_id = ? AND status = 'delivered'`,
+      )
+      .run(
+        input.reason,
+        now,
+        now,
+        now,
+        JSON.stringify(summary),
+        JSON.stringify(input.payload),
+        now,
+        input.runId,
+        input.taskId,
+      );
+    if (changed.changes !== 1) return false;
+
+    db.prepare(
+      `UPDATE scheduled_tasks SET status = 'completed', updated_at = ?
+       WHERE id = ? AND schedule_type = 'once' AND next_run IS NULL
+         AND status IN ('active','paused')`,
+    ).run(now, input.taskId);
     return true;
   })();
 }
@@ -7506,7 +7638,7 @@ export function cleanupOldTaskRunLogs(retentionDays = 30): number {
     .prepare(
       `DELETE FROM task_runs
        WHERE completed_at IS NOT NULL AND completed_at < ?
-         AND status IN ('success','failed','cancelled','missed','delivered')`,
+         AND status IN ('success','failed','cancelled','missed')`,
     )
     .run(cutoff);
   return result.changes + durable.changes;
@@ -10892,7 +11024,17 @@ export function rebuildWorkspacePersistentState(input: {
              FROM task_runs tr
              JOIN scheduled_tasks st ON st.id = tr.task_id
              WHERE st.group_folder = ?
-               AND tr.status IN ('queued','running','retry_wait')
+               AND (
+                 tr.status IN ('queued','running','retry_wait')
+                 OR (
+                   tr.status = 'delivered'
+                   AND json_valid(tr.definition_snapshot)
+                   AND json_extract(
+                     tr.definition_snapshot,
+                     '$.context_mode'
+                   ) = 'group'
+                 )
+               )
              ORDER BY tr.created_at, tr.id`,
           )
           .all(input.groupFolder) as Array<{ id: string }>

--- a/src/index.ts
+++ b/src/index.ts
@@ -439,6 +439,7 @@ import {
   computeNextRunForTaskResume,
   getRunningTaskIds,
   formatScheduledTaskWorkspaceResult,
+  hasAuthoritativeScheduledGroupTerminal,
   resolveScheduledGroupRunsForOutput,
   resolveTerminalScheduledGroupPromptRun,
   scheduledGroupPromptMessageId,
@@ -5442,7 +5443,11 @@ async function projectTerminalScheduledGroupRuns(input: {
   for (const staleRun of input.runs) {
     const run = getTaskRunById(staleRun.id);
     if (!run) continue;
-    if (run.status === input.status && run.error === input.error) {
+    // A genuine terminal already committed for this exact prompt is
+    // authoritative. Provider shutdown/error callbacks can arrive after a
+    // user cancellation or successful result and must not create a competing
+    // generic terminal message.
+    if (hasAuthoritativeScheduledGroupTerminal(run)) {
       sawDeliveredRun = true;
       continue;
     }
@@ -5455,8 +5460,11 @@ async function projectTerminalScheduledGroupRuns(input: {
           runId: run.id,
           result: null,
           error: input.error,
+          status: input.status,
         })
-      : `## ❌ 定时任务执行失败\n\n**任务 ID**：\`${run.task_id}\`\n**运行 ID**：\`${run.id}\`\n**错误**：${input.error}`;
+      : input.status === 'cancelled'
+        ? `## ⏹️ 定时任务已取消\n\n**任务 ID**：\`${run.task_id}\`\n**运行 ID**：\`${run.id}\`\n**原因**：${input.error}`
+        : `## ❌ 定时任务执行失败\n\n**任务 ID**：\`${run.task_id}\`\n**运行 ID**：\`${run.id}\`\n**错误**：${input.error}`;
     const messageId = `scheduled-group-terminal:${run.id}`;
     const outcome = await sendMessageWithOutcome(input.chatJid, text, {
       messageId,

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -23,6 +23,7 @@ import {
 import { PROVIDER_FAILURE_USER_NOTICE } from './provider-failure.js';
 import {
   advanceSkippedTask,
+  cancelDeliveredGroupTaskRunWithWorkspaceIntent,
   cancelTaskRun,
   claimNextTaskRunNotification,
   ClaimedTaskRunNotification,
@@ -518,23 +519,38 @@ export function formatScheduledTaskWorkspaceResult(input: {
   runId: string;
   result: string | null;
   error: string | null;
+  status?: 'success' | 'failed' | 'cancelled';
 }): string {
-  const title = input.error
-    ? '## ❌ 定时任务执行失败'
-    : '## ✅ 定时任务执行完成';
+  const status =
+    input.status ?? (input.error ? ('failed' as const) : ('success' as const));
+  const title =
+    status === 'cancelled'
+      ? '## ⏹️ 定时任务已取消'
+      : status === 'failed'
+        ? '## ❌ 定时任务执行失败'
+        : '## ✅ 定时任务执行完成';
   const metadata = [
     `**任务**：${scheduledTaskDisplayName(input.task)}`,
     `**运行 ID**：\`${input.runId}\``,
   ];
-  if (input.error) metadata.push(`**错误**：${input.error}`);
+  if (input.error) {
+    metadata.push(
+      status === 'cancelled'
+        ? `**原因**：${input.error}`
+        : `**错误**：${input.error}`,
+    );
+  }
 
   const content = input.result?.trim();
   if (content) {
     return `${title}\n\n${metadata.join('\n')}\n\n---\n\n${content}`;
   }
-  const emptyNotice = input.error
-    ? '本次运行没有留下可展示的业务结果，请查看执行日志。'
-    : '本次运行已结束，但 Agent 没有返回可展示的业务结果。';
+  const emptyNotice =
+    status === 'cancelled'
+      ? '本次运行已由用户取消。'
+      : input.error
+        ? '本次运行没有留下可展示的业务结果，请查看执行日志。'
+        : '本次运行已结束，但 Agent 没有返回可展示的业务结果。';
   return `${title}\n\n${metadata.join('\n')}\n\n${emptyNotice}`;
 }
 
@@ -1977,7 +1993,7 @@ export function resolveScheduledGroupRunsForOutput(input: {
       !run ||
       run.task_id !== message.task_id ||
       run.definition_snapshot.context_mode !== 'group' ||
-      !['delivered', 'success', 'failed'].includes(run.status)
+      !['delivered', 'success', 'failed', 'cancelled'].includes(run.status)
     ) {
       continue;
     }
@@ -1985,6 +2001,15 @@ export function resolveScheduledGroupRunsForOutput(input: {
     runs.push(run);
   }
   return runs;
+}
+
+/**
+ * A terminal committed for an exact scheduler prompt wins over later provider
+ * shutdown/error callbacks. Those callbacks are transport lifecycle events,
+ * not authority to replace an already-visible business result.
+ */
+export function hasAuthoritativeScheduledGroupTerminal(run: TaskRun): boolean {
+  return ['success', 'failed', 'cancelled'].includes(run.status);
 }
 
 /**
@@ -3358,10 +3383,68 @@ export function cancelTaskRunNow(runId: string): {
 } {
   const run = getTaskRunById(runId);
   if (!run) return { success: false, error: 'Task run not found' };
-  if (!['queued', 'running', 'retry_wait'].includes(run.status)) {
+  const cancellingDeliveredGroupRun =
+    run.status === 'delivered' &&
+    run.definition_snapshot.context_mode === 'group';
+  if (
+    !cancellingDeliveredGroupRun &&
+    !['queued', 'running', 'retry_wait'].includes(run.status)
+  ) {
     return { success: false, error: `Task run is already ${run.status}` };
   }
-  if (!cancelTaskRun(runId)) {
+  const reason = 'Cancelled by user';
+  const task = cancellingDeliveredGroupRun ? getTaskById(run.task_id) : null;
+  const snapshotTask =
+    task && cancellingDeliveredGroupRun
+      ? {
+          ...task,
+          prompt: run.definition_snapshot.prompt,
+          group_folder: run.definition_snapshot.group_folder,
+          chat_jid: run.definition_snapshot.chat_jid,
+          delivery_route_jid:
+            run.definition_snapshot.delivery_route_jid ??
+            run.definition_snapshot.chat_jid,
+          context_mode: run.definition_snapshot.context_mode,
+          execution_type: run.definition_snapshot.execution_type,
+          execution_mode: run.definition_snapshot.execution_mode,
+          script_command: run.definition_snapshot.script_command,
+          notify_channels: run.definition_snapshot.notify_channels,
+        }
+      : null;
+  const deliveryRouteJid =
+    run.definition_snapshot.delivery_route_jid ??
+    run.definition_snapshot.chat_jid;
+  const cancelled = cancellingDeliveredGroupRun
+    ? !!snapshotTask &&
+      cancelDeliveredGroupTaskRunWithWorkspaceIntent({
+        runId,
+        taskId: run.task_id,
+        reason,
+        payload: {
+          kind: 'workspace_result',
+          chatJid: deliveryRouteJid,
+          text: formatScheduledTaskWorkspaceResult({
+            task: snapshotTask,
+            runId,
+            result: null,
+            error: reason,
+            status: 'cancelled',
+          }),
+          groupRunId: runId,
+          groupTaskId: run.task_id,
+          groupStatus: 'cancelled',
+          groupResult: null,
+          groupError: reason,
+          options: {
+            sourceKind: 'scheduled_task_result',
+            messageId: `scheduled-group-terminal:${runId}`,
+            skipStore: false,
+            workspaceFolder: run.definition_snapshot.group_folder,
+          },
+        },
+      })
+    : cancelTaskRun(runId, reason);
+  if (!cancelled) {
     return {
       success: false,
       error: 'Task run state changed; refresh and retry',

--- a/tests/frontend-task-run-status.test.ts
+++ b/tests/frontend-task-run-status.test.ts
@@ -28,6 +28,10 @@ describe('task run status contract', () => {
     expect(detail).toMatch(/queued:\s*\{[\s\S]*label: '已排队'/);
     expect(detail).toContain("label: '等待重试'");
     expect(detail).toContain("label: '已投递到主会话'");
+    expect(card).toContain('queued|running|recovering|retry_wait|delivered');
+    expect(card).toMatch(
+      /\[\s*'queued',\s*'running',\s*'recovering',\s*'retry_wait',\s*'delivered',?\s*\]/,
+    );
     expect(detail).toContain('定时任务完整结果');
     expect(detail).toContain('setSelectedLog(log)');
     expect(detail).toContain('<MarkdownRenderer');

--- a/tests/routes-groups-rebuild-memory.test.ts
+++ b/tests/routes-groups-rebuild-memory.test.ts
@@ -51,6 +51,7 @@ vi.mock('../src/web.js', () => ({
 }));
 
 const db = await import('../src/db.js');
+const { cancelTaskRunNow } = await import('../src/task-scheduler.js');
 const memoryStore = await import('../src/memory-store.js');
 const ownerProfile = await import('../src/owner-profile-store.js');
 const webContext = await import('../src/web-context.js');
@@ -62,9 +63,7 @@ const stopGroup = vi.fn(async () => {});
 const pauseToken = { id: 1 };
 const pauseGroupsForMutation = vi.fn(() => pauseToken);
 const resumeGroupsAfterMutation = vi.fn();
-const cancelTaskRun = vi.fn((runId: string) => ({
-  success: db.cancelTaskRun(runId),
-}));
+const cancelTaskRun = vi.fn((runId: string) => cancelTaskRunNow(runId));
 const waitForTaskRunsToStop = vi.fn(async () => true);
 const sessions: Record<string, unknown> = {};
 
@@ -165,7 +164,7 @@ describe('POST /:jid/clear-history workspace rebuild', () => {
       prompt: 'This task must move to the recycle bin.',
       schedule_type: 'cron',
       schedule_value: '0 9 * * *',
-      context_mode: 'isolated',
+      context_mode: 'group',
       execution_type: 'agent',
       execution_mode: 'container',
       script_command: null,
@@ -181,6 +180,30 @@ describe('POST /:jid/clear-history workspace rebuild', () => {
       triggerType: 'manual',
       idempotencyKey: 'rebuild-active-run',
     }).run;
+    const activeClaim = db.claimNextTaskRun(
+      'rebuild-delivered-worker',
+      60_000,
+    )!;
+    expect(activeClaim.id).toBe(activeRun.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        activeClaim.id,
+        activeClaim.lease_owner,
+        activeClaim.lease_token,
+      ),
+    ).toBe(true);
+    expect(
+      db.completeTaskRun(
+        activeClaim.id,
+        activeClaim.lease_owner,
+        activeClaim.lease_token,
+        {
+          status: 'delivered',
+          result: '已排队到源工作区，等待智能体执行',
+          notificationStatus: 'skipped',
+        },
+      ),
+    ).toBe(true);
 
     const workspaceDir = path.join(groupsDir, FOLDER);
     const legacyMemoryDir = path.join(root, 'memory', FOLDER);

--- a/tests/routes-tasks-contract.test.ts
+++ b/tests/routes-tasks-contract.test.ts
@@ -191,6 +191,7 @@ beforeEach(() => {
     'purge-stale-route-task-a',
     'purge-stale-route-task-b',
     'route-move-task',
+    'delivered-group-list-task',
   ]) {
     try {
       db.deleteTask(id);
@@ -884,6 +885,56 @@ describe('tasks route ownership and cleanup contract', () => {
       attempt: 0,
       notification_status: 'pending',
     });
+  });
+
+  test('task list exposes a delivered group run as stoppable current work', async () => {
+    createTask('delivered-group-list-task', OWNER_ID, {
+      context_mode: 'group',
+    });
+    const task = db.getTaskById('delivered-group-list-task')!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'delivered-group-list-run',
+    });
+    const claim = db.claimNextTaskRun('delivered-group-list-worker', 60_000)!;
+    expect(claim.id).toBe(created.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      ),
+    ).toBe(true);
+    expect(
+      db.completeTaskRun(claim.id, claim.lease_owner, claim.lease_token, {
+        status: 'delivered',
+        result: '已投递到主会话',
+        notificationStatus: 'skipped',
+      }),
+    ).toBe(true);
+    asUser(OWNER_ID);
+
+    const response = await tasksRoutes.request('/');
+    expect(response.status).toBe(200);
+    const listed = (await response.json()).tasks.find(
+      (candidate: any) => candidate.id === task.id,
+    );
+    expect(listed).toMatchObject({
+      current_run: {
+        id: created.run.id,
+        status: 'delivered',
+      },
+      permissions: {
+        can_stop: true,
+      },
+    });
+    expect(
+      db.finalizeDeliveredGroupTaskRun(created.run.id, task.id, {
+        status: 'cancelled',
+        error: 'test cleanup',
+      }),
+    ).toBe(true);
   });
 
   test('runs endpoint merges pre-upgrade history with V2 runs and removes duplicates', async () => {

--- a/tests/task-runs-v2.test.ts
+++ b/tests/task-runs-v2.test.ts
@@ -119,6 +119,96 @@ describe('scheduled task definition revisions', () => {
 });
 
 describe('durable task occurrences', () => {
+  test('treats only delivered group runs as active and prioritizes executable work', () => {
+    const groupTask = createDefinition('active-delivered-group', {
+      context_mode: 'group',
+    });
+    const delivered = db.createTaskRun({
+      task: groupTask,
+      triggerType: 'manual',
+      idempotencyKey: 'active-delivered-group-first',
+    });
+    const groupClaim = db.claimNextTaskRun(
+      'active-delivered-group-worker',
+      60_000,
+    )!;
+    expect(groupClaim.id).toBe(delivered.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        groupClaim.id,
+        groupClaim.lease_owner,
+        groupClaim.lease_token,
+      ),
+    ).toBe(true);
+    expect(
+      db.completeTaskRun(
+        groupClaim.id,
+        groupClaim.lease_owner,
+        groupClaim.lease_token,
+        {
+          status: 'delivered',
+          result: 'queued in workspace',
+          notificationStatus: 'skipped',
+        },
+      ),
+    ).toBe(true);
+    expect(db.getActiveTaskRunForTask(groupTask.id)?.id).toBe(delivered.run.id);
+
+    const queued = db.createTaskRun({
+      task: groupTask,
+      triggerType: 'manual',
+      idempotencyKey: 'active-delivered-group-second',
+    });
+    expect(queued.created).toBe(true);
+    expect(db.getActiveTaskRunForTask(groupTask.id)?.id).toBe(queued.run.id);
+    expect(db.cancelTaskRun(queued.run.id)).toBe(true);
+    expect(db.getActiveTaskRunForTask(groupTask.id)?.id).toBe(delivered.run.id);
+    expect(
+      db.finalizeDeliveredGroupTaskRun(delivered.run.id, groupTask.id, {
+        status: 'cancelled',
+        error: 'test cleanup',
+      }),
+    ).toBe(true);
+
+    const isolatedTask = createDefinition('inactive-delivered-isolated');
+    const isolated = db.createTaskRun({
+      task: isolatedTask,
+      triggerType: 'manual',
+      idempotencyKey: 'inactive-delivered-isolated-run',
+    });
+    const isolatedClaim = db.claimNextTaskRun(
+      'inactive-delivered-isolated-worker',
+      60_000,
+    )!;
+    expect(isolatedClaim.id).toBe(isolated.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        isolatedClaim.id,
+        isolatedClaim.lease_owner,
+        isolatedClaim.lease_token,
+      ),
+    ).toBe(true);
+    expect(
+      db.completeTaskRun(
+        isolatedClaim.id,
+        isolatedClaim.lease_owner,
+        isolatedClaim.lease_token,
+        {
+          status: 'delivered',
+          result: 'legacy isolated delivery',
+          notificationStatus: 'skipped',
+        },
+      ),
+    ).toBe(true);
+    expect(db.getActiveTaskRunForTask(isolatedTask.id)).toBeUndefined();
+    expect(
+      db.finalizeDeliveredGroupTaskRun(isolated.run.id, isolatedTask.id, {
+        status: 'failed',
+        error: 'test cleanup',
+      }),
+    ).toBe(true);
+  });
+
   test('freezes the concrete delivery route in each run snapshot', () => {
     const originalRoute =
       'feishu:oc_snapshot#account:bot-a#thread:t-1#root:m-1';

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -128,6 +128,7 @@ const {
   deliverPersistedNotificationPayload,
   enqueueIsolatedScheduledTask,
   getRunningTaskIds,
+  hasAuthoritativeScheduledGroupTerminal,
   processClaimedTaskRunNotification,
   resolveScheduledGroupRunsForOutput,
   resolveTerminalScheduledGroupPromptRun,
@@ -687,16 +688,173 @@ describe('scheduled task workspace/session contract', () => {
     expect(storedPrompt).toContain('工具投递不能替代上述完整最终文本');
   });
 
+  test('cancels a delivered group run and durably projects the cancellation into its workspace', async () => {
+    const baseJid = 'feishu:oc_cancel#account:bot-a';
+    const deliveryRouteJid = `${baseJid}#thread:thread-a#root:root-a`;
+    db.setRegisteredGroup(baseJid, {
+      ...db.getRegisteredGroup(GROUP_JID)!,
+      folder: GROUP_FOLDER,
+    });
+    const taskId = createTask({
+      id: 'task-group-delivered-cancel',
+      context_mode: 'group',
+      chat_jid: baseJid,
+      delivery_route_jid: deliveryRouteJid,
+    });
+    const groups = {
+      [baseJid]: db.getRegisteredGroup(baseJid)!,
+    };
+    const { deps } = makeDeps(groups);
+
+    const trigger = triggerTaskNow(taskId, deps);
+    expect(trigger).toMatchObject({
+      success: true,
+      runId: expect.any(String),
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'delivered',
+      notification_status: 'skipped',
+    });
+
+    expect(
+      db.cancelDeliveredGroupTaskRunWithWorkspaceIntent({
+        runId: trigger.runId!,
+        taskId,
+        reason: 'Cancelled by user',
+        payload: {
+          kind: 'workspace_result',
+          chatJid: baseJid,
+          text: 'must not commit on the wrong route',
+          groupRunId: trigger.runId!,
+          groupTaskId: taskId,
+          groupStatus: 'cancelled',
+          groupResult: null,
+          groupError: 'Cancelled by user',
+          options: {
+            sourceKind: 'scheduled_task_result',
+            messageId: `scheduled-group-terminal:${trigger.runId}`,
+            skipStore: false,
+            workspaceFolder: GROUP_FOLDER,
+          },
+        },
+      }),
+    ).toBe(false);
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'delivered',
+      notification_status: 'skipped',
+    });
+
+    db.updateTask(taskId, { prompt: 'edited prompt must not leak' });
+    expect(cancelTaskRunNow(trigger.runId!)).toEqual({ success: true });
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'cancelled',
+      result: null,
+      error: 'Cancelled by user',
+      notification_status: 'pending',
+    });
+
+    const lateMessageId = `scheduled-group-late:${trigger.runId}`;
+    expect(() =>
+      db.storeScheduledGroupWorkspaceResultAndFinalize({
+        messageId: lateMessageId,
+        chatJid: deliveryRouteJid,
+        senderId: 'happyclaw-agent',
+        senderName: 'HappyClaw',
+        text: '迟到的成功结果',
+        timestamp: new Date().toISOString(),
+        messageMeta: { sourceKind: 'scheduled_task_result' },
+        finalizations: [
+          {
+            runId: trigger.runId!,
+            taskId,
+            status: 'success',
+            result: '迟到的成功结果',
+            error: null,
+          },
+        ],
+      }),
+    ).toThrow(/could not atomically accept/);
+    expect(db.getMessage(deliveryRouteJid, lateMessageId)).toBeNull();
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'cancelled',
+      result: null,
+      error: 'Cancelled by user',
+      notification_status: 'pending',
+    });
+
+    const notification = db.claimTaskRunNotificationById(
+      trigger.runId!,
+      'group-cancel-workspace-projector',
+      60_000,
+    )!;
+    expect(notification.payload).toMatchObject({
+      kind: 'workspace_result',
+      chatJid: deliveryRouteJid,
+      groupRunId: trigger.runId,
+      groupTaskId: taskId,
+      groupStatus: 'cancelled',
+      groupResult: null,
+      groupError: 'Cancelled by user',
+      options: {
+        sourceKind: 'scheduled_task_result',
+        messageId: `scheduled-group-terminal:${trigger.runId}`,
+        skipStore: false,
+        workspaceFolder: GROUP_FOLDER,
+      },
+    });
+    expect(notification.payload).toMatchObject({
+      text: expect.stringContaining('定时任务已取消'),
+    });
+    expect(notification.payload).toMatchObject({
+      text: expect.stringContaining('write a short status'),
+    });
+    expect(notification.payload).toMatchObject({
+      text: expect.stringContaining('Cancelled by user'),
+    });
+    expect((notification.payload as { text: string }).text).not.toContain(
+      '执行失败',
+    );
+    expect((notification.payload as { text: string }).text).not.toContain(
+      'edited prompt must not leak',
+    );
+    expect(
+      await processClaimedTaskRunNotification(notification, deps, 60_000),
+    ).toBe(true);
+    expect(deps.storeResultAndNotify).toHaveBeenCalledWith(
+      deliveryRouteJid,
+      expect.stringContaining('Cancelled by user'),
+      expect.objectContaining({
+        messageId: `scheduled-group-terminal:${trigger.runId}`,
+        skipStore: false,
+      }),
+    );
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'cancelled',
+      notification_status: 'success',
+      notification_error: null,
+    });
+  });
+
   test('resolves exact cold and warm group runs, including multi-prompt batches, without guessing from ordinary messages', () => {
-    const run = (id: string, taskId: string) =>
+    const run = (
+      id: string,
+      taskId: string,
+      status: 'delivered' | 'success' | 'failed' | 'cancelled' = 'delivered',
+    ) =>
       ({
         id,
         task_id: taskId,
-        status: 'delivered',
+        status,
         definition_snapshot: { context_mode: 'group' },
       }) as any;
     const runA = run('11111111-1111-4111-8111-111111111111', 'group-task-a');
     const runB = run('22222222-2222-4222-8222-222222222222', 'group-task-b');
+    const runC = run(
+      '33333333-3333-4333-8333-333333333333',
+      'group-task-c',
+      'cancelled',
+    );
     const promptA = {
       id: scheduledGroupPromptMessageId(runA.id),
       chat_jid: GROUP_JID,
@@ -709,6 +867,12 @@ describe('scheduled task workspace/session contract', () => {
       source_kind: 'scheduled_task_prompt',
       task_id: runB.task_id,
     };
+    const promptC = {
+      id: scheduledGroupPromptMessageId(runC.id),
+      chat_jid: GROUP_JID,
+      source_kind: 'scheduled_task_prompt',
+      task_id: runC.task_id,
+    };
     const ordinary = {
       id: 'ordinary-user-input',
       chat_jid: GROUP_JID,
@@ -716,11 +880,15 @@ describe('scheduled task workspace/session contract', () => {
       task_id: null,
     };
     const messages = new Map(
-      [promptA, ordinary, promptB].map((message) => [message.id, message]),
+      [promptA, ordinary, promptB, promptC].map((message) => [
+        message.id,
+        message,
+      ]),
     );
     const runs = new Map([
       [runA.id, runA],
       [runB.id, runB],
+      [runC.id, runC],
     ]);
     const common = {
       chatJid: GROUP_JID,
@@ -761,12 +929,18 @@ describe('scheduled task workspace/session contract', () => {
                 timestamp: '2026-07-30T00:00:02.000Z',
                 id: promptB.id,
               },
+              {
+                timestamp: '2026-07-30T00:00:03.000Z',
+                id: promptC.id,
+              },
             ],
           } as any,
         ],
       },
     });
-    expect(warm.map((item) => item.id)).toEqual([runA.id, runB.id]);
+    expect(warm.map((item) => item.id)).toEqual([runA.id, runB.id, runC.id]);
+    expect(hasAuthoritativeScheduledGroupTerminal(runC)).toBe(true);
+    expect(hasAuthoritativeScheduledGroupTerminal(runA)).toBe(false);
 
     const ordinaryOnly = resolveScheduledGroupRunsForOutput({
       ...common,
@@ -820,6 +994,15 @@ describe('scheduled task workspace/session contract', () => {
         result: '迟到的不同回调',
       }),
     ).toBe(false);
+    expect(db.getTaskRunById(claim.id)).toMatchObject({
+      status: 'success',
+      result: '完整业务结果',
+      error: null,
+    });
+    expect(cancelTaskRunNow(claim.id)).toEqual({
+      success: false,
+      error: 'Task run is already success',
+    });
     expect(db.getTaskRunById(claim.id)).toMatchObject({
       status: 'success',
       result: '完整业务结果',
@@ -1423,6 +1606,15 @@ describe('scheduled task workspace/session contract', () => {
         db.getTaskRunById,
       ),
     ).toBeNull();
+    expect(
+      db.finalizeDeliveredGroupTaskRun(laterCreated.run.id, taskId, {
+        status: 'cancelled',
+        error: 'Cancelled by user',
+      }),
+    ).toBe(true);
+    expect(
+      resolveTerminalScheduledGroupPromptRun(laterPrompt, db.getTaskRunById),
+    ).toMatchObject({ id: laterCreated.run.id, status: 'cancelled' });
   });
 
   test('host task cannot use an admin creator to bypass a downgraded workspace owner', async () => {

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -52,7 +52,9 @@ export function TaskCard({
   const currentRun = task.current_run;
   const effectiveRunning =
     isRunning ||
-    !!currentRun?.status.match(/^(queued|running|recovering|retry_wait)$/);
+    !!currentRun?.status.match(
+      /^(queued|running|recovering|retry_wait|delivered)$/,
+    );
 
   const runStatusLabel = (run: TaskRun): string => {
     switch (run.status) {
@@ -275,9 +277,13 @@ export function TaskCard({
           {currentRun &&
             onStopRun &&
             task.permissions?.can_stop !== false &&
-            ['queued', 'running', 'recovering', 'retry_wait'].includes(
-              currentRun.status,
-            ) && (
+            [
+              'queued',
+              'running',
+              'recovering',
+              'retry_wait',
+              'delivered',
+            ].includes(currentRun.status) && (
               <button
                 type="button"
                 onClick={(event) => {


### PR DESCRIPTION
## Summary
- treat delivered group task runs as cancellable business work until their full workspace result is durable
- atomically persist cancellation intent on the immutable delivery route and suppress late Agent/provider terminals
- expose stop controls in task APIs/UI and protect workspace rebuild/retention boundaries

## Validation
- npm test -- --run --maxWorkers=4 (321 files, 2717 tests)
- npm run build:all
- npm run typecheck
- npm run format:check
- npm run docs:check
- git diff --check