### PR TITLE
fix(tasks): finalize first scheduled group result

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -91,7 +91,10 @@ import {
   latestIpcInputMessage,
   orderIpcInputMessages,
   parseIpcReceipt,
+  partitionIpcMessagesForLogicalTurn,
   requeueIpcInputMessages,
+  resolveLogicalQueryInputTurnId,
+  shouldAcceptIpcMessagesDuringQuery,
   type IpcDeliveryReceipt,
   type IpcInputMessage,
 } from './ipc-delivery.js';
@@ -1661,6 +1664,8 @@ async function runQueryAttempt(
   sourceKindOverride?: ContainerOutput['sourceKind'],
   initialIpcMessages: IpcInputMessage[] = [],
   mcpToolsContext?: McpContext,
+  logicalInputTurnIdOverride?: string,
+  acceptIpcMessagesDuringQuery = true,
 ): Promise<{
   newSessionId?: string;
   lastAssistantUuid?: string;
@@ -1696,10 +1701,15 @@ async function runQueryAttempt(
   // name in the return type, this includes the initial startup/idle-drain batch
   // as well as messages piped while the query is active.
   const ipcDeliveryTracker = new IpcTurnDeliveryTracker(initialIpcMessages);
-  const coldInputTurnId = containerInput.turnId || generateTurnId();
+  const coldInputTurnId =
+    resolveLogicalQueryInputTurnId(
+      containerInput.turnId,
+      logicalInputTurnIdOverride,
+    ) ?? generateTurnId();
   const outputCorrelation = new IpcTurnOutputCorrelation(
     ipcDeliveryTracker,
     coldInputTurnId,
+    logicalInputTurnIdOverride,
   );
   const activateCurrentInputTurn = (
     fallbackInputTurnId: string = outputCorrelation.currentInputTurnId,
@@ -1898,6 +1908,7 @@ async function runQueryAttempt(
       status: 'success',
       result: `\u26a0\ufe0f ${reason}`,
       newSessionId: undefined,
+      sourceKind: 'input_rejection_warning',
     });
   }
 
@@ -2110,11 +2121,16 @@ async function runQueryAttempt(
       ipcQueryWatcher.close();
       return;
     }
-    // Maintenance side-queries (emitOutput=false) must NOT consume user IPC
-    // messages — those belong to the main query loop. Only sentinels
-    // are checked above. Without this guard, a user message arriving during a side-query
-    // gets silently consumed, leaving queryInFlight=true on the host forever (bug #259).
-    if (!emitOutput) {
+    // Maintenance and internal continuation queries must NOT consume later
+    // user IPC messages — those belong to the main query loop. Only sentinels
+    // are checked above. The preceding truncated query requeues anything it
+    // already drained before the continuation disables consumption here.
+    if (
+      !shouldAcceptIpcMessagesDuringQuery(
+        emitOutput,
+        acceptIpcMessagesDuringQuery,
+      )
+    ) {
       return; // No setTimeout needed — watcher will trigger next check on file change
     }
 
@@ -3708,6 +3724,8 @@ async function runQuery(
   sourceKindOverride?: ContainerOutput['sourceKind'],
   initialIpcMessages: IpcInputMessage[] = [],
   mcpToolsContext?: McpContext,
+  logicalInputTurnIdOverride?: string,
+  acceptIpcMessagesDuringQuery = true,
 ): Promise<RunQueryResult> {
   const first = await runQueryAttempt(
     prompt,
@@ -3723,6 +3741,8 @@ async function runQuery(
     sourceKindOverride,
     initialIpcMessages,
     mcpToolsContext,
+    logicalInputTurnIdOverride,
+    acceptIpcMessagesDuringQuery,
   );
   const failed = first.providerFailureTurn;
   if (!failed) return first;
@@ -3757,6 +3777,8 @@ async function runQuery(
     sourceKindOverride,
     failed.ipcMessages,
     mcpToolsContext,
+    logicalInputTurnIdOverride,
+    acceptIpcMessagesDuringQuery,
   );
 }
 
@@ -4370,7 +4392,21 @@ async function main(): Promise<void> {
       let truncatedTail = ranCompactionContinue
         ? undefined
         : queryResult.suspectTruncatedTail;
-      let truncationIpcMessages = queryResult.pipedMessagesDuringQuery;
+      const truncationLogicalInputTurnId = activeOutputInputTurnId;
+      const initialTruncationInputs = partitionIpcMessagesForLogicalTurn(
+        queryResult.pipedMessagesDuringQuery,
+        truncationLogicalInputTurnId,
+      );
+      let truncationIpcMessages = initialTruncationInputs.owned;
+      if (initialTruncationInputs.deferred.length > 0) {
+        requeueIpcInputMessages(
+          IPC_INPUT_DIR,
+          initialTruncationInputs.deferred,
+        );
+        log(
+          `Re-enqueued ${initialTruncationInputs.deferred.length} later IPC message(s) before truncation continuation`,
+        );
+      }
       let truncationContinues = 0;
       const MAX_TRUNCATION_CONTINUES = 2;
       let closedDuringTruncationContinue = false;
@@ -4401,6 +4437,8 @@ async function main(): Promise<void> {
           'truncation_continue',
           truncationIpcMessages,
           mcpToolsConfig,
+          truncationLogicalInputTurnId,
+          false,
         );
         truncationIpcMessages = contResult.pipedMessagesDuringQuery;
         currentIpcMessages = truncationIpcMessages;
@@ -4496,7 +4534,6 @@ async function main(): Promise<void> {
           },
         });
       }
-
       log('Query ended, waiting for next IPC message...');
 
       // Wait for the next message or _close sentinel

--- a/container/agent-runner/src/ipc-delivery.ts
+++ b/container/agent-runner/src/ipc-delivery.ts
@@ -236,8 +236,12 @@ export class IpcTurnOutputCorrelation {
   constructor(
     private readonly tracker: IpcTurnDeliveryTracker,
     coldHostTurnId: string,
+    private readonly forcedLogicalInputTurnId?: string,
   ) {
-    this.inputTurnIdValue = tracker.currentTurnDeliveryId || coldHostTurnId;
+    this.inputTurnIdValue =
+      forcedLogicalInputTurnId ||
+      tracker.currentTurnDeliveryId ||
+      coldHostTurnId;
   }
 
   get currentInputTurnId(): string {
@@ -246,13 +250,51 @@ export class IpcTurnOutputCorrelation {
 
   syncCurrentTurn(fallbackInputTurnId = this.inputTurnIdValue): string {
     this.inputTurnIdValue =
-      this.tracker.currentTurnDeliveryId || fallbackInputTurnId;
+      this.forcedLogicalInputTurnId ||
+      this.tracker.currentTurnDeliveryId ||
+      fallbackInputTurnId;
     return this.inputTurnIdValue;
   }
 
   correlate(output: ContainerOutput): ContainerOutput {
     return { ...output, inputTurnId: this.inputTurnIdValue };
   }
+}
+
+/** Internal continuation queries may rotate their presentation turn id, but
+ * every emitted frame must retain the immutable user-input identity. */
+export function resolveLogicalQueryInputTurnId(
+  presentationTurnId: string | undefined,
+  logicalInputTurnIdOverride?: string,
+): string | undefined {
+  return logicalInputTurnIdOverride ?? presentationTurnId;
+}
+
+export function partitionIpcMessagesForLogicalTurn(
+  messages: IpcInputMessage[],
+  logicalInputTurnId: string | undefined,
+): {
+  owned: IpcInputMessage[];
+  deferred: IpcInputMessage[];
+} {
+  if (!logicalInputTurnId) return { owned: [...messages], deferred: [] };
+  const owned: IpcInputMessage[] = [];
+  const deferred: IpcInputMessage[] = [];
+  for (const message of messages) {
+    if (!message.receipt || message.receipt.deliveryId === logicalInputTurnId) {
+      owned.push(message);
+    } else {
+      deferred.push(message);
+    }
+  }
+  return { owned, deferred };
+}
+
+export function shouldAcceptIpcMessagesDuringQuery(
+  emitOutput: boolean,
+  acceptIpcMessagesDuringQuery: boolean,
+): boolean {
+  return emitOutput && acceptIpcMessagesDuringQuery;
 }
 
 export function serializeIpcInputMessage(message: IpcInputMessage): object {

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -330,6 +330,7 @@ export interface ContainerOutput {
     | 'sdk_final'
     | 'sdk_send_message'
     | 'proactive_sdk_fallback'
+    | 'input_rejection_warning'
     | 'interrupt_partial'
     | 'overflow_partial'
     | 'compact_partial'

--- a/src/db.ts
+++ b/src/db.ts
@@ -130,7 +130,8 @@ function stmts() {
     _stmts = {
       storeMessageSelect: db.prepare(
         `SELECT id FROM messages
-         WHERE chat_jid = ? AND turn_id = ? AND source_kind = 'sdk_final'
+         WHERE chat_jid = ? AND turn_id = ?
+           AND source_kind IN ('sdk_final','truncation_continue','scheduled_task_result')
          ORDER BY timestamp DESC LIMIT 1`,
       ),
       storeMessageInsert: db.prepare(
@@ -2671,11 +2672,13 @@ export function storeMessageDirect(
 ): string {
   const { attachments, tokenUsage, sourceJid, channelContext, meta } =
     opts ?? {};
-  // truncation_continue 与 sdk_final 同属"最终回复"：截断自动续写的后续 turn
-  // 复用挂起序列的 turnId 时必须命中同一行（全渠道一条回复的 DB 合并基础）。
+  // SDK/continuation/scheduled terminals share one logical final-answer row.
+  // A scheduled terminal must upgrade an earlier held sdk_final checkpoint,
+  // while replay of scheduled_task_result must remain idempotent.
   const existingFinalRow =
     (meta?.sourceKind === 'sdk_final' ||
-      meta?.sourceKind === 'truncation_continue') &&
+      meta?.sourceKind === 'truncation_continue' ||
+      meta?.sourceKind === 'scheduled_task_result') &&
     meta.turnId
       ? (stmts().storeMessageSelect.get(chatJid, meta.turnId) as
           | { id: string }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,10 @@ import {
   acknowledgeIpcReplyTurn,
   decideAssistantPrimaryProjection,
   isGenuineReplyResult,
+  occupiesPrimaryReplyDeliverySlot,
+  resolveHeldReplyDbText,
   setIpcReplyInputTurn,
+  shouldFinalizeScheduledGroupPrimaryResult,
   shouldSkipRetryAfterLateError,
   wasGenuineReplyDeliveredForInput,
   type IpcReplyTurnTracker,
@@ -1246,6 +1249,7 @@ type ReplyRouteAdmission = (
   inputTurnId: string,
   inputCursor?: MessageCursor,
   coveredInputs?: Array<{ id: string; sourceJid?: string }>,
+  receipt?: IpcDeliveryReceipt,
 ) => IpcPrePublishAdmission | false;
 const activeRouteAdmissions = new Map<string, ReplyRouteAdmission>();
 
@@ -1268,6 +1272,7 @@ function invokeActiveRouteAdmission(
           id: cursor.id,
           sourceJid: cursor.sourceJid,
         })),
+        receipt,
       )
     : false;
 }
@@ -6480,7 +6485,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   bindTurnOutputCoordinator(lastProcessed.id);
   activeRouteAdmissions.set(
     mainAdmissionKey,
-    (newSourceJid, inputTurnId, inputCursor, coveredInputs) => {
+    (newSourceJid, inputTurnId, inputCursor, coveredInputs, receipt) => {
       const isCurrentOrNewer =
         !inputCursor ||
         isCursorAfter(inputCursor, currentInputCursor) ||
@@ -6578,10 +6583,21 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           );
         }
       }
+      // This runs in GroupQueue's beforePublish hook, before the IPC temp file
+      // is atomically renamed into the runner-visible inbox. A host runner can
+      // therefore never emit its first primary result before the exact
+      // scheduled prompt cursors have been bound to this random delivery id.
+      if (receipt?.deliveryId === inputTurnId) {
+        rememberScheduledGroupRuns({
+          inputTurnId,
+          ipcReceipts: [receipt],
+        });
+      }
       return {
         rollback: () => {
           const admitted = admittedWarmMainInputs.get(inputTurnId);
           if (!admitted) return;
+          scheduledGroupRunsByInput.delete(inputTurnId);
           admittedWarmMainInputs.delete(inputTurnId);
           channelTurnRuntimes.delete(inputTurnId);
           channelOutboxScopesByInput.delete(inputTurnId);
@@ -7914,6 +7930,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                   : (result.pendingBgTasks ?? 0) > 0
                     ? 'bg_tasks'
                     : null;
+              if (!holdReason) text = stripRedundantCompletionPreamble(text);
+              // Keep the substantive fragment separately: a healthy
+              // truncation_continue must concatenate the original fragment
+              // without preserving this transient progress notice.
+              const heldPartText = text;
               // 状态提示追加进正文：进入 DB / Web / 卡片转录，非卡渠道（QQ 纯文本
               // 等无法挂起的通道）也能看到"还没完"。
               if (result.finalizationReason === 'truncated') {
@@ -7921,7 +7942,6 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               } else if ((result.pendingBgTasks ?? 0) > 0) {
                 text += `\n\n> ⏳ ${result.pendingBgTasks} 个后台任务运行中，完成后将继续汇总`;
               }
-              if (!holdReason) text = stripRedundantCompletionPreamble(text);
               const localImagePaths = extractLocalImImagePaths(
                 text,
                 effectiveGroup.folder,
@@ -7931,6 +7951,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               // DB 合并用：进入卡片分支前留存已有挂起前缀（分支内会改动 parts）
               const heldBaseForDb = heldCardBaseText();
               const wasInHeldSeq = heldDbTurnId !== null;
+              const heldSequenceTurnId = heldDbTurnId;
+              const occupiesPrimarySlot = occupiesPrimaryReplyDeliverySlot(
+                result.sourceKind,
+              );
 
               // ── Complete or hold Feishu streaming card ──
               // If a streaming card is active, finalize it with the complete text.
@@ -7942,7 +7966,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 | NonNullable<typeof outputStreamingSession>
                 | undefined;
               if (holdReason) {
-                heldCardParts.push(text);
+                heldCardParts.push(heldPartText);
                 cardHeldThisResult = true;
                 if (outputStreamingSession?.isActive()) {
                   streamingCardHandledIM = true;
@@ -7971,7 +7995,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                   },
                   'Reply held open (background tasks / truncation continue)',
                 );
-              } else if (outputStreamingSession?.isActive()) {
+              } else if (
+                occupiesPrimarySlot &&
+                outputStreamingSession?.isActive()
+              ) {
                 pendingStreamingCardCompletion = outputStreamingSession;
                 streamingCardHandledIM = true;
               }
@@ -8088,28 +8115,39 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 // Intermediate held turns remain visible while running. The
                 // healthy completion replaces them with the authoritative
                 // final answer; WorkflowRunCard preserves the execution trace.
-                dbText = holdReason ? heldBaseForDb + text : text;
+                dbText = resolveHeldReplyDbText({
+                  heldBaseText: heldBaseForDb,
+                  text,
+                  sourceKind: result.sourceKind,
+                  holdReason,
+                  wasInHeldSequence: wasInHeldSeq,
+                });
                 if (!holdReason) heldDbTurnId = null; // healthy 收尾，序列结束
               } else {
                 turnIdForDb = effectiveTurnId;
               }
-              const isGenuineCompletedGroupResult =
-                result.status === 'success' &&
-                !result.providerFailure &&
-                !holdReason &&
-                result.inputTurnCompleted === true &&
-                isGenuineReplyResult({
+              const scheduledGroupCorrelationInputId =
+                result.sourceKind === 'truncation_continue' &&
+                heldSequenceTurnId
+                  ? heldSequenceTurnId
+                  : effectiveTurnId;
+              const correlatedScheduledGroupRuns = [
+                ...(scheduledGroupRunsByInput
+                  .get(scheduledGroupCorrelationInputId)
+                  ?.values() ?? []),
+              ];
+              const scheduledGroupRuns =
+                shouldFinalizeScheduledGroupPrimaryResult({
+                  status: result.status,
+                  providerFailure: result.providerFailure,
                   holdReason,
                   sourceKind: result.sourceKind,
                   finalizationReason: result.finalizationReason,
-                });
-              const scheduledGroupRuns = isGenuineCompletedGroupResult
-                ? [
-                    ...(scheduledGroupRunsByInput
-                      .get(effectiveTurnId)
-                      ?.values() ?? []),
-                  ]
-                : [];
+                  hasScheduledGroupRuns:
+                    correlatedScheduledGroupRuns.length > 0,
+                })
+                  ? correlatedScheduledGroupRuns
+                  : [];
               const scheduledGroupResultMessageId =
                 scheduledGroupRuns.length > 0
                   ? `scheduled-group-result:${crypto
@@ -8154,7 +8192,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                     turnId: turnIdForDb,
                     sessionId: result.sessionId || activeSessionId,
                     sdkMessageUuid: result.sdkMessageUuid,
-                    sourceKind: result.sourceKind || 'sdk_final',
+                    sourceKind:
+                      scheduledGroupRuns.length > 0
+                        ? 'scheduled_task_result'
+                        : result.sourceKind || 'sdk_final',
                     finalizationReason:
                       result.finalizationReason || 'completed',
                   },
@@ -8237,7 +8278,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
                 const cardFinalization = await finalizeChannelCardAfterDelivery(
                   pendingStreamingCardCompletion,
-                  text,
+                  dbText,
                   streamingCardAttachmentsDelivered,
                   streamingCardAttachmentsDelivered
                     ? '回复投递未确认，系统将重试'
@@ -8387,8 +8428,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 replyDeliveryAcknowledged &&= scheduledGroupProjectionDurable;
               }
 
-              sentReply = true;
-              sentReplyByInput.set(outputChannelScope.inputId, true);
+              if (occupiesPrimarySlot) {
+                sentReply = true;
+                sentReplyByInput.set(outputChannelScope.inputId, true);
+              }
               // See isGenuineReplyResult's doc comment (src/reply-delivery.ts)
               // for why a held/partial result must not count. Only ever SET
               // to true, never overwrite back to false: a later held/partial
@@ -8426,7 +8469,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               // Persist cursor as soon as a visible reply is emitted.
               // Long-lived runners may stay alive for idleTimeout, and waiting
               // until process exit would cause duplicate replay after restart.
-              if (replyDeliveryAcknowledged) {
+              if (replyDeliveryAcknowledged && occupiesPrimarySlot) {
                 const acknowledgedInputIds = result.ipcReceipts?.length
                   ? result.ipcReceipts.map((receipt) => receipt.deliveryId)
                   : [result.inputTurnId ?? lastProcessed.id];
@@ -15650,13 +15693,20 @@ async function processAgentConversation(
             : (output.pendingBgTasks ?? 0) > 0
               ? 'bg_tasks'
               : null;
+        if (!holdReason) text = stripRedundantCompletionPreamble(text);
+        // Retain only business content in the held accumulator. The visible
+        // checkpoint may carry a progress notice, but the completed
+        // truncation continuation must not include that obsolete notice.
+        const heldPartText = text;
         // 状态提示追加进正文（DB / Web / 卡片转录一致可见）
         if (output.finalizationReason === 'truncated') {
           text += '\n\n> ⚠️ 回复在生成中被上游截断，正在自动续写…';
         } else if ((output.pendingBgTasks ?? 0) > 0) {
           text += `\n\n> ⏳ ${output.pendingBgTasks} 个后台任务运行中，完成后将继续汇总`;
         }
-        if (!holdReason) text = stripRedundantCompletionPreamble(text);
+        const occupiesPrimarySlot = occupiesPrimaryReplyDeliverySlot(
+          output.sourceKind,
+        );
         heldAgentUsagePatchPending = false;
         const isFirstReply = !(
           agentReplySentByInput.get(outputAgentScope.inputId) ?? false
@@ -15670,7 +15720,13 @@ async function processAgentConversation(
         const msgId = heldAgentDbMsgId ?? crypto.randomUUID();
         // Keep progress visible while held, then replace it with the final
         // answer so process narration never becomes part of the conclusion.
-        const dbText = holdReason ? heldBaseForDb + text : text;
+        const dbText = resolveHeldReplyDbText({
+          heldBaseText: heldBaseForDb,
+          text,
+          sourceKind: output.sourceKind,
+          holdReason,
+          wasInHeldSequence: heldAgentDbTurnId !== null,
+        });
         const dbTurnId = inHeldSeq
           ? heldAgentDbTurnId || outputAgentScope.inputId
           : outputAgentScope.inputId;
@@ -15735,7 +15791,11 @@ async function processAgentConversation(
         }
 
         // Async LLM title upgrade after the first substantive reply.
-        if (isFirstReply && agent.kind === 'conversation') {
+        if (
+          occupiesPrimarySlot &&
+          isFirstReply &&
+          agent.kind === 'conversation'
+        ) {
           const fresh = getAgent(agentId);
           if (fresh?.title_source === 'auto_pending') {
             void generateAndApplyLLMTitle(agentId, chatJid, virtualChatJid);
@@ -15757,7 +15817,7 @@ async function processAgentConversation(
         if (holdReason) {
           // 挂起：不定稿，正文进 heldAgentParts，有卡片则状态行提示，后续
           // turn 的流式增量继续追加到同一张卡（Sub 路径 session 本就不轮换）。
-          heldAgentParts.push(text);
+          heldAgentParts.push(heldPartText);
           agentStreamingAccText = '';
           if (outputAgentStreamingSession?.isActive()) {
             streamingCardHandledIM = true;
@@ -15785,7 +15845,10 @@ async function processAgentConversation(
             },
             'Agent reply held open (background tasks / truncation continue)',
           );
-        } else if (outputAgentStreamingSession?.isActive()) {
+        } else if (
+          occupiesPrimarySlot &&
+          outputAgentStreamingSession?.isActive()
+        ) {
           // Provisional only: DB/Web persistence above is durable, but the
           // provider card must remain active until every local attachment has
           // a physical, exact-turn Outbox ACK.
@@ -15844,7 +15907,7 @@ async function processAgentConversation(
         if (pendingAgentCardCompletion) {
           const cardFinalization = await finalizeChannelCardAfterDelivery(
             pendingAgentCardCompletion,
-            text,
+            dbText,
             agentCardAttachmentsDelivered,
             agentCardAttachmentsDelivered
               ? '回复投递未确认，已切换为消息发送'
@@ -15994,7 +16057,7 @@ async function processAgentConversation(
               agentCardAttachmentsDelivered) ||
             agentStaticImDelivered) &&
           agentMirrorDeliveryAcknowledged;
-        if (agentReplyDeliveryAcknowledged) {
+        if (agentReplyDeliveryAcknowledged && occupiesPrimarySlot) {
           const acknowledgedInputIds = output.ipcReceipts?.length
             ? output.ipcReceipts.map((receipt) => receipt.deliveryId)
             : [output.inputTurnId ?? lastProcessed.id];

--- a/src/reply-delivery.ts
+++ b/src/reply-delivery.ts
@@ -29,6 +29,7 @@ export interface ReplyResultInfo {
 export function isGenuineReplyResult(info: ReplyResultInfo): boolean {
   if (info.holdReason) return false;
   if (
+    info.sourceKind === 'input_rejection_warning' ||
     info.sourceKind === 'overflow_partial' ||
     info.sourceKind === 'compact_partial'
   ) {
@@ -36,6 +37,55 @@ export function isGenuineReplyResult(info: ReplyResultInfo): boolean {
   }
   if (info.finalizationReason === 'truncated') return false;
   return true;
+}
+
+export interface ScheduledGroupPrimaryResultInfo extends ReplyResultInfo {
+  status: 'success' | 'error' | 'stream' | 'closed';
+  providerFailure?: boolean;
+  hasScheduledGroupRuns: boolean;
+}
+
+/**
+ * A scheduled group run is finalized by the same substantive primary answer
+ * that the user sees. Host runners may emit that answer before a later,
+ * content-free `inputTurnCompleted` lifecycle frame; requiring the lifecycle
+ * flag would persist the answer as ordinary `sdk_final` and strand the exact
+ * run in `delivered`.
+ *
+ * Held/partial/provider-failure outputs remain ineligible, so an intermediate
+ * checkpoint can never become the business terminal.
+ */
+export function shouldFinalizeScheduledGroupPrimaryResult(
+  info: ScheduledGroupPrimaryResultInfo,
+): boolean {
+  return (
+    info.hasScheduledGroupRuns &&
+    info.status === 'success' &&
+    !info.providerFailure &&
+    (info.sourceKind === 'sdk_final' ||
+      info.sourceKind === 'truncation_continue') &&
+    isGenuineReplyResult(info)
+  );
+}
+
+export function occupiesPrimaryReplyDeliverySlot(
+  sourceKind?: string | null,
+): boolean {
+  return sourceKind !== 'input_rejection_warning';
+}
+
+export function resolveHeldReplyDbText(input: {
+  heldBaseText: string;
+  text: string;
+  sourceKind?: string | null;
+  holdReason: 'bg_tasks' | 'truncated' | null;
+  wasInHeldSequence: boolean;
+}): string {
+  if (input.holdReason) return input.heldBaseText + input.text;
+  if (input.wasInHeldSequence && input.sourceKind === 'truncation_continue') {
+    return input.heldBaseText + input.text;
+  }
+  return input.text;
 }
 
 export interface RetrySkipDecisionInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -459,6 +459,7 @@ export type MessageSourceKind =
   | 'sdk_final'
   | 'sdk_send_message'
   | 'proactive_sdk_fallback'
+  | 'input_rejection_warning'
   | 'interrupt_partial'
   | 'overflow_partial'
   | 'compact_partial'

--- a/tests/agent-runner-ipc-delivery.test.ts
+++ b/tests/agent-runner-ipc-delivery.test.ts
@@ -11,7 +11,10 @@ import {
   latestIpcInputMessage,
   orderIpcInputMessages,
   parseIpcReceipt,
+  partitionIpcMessagesForLogicalTurn,
   requeueIpcInputMessages,
+  resolveLogicalQueryInputTurnId,
+  shouldAcceptIpcMessagesDuringQuery,
   serializeIpcInputMessage,
   type IpcDeliveryReceipt,
   type IpcInputMessage,
@@ -195,6 +198,46 @@ describe('agent-runner IPC delivery turn tracker', () => {
       correlation.correlate({ status: 'success', result: 'cold result' })
         .inputTurnId,
     ).toBe('host-turn-cold');
+  });
+
+  test('keeps an internal truncation continuation on the original logical input', () => {
+    expect(
+      resolveLogicalQueryInputTurnId(
+        'presentation-turn-for-continuation',
+        'scheduled-prompt-logical-input',
+      ),
+    ).toBe('scheduled-prompt-logical-input');
+    expect(resolveLogicalQueryInputTurnId('ordinary-turn')).toBe(
+      'ordinary-turn',
+    );
+  });
+
+  test('keeps continuation A authoritative while deferring later IPC B', () => {
+    const turnA = message('1');
+    const turnB = message('2');
+    const logicalA = turnA.receipt!.deliveryId;
+    const { owned, deferred } = partitionIpcMessagesForLogicalTurn(
+      [turnA, turnB],
+      logicalA,
+    );
+    expect(owned).toEqual([turnA]);
+    expect(deferred).toEqual([turnB]);
+
+    // Even a malformed/unpartitioned legacy call cannot let receipt B override
+    // the explicit continuation owner A.
+    const tracker = new IpcTurnDeliveryTracker([turnB]);
+    const correlation = new IpcTurnOutputCorrelation(
+      tracker,
+      'presentation-continuation',
+      logicalA,
+    );
+    expect(
+      correlation.correlate({ status: 'success', result: 'A continued' })
+        .inputTurnId,
+    ).toBe(logicalA);
+    expect(correlation.syncCurrentTurn()).toBe(logicalA);
+    expect(shouldAcceptIpcMessagesDuringQuery(true, false)).toBe(false);
+    expect(shouldAcceptIpcMessagesDuringQuery(true, true)).toBe(true);
   });
 
   test('pending background, truncation, error and interrupt are not completions', () => {

--- a/tests/channel-side-effect-ack-contract.test.ts
+++ b/tests/channel-side-effect-ack-contract.test.ts
@@ -69,7 +69,7 @@ describe('strict physical acknowledgement contract', () => {
   test('main and agent mirror paths await exact-target durable Outboxes and join primary ACK', () => {
     const mainMirror = sliceBetween(
       '// Optional mirror mode for explicitly bound IM channels',
-      '\n              sentReply = true;',
+      '\n              if (occupiesPrimarySlot) {',
     );
     expect(mainMirror).toContain('const mirrorScope = bindChannelOutboxScope(');
     expect(mainMirror).toContain('const delivered = await sendImWithRetry(');
@@ -81,7 +81,7 @@ describe('strict physical acknowledgement contract', () => {
 
     const agentMirror = sliceBetween(
       '// Optional mirror mode for linked IM channels',
-      '\n        if (agentReplyDeliveryAcknowledged)',
+      '\n        if (agentReplyDeliveryAcknowledged && occupiesPrimarySlot)',
     );
     expect(agentMirror).toContain(
       'const mirrorScope = bindChannelOutboxScope(',

--- a/tests/group-queue-ipc-receipts.test.ts
+++ b/tests/group-queue-ipc-receipts.test.ts
@@ -409,6 +409,39 @@ describe('GroupQueue IPC delivery receipts', () => {
     expect(abandoned).not.toHaveBeenCalled();
   });
 
+  test('completes admission before publishing the runner-visible IPC file', async () => {
+    await startRunner();
+    const order: string[] = [];
+
+    expect(
+      queue.sendMessage(
+        JID,
+        'bind-before-publish',
+        undefined,
+        () => {
+          order.push('injected');
+          expect(readPayloads()).toHaveLength(1);
+        },
+        JID,
+        'scheduled-task',
+        {
+          chatJid: JID,
+          coveredCursors: [cursor('scheduled-prompt')],
+          cursor: cursor('scheduled-prompt'),
+        },
+        undefined,
+        (receipt) => {
+          order.push('admitted');
+          expect(receipt?.deliveryId).toBeTruthy();
+          expect(readPayloads()).toEqual([]);
+          return {};
+        },
+      ),
+    ).toBe('sent');
+
+    expect(order).toEqual(['admitted', 'injected']);
+  });
+
   test('disk publish failure rolls back admission and removes the temp file', async () => {
     await startRunner();
     const rollback = vi.fn();

--- a/tests/reply-delivery.test.ts
+++ b/tests/reply-delivery.test.ts
@@ -6,7 +6,10 @@ import {
   acknowledgeIpcReplyTurn,
   decideAssistantPrimaryProjection,
   isGenuineReplyResult,
+  occupiesPrimaryReplyDeliverySlot,
+  resolveHeldReplyDbText,
   setIpcReplyInputTurn,
+  shouldFinalizeScheduledGroupPrimaryResult,
   shouldSkipRetryAfterLateError,
   wasGenuineReplyDeliveredForInput,
 } from '../src/reply-delivery.js';
@@ -86,6 +89,146 @@ describe('isGenuineReplyResult', () => {
         finalizationReason: 'truncated',
       }),
     ).toBe(false);
+  });
+
+  test('an input rejection warning is visible but never marks the primary reply complete', () => {
+    expect(
+      isGenuineReplyResult({
+        holdReason: null,
+        sourceKind: 'input_rejection_warning',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldFinalizeScheduledGroupPrimaryResult', () => {
+  test('finalizes the first substantive primary before a lifecycle completion frame', () => {
+    expect(
+      shouldFinalizeScheduledGroupPrimaryResult({
+        status: 'success',
+        providerFailure: false,
+        hasScheduledGroupRuns: true,
+        holdReason: null,
+        sourceKind: 'sdk_final',
+        finalizationReason: 'completed',
+      }),
+    ).toBe(true);
+  });
+
+  test('finalizes a healthy continuation that completes a truncated scheduled answer', () => {
+    expect(
+      shouldFinalizeScheduledGroupPrimaryResult({
+        status: 'success',
+        providerFailure: false,
+        hasScheduledGroupRuns: true,
+        holdReason: null,
+        sourceKind: 'truncation_continue',
+        finalizationReason: 'completed',
+      }),
+    ).toBe(true);
+  });
+
+  test.each([
+    {
+      label: 'unrelated',
+      status: 'success' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: false,
+      holdReason: null,
+      sourceKind: 'sdk_final',
+    },
+    {
+      label: 'provider failure',
+      status: 'success' as const,
+      providerFailure: true,
+      hasScheduledGroupRuns: true,
+      holdReason: null,
+      sourceKind: 'sdk_final',
+    },
+    {
+      label: 'input rejection warning without a primary source',
+      status: 'success' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: true,
+      holdReason: null,
+      sourceKind: 'input_rejection_warning',
+    },
+    {
+      label: 'internal continuation output',
+      status: 'success' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: true,
+      holdReason: null,
+      sourceKind: 'auto_continue',
+    },
+    {
+      label: 'background checkpoint',
+      status: 'success' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: true,
+      holdReason: 'bg_tasks' as const,
+      sourceKind: 'sdk_final',
+    },
+    {
+      label: 'partial continuation',
+      status: 'success' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: true,
+      holdReason: null,
+      sourceKind: 'overflow_partial',
+    },
+    {
+      label: 'still-truncated continuation',
+      status: 'success' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: true,
+      holdReason: 'truncated' as const,
+      sourceKind: 'truncation_continue',
+      finalizationReason: 'truncated',
+    },
+    {
+      label: 'stream event',
+      status: 'stream' as const,
+      providerFailure: false,
+      hasScheduledGroupRuns: true,
+      holdReason: null,
+      sourceKind: 'sdk_final',
+    },
+  ])('rejects $label output', (input) => {
+    expect(shouldFinalizeScheduledGroupPrimaryResult(input)).toBe(false);
+  });
+});
+
+describe('scheduled result presentation boundaries', () => {
+  test('an input rejection warning remains auxiliary and does not occupy the primary delivery slot', () => {
+    expect(occupiesPrimaryReplyDeliverySlot('input_rejection_warning')).toBe(
+      false,
+    );
+    expect(occupiesPrimaryReplyDeliverySlot('sdk_final')).toBe(true);
+  });
+
+  test('a healthy truncation continuation persists the complete business result', () => {
+    expect(
+      resolveHeldReplyDbText({
+        heldBaseText: '调研首段：市场规模 100\n\n---\n\n',
+        text: '续写尾段：结论为增长。',
+        sourceKind: 'truncation_continue',
+        holdReason: null,
+        wasInHeldSequence: true,
+      }),
+    ).toBe('调研首段：市场规模 100\n\n---\n\n续写尾段：结论为增长。');
+  });
+
+  test('an ordinary healthy SDK final remains authoritative over held progress', () => {
+    expect(
+      resolveHeldReplyDbText({
+        heldBaseText: '中间进度\n\n---\n\n',
+        text: '完整的最终汇总',
+        sourceKind: 'sdk_final',
+        holdReason: null,
+        wasInHeldSequence: true,
+      }),
+    ).toBe('完整的最终汇总');
   });
 });
 
@@ -347,8 +490,31 @@ describe('Assistant primary projection boundary', () => {
     expect(source).toContain(
       'agentAnyReplyProjectedByInput.set(outputAgentScope.inputId, true);',
     );
+    expect(source).toMatch(
+      /activeRouteAdmissions\.set\(\s+mainAdmissionKey,\s+\(newSourceJid, inputTurnId, inputCursor, coveredInputs, receipt\) => \{/,
+    );
+    expect(source).toMatch(
+      /beforePublish hook,[\s\S]{0,500}if \(receipt\?\.deliveryId === inputTurnId\) \{\s+rememberScheduledGroupRuns\(\{\s+inputTurnId,\s+ipcReceipts: \[receipt\],/,
+    );
+    expect(source).toContain('scheduledGroupRunsByInput.delete(inputTurnId);');
+    expect(
+      source.match(
+        /finalizeChannelCardAfterDelivery\(\s+pending(?:StreamingCard|AgentCard)Completion,\s+dbText,/g,
+      ),
+    ).toHaveLength(2);
     expect(source).not.toContain(
       'outputAlreadySent && effectiveTurnId === lastSavedTurnId',
+    );
+
+    const runnerSource = fs.readFileSync(
+      path.join(process.cwd(), 'container/agent-runner/src/index.ts'),
+      'utf8',
+    );
+    expect(runnerSource).toMatch(
+      /result: `\\u26a0\\ufe0f \$\{reason\}`,[\s\S]{0,120}sourceKind: 'input_rejection_warning'/,
+    );
+    expect(runnerSource).toMatch(
+      /const truncationLogicalInputTurnId = activeOutputInputTurnId;[\s\S]{0,3500}'truncation_continue',\s+truncationIpcMessages,\s+mcpToolsConfig,\s+truncationLogicalInputTurnId,\s+false,/,
     );
   });
 });

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -1142,6 +1142,95 @@ describe('scheduled task workspace/session contract', () => {
     }
   });
 
+  test('upgrades one held sdk_final row to the complete scheduled result', () => {
+    const taskId = createTask({
+      id: 'task-group-truncation-merge',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'group-truncation-merge',
+    });
+    const claim = db.claimNextTaskRun('group-truncation-merge-worker', 60_000)!;
+    expect(claim.id).toBe(created.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      ),
+    ).toBe(true);
+    expect(
+      db.completeTaskRun(claim.id, claim.lease_owner, claim.lease_token, {
+        status: 'delivered',
+        result: '已排队',
+        notificationStatus: 'skipped',
+      }),
+    ).toBe(true);
+
+    const turnId = 'scheduled-truncated-logical-input';
+    const heldMessageId = db.storeMessageDirect(
+      'scheduled-truncated-held',
+      GROUP_JID,
+      'happyclaw-agent',
+      'HappyClaw',
+      '首段业务数据\n\n> ⚠️ 回复在生成中被上游截断，正在自动续写…',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId,
+          sourceKind: 'sdk_final',
+          finalizationReason: 'truncated',
+        },
+      },
+    );
+    const completeResult = '首段业务数据\n\n---\n\n续写后的最终结论';
+
+    expect(
+      db.storeScheduledGroupWorkspaceResultAndFinalize({
+        messageId: 'scheduled-group-result:truncation-merge',
+        chatJid: GROUP_JID,
+        senderId: 'happyclaw-agent',
+        senderName: 'HappyClaw',
+        text: completeResult,
+        timestamp: new Date().toISOString(),
+        messageMeta: {
+          turnId,
+          sourceKind: 'scheduled_task_result',
+          finalizationReason: 'completed',
+        },
+        finalizations: [
+          {
+            runId: created.run.id,
+            taskId,
+            status: 'success',
+            result: completeResult,
+            error: null,
+          },
+        ],
+      }),
+    ).toBe(heldMessageId);
+
+    const rows = db
+      .getMessagesPage(GROUP_JID)
+      .filter((message) => message.turn_id === turnId);
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: heldMessageId,
+        content: completeResult,
+        source_kind: 'scheduled_task_result',
+        finalization_reason: 'completed',
+      }),
+    ]);
+    expect(db.getTaskRunById(created.run.id)).toMatchObject({
+      status: 'success',
+      result: completeResult,
+    });
+  });
+
   test('rolls back the canonical group message and earlier run transitions when any represented run rejects', () => {
     const taskA = createTask({
       id: 'task-group-result-rollback-a',

--- a/tests/workspace-interaction-runtime.test.ts
+++ b/tests/workspace-interaction-runtime.test.ts
@@ -111,6 +111,13 @@ describe('workspace interaction runtime policy', () => {
       shouldResolveFrameworkPrimaryAnswer({
         mode: 'assistant',
         status: 'success',
+        sourceKind: 'input_rejection_warning',
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveFrameworkPrimaryAnswer({
+        mode: 'assistant',
+        status: 'success',
         providerFailure: true,
       }),
     ).toBe(false);


### PR DESCRIPTION
## Summary
- pre-bind warm IPC scheduled group runs from the exact delivery receipt before runner output can arrive
- finalize the first genuine primary answer instead of waiting for a lifecycle-only completion frame
- persist the canonical workspace message as scheduled_task_result while leaving feishu-cli as an ordinary agent tool call

## Validation
- npm test -- --run --maxWorkers=4 (321 files, 2723 tests)
- npm run build:all
- npm run typecheck
- npm run format:check
- npm run docs:check
- git diff --check