### PR TITLE
fix(ci): retry Docker Hub manifest verification

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -173,9 +173,26 @@ jobs:
           docker buildx imagetools create \
             --tag "${IMAGE_NAME}:latest" \
             "${IMAGE_NAME}@${MANIFEST_DIGEST}"
-          latest_digest="$(
-            docker buildx imagetools inspect "${IMAGE_NAME}:latest" |
-              awk '$1 == "Digest:" { print $2; exit }'
-          )"
+
+          # Docker Hub can acknowledge the tag mutation before every registry
+          # read path can resolve it. Retry the read-after-write verification
+          # instead of marking an already-published image as failed.
+          latest_digest=""
+          for attempt in {1..12}; do
+            if inspection="$(
+              docker buildx imagetools inspect "${IMAGE_NAME}:latest" 2>&1
+            )"; then
+              latest_digest="$(
+                awk '$1 == "Digest:" { print $2; exit }' <<<"$inspection"
+              )"
+              if [ "$latest_digest" = "$MANIFEST_DIGEST" ]; then
+                break
+              fi
+              echo "latest resolved to ${latest_digest:-no digest}; waiting for ${MANIFEST_DIGEST}" >&2
+            else
+              echo "latest is not readable yet (attempt ${attempt}/12): ${inspection}" >&2
+            fi
+            sleep 5
+          done
           test "$latest_digest" = "$MANIFEST_DIGEST"
           echo "Published ${IMAGE_NAME}:latest at ${MANIFEST_DIGEST}"

--- a/tests/docker-publish-workflow-contract.test.ts
+++ b/tests/docker-publish-workflow-contract.test.ts
@@ -38,6 +38,8 @@ describe('Docker image distribution contract', () => {
     expect(workflow).toContain('cosign sign --yes');
     expect(workflow).toContain('cosign verify');
     expect(workflow).toContain('--tag "${IMAGE_NAME}:latest"');
+    expect(workflow).toContain('for attempt in {1..12}');
+    expect(workflow).toContain('if [ "$latest_digest" = "$MANIFEST_DIGEST" ]');
     expect(workflow).toContain('username: ${{ secrets.DOCKERHUB_USERNAME }}');
     expect(workflow).toContain('password: ${{ secrets.DOCKERHUB_TOKEN }}');
     expect(workflow).not.toContain(`${['dckr', 'pat'].join('_')}_`);


### PR DESCRIPTION
## Summary
- tolerate Docker Hub read-after-write propagation after an exact signed manifest is tagged as latest
- keep fail-closed verification against the expected manifest digest
- cover the bounded retry contract

## Incident
Run 30562639309 successfully built/smoked both native platforms and pushed latest at the expected digest, but the immediate registry inspection exited 255. A later inspect resolved the exact expected digest.

## Validation
- npm test -- --run tests/docker-publish-workflow-contract.test.ts
- npm run typecheck
- npm run format:check
- git diff --check