### PR TITLE
fix: bind the warm outbox scope to the runner's IPC deliveryId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2489,6 +2489,17 @@ interface ChannelOutboxDeliveryRef {
   ordinalSlot?: string;
 }
 
+/**
+ * `inputTurnId` is the correlation key runner-side MCP output resolves against,
+ * so it must be the id the runner actually reports — its IPC deliveryId for a
+ * warm turn, or ContainerInput.turnId for the cold startup turn.
+ *
+ * The runtime's own `inputTurnId` only matches on the cold path, where the
+ * durable message id and the runner turn id are the same value. Warm admission
+ * starts the runtime from the native message id (durable turn idempotency) but
+ * hands the runner a random deliveryId, so those callers must pass the
+ * deliveryId explicitly or every MCP-sent output would fail closed.
+ */
 function bindChannelOutboxScope(
   key: string,
   runtime: ChannelTurnRuntime,
@@ -2500,13 +2511,14 @@ function bindChannelOutboxScope(
     rootId?: string | null;
     threadId?: string | null;
   },
+  inputTurnId: string | undefined = runtime.inputTurnId,
 ): ActiveChannelOutboxScope {
   return activeChannelOutboxScopes.bind(key, {
     ...route,
     rootId: route.rootId ?? null,
     threadId: route.threadId ?? null,
     turnRunId: runtime.runId,
-    inputTurnId: runtime.inputTurnId,
+    inputTurnId,
     owner: `happyclaw-outbox:${process.pid}:${runtime.runId}`,
   });
 }
@@ -2553,6 +2565,10 @@ async function deliverScopedChannelOutput(
         targetJid,
         scopeKey: ref.scopeKey,
         operationKey: ref.operationKey,
+        // Carries the unresolved correlation id as `missing:<inputTurnId>` when
+        // the lookup failed, which is what distinguishes a genuinely expired
+        // scope from a correlation-key mismatch.
+        scopeToken: ref.scopeToken,
       },
       'Suppressed channel side effect because its exact outbox scope is unavailable',
     );
@@ -6575,14 +6591,21 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           nextRuntime.dispose();
           return false;
         }
-        nextScope = bindChannelOutboxScope(mainAdmissionKey, nextRuntime, {
-          provider: nextAddress.provider,
-          accountId: nextAccountId,
-          sourceJid: newImJid,
-          chatId: nextAddress.externalChatId,
-          rootId: nextAddress.rootMessageId,
-          threadId: nextAddress.threadId,
-        });
+        nextScope = bindChannelOutboxScope(
+          mainAdmissionKey,
+          nextRuntime,
+          {
+            provider: nextAddress.provider,
+            accountId: nextAccountId,
+            sourceJid: newImJid,
+            chatId: nextAddress.externalChatId,
+            rootId: nextAddress.rootMessageId,
+            threadId: nextAddress.threadId,
+          },
+          // The runtime keys durable idempotency off the native message id,
+          // but the runner correlates its MCP output with this deliveryId.
+          inputTurnId,
+        );
         channelTurnRuntimes.set(inputTurnId, nextRuntime);
         channelOutboxScopesByInput.set(inputTurnId, nextScope);
       }
@@ -14815,14 +14838,20 @@ async function processAgentConversation(
           nextRuntime.dispose();
           return false;
         }
-        nextScope = bindChannelOutboxScope(agentAdmissionKey, nextRuntime, {
-          provider: nextAddress.provider,
-          accountId: nextAccountId,
-          sourceJid: targetSourceJid,
-          chatId: nextAddress.externalChatId,
-          rootId: nextAddress.rootMessageId,
-          threadId: nextAddress.threadId,
-        });
+        nextScope = bindChannelOutboxScope(
+          agentAdmissionKey,
+          nextRuntime,
+          {
+            provider: nextAddress.provider,
+            accountId: nextAccountId,
+            sourceJid: targetSourceJid,
+            chatId: nextAddress.externalChatId,
+            rootId: nextAddress.rootMessageId,
+            threadId: nextAddress.threadId,
+          },
+          // Same warm-path correlation split as the main workspace admission.
+          inputTurnId,
+        );
         agentChannelTurnRuntimes.set(inputTurnId, nextRuntime);
         agentChannelOutboxScopesByInput.set(inputTurnId, nextScope);
       }

