### PR TITLE
fix(tasks): preserve cold scheduled prompt identity

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -188,7 +188,7 @@ function stmts() {
          )`,
       ),
       getMessagesSince: db.prepare(
-        `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, channel_context, task_id,
+        `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, channel_context, source_kind, task_id,
                 delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
          FROM messages
          WHERE chat_jid = ? AND (timestamp > ? OR (timestamp = ? AND id > ?)) AND is_from_me = 0
@@ -208,7 +208,7 @@ function getNewMessagesStmt(jidCount: number): any {
   if (!s) {
     const placeholders = Array(jidCount).fill('?').join(',');
     s = db.prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, channel_context, task_id,
+      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, channel_context, source_kind, task_id,
               delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
        FROM messages
        WHERE (timestamp > ? OR (timestamp = ? AND id > ?))

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -1974,11 +1974,17 @@ export function resolveScheduledGroupRunsForOutput(input: {
   const runs: TaskRun[] = [];
   for (const ref of refs) {
     if (ref.chatJid !== input.chatJid) continue;
+    const coldMessage = input.coldMessages.find(
+      (candidate) =>
+        candidate.chat_jid === ref.chatJid && candidate.id === ref.messageId,
+    );
+    // Incremental message queries are deliberately narrow projections. If an
+    // older caller omits scheduler ownership metadata, re-read the canonical
+    // row instead of treating the prompt as an ordinary user message.
     const message =
-      input.coldMessages.find(
-        (candidate) =>
-          candidate.chat_jid === ref.chatJid && candidate.id === ref.messageId,
-      ) ?? input.getMessage(ref.chatJid, ref.messageId);
+      coldMessage?.source_kind && coldMessage.task_id
+        ? coldMessage
+        : (input.getMessage(ref.chatJid, ref.messageId) ?? coldMessage);
     if (
       !message ||
       message.source_kind !== 'scheduled_task_prompt' ||

--- a/tests/task-meta.test.ts
+++ b/tests/task-meta.test.ts
@@ -60,6 +60,7 @@ describe('storeMessageDirect + task_id propagation', () => {
     const rows = getMessagesSince(chatJid, EMPTY_CURSOR);
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe('m-A-1');
+    expect(rows[0].source_kind).toBe('scheduled_task_prompt');
     expect(rows[0].task_id).toBe('t1');
   });
 
@@ -129,6 +130,7 @@ describe('storeMessageDirect + task_id propagation', () => {
     expect(ids).toContain('m-C-1');
     expect(ids).not.toContain('m-C-2'); // scheduled_task_prompt is filtered
     const surfaced = messages.find((m) => m.id === 'm-C-1');
+    expect(surfaced!.source_kind).toBe('legacy');
     expect(surfaced!.task_id).toBe('t2');
   });
 

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -905,6 +905,20 @@ describe('scheduled task workspace/session contract', () => {
     });
     expect(cold.map((item) => item.id)).toEqual([runA.id, runB.id]);
 
+    const coldFromNarrowProjection = resolveScheduledGroupRunsForOutput({
+      ...common,
+      fallbackInputTurnId: promptB.id,
+      coldMessages: [
+        {
+          id: promptB.id,
+          chat_jid: GROUP_JID,
+          task_id: promptB.task_id,
+        },
+      ],
+      output: { inputTurnId: promptB.id },
+    });
+    expect(coldFromNarrowProjection.map((item) => item.id)).toEqual([runB.id]);
+
     const warm = resolveScheduledGroupRunsForOutput({
       ...common,
       fallbackInputTurnId: 'unrelated-cold-input',
@@ -949,6 +963,74 @@ describe('scheduled task workspace/session contract', () => {
       output: { inputTurnId: ordinary.id },
     });
     expect(ordinaryOnly).toEqual([]);
+  });
+
+  test('resolves a cold group run from the real incremental message projection', () => {
+    const chatJid = 'web:task-contract-cold-db-projection';
+    db.setRegisteredGroup(chatJid, {
+      ...db.getRegisteredGroup(GROUP_JID)!,
+      folder: 'task-contract-cold-db-projection',
+    });
+    const taskId = createTask({
+      id: 'task-group-cold-db-projection',
+      chat_jid: chatJid,
+      group_folder: 'task-contract-cold-db-projection',
+      context_mode: 'group',
+    });
+    const task = db.getTaskById(taskId)!;
+    const created = db.createTaskRun({
+      task,
+      triggerType: 'manual',
+      idempotencyKey: 'group-cold-db-projection',
+    });
+    const claim = db.claimNextTaskRun(
+      'group-cold-db-projection-worker',
+      60_000,
+    )!;
+    expect(claim.id).toBe(created.run.id);
+    expect(
+      db.markTaskRunExecutionStarted(
+        claim.id,
+        claim.lease_owner,
+        claim.lease_token,
+      ),
+    ).toBe(true);
+    const promptId = scheduledGroupPromptMessageId(claim.id);
+    db.storeScheduledGroupPromptAndCompleteRun({
+      runId: claim.id,
+      taskId,
+      leaseOwner: claim.lease_owner,
+      leaseToken: claim.lease_token,
+      messageId: promptId,
+      chatJid,
+      senderId: 'system',
+      senderName: '定时任务',
+      text: 'run the production-shaped cold report',
+      queuedResult: '已排队',
+    });
+
+    const coldMessages = db.getMessagesSince(chatJid, {
+      timestamp: '',
+      id: '',
+    });
+    expect(coldMessages).toEqual([
+      expect.objectContaining({
+        id: promptId,
+        source_kind: 'scheduled_task_prompt',
+        task_id: taskId,
+      }),
+    ]);
+    expect(
+      resolveScheduledGroupRunsForOutput({
+        chatJid,
+        fallbackInputTurnId: promptId,
+        coldMessages,
+        output: { inputTurnId: promptId },
+        getMessage: (targetJid, messageId) =>
+          db.getMessage(targetJid, messageId) as any,
+        getRun: db.getTaskRunById,
+      }).map((run) => run.id),
+    ).toEqual([claim.id]);
   });
 
   test('upgrades a delivered group run with the full result exactly once', () => {


### PR DESCRIPTION
## Summary
- include source_kind in incremental message projections used by cold group turns
- re-read canonical scheduled prompt metadata when an older narrow projection is incomplete
- cover the production-shaped delivered prompt -> getMessagesSince -> exact run correlation path

## Validation
- 321 test files / 2736 tests
- npm run build:all
- npm run typecheck
- npm run format:check
- npm run docs:check
- two independent Agent reviews: PASS