### PR TITLE
修复: 自动压缩看门狗误判 + 容器会话文件宿主权限(UID 重映射)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1029,11 +1029,17 @@ function createPreCompactHook(deps: {
   emit: (output: ContainerOutput) => void;
   getFullText: () => string;
   resetFullText: () => void;
+  onCompactionStart?: () => void;
 }): HookCallback {
   return async (input, _toolUseId, _context) => {
     const preCompact = input as PreCompactHookInput;
     const transcriptPath = preCompact.transcript_path;
     const sessionId = preCompact.session_id;
+
+    // Compaction is a legitimate long model round-trip, not a stalled provider.
+    // Suspend the first-response watchdog before it can misfire during the
+    // summarization request (which emits nothing to the outer SDK iterator).
+    deps.onCompactionStart?.();
 
     // Skip sub-agent compactions — they'd archive the unchanged main transcript
     // and set hadCompaction, triggering a spurious main-session auto-continue.
@@ -2660,6 +2666,7 @@ async function runQueryAttempt(
                 emit,
                 getFullText: () => processor.getFullText(),
                 resetFullText: () => processor.resetFullTextAccumulator(),
+                onCompactionStart: () => firstResponseWatchdog?.pause(),
               }),
             ],
           },

--- a/container/agent-runner/src/sdk-control.ts
+++ b/container/agent-runner/src/sdk-control.ts
@@ -66,6 +66,20 @@ export class SdkFirstResponseWatchdog {
     this.clear();
   }
 
+  /**
+   * Suspend the first-response deadline for a known-legitimate long operation.
+   * An auto-compaction is a full model round-trip that summarizes the whole
+   * conversation; on a near-full context it can easily exceed the first-response
+   * budget while emitting no `assistant`/`stream_event`/`result` to the outer
+   * iterator. Without this, a slow compaction is misclassified as a stalled
+   * provider and surfaced as a terminal "provider exhausted" failure. The real
+   * post-compaction model response still clears the guard via observe().
+   */
+  pause(): void {
+    if (this.observed) return;
+    this.clear();
+  }
+
   clear(): void {
     if (this.timer) clearTimeout(this.timer);
     this.timer = undefined;

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -6,6 +6,20 @@ set -e
 # Without this, the host cannot delete/modify files created by the container.
 umask 0000
 
+# Remap the container `node` user's UID/GID to match the host backend user.
+# Claude SDK creates session transcript files with mode 0600 (owner-only).
+# Without UID remapping, these files are owned by uid 1000 (ubuntu on host)
+# and unreadable by the host backend (agent, uid 1002). Remapping makes the
+# container user and host user the same identity, so 0600 files remain
+# accessible to the host even if the cleanup trap is skipped (docker kill).
+HOST_UID=${HOST_UID:-1000}
+HOST_GID=${HOST_GID:-1000}
+if [ "$(id -u node)" != "$HOST_UID" ]; then
+  sed -i "s/^node:x:[0-9]*:[0-9]*/node:x:${HOST_UID}:${HOST_GID}/" /etc/passwd
+  sed -i "s/^node:x:[0-9]*/node:x:${HOST_GID}/" /etc/group
+  chown -R "${HOST_UID}:${HOST_GID}" /home/node 2>/dev/null || true
+fi
+
 # Fix ownership on mounted volumes.
 # Host uid may differ from container node user (uid 1000), especially in
 # rootless podman where uid remapping causes EACCES on bind mounts.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -1544,6 +1544,13 @@ function buildContainerArgs(
   // Set timezone so container Node.js processes use local time (Asia/Shanghai)
   args.push('-e', `TZ=${tz}`);
 
+  // Pass host UID/GID so the entrypoint can remap the container `node` user
+  // to match the host backend user. Without this, files created by the
+  // container (node/uid 1000) are owned by a different user on the host and
+  // Claude SDK's 0600 transcript files become unreadable by the host backend.
+  args.push('-e', `HOST_UID=${process.getuid!()}`);
+  args.push('-e', `HOST_GID=${process.getgid!()}`);
+
   // Docker: -v with :ro suffix for readonly
   for (const mount of mounts) {
     if (mount.readonly) {

--- a/tests/agent-runner-sdk-control.test.ts
+++ b/tests/agent-runner-sdk-control.test.ts
@@ -83,6 +83,30 @@ describe('agent-runner SDK control requests', () => {
     },
   );
 
+  test('pause() suspends the deadline for a long compaction round-trip', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const watchdog = new SdkFirstResponseWatchdog(60_000, onTimeout);
+
+      // Compaction starts early in the turn (PreCompact) before the budget
+      // elapses; the summarization request itself emits no first-response.
+      await vi.advanceTimersByTimeAsync(3_000);
+      watchdog.pause();
+
+      // A slow compaction can far exceed the original first-response budget.
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      // The real post-compaction model response still clears the guard.
+      watchdog.observe('assistant');
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test('does not treat a non-terminal rate-limit warning as a model response', () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
本 PR 汇总两个相互独立的稳定性修复:自动压缩期间的首响应看门狗误判,以及容器会话文件的宿主可读性问题。

---

## 修复一:自动压缩期间暂停首响应看门狗,避免误判 Provider 故障

### 说明 / 背景
近满上下文的会话在每轮回复前需要先做一次**自动压缩**(对整段会话做总结的模型往返)。在近满上下文下,这次压缩往返耗时常常超过 60s 的首响应看门狗预算,且压缩期间**不会**向外层 SDK 迭代器发出 `assistant` / `stream_event` / `result` 事件。

看门狗因此把"正在压缩"误判为 **Provider 卡死**,进而弹出「额度已用尽」终态失败并中断压缩 —— 结果上下文永远压不下去,陷入**死循环**:每轮都试图压缩、每轮都被看门狗打断。

### 修复方式
- 在 `PreCompact` hook 触发时调用 `SdkFirstResponseWatchdog.pause()`,暂停首响应截止计时。
- 压缩本身是**合法的长操作**;压缩完成后真正的模型响应仍会经 `observe()` 正常清除看门狗。
- 仅当会话**完全未开始**(真正卡死)时,看门狗照常生效,不削弱原有的卡死保护。

### 影响范围
`container/agent-runner/src/index.ts`、`container/agent-runner/src/sdk-control.ts`

---

## 修复二:容器 UID/GID 重映射为宿主用户,避免 SDK 0600 会话文件宿主不可读

### 说明 / 背景
容器内 `node` 用户(uid 1000)创建的 Claude SDK 会话 transcript 文件是 **0600**(仅属主可读写)权限。当宿主后端进程以**不同 uid** 运行时,这些文件对宿主**不可读**;若容器被 `docker kill`(跳过清理 trap),还会在挂载卷里残留宿主**无法删除**的文件。

### 修复方式
- 宿主在启动容器时通过 `-e HOST_UID` / `-e HOST_GID` 传入自身 UID/GID(`src/container-runner.ts`)。
- `entrypoint.sh` 在启动时把容器 `node` 用户重映射为宿主身份(改写 `/etc/passwd`、`/etc/group` 并 `chown /home/node`),使容器与宿主是**同一身份**。
- 这样即便清理 trap 被跳过,0600 文件对宿主仍保持**可读可删**。
- 向后兼容:`HOST_UID`/`HOST_GID` 缺省回退 1000,旧行为不变。

### 影响范围
`src/container-runner.ts`、`container/entrypoint.sh`

> ⚠️ **部署注意**:`entrypoint.sh` 是 `COPY` 进镜像的,需**重建 `happyclaw-agent` 镜像**后才生效;`container-runner.ts` 侧随主服务 `tsc` 构建即可。

---

## 测试
| 项目 | 命令 | 结果 |
|------|------|------|
| 看门狗单测 | `npx vitest run tests/agent-runner-sdk-control.test.ts` | ✅ 9/9 passed |
| entrypoint 语法 | `bash -n container/entrypoint.sh` | ✅ OK |
| 后端类型/构建 | `tsc`(container-runner.ts) | ✅ 通过(已产出 `dist/container-runner.js`) |

## 备注
两个修复彼此独立、互不影响,合并在一个 PR 中提交;如需拆分为两个 PR 分别评审,我可以拆开。