--- a/tests/warm-channel-outbox-scope-correlation.test.ts
+++ b/tests/warm-channel-outbox-scope-correlation.test.ts
@@ -1,0 +1,234 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'warm-outbox-scope-'));
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+const { ChannelTurnRuntime } = await import('../src/channel-turn-runtime.js');
+const { ActiveChannelOutboxScopeRegistry } =
+  await import('../src/channel-outbox-runtime-scope.js');
+
+const repoRoot = process.cwd();
+const read = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+function section(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+// A legacy QQ C2C address: no account fragment, no thread, no root. This is the
+// shape that first exposed the regression, because Proactive mode makes the MCP
+// send the only delivery path.
+const c2cJid = 'qq:c2c:openid-fixture';
+const route = {
+  provider: 'qq',
+  accountId: 'bot-fixture',
+  sourceJid: c2cJid,
+  chatId: 'c2c:openid-fixture',
+  rootId: null,
+  threadId: null,
+};
+
+// Warm admission owns two distinct ids for one turn:
+//   - the native/durable message id, which keys Turn idempotency
+//   - a random IPC deliveryId, which is what the runner echoes back on output
+const nativeMessageId = 'msg-warm-fixture';
+const ipcDeliveryId = 'delivery-warm-fixture';
+
+beforeAll(() => db.initDatabase());
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('warm channel outbox scope correlation', () => {
+  test('a warm turn runtime is still keyed by the native message id', () => {
+    const runtime = ChannelTurnRuntime.start({
+      ...route,
+      externalMessageId: nativeMessageId,
+    });
+    try {
+      // Guards the durable-idempotency fix: warm admission must NOT go back to
+      // seeding the runtime from the random deliveryId.
+      expect(runtime.inputTurnId).toBe(nativeMessageId);
+      expect(runtime.inputTurnId).not.toBe(ipcDeliveryId);
+    } finally {
+      runtime.dispose();
+    }
+  });
+
+  test('scope bound with the deliveryId resolves the runner-reported input', () => {
+    const registry = new ActiveChannelOutboxScopeRegistry();
+    const runtime = ChannelTurnRuntime.start({
+      ...route,
+      externalMessageId: `${nativeMessageId}-resolves`,
+    });
+    try {
+      const scope = registry.bind('workspace', {
+        ...route,
+        turnRunId: runtime.runId,
+        // What the fixed warm call sites pass explicitly.
+        inputTurnId: ipcDeliveryId,
+        owner: 'owner-warm',
+      });
+
+      expect(registry.resolveInput('workspace', ipcDeliveryId, c2cJid)).toEqual(
+        scope,
+      );
+      expect(registry.resolveToken('workspace', scope.token, c2cJid)).toEqual(
+        scope,
+      );
+    } finally {
+      runtime.dispose();
+    }
+  });
+
+  test('scope bound with the native message id cannot resolve the deliveryId', () => {
+    const registry = new ActiveChannelOutboxScopeRegistry();
+    const runtime = ChannelTurnRuntime.start({
+      ...route,
+      externalMessageId: `${nativeMessageId}-regression`,
+    });
+    try {
+      // Reproduces the regression: binding from runtime.inputTurnId on the warm
+      // path leaves the registry keyed by an id the runner never reports, so
+      // every MCP-sent output fails closed before reaching the connector.
+      registry.bind('workspace', {
+        ...route,
+        turnRunId: runtime.runId,
+        inputTurnId: runtime.inputTurnId,
+        owner: 'owner-warm-regression',
+      });
+
+      expect(
+        registry.resolveInput('workspace', ipcDeliveryId, c2cJid),
+      ).toBeNull();
+    } finally {
+      runtime.dispose();
+    }
+  });
+
+  test('resolveInput still refuses a matching id on a different route', () => {
+    const registry = new ActiveChannelOutboxScopeRegistry();
+    registry.bind('workspace', {
+      ...route,
+      turnRunId: 'turn-route-fence',
+      inputTurnId: ipcDeliveryId,
+      owner: 'owner-route-fence',
+    });
+
+    expect(
+      registry.resolveInput('workspace', ipcDeliveryId, 'qq:c2c:other-fixture'),
+    ).toBeNull();
+  });
+});
+
+describe('warm channel outbox scope wiring contract', () => {
+  test('bindChannelOutboxScope takes an explicit correlation id, defaulting to the runtime', () => {
+    const host = read('src/index.ts');
+    const signature = section(
+      host,
+      'function bindChannelOutboxScope(',
+      'return activeChannelOutboxScopes.bind(',
+    );
+    expect(signature).toMatch(
+      /inputTurnId:\s*string\s*\|\s*undefined\s*=\s*runtime\.inputTurnId/,
+    );
+    const body = section(
+      host,
+      'return activeChannelOutboxScopes.bind(',
+      'function channelOutboxRefForInput(',
+    );
+    // The bound scope must carry the parameter, never re-derive it.
+    expect(body).toMatch(/\n\s*inputTurnId,\n/);
+    expect(body).not.toMatch(/inputTurnId:\s*runtime\.inputTurnId/);
+  });
+
+  test('both warm admissions bind the scope with the IPC deliveryId', () => {
+    const host = read('src/index.ts');
+
+    const mainAdmission = section(
+      host,
+      'activeRouteAdmissions.set(\n    mainAdmissionKey,',
+      'admittedWarmMainInputs.set(inputTurnId, {',
+    );
+    expect(mainAdmission).toMatch(
+      /bindChannelOutboxScope\(\s*mainAdmissionKey,[\s\S]*?\n\s*inputTurnId,\n\s*\);/,
+    );
+    // The runtime itself stays on the native message id (durable idempotency).
+    expect(mainAdmission).toMatch(
+      /externalMessageId:\s*inputCursor\?\.id \?\? inputTurnId/,
+    );
+
+    const agentAdmission = section(
+      host,
+      'activeRouteAdmissions.set(\n    agentAdmissionKey,',
+      'admittedWarmAgentInputs.set(inputTurnId, {',
+    );
+    expect(agentAdmission).toMatch(
+      /bindChannelOutboxScope\(\s*agentAdmissionKey,[\s\S]*?\n\s*inputTurnId,\n\s*\);/,
+    );
+    expect(agentAdmission).toMatch(
+      /externalMessageId:\s*inputCursor\?\.id \?\? inputTurnId/,
+    );
+  });
+
+  test('cold turns keep relying on the runtime default', () => {
+    const host = read('src/index.ts');
+    // On the cold path the runtime is started from lastProcessed.id, which is
+    // also the ContainerInput.turnId the runner reports, so the default is
+    // already correct and must not be overridden with an unrelated id.
+    for (const scopeSetter of [
+      'channelOutboxScopesByInput.set(lastProcessed.id, channelOutboxScope);',
+      'agentChannelOutboxScopesByInput.set(\n        lastProcessed.id,',
+    ]) {
+      expect(host).toContain(scopeSetter);
+    }
+    expect(host).toContain('externalMessageId: lastProcessed.id,');
+  });
+
+  test('the runner correlates warm output with its IPC deliveryId', () => {
+    const runner = read('container/agent-runner/src/index.ts');
+    const tools = read('container/agent-runner/src/mcp-tools.ts');
+    // Counterpart of the host-side fix. If this ever changes back to the plain
+    // turn id, the host must be revisited in the same commit.
+    expect(
+      runner.match(
+        /mcpToolsConfig\.currentInputTurnId =\s*\n?\s*latestIpcDeliveryId\(/g,
+      )?.length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(tools).toMatch(/data\.inputTurnId = ctx\.currentInputTurnId;/);
+  });
+
+  test('an unresolvable scope logs the correlation id it failed to match', () => {
+    const host = read('src/index.ts');
+    const suppression = section(
+      host,
+      'async function deliverScopedChannelOutput(',
+      'Suppressed channel side effect because its exact outbox scope is unavailable',
+    );
+    expect(suppression).toMatch(/scopeToken:\s*ref\.scopeToken,/);
+    // `missing:<inputTurnId>` is the token shape that makes a correlation-key
+    // mismatch distinguishable from a genuinely expired scope.
+    expect(host).toMatch(/scopeToken:\s*scope\?\.token \?\? `missing:\$\{/);
+  });
+});


### PR DESCRIPTION
## Problem

In Proactive reply mode every user-visible message goes through the MCP `send_message` tool. On a **warm** turn each of those sends resolved no outbox scope and failed closed with the generic `Message could not be delivered to its target.` Nothing reached the connector — no `channel_outbox` row was ever enqueued, and no provider API call was made.

Inbound kept working, so the symptom is a one-directional outage: the workspace answers on Web, and the IM channel stays silent.

## Root cause

A turn carries two distinct ids:

- the **native message id**, which keys durable Turn idempotency
- a random **IPC deliveryId**, which is what the runner echoes back as `inputTurnId` on its output

Warm admission starts `ChannelTurnRuntime` from the native message id (correct — that is what survives a reconnect), but `bindChannelOutboxScope` derived the scope's correlation key from `runtime.inputTurnId`. The registry therefore ended up keyed by an id the runner never reports, and `ActiveChannelOutboxScopeRegistry.resolveInput` could not match it. The lookup returned `null`, the ref degraded to a `missing:<id>` token, and `deliverScopedChannelOutput` correctly failed closed.

Two things kept this hidden:

- **Cold turns are unaffected.** There the runtime starts from `lastProcessed.id`, which is also the `ContainerInput.turnId` the runner reports, so both ids coincide.
- **Assistant mode is unaffected.** When the framework publishes the answer it resolves the scope through `channelOutboxScopesByInput`, a map that is already keyed by deliveryId.

So the failure needs Proactive mode *and* a warm runner — which is why it went unnoticed.

Introduced in `a68c026`. That commit deliberately left `inputTurnId` alone because it keys the in-memory admission maps, but `ActiveChannelOutboxScope.inputTurnId` is *derived from the runtime* rather than from the map key.

## Change

- `bindChannelOutboxScope` takes an explicit `inputTurnId`, still defaulting to `runtime.inputTurnId`.
- Both warm admission sites — main workspace and agent conversation — pass the admission's deliveryId.
- Cold sites are untouched; the default is already correct there.
- Mirror and system-notice scopes are intentionally left alone: they are resolved by token, never by input id, and keying them by deliveryId could let `resolveInput` match a mirror scope.
- The suppression path now logs `ref.scopeToken`. It carries the unresolved id as `missing:<inputTurnId>`, which is what distinguishes a correlation-key mismatch from a genuinely expired scope.

## Tests

New `tests/warm-channel-outbox-scope-correlation.test.ts`, 9 cases in two layers:

- **Behavioral** — a real `ChannelTurnRuntime` plus a real registry reproduce the id split: a scope bound with the deliveryId resolves, one bound with the native message id does not, and `resolveInput`'s route fence still rejects a matching id on a different route.
- **Source contract** — pins both warm call sites, the cold-path default, the runner's `latestIpcDeliveryId` counterpart, and that warm admission still seeds the runtime from the native message id (so nobody "fixes" a regression here by reverting `a68c026`).

The three contract cases fail against the unfixed source — verified by stashing `src/index.ts` and re-running.

## Verification

- `make typecheck`, `npm run docs:check`, `make build` pass.
- Full suite green: 322 files, 2745 tests.
- Reproduced and confirmed on a live host-mode instance in Proactive mode over an IM channel: before the fix, six consecutive warm-turn sends were suppressed and `channel_outbox` had zero new rows; after rebuilding and restarting, a warm follow-up turn (no new `Spawning host agent` in the log) delivered normally, with zero suppression errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)