### PR TITLE
fix: make warm-path IPC follow-ups visible to stuck-runner recovery (#618)

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -1001,6 +1001,11 @@ export class GroupQueue {
     const state = this.resolveActiveState(groupJid);
     if (!state?.active) return;
     state.hasIpcInjectedMessages = true;
+    // Restart the idle window at the user's latest message: stuck detection
+    // must measure silence *after* the inject, not since the previous turn's
+    // last output — otherwise a follow-up injected into a long-idle warm
+    // runner would look instantly stuck (#618).
+    state.lastActivityAt = Date.now();
   }
 
   acknowledgeIpcDeliveries(
@@ -1139,22 +1144,38 @@ export class GroupQueue {
     return true;
   }
 
-  getStuckPendingGroups(
-    idleThresholdMs: number,
-  ): Array<{ jid: string; idleMs: number }> {
+  getStuckPendingGroups(idleThresholdMs: number): Array<{
+    jid: string;
+    idleMs: number;
+    reason: 'pending_messages' | 'ipc_injected';
+  }> {
     const now = Date.now();
-    const stuck: Array<{ jid: string; idleMs: number }> = [];
+    const stuck: Array<{
+      jid: string;
+      idleMs: number;
+      reason: 'pending_messages' | 'ipc_injected';
+    }> = [];
     for (const [jid, state] of this.groups.entries()) {
       if (!state.active) continue;
       if (state.activeRunnerIsTask) continue;
-      if (!state.pendingMessages) continue;
+      // Warm follow-ups are IPC-injected without re-arming pendingMessages, so
+      // a wedged in-flight turn with injected input was invisible here (#618).
+      // queryInFlight gates the IPC signal: once the runner reports the turn
+      // idle, a warm runner sitting between turns is not owed work and must
+      // not be restarted.
+      const hasIpcOwed = state.hasIpcInjectedMessages && state.queryInFlight;
+      if (!state.pendingMessages && !hasIpcOwed) continue;
       if (state.agentId !== null) continue;
       if (state.restarting) continue;
       const lastActivityAt = state.lastActivityAt ?? 0;
       if (lastActivityAt <= 0) continue;
       const idleMs = now - lastActivityAt;
       if (idleMs < idleThresholdMs) continue;
-      stuck.push({ jid, idleMs });
+      stuck.push({
+        jid,
+        idleMs,
+        reason: hasIpcOwed ? 'ipc_injected' : 'pending_messages',
+      });
     }
     return stuck;
   }
@@ -1595,6 +1616,8 @@ export class GroupQueue {
       // section. Mutation pause/stop cannot observe a written file without its
       // recovery metadata (the old callback→mark race window).
       state.hasIpcInjectedMessages = true;
+      // Idle window restarts at the user's latest injected message (#618).
+      state.lastActivityAt = Date.now();
       if (receipt) {
         state.pendingIpcDeliveries ??= new Map();
         state.pendingIpcDeliveries.set(receipt.deliveryId, receipt);

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -9,7 +9,10 @@ import { getTaskById } from './db.js';
 import { getSystemSettings } from './runtime-config.js';
 import { logger } from './logger.js';
 import { resolveFeishuCliBoundAccountId } from './feishu-cli-runtime.js';
-import type { RunnerRuntime } from './stuck-runner-recovery.js';
+import type {
+  RunnerRuntime,
+  StuckRecoveryCandidate,
+} from './stuck-runner-recovery.js';
 import type { ChannelTurnContext } from './types.js';
 export type SendMessageResult = 'sent' | 'no_active';
 export interface IpcMessageCursor {
@@ -124,6 +127,8 @@ interface GroupState {
    * guessing from docker-kill completion or polling child-process state. */
   teardownWaiters: Set<() => void>;
   active: boolean;
+  /** Monotonic identity for each concrete runForGroup/runTask lifecycle. */
+  runnerGeneration: number;
   /** Runtime actually assigned when this runner was launched. */
   runnerRuntime: RunnerRuntime | null;
   /** True when the active runner is executing a scheduled task (not user messages). */
@@ -269,6 +274,7 @@ export class GroupQueue {
         stopRequested: false,
         teardownWaiters: new Set(),
         active: false,
+        runnerGeneration: 0,
         runnerRuntime: null,
         activeRunnerIsTask: false,
         activeTask: null,
@@ -1156,56 +1162,100 @@ export class GroupQueue {
     return true;
   }
 
+  private snapshotStuckRecoveryCandidate(
+    jid: string,
+    state: GroupState,
+    now: number,
+    idleThresholdMs: number,
+    ipcForceThresholdMs = Number.POSITIVE_INFINITY,
+  ): StuckRecoveryCandidate | null {
+    if (!state.active) return null;
+    if (state.activeRunnerIsTask) return null;
+    // Warm follow-ups are IPC-injected without re-arming pendingMessages, so
+    // a wedged in-flight turn with injected input was invisible here (#618).
+    // The dedicated debt timestamp is cleared when the query reports idle;
+    // unlike hasIpcInjectedMessages, it does not persist for the runner's
+    // lifetime and ordinary output never refreshes it.
+    const ipcOwedSinceAt = state.ipcOwedSinceAt ?? null;
+    const hasIpcOwed = ipcOwedSinceAt !== null && state.queryInFlight;
+    if (!state.pendingMessages && !hasIpcOwed) return null;
+    if (state.agentId !== null) return null;
+    if (state.restarting) return null;
+    const lastActivityAt = state.lastActivityAt ?? 0;
+    if (lastActivityAt <= 0) return null;
+    const idleMs = now - lastActivityAt;
+    const ipcOwedMs = hasIpcOwed ? Math.max(0, now - ipcOwedSinceAt) : null;
+    const reachedIdleThreshold = idleMs >= idleThresholdMs;
+    const reachedAbsoluteIpcCeiling =
+      ipcOwedMs !== null && ipcOwedMs >= ipcForceThresholdMs;
+    if (!reachedIdleThreshold && !reachedAbsoluteIpcCeiling) return null;
+    return {
+      jid,
+      idleMs,
+      reason: hasIpcOwed ? 'ipc_injected' : 'pending_messages',
+      runtime:
+        state.runnerRuntime ??
+        (state.containerName !== null ? 'container' : 'host'),
+      runnerGeneration: state.runnerGeneration ?? 0,
+      queryId: state.queryId,
+      runnerPid: state.process?.pid ?? null,
+      ipcOwedSinceAt,
+      ipcOwedMs,
+    };
+  }
+
   getStuckPendingGroups(
     idleThresholdMs: number,
     ipcForceThresholdMs = Number.POSITIVE_INFINITY,
-  ): Array<{
-    jid: string;
-    idleMs: number;
-    reason: 'pending_messages' | 'ipc_injected';
-    runtime: RunnerRuntime;
-    ipcOwedMs: number | null;
-  }> {
+  ): StuckRecoveryCandidate[] {
     const now = Date.now();
-    const stuck: Array<{
-      jid: string;
-      idleMs: number;
-      reason: 'pending_messages' | 'ipc_injected';
-      runtime: RunnerRuntime;
-      ipcOwedMs: number | null;
-    }> = [];
+    const stuck: StuckRecoveryCandidate[] = [];
     for (const [jid, state] of this.groups.entries()) {
-      if (!state.active) continue;
-      if (state.activeRunnerIsTask) continue;
-      // Warm follow-ups are IPC-injected without re-arming pendingMessages, so
-      // a wedged in-flight turn with injected input was invisible here (#618).
-      // The dedicated debt timestamp is cleared when the query reports idle;
-      // unlike hasIpcInjectedMessages, it does not persist for the runner's
-      // lifetime and ordinary output never refreshes it.
-      const ipcOwedSinceAt = state.ipcOwedSinceAt ?? null;
-      const hasIpcOwed = ipcOwedSinceAt !== null && state.queryInFlight;
-      if (!state.pendingMessages && !hasIpcOwed) continue;
-      if (state.agentId !== null) continue;
-      if (state.restarting) continue;
-      const lastActivityAt = state.lastActivityAt ?? 0;
-      if (lastActivityAt <= 0) continue;
-      const idleMs = now - lastActivityAt;
-      const ipcOwedMs = hasIpcOwed ? Math.max(0, now - ipcOwedSinceAt) : null;
-      const reachedIdleThreshold = idleMs >= idleThresholdMs;
-      const reachedAbsoluteIpcCeiling =
-        ipcOwedMs !== null && ipcOwedMs >= ipcForceThresholdMs;
-      if (!reachedIdleThreshold && !reachedAbsoluteIpcCeiling) continue;
-      stuck.push({
+      const candidate = this.snapshotStuckRecoveryCandidate(
         jid,
-        idleMs,
-        reason: hasIpcOwed ? 'ipc_injected' : 'pending_messages',
-        runtime:
-          state.runnerRuntime ??
-          (state.containerName !== null ? 'container' : 'host'),
-        ipcOwedMs,
-      });
+        state,
+        now,
+        idleThresholdMs,
+        ipcForceThresholdMs,
+      );
+      if (candidate) stuck.push(candidate);
     }
     return stuck;
+  }
+
+  /**
+   * Re-snapshot a candidate after an asynchronous CPU probe and accept it only
+   * if the exact runner/query/debt identity is unchanged. This synchronous
+   * check closes the probe-to-restart TOCTOU window: a completed old turn or a
+   * newly-started healthy turn must never be killed by its predecessor's stale
+   * recovery decision.
+   */
+  revalidateStuckRecoveryCandidate(
+    candidate: StuckRecoveryCandidate,
+    idleThresholdMs: number,
+    ipcForceThresholdMs = Number.POSITIVE_INFINITY,
+  ): StuckRecoveryCandidate | null {
+    const state = this.groups.get(candidate.jid);
+    if (!state) return null;
+    const current = this.snapshotStuckRecoveryCandidate(
+      candidate.jid,
+      state,
+      Date.now(),
+      idleThresholdMs,
+      ipcForceThresholdMs,
+    );
+    if (!current) return null;
+    if (
+      current.runnerGeneration !== candidate.runnerGeneration ||
+      current.queryId !== candidate.queryId ||
+      current.runtime !== candidate.runtime ||
+      current.runnerPid !== candidate.runnerPid ||
+      current.reason !== candidate.reason ||
+      current.ipcOwedSinceAt !== candidate.ipcOwedSinceAt
+    ) {
+      return null;
+    }
+    return current;
   }
 
   /**
@@ -2294,6 +2344,7 @@ export class GroupQueue {
     state.stopRequested = false;
     const isHostMode = this.isHostMode(groupJid);
     state.active = true;
+    state.runnerGeneration = (state.runnerGeneration ?? 0) + 1;
     state.runnerRuntime = isHostMode ? 'host' : 'container';
     state.activeRunnerIsTask = false;
     state.lastActivityAt = Date.now();
@@ -2498,6 +2549,7 @@ export class GroupQueue {
     const isHostMode = this.isHostMode(groupJid);
     state.stopRequested = false;
     state.active = true;
+    state.runnerGeneration = (state.runnerGeneration ?? 0) + 1;
     state.runnerRuntime = isHostMode ? 'host' : 'container';
     state.activeRunnerIsTask = true;
     state.activeTask = task;

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -9,6 +9,7 @@ import { getTaskById } from './db.js';
 import { getSystemSettings } from './runtime-config.js';
 import { logger } from './logger.js';
 import { resolveFeishuCliBoundAccountId } from './feishu-cli-runtime.js';
+import type { RunnerRuntime } from './stuck-runner-recovery.js';
 import type { ChannelTurnContext } from './types.js';
 export type SendMessageResult = 'sent' | 'no_active';
 export interface IpcMessageCursor {
@@ -123,6 +124,8 @@ interface GroupState {
    * guessing from docker-kill completion or polling child-process state. */
   teardownWaiters: Set<() => void>;
   active: boolean;
+  /** Runtime actually assigned when this runner was launched. */
+  runnerRuntime: RunnerRuntime | null;
   /** True when the active runner is executing a scheduled task (not user messages). */
   activeRunnerIsTask: boolean;
   /** Exact task currently owning this state. Mutation stops park this task so
@@ -172,6 +175,9 @@ interface GroupState {
    *  re-read those messages.  The close handler uses this flag to force pendingMessages
    *  so drainGroup triggers a fresh run. */
   hasIpcInjectedMessages: boolean;
+  /** Oldest IPC inject still owed by the current logical query. Unlike
+   * lastActivityAt, ordinary runner output must never refresh this timestamp. */
+  ipcOwedSinceAt: number | null;
   /** IPC deliveries written to this runner but not yet acknowledged by a
    * healthy agent query result. Keyed by deliveryId for out-of-order acks. */
   pendingIpcDeliveries: Map<string, IpcDeliveryReceipt>;
@@ -263,6 +269,7 @@ export class GroupQueue {
         stopRequested: false,
         teardownWaiters: new Set(),
         active: false,
+        runnerRuntime: null,
         activeRunnerIsTask: false,
         activeTask: null,
         lastActivityAt: null,
@@ -287,6 +294,7 @@ export class GroupQueue {
         feishuCliAccountId: null,
         drainSentinelWritten: false,
         hasIpcInjectedMessages: false,
+        ipcOwedSinceAt: null,
         pendingIpcDeliveries: new Map(),
         acknowledgedIpcDeliveryIds: new Set(),
       };
@@ -1005,7 +1013,9 @@ export class GroupQueue {
     // must measure silence *after* the inject, not since the previous turn's
     // last output — otherwise a follow-up injected into a long-idle warm
     // runner would look instantly stuck (#618).
-    state.lastActivityAt = Date.now();
+    const injectedAt = Date.now();
+    state.lastActivityAt = injectedAt;
+    state.ipcOwedSinceAt ??= injectedAt;
   }
 
   acknowledgeIpcDeliveries(
@@ -1079,6 +1089,7 @@ export class GroupQueue {
     if (!state?.active || !state.queryInFlight) return;
     const completedQueryId = state.queryId;
     state.queryInFlight = false;
+    state.ipcOwedSinceAt = null;
     state.queryId = null;
     state.queryStartedAt = null;
     state.announcedQueryId = null;
@@ -1126,6 +1137,7 @@ export class GroupQueue {
       return false;
     }
     state.queryInFlight = false;
+    state.ipcOwedSinceAt = null;
     state.queryId = null;
     state.queryStartedAt = null;
     state.announcedQueryId = null;
@@ -1144,37 +1156,53 @@ export class GroupQueue {
     return true;
   }
 
-  getStuckPendingGroups(idleThresholdMs: number): Array<{
+  getStuckPendingGroups(
+    idleThresholdMs: number,
+    ipcForceThresholdMs = Number.POSITIVE_INFINITY,
+  ): Array<{
     jid: string;
     idleMs: number;
     reason: 'pending_messages' | 'ipc_injected';
+    runtime: RunnerRuntime;
+    ipcOwedMs: number | null;
   }> {
     const now = Date.now();
     const stuck: Array<{
       jid: string;
       idleMs: number;
       reason: 'pending_messages' | 'ipc_injected';
+      runtime: RunnerRuntime;
+      ipcOwedMs: number | null;
     }> = [];
     for (const [jid, state] of this.groups.entries()) {
       if (!state.active) continue;
       if (state.activeRunnerIsTask) continue;
       // Warm follow-ups are IPC-injected without re-arming pendingMessages, so
       // a wedged in-flight turn with injected input was invisible here (#618).
-      // queryInFlight gates the IPC signal: once the runner reports the turn
-      // idle, a warm runner sitting between turns is not owed work and must
-      // not be restarted.
-      const hasIpcOwed = state.hasIpcInjectedMessages && state.queryInFlight;
+      // The dedicated debt timestamp is cleared when the query reports idle;
+      // unlike hasIpcInjectedMessages, it does not persist for the runner's
+      // lifetime and ordinary output never refreshes it.
+      const ipcOwedSinceAt = state.ipcOwedSinceAt ?? null;
+      const hasIpcOwed = ipcOwedSinceAt !== null && state.queryInFlight;
       if (!state.pendingMessages && !hasIpcOwed) continue;
       if (state.agentId !== null) continue;
       if (state.restarting) continue;
       const lastActivityAt = state.lastActivityAt ?? 0;
       if (lastActivityAt <= 0) continue;
       const idleMs = now - lastActivityAt;
-      if (idleMs < idleThresholdMs) continue;
+      const ipcOwedMs = hasIpcOwed ? Math.max(0, now - ipcOwedSinceAt) : null;
+      const reachedIdleThreshold = idleMs >= idleThresholdMs;
+      const reachedAbsoluteIpcCeiling =
+        ipcOwedMs !== null && ipcOwedMs >= ipcForceThresholdMs;
+      if (!reachedIdleThreshold && !reachedAbsoluteIpcCeiling) continue;
       stuck.push({
         jid,
         idleMs,
         reason: hasIpcOwed ? 'ipc_injected' : 'pending_messages',
+        runtime:
+          state.runnerRuntime ??
+          (state.containerName !== null ? 'container' : 'host'),
+        ipcOwedMs,
       });
     }
     return stuck;
@@ -1424,6 +1452,7 @@ export class GroupQueue {
     const state = this.getGroup(groupJid);
     state.process = proc;
     state.containerName = opts.containerName;
+    state.runnerRuntime = opts.containerName === null ? 'host' : 'container';
     state.displayName = opts.displayName || null;
     if (opts.groupFolder) state.groupFolder = opts.groupFolder;
     state.agentId = opts.agentId || null;
@@ -1617,7 +1646,9 @@ export class GroupQueue {
       // recovery metadata (the old callback→mark race window).
       state.hasIpcInjectedMessages = true;
       // Idle window restarts at the user's latest injected message (#618).
-      state.lastActivityAt = Date.now();
+      const injectedAt = Date.now();
+      state.lastActivityAt = injectedAt;
+      state.ipcOwedSinceAt ??= injectedAt;
       if (receipt) {
         state.pendingIpcDeliveries ??= new Map();
         state.pendingIpcDeliveries.set(receipt.deliveryId, receipt);
@@ -2263,9 +2294,11 @@ export class GroupQueue {
     state.stopRequested = false;
     const isHostMode = this.isHostMode(groupJid);
     state.active = true;
+    state.runnerRuntime = isHostMode ? 'host' : 'container';
     state.activeRunnerIsTask = false;
     state.lastActivityAt = Date.now();
     state.queryInFlight = true;
+    state.ipcOwedSinceAt = null;
     state.queryId = randomUUID();
     state.queryStartedAt = Date.now();
     state.announcedQueryId = null;
@@ -2381,6 +2414,7 @@ export class GroupQueue {
       state.active = false;
       state.drainSentinelWritten = false;
       state.hasIpcInjectedMessages = false;
+      state.ipcOwedSinceAt = null;
       state.lastActivityAt = null;
       state.queryInFlight = false;
       state.queryId = null;
@@ -2399,6 +2433,7 @@ export class GroupQueue {
       state.groupFolder = null;
       state.agentId = null;
       state.taskRunId = null;
+      state.runnerRuntime = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;
@@ -2417,7 +2452,12 @@ export class GroupQueue {
       }
       // Skip auto-drain when a stop was just requested — drainGroup would
       // start a fresh runForGroup if any pending* slipped through.
-      if (!isStopRequested || preserveMutationWork) {
+      if (state.restarting) {
+        logger.debug(
+          { groupJid, folder: exitFolder },
+          'Restart in progress; deferring replacement launch to restartGroup',
+        );
+      } else if (!isStopRequested || preserveMutationWork) {
         try {
           this.drainGroup(groupJid);
         } catch (err) {
@@ -2458,10 +2498,12 @@ export class GroupQueue {
     const isHostMode = this.isHostMode(groupJid);
     state.stopRequested = false;
     state.active = true;
+    state.runnerRuntime = isHostMode ? 'host' : 'container';
     state.activeRunnerIsTask = true;
     state.activeTask = task;
     state.lastActivityAt = Date.now();
     state.queryInFlight = groupJid.includes('#agent:');
+    state.ipcOwedSinceAt = null;
     state.queryId = state.queryInFlight ? randomUUID() : null;
     state.queryStartedAt = state.queryInFlight ? Date.now() : null;
     state.announcedQueryId = null;
@@ -2532,6 +2574,7 @@ export class GroupQueue {
       state.activeTask = null;
       state.drainSentinelWritten = false;
       state.lastActivityAt = null;
+      state.ipcOwedSinceAt = null;
       state.queryInFlight = false;
       state.queryId = null;
       state.queryStartedAt = null;
@@ -2549,6 +2592,7 @@ export class GroupQueue {
       state.groupFolder = null;
       state.agentId = null;
       state.taskRunId = null;
+      state.runnerRuntime = null;
       this.activeCount--;
       if (isHostMode) {
         this.activeHostProcessCount--;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17300,11 +17300,30 @@ async function recoverStuckPendingGroups(): Promise<void> {
     STUCK_RUNNER_FORCE_RESTART_MS,
   );
   for (const candidate of stuckGroups) {
-    const { jid, idleMs, reason, runtime, ipcOwedMs } = candidate;
-    const pid = queue.getRunnerPid(jid);
-    const cpuActivity = await resolveRunnerCpuActivity(candidate, pid);
-    const decision = decideStuckRunnerRecovery(
+    const pid = candidate.runnerPid ?? undefined;
+    const cpuActivity = await resolveRunnerCpuActivity(candidate);
+    const currentCandidate = queue.revalidateStuckRecoveryCandidate(
       candidate,
+      STUCK_RUNNER_IDLE_MS,
+      STUCK_RUNNER_FORCE_RESTART_MS,
+    );
+    if (!currentCandidate) {
+      logger.info(
+        {
+          chatJid: candidate.jid,
+          queryId: candidate.queryId,
+          runnerGeneration: candidate.runnerGeneration,
+          pid,
+          reason: candidate.reason,
+          runtime: candidate.runtime,
+        },
+        'Skipping stale stuck-runner candidate after CPU probe',
+      );
+      continue;
+    }
+    const { jid, idleMs, reason, runtime, ipcOwedMs } = currentCandidate;
+    const decision = decideStuckRunnerRecovery(
+      currentCandidate,
       cpuActivity,
       STUCK_RUNNER_FORCE_RESTART_MS,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1229,6 +1229,10 @@ const EMPTY_CURSOR: MessageCursor = { timestamp: '', id: '' };
 const terminalWarmupInFlight = new Set<string>();
 const STUCK_RUNNER_CHECK_INTERVAL_POLLS = 15;
 const STUCK_RUNNER_IDLE_MS = 3 * 60 * 1000;
+// Absolute ceiling for IPC-owed work: a spinning tool keeps child CPU non-zero
+// indefinitely, so the CPU-active grace alone can defer restart forever while
+// the user's injected follow-ups sit unanswered (#618).
+const STUCK_RUNNER_FORCE_RESTART_MS = 10 * 60 * 1000;
 let stuckRunnerCheckCounter = 0;
 
 // OOM auto-recovery: track consecutive OOM (exit code 137) exits per folder.
@@ -17331,19 +17335,21 @@ async function hasActiveCpuDescendants(pid: number): Promise<boolean> {
 
 async function recoverStuckPendingGroups(): Promise<void> {
   const stuckGroups = queue.getStuckPendingGroups(STUCK_RUNNER_IDLE_MS);
-  for (const { jid, idleMs } of stuckGroups) {
+  for (const { jid, idleMs, reason } of stuckGroups) {
     const pid = queue.getRunnerPid(jid);
-    if (pid && (await hasActiveCpuDescendants(pid))) {
+    const cpuGraceApplies =
+      reason !== 'ipc_injected' || idleMs < STUCK_RUNNER_FORCE_RESTART_MS;
+    if (cpuGraceApplies && pid && (await hasActiveCpuDescendants(pid))) {
       logger.info(
-        { chatJid: jid, idleMs, pid },
+        { chatJid: jid, idleMs, pid, reason },
         'Runner idle but has CPU-active child processes; skipping restart',
       );
       continue;
     }
 
     logger.warn(
-      { chatJid: jid, idleMs },
-      'Runner has pending messages but no activity; restarting',
+      { chatJid: jid, idleMs, reason },
+      'Runner has owed user work but no activity; restarting',
     );
     queue.restartGroup(jid).catch((err) => {
       logger.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,10 @@ import {
   writeTasksSnapshot,
 } from './container-runner.js';
 import { resolveRunnerLivenessTimeouts } from './runner-liveness.js';
+import {
+  decideStuckRunnerRecovery,
+  resolveRunnerCpuActivity,
+} from './stuck-runner-recovery.js';
 import { resolveFeishuCliBoundAccountId } from './feishu-cli-runtime.js';
 import { isValidWorkspaceFolderName } from './workspace-folder.js';
 import { PROVIDER_FAILURE_USER_NOTICE } from './provider-failure.js';
@@ -1229,9 +1233,9 @@ const EMPTY_CURSOR: MessageCursor = { timestamp: '', id: '' };
 const terminalWarmupInFlight = new Set<string>();
 const STUCK_RUNNER_CHECK_INTERVAL_POLLS = 15;
 const STUCK_RUNNER_IDLE_MS = 3 * 60 * 1000;
-// Absolute ceiling for IPC-owed work: a spinning tool keeps child CPU non-zero
-// indefinitely, so the CPU-active grace alone can defer restart forever while
-// the user's injected follow-ups sit unanswered (#618).
+// Recovery grace is bounded at 10 minutes. IPC-injected work measures this
+// against its dedicated debt clock so ordinary runner output cannot postpone
+// the ceiling; other candidates use their uninterrupted idle age (#618).
 const STUCK_RUNNER_FORCE_RESTART_MS = 10 * 60 * 1000;
 let stuckRunnerCheckCounter = 0;
 
@@ -17290,65 +17294,47 @@ async function startMessageLoop(): Promise<void> {
   }
 }
 
-/**
- * Check if a process tree has actively working descendant processes.
- * Returns true if any descendant (not just direct children) is consuming
- * CPU (> 0.5%), indicating real work rather than a network-blocked hang.
- */
-async function hasActiveCpuDescendants(pid: number): Promise<boolean> {
-  const execFileAsync = promisify(execFile);
-  try {
-    const { stdout } = await execFileAsync('ps', ['-eo', 'pid=,ppid=,pcpu='], {
-      timeout: 3000,
-    });
-
-    const children = new Map<number, number[]>();
-    const cpuByPid = new Map<number, number>();
-    for (const line of stdout.trim().split('\n')) {
-      const parts = line.trim().split(/\s+/);
-      if (parts.length < 3) continue;
-      const p = parseInt(parts[0], 10);
-      const pp = parseInt(parts[1], 10);
-      const cpu = parseFloat(parts[2]);
-      if (isNaN(p) || isNaN(pp)) continue;
-      if (!children.has(pp)) children.set(pp, []);
-      children.get(pp)!.push(p);
-      cpuByPid.set(p, cpu);
-    }
-
-    // Walk the full descendant tree (not just direct children)
-    const stack = [pid];
-    while (stack.length > 0) {
-      const current = stack.pop()!;
-      const kids = children.get(current);
-      if (!kids) continue;
-      for (const kid of kids) {
-        if ((cpuByPid.get(kid) ?? 0) > 0.5) return true;
-        stack.push(kid);
-      }
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
 async function recoverStuckPendingGroups(): Promise<void> {
-  const stuckGroups = queue.getStuckPendingGroups(STUCK_RUNNER_IDLE_MS);
-  for (const { jid, idleMs, reason } of stuckGroups) {
+  const stuckGroups = queue.getStuckPendingGroups(
+    STUCK_RUNNER_IDLE_MS,
+    STUCK_RUNNER_FORCE_RESTART_MS,
+  );
+  for (const candidate of stuckGroups) {
+    const { jid, idleMs, reason, runtime, ipcOwedMs } = candidate;
     const pid = queue.getRunnerPid(jid);
-    const cpuGraceApplies =
-      reason !== 'ipc_injected' || idleMs < STUCK_RUNNER_FORCE_RESTART_MS;
-    if (cpuGraceApplies && pid && (await hasActiveCpuDescendants(pid))) {
+    const cpuActivity = await resolveRunnerCpuActivity(candidate, pid);
+    const decision = decideStuckRunnerRecovery(
+      candidate,
+      cpuActivity,
+      STUCK_RUNNER_FORCE_RESTART_MS,
+    );
+    if (decision.action === 'defer') {
       logger.info(
-        { chatJid: jid, idleMs, pid, reason },
-        'Runner idle but has CPU-active child processes; skipping restart',
+        {
+          chatJid: jid,
+          idleMs,
+          ipcOwedMs,
+          pid,
+          reason,
+          runtime,
+          cpuActivity,
+          deferReason: decision.reason,
+        },
+        'Runner recovery deferred while owed work remains within its grace policy',
       );
       continue;
     }
 
     logger.warn(
-      { chatJid: jid, idleMs, reason },
+      {
+        chatJid: jid,
+        idleMs,
+        ipcOwedMs,
+        reason,
+        runtime,
+        cpuActivity,
+        restartReason: decision.reason,
+      },
       'Runner has owed user work but no activity; restarting',
     );
     queue.restartGroup(jid).catch((err) => {

--- a/src/stuck-runner-recovery.ts
+++ b/src/stuck-runner-recovery.ts
@@ -1,0 +1,164 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+import { logger } from './logger.js';
+
+export type RunnerRuntime = 'host' | 'container';
+export type RunnerCpuActivity =
+  | 'active'
+  | 'inactive'
+  | 'unknown'
+  | 'unavailable';
+
+export interface StuckRecoveryCandidate {
+  jid: string;
+  idleMs: number;
+  reason: 'pending_messages' | 'ipc_injected';
+  runtime: RunnerRuntime;
+  /** Age of the oldest IPC input still owed by the current logical query. */
+  ipcOwedMs: number | null;
+}
+
+export type StuckRecoveryDecision =
+  | {
+      action: 'restart';
+      reason: 'idle' | 'idle_ceiling' | 'absolute_ipc_ceiling';
+    }
+  | {
+      action: 'defer';
+      reason: 'container_grace' | 'cpu_active' | 'cpu_unknown';
+    };
+
+export type HostProcessTableReader = () => Promise<string>;
+export type HostRunnerCpuProbe = (
+  pid: number,
+  context: StuckRecoveryCandidate,
+) => Promise<RunnerCpuActivity>;
+
+const execFileAsync = promisify(execFile);
+
+async function readHostProcessTable(): Promise<string> {
+  const { stdout } = await execFileAsync('ps', ['-eo', 'pid=,ppid=,pcpu='], {
+    timeout: 3000,
+    encoding: 'utf8',
+  });
+  return stdout;
+}
+
+/**
+ * Inspect a host runner's real descendant process tree. Docker workloads are
+ * deliberately excluded: container processes belong to Docker/containerd,
+ * not to the host-side `docker` CLI process tree.
+ */
+export async function probeHostRunnerCpu(
+  pid: number,
+  context: Pick<
+    StuckRecoveryCandidate,
+    'jid' | 'idleMs' | 'reason' | 'runtime' | 'ipcOwedMs'
+  >,
+  readProcessTable: HostProcessTableReader = readHostProcessTable,
+): Promise<RunnerCpuActivity> {
+  try {
+    const stdout = await readProcessTable();
+    const children = new Map<number, number[]>();
+    const cpuByPid = new Map<number, number>();
+    for (const line of stdout.trim().split('\n')) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 3) continue;
+      const processPid = Number.parseInt(parts[0], 10);
+      const parentPid = Number.parseInt(parts[1], 10);
+      const cpu = Number.parseFloat(parts[2]);
+      if (
+        Number.isNaN(processPid) ||
+        Number.isNaN(parentPid) ||
+        Number.isNaN(cpu)
+      ) {
+        continue;
+      }
+      const siblings = children.get(parentPid) ?? [];
+      siblings.push(processPid);
+      children.set(parentPid, siblings);
+      cpuByPid.set(processPid, cpu);
+    }
+
+    const visited = new Set<number>();
+    const stack = [pid];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const descendants = children.get(current);
+      if (!descendants) continue;
+      for (const descendant of descendants) {
+        if ((cpuByPid.get(descendant) ?? 0) > 0.5) return 'active';
+        stack.push(descendant);
+      }
+    }
+    return 'inactive';
+  } catch (err) {
+    logger.warn(
+      {
+        err,
+        chatJid: context.jid,
+        pid,
+        idleMs: context.idleMs,
+        reason: context.reason,
+        runtime: context.runtime,
+        ipcOwedMs: context.ipcOwedMs,
+      },
+      'Failed to inspect host runner descendant CPU; deferring stuck restart',
+    );
+    return 'unknown';
+  }
+}
+
+/**
+ * Resolve observable CPU activity without crossing runtime boundaries. The
+ * host-side Docker CLI PID is lifecycle plumbing, not the container workload.
+ */
+export async function resolveRunnerCpuActivity(
+  candidate: StuckRecoveryCandidate,
+  pid: number | undefined,
+  probe: HostRunnerCpuProbe = probeHostRunnerCpu,
+): Promise<RunnerCpuActivity> {
+  if (candidate.runtime !== 'host' || !pid) return 'unavailable';
+  return probe(pid, candidate);
+}
+
+/**
+ * Decide whether an already-idle candidate should restart now. IPC work uses
+ * an absolute debt age that ordinary output cannot refresh. Before that
+ * ceiling, container work is conservatively preserved because host `ps`
+ * cannot observe CPU inside Docker; host probe failures are likewise deferred.
+ */
+export function decideStuckRunnerRecovery(
+  candidate: StuckRecoveryCandidate,
+  cpuActivity: RunnerCpuActivity,
+  forceRestartMs: number,
+): StuckRecoveryDecision {
+  if (
+    candidate.reason === 'ipc_injected' &&
+    candidate.ipcOwedMs !== null &&
+    candidate.ipcOwedMs >= forceRestartMs
+  ) {
+    return { action: 'restart', reason: 'absolute_ipc_ceiling' };
+  }
+
+  // CPU activity and unobservable container work are grace signals, not an
+  // unlimited veto. Pending-message recovery still needs a hard upper bound.
+  if (candidate.idleMs >= forceRestartMs) {
+    return { action: 'restart', reason: 'idle_ceiling' };
+  }
+
+  if (candidate.runtime === 'container') {
+    return { action: 'defer', reason: 'container_grace' };
+  }
+
+  if (cpuActivity === 'active') {
+    return { action: 'defer', reason: 'cpu_active' };
+  }
+  if (cpuActivity === 'unknown') {
+    return { action: 'defer', reason: 'cpu_unknown' };
+  }
+  return { action: 'restart', reason: 'idle' };
+}

--- a/src/stuck-runner-recovery.ts
+++ b/src/stuck-runner-recovery.ts
@@ -15,6 +15,14 @@ export interface StuckRecoveryCandidate {
   idleMs: number;
   reason: 'pending_messages' | 'ipc_injected';
   runtime: RunnerRuntime;
+  /** Monotonic identity of the concrete GroupQueue runner lifecycle. */
+  runnerGeneration: number;
+  /** Exact logical query observed when the candidate was selected. */
+  queryId: string | null;
+  /** Host-side process identity used by the CPU probe, if registered. */
+  runnerPid: number | null;
+  /** Absolute debt clock used to reject a later query's fresh IPC work. */
+  ipcOwedSinceAt: number | null;
   /** Age of the oldest IPC input still owed by the current logical query. */
   ipcOwedMs: number | null;
 }
@@ -118,9 +126,9 @@ export async function probeHostRunnerCpu(
  */
 export async function resolveRunnerCpuActivity(
   candidate: StuckRecoveryCandidate,
-  pid: number | undefined,
   probe: HostRunnerCpuProbe = probeHostRunnerCpu,
 ): Promise<RunnerCpuActivity> {
+  const pid = candidate.runnerPid;
   if (candidate.runtime !== 'host' || !pid) return 'unavailable';
   return probe(pid, candidate);
 }

--- a/tests/group-queue-ipc-receipts.test.ts
+++ b/tests/group-queue-ipc-receipts.test.ts
@@ -632,6 +632,47 @@ describe('GroupQueue IPC delivery receipts', () => {
     expect(recovered).toEqual([[receipt]]);
   });
 
+  test('restart owns one DB replay and produces exactly one replacement reply', async () => {
+    let attempts = 0;
+    let replies = 0;
+    let finishStuckRun: ((success: boolean) => void) | undefined;
+    const durableReplay: Receipt[] = [];
+    const recoveryCalls: string[][] = [];
+
+    queue.setProcessMessagesFn(async () => {
+      attempts++;
+      if (attempts === 1) {
+        return new Promise<boolean>((resolve) => {
+          finishStuckRun = resolve;
+          releaseRun = () => resolve(false);
+        });
+      }
+
+      const replay = durableReplay.shift();
+      if (replay) replies++;
+      return true;
+    });
+    queue.setOnUnacknowledgedIpcDeliveries((_jid, receipts) => {
+      recoveryCalls.push(receipts.map((receipt) => receipt.cursor.id));
+      durableReplay.push(...receipts);
+    });
+
+    await startRunner();
+    inject('stuck-follow-up');
+
+    const restarting = queue.restartGroup(JID);
+    finishStuckRun?.(false);
+    await restarting;
+    await tick();
+    await tick();
+
+    expect(recoveryCalls).toEqual([['stuck-follow-up']]);
+    expect(durableReplay).toEqual([]);
+    expect(attempts).toBe(2);
+    expect(replies).toBe(1);
+    expect(readPayloads()).toEqual([]);
+  });
+
   test('explicit stop abandons instead of replaying accepted deliveries', async () => {
     await startRunner();
     const receipt = inject('cancelled');

--- a/tests/group-queue-stuck-recovery.test.ts
+++ b/tests/group-queue-stuck-recovery.test.ts
@@ -6,10 +6,9 @@ import { GroupQueue } from '../src/group-queue.js';
 import { DATA_DIR } from '../src/config.js';
 
 // Regression coverage for #618: warm-path IPC follow-ups must be visible to
-// stuck-runner recovery. Follow-ups injected into a live runner set
-// hasIpcInjectedMessages without re-arming pendingMessages, so a wedged
-// in-flight turn with injected input was invisible to getStuckPendingGroups
-// and the user got no reply until a manual kill.
+// stuck-runner recovery. Follow-ups injected into a live runner establish a
+// dedicated IPC-debt timestamp without re-arming pendingMessages, so a wedged
+// in-flight turn remains visible even when ordinary output refreshes activity.
 //
 // State is seeded directly into the internal map (same approach as
 // conversation-agent-warm-lifecycle.test.ts) so the tests stay hermetic.
@@ -20,17 +19,20 @@ interface SeedOpts {
   active?: boolean;
   groupFolder?: string;
   agentId?: string | null;
+  runnerRuntime?: 'host' | 'container' | null;
   queryInFlight?: boolean;
   activeRunnerIsTask?: boolean;
   lastActivityAt?: number | null;
   pendingMessages?: boolean;
   hasIpcInjectedMessages?: boolean;
+  ipcOwedSinceAt?: number | null;
 }
 
 function seedRunner(q: GroupQueue, jid: string, opts: SeedOpts = {}) {
   const anyQ = q as unknown as { groups: Map<string, Record<string, unknown>> };
   anyQ.groups.set(jid, {
     active: opts.active ?? true,
+    runnerRuntime: opts.runnerRuntime ?? 'host',
     activeRunnerIsTask: opts.activeRunnerIsTask ?? false,
     lastActivityAt: opts.lastActivityAt ?? null,
     queryInFlight: opts.queryInFlight ?? false,
@@ -48,6 +50,7 @@ function seedRunner(q: GroupQueue, jid: string, opts: SeedOpts = {}) {
     selectedProviderId: null,
     drainSentinelWritten: false,
     hasIpcInjectedMessages: opts.hasIpcInjectedMessages ?? false,
+    ipcOwedSinceAt: opts.ipcOwedSinceAt ?? null,
   });
 }
 
@@ -71,6 +74,7 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
       groupFolder: folder,
       queryInFlight: true,
       hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
       lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
     });
 
@@ -91,6 +95,7 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
       groupFolder: folder,
       queryInFlight: false,
       hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
       lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
     });
 
@@ -127,6 +132,7 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
     expect(q.sendMessage(jid, 'follow-up message')).toBe('sent');
     expect(getState(q, jid).hasIpcInjectedMessages).toBe(true);
     expect(getState(q, jid).queryInFlight).toBe(true);
+    expect(getState(q, jid).ipcOwedSinceAt).toEqual(expect.any(Number));
     expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
   });
 
@@ -145,6 +151,43 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
     const last = getState(q, jid).lastActivityAt as number;
     expect(last).toBeGreaterThanOrEqual(before);
     expect(last).toBeLessThanOrEqual(after);
+    expect(getState(q, jid).ipcOwedSinceAt).toBe(last);
+  });
+
+  test('ordinary runner output refreshes idle activity without moving the absolute IPC debt clock', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: 1,
+      lastActivityAt: 1,
+    });
+
+    q.markRunnerActivity(jid);
+
+    expect(getState(q, jid).lastActivityAt).toBeGreaterThan(1);
+    expect(getState(q, jid).ipcOwedSinceAt).toBe(1);
+  });
+
+  test('absolute IPC ceiling remains visible despite recent runner output', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    const forceRestartMs = 10 * 60 * 1000;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - forceRestartMs - 1000,
+      lastActivityAt: Date.now() - 30_000,
+    });
+
+    const stuck = q.getStuckPendingGroups(IDLE_THRESHOLD_MS, forceRestartMs);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].reason).toBe('ipc_injected');
+    expect(stuck[0].idleMs).toBeLessThan(IDLE_THRESHOLD_MS);
+    expect(stuck[0].ipcOwedMs).toBeGreaterThanOrEqual(forceRestartMs);
   });
 
   test('in-flight injected turn below the idle threshold is not stuck', () => {
@@ -154,20 +197,23 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
       groupFolder: folder,
       queryInFlight: true,
       hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - 30_000,
       lastActivityAt: Date.now() - 30_000,
     });
 
     expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
   });
 
-  test('runtime-session (agentId) runners remain excluded from stuck recovery', () => {
+  test('conversation-agent task lanes remain explicitly owned by their task lifecycle', () => {
     const q = new GroupQueue();
     const jid = `web:${folder}#agent:sess1`;
     seedRunner(q, jid, {
       groupFolder: folder,
       agentId: 'sess1',
+      activeRunnerIsTask: true,
       queryInFlight: true,
       hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
       lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
     });
 

--- a/tests/group-queue-stuck-recovery.test.ts
+++ b/tests/group-queue-stuck-recovery.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import { GroupQueue } from '../src/group-queue.js';
+import { DATA_DIR } from '../src/config.js';
+
+// Regression coverage for #618: warm-path IPC follow-ups must be visible to
+// stuck-runner recovery. Follow-ups injected into a live runner set
+// hasIpcInjectedMessages without re-arming pendingMessages, so a wedged
+// in-flight turn with injected input was invisible to getStuckPendingGroups
+// and the user got no reply until a manual kill.
+//
+// State is seeded directly into the internal map (same approach as
+// conversation-agent-warm-lifecycle.test.ts) so the tests stay hermetic.
+
+const IDLE_THRESHOLD_MS = 3 * 60 * 1000;
+
+interface SeedOpts {
+  active?: boolean;
+  groupFolder?: string;
+  agentId?: string | null;
+  queryInFlight?: boolean;
+  activeRunnerIsTask?: boolean;
+  lastActivityAt?: number | null;
+  pendingMessages?: boolean;
+  hasIpcInjectedMessages?: boolean;
+}
+
+function seedRunner(q: GroupQueue, jid: string, opts: SeedOpts = {}) {
+  const anyQ = q as unknown as { groups: Map<string, Record<string, unknown>> };
+  anyQ.groups.set(jid, {
+    active: opts.active ?? true,
+    activeRunnerIsTask: opts.activeRunnerIsTask ?? false,
+    lastActivityAt: opts.lastActivityAt ?? null,
+    queryInFlight: opts.queryInFlight ?? false,
+    pendingMessages: opts.pendingMessages ?? false,
+    pendingTasks: [],
+    process: null,
+    containerName: null,
+    displayName: null,
+    groupFolder: opts.groupFolder ?? 'main',
+    agentId: opts.agentId ?? null,
+    taskRunId: null,
+    retryCount: 0,
+    retryTimer: null,
+    restarting: false,
+    selectedProviderId: null,
+    drainSentinelWritten: false,
+    hasIpcInjectedMessages: opts.hasIpcInjectedMessages ?? false,
+  });
+}
+
+function getState(q: GroupQueue, jid: string): Record<string, unknown> {
+  const anyQ = q as unknown as { groups: Map<string, Record<string, unknown>> };
+  return anyQ.groups.get(jid)!;
+}
+
+describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
+  const folder = `stuck-test-${process.pid}-${Date.now()}`;
+  const ipcDir = path.join(DATA_DIR, 'ipc', folder);
+
+  afterEach(() => {
+    fs.rmSync(ipcDir, { recursive: true, force: true });
+  });
+
+  test('wedged in-flight turn with injected input is reported as stuck (ipc_injected)', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+
+    const stuck = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].jid).toBe(jid);
+    expect(stuck[0].reason).toBe('ipc_injected');
+    expect(stuck[0].idleMs).toBeGreaterThanOrEqual(IDLE_THRESHOLD_MS);
+  });
+
+  test('warm runner idle between turns is NOT stuck: turn completed, no owed work', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    // hasIpcInjectedMessages stays true for the runner lifetime (exit-replay
+    // safety), but queryInFlight=false means the runner reported the turn
+    // idle. IDLE_TIMEOUT owns this runner, not stuck recovery.
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: false,
+      hasIpcInjectedMessages: true,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+
+    expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
+  });
+
+  test('pendingMessages path still reports stuck with pending_messages reason', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      pendingMessages: true,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+
+    const stuck = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].reason).toBe('pending_messages');
+  });
+
+  test('a recently injected follow-up is not stuck: sendMessage restarts the idle window', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    // Warm runner sitting idle long past the threshold when the user's
+    // follow-up arrives. Without the lastActivityAt refresh at inject time,
+    // the runner would look instantly stuck and get restarted before it had
+    // any chance to answer.
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: false,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+
+    expect(q.sendMessage(jid, 'follow-up message')).toBe('sent');
+    expect(getState(q, jid).hasIpcInjectedMessages).toBe(true);
+    expect(getState(q, jid).queryInFlight).toBe(true);
+    expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
+  });
+
+  test('markIpcInjectedMessage restarts the idle window', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      lastActivityAt: 1,
+    });
+
+    const before = Date.now();
+    q.markIpcInjectedMessage(jid);
+    const after = Date.now();
+
+    const last = getState(q, jid).lastActivityAt as number;
+    expect(last).toBeGreaterThanOrEqual(before);
+    expect(last).toBeLessThanOrEqual(after);
+  });
+
+  test('in-flight injected turn below the idle threshold is not stuck', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      lastActivityAt: Date.now() - 30_000,
+    });
+
+    expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
+  });
+
+  test('runtime-session (agentId) runners remain excluded from stuck recovery', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}#agent:sess1`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      agentId: 'sess1',
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+
+    expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
+  });
+});

--- a/tests/group-queue-stuck-recovery.test.ts
+++ b/tests/group-queue-stuck-recovery.test.ts
@@ -20,7 +20,10 @@ interface SeedOpts {
   groupFolder?: string;
   agentId?: string | null;
   runnerRuntime?: 'host' | 'container' | null;
+  runnerGeneration?: number;
+  runnerPid?: number | null;
   queryInFlight?: boolean;
+  queryId?: string | null;
   activeRunnerIsTask?: boolean;
   lastActivityAt?: number | null;
   pendingMessages?: boolean;
@@ -32,13 +35,23 @@ function seedRunner(q: GroupQueue, jid: string, opts: SeedOpts = {}) {
   const anyQ = q as unknown as { groups: Map<string, Record<string, unknown>> };
   anyQ.groups.set(jid, {
     active: opts.active ?? true,
+    runnerGeneration: opts.runnerGeneration ?? 1,
     runnerRuntime: opts.runnerRuntime ?? 'host',
     activeRunnerIsTask: opts.activeRunnerIsTask ?? false,
     lastActivityAt: opts.lastActivityAt ?? null,
     queryInFlight: opts.queryInFlight ?? false,
+    queryId:
+      opts.queryId !== undefined
+        ? opts.queryId
+        : opts.queryInFlight
+          ? 'query-1'
+          : null,
     pendingMessages: opts.pendingMessages ?? false,
     pendingTasks: [],
-    process: null,
+    process:
+      opts.runnerPid === undefined || opts.runnerPid === null
+        ? null
+        : { pid: opts.runnerPid },
     containerName: null,
     displayName: null,
     groupFolder: opts.groupFolder ?? 'main',
@@ -188,6 +201,128 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
     expect(stuck[0].reason).toBe('ipc_injected');
     expect(stuck[0].idleMs).toBeLessThan(IDLE_THRESHOLD_MS);
     expect(stuck[0].ipcOwedMs).toBeGreaterThanOrEqual(forceRestartMs);
+  });
+
+  test('probe result is rejected when the old turn becomes idle', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      runnerPid: 101,
+      queryInFlight: true,
+      queryId: 'old-query',
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+    const [candidate] = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+
+    q.markRunnerQueryIdle(jid);
+
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
+  });
+
+  test('probe result is rejected when fresh activity drops below the idle threshold', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      runnerPid: 106,
+      queryInFlight: true,
+      queryId: 'recovering-query',
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+    const [candidate] = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+
+    q.markRunnerActivity(jid);
+
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
+  });
+
+  test('probe result cannot restart a new healthy query on the same warm runner', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      runnerPid: 102,
+      queryInFlight: true,
+      queryId: 'old-query',
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+    const [candidate] = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+
+    q.markRunnerQueryIdle(jid);
+    expect(q.sendMessage(jid, 'new healthy turn')).toBe('sent');
+    expect(getState(q, jid).queryId).not.toBe(candidate.queryId);
+
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
+  });
+
+  test('probe result is rejected when the query, PID, or generation changes', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      runnerPid: 103,
+      queryInFlight: true,
+      queryId: 'same-query',
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+    const [candidate] = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+    const state = getState(q, jid);
+
+    state.queryId = 'replacement-query';
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
+
+    state.queryId = 'same-query';
+    state.process = { pid: 104 };
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
+
+    state.process = { pid: 103 };
+    state.runnerGeneration = 2;
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
+  });
+
+  test('probe result is accepted only while the same IPC debt remains owed', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      runnerPid: 105,
+      queryInFlight: true,
+      queryId: 'same-query',
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 2000,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 2000,
+    });
+    const [candidate] = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toMatchObject({
+      runnerGeneration: candidate.runnerGeneration,
+      queryId: candidate.queryId,
+      runnerPid: candidate.runnerPid,
+      ipcOwedSinceAt: candidate.ipcOwedSinceAt,
+    });
+
+    getState(q, jid).ipcOwedSinceAt = Date.now() - IDLE_THRESHOLD_MS - 1000;
+    expect(
+      q.revalidateStuckRecoveryCandidate(candidate, IDLE_THRESHOLD_MS),
+    ).toBeNull();
   });
 
   test('in-flight injected turn below the idle threshold is not stuck', () => {

--- a/tests/stuck-runner-recovery-policy.test.ts
+++ b/tests/stuck-runner-recovery-policy.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const {
+  decideStuckRunnerRecovery,
+  probeHostRunnerCpu,
+  resolveRunnerCpuActivity,
+} = await import('../src/stuck-runner-recovery.js');
+const { logger } = await import('../src/logger.js');
+
+type Candidate =
+  import('../src/stuck-runner-recovery.js').StuckRecoveryCandidate;
+
+const FORCE_RESTART_MS = 10 * 60 * 1000;
+
+function ipcCandidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    jid: 'web:stuck-policy',
+    idleMs: 3 * 60 * 1000,
+    reason: 'ipc_injected',
+    runtime: 'host',
+    ipcOwedMs: 3 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('stuck runner recovery policy', () => {
+  test('host CPU activity defers at 3m but the absolute IPC ceiling forces at 10m', () => {
+    expect(
+      decideStuckRunnerRecovery(ipcCandidate(), 'active', FORCE_RESTART_MS),
+    ).toEqual({ action: 'defer', reason: 'cpu_active' });
+
+    expect(
+      decideStuckRunnerRecovery(
+        ipcCandidate({ ipcOwedMs: FORCE_RESTART_MS }),
+        'active',
+        FORCE_RESTART_MS,
+      ),
+    ).toEqual({ action: 'restart', reason: 'absolute_ipc_ceiling' });
+
+    expect(
+      decideStuckRunnerRecovery(
+        ipcCandidate({
+          reason: 'pending_messages',
+          idleMs: FORCE_RESTART_MS,
+          ipcOwedMs: null,
+        }),
+        'active',
+        FORCE_RESTART_MS,
+      ),
+    ).toEqual({ action: 'restart', reason: 'idle_ceiling' });
+  });
+
+  test('container work is never inferred from the host docker CLI process tree', () => {
+    expect(
+      decideStuckRunnerRecovery(
+        ipcCandidate({ runtime: 'container' }),
+        'unavailable',
+        FORCE_RESTART_MS,
+      ),
+    ).toEqual({ action: 'defer', reason: 'container_grace' });
+
+    expect(
+      decideStuckRunnerRecovery(
+        ipcCandidate({
+          runtime: 'container',
+          idleMs: 30_000,
+          ipcOwedMs: FORCE_RESTART_MS,
+        }),
+        'unavailable',
+        FORCE_RESTART_MS,
+      ),
+    ).toEqual({ action: 'restart', reason: 'absolute_ipc_ceiling' });
+
+    expect(
+      decideStuckRunnerRecovery(
+        ipcCandidate({
+          reason: 'pending_messages',
+          runtime: 'container',
+          idleMs: FORCE_RESTART_MS,
+          ipcOwedMs: null,
+        }),
+        'unavailable',
+        FORCE_RESTART_MS,
+      ),
+    ).toEqual({ action: 'restart', reason: 'idle_ceiling' });
+  });
+
+  test('container runtime never invokes the host process-tree probe', async () => {
+    const hostProbe = vi.fn().mockResolvedValue('active');
+
+    await expect(
+      resolveRunnerCpuActivity(
+        ipcCandidate({ runtime: 'container' }),
+        4242,
+        hostProbe,
+      ),
+    ).resolves.toBe('unavailable');
+    expect(hostProbe).not.toHaveBeenCalled();
+  });
+
+  test('host CPU probe failures log context and conservatively defer', async () => {
+    const candidate = ipcCandidate();
+    const cpuActivity = await probeHostRunnerCpu(4242, candidate, async () => {
+      throw new Error('ps unavailable');
+    });
+
+    expect(cpuActivity).toBe('unknown');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatJid: candidate.jid,
+        pid: 4242,
+        idleMs: candidate.idleMs,
+        reason: candidate.reason,
+        runtime: candidate.runtime,
+        ipcOwedMs: candidate.ipcOwedMs,
+      }),
+      'Failed to inspect host runner descendant CPU; deferring stuck restart',
+    );
+    expect(
+      decideStuckRunnerRecovery(candidate, cpuActivity, FORCE_RESTART_MS),
+    ).toEqual({ action: 'defer', reason: 'cpu_unknown' });
+
+    expect(
+      decideStuckRunnerRecovery(
+        { ...candidate, idleMs: FORCE_RESTART_MS },
+        cpuActivity,
+        FORCE_RESTART_MS,
+      ),
+    ).toEqual({ action: 'restart', reason: 'idle_ceiling' });
+  });
+
+  test('host CPU probe detects active nested descendants', async () => {
+    const cpuActivity = await probeHostRunnerCpu(
+      100,
+      ipcCandidate(),
+      async () => ['100 1 0.0', '200 100 0.0', '300 200 1.5'].join('\n'),
+    );
+
+    expect(cpuActivity).toBe('active');
+  });
+
+  test('container pending-message recovery gets the same 3m grace', () => {
+    const pending: Candidate = {
+      ...ipcCandidate(),
+      reason: 'pending_messages',
+      runtime: 'container',
+      ipcOwedMs: null,
+    };
+
+    expect(
+      decideStuckRunnerRecovery(pending, 'unavailable', FORCE_RESTART_MS),
+    ).toEqual({ action: 'defer', reason: 'container_grace' });
+  });
+});

--- a/tests/stuck-runner-recovery-policy.test.ts
+++ b/tests/stuck-runner-recovery-policy.test.ts
@@ -27,6 +27,10 @@ function ipcCandidate(overrides: Partial<Candidate> = {}): Candidate {
     idleMs: 3 * 60 * 1000,
     reason: 'ipc_injected',
     runtime: 'host',
+    runnerGeneration: 1,
+    queryId: 'query-1',
+    runnerPid: 4242,
+    ipcOwedSinceAt: 1,
     ipcOwedMs: 3 * 60 * 1000,
     ...overrides,
   };
@@ -103,8 +107,7 @@ describe('stuck runner recovery policy', () => {
 
     await expect(
       resolveRunnerCpuActivity(
-        ipcCandidate({ runtime: 'container' }),
-        4242,
+        ipcCandidate({ runtime: 'container', runnerPid: 4242 }),
         hostProbe,
       ),
     ).resolves.toBe('unavailable');


### PR DESCRIPTION
Fixes #618

## Problem

Warm-runner follow-up messages are IPC-injected without re-arming pendingMessages. If that in-flight turn wedges, the old stuck-runner detector cannot see the owed work, so the user receives no reply until a manual restart.

## Changes

- Track a dedicated IPC-debt timestamp only while an injected query is in flight. An idle warm runner between turns is not considered stuck.
- Refresh the activity window at injection time so a follow-up to a long-idle runner is not killed immediately.
- Keep the existing CPU-active grace, but apply a 10-minute absolute ceiling to wedged IPC turns; the legacy pending-message path is unchanged.
- Seal each recovery candidate with runner generation, query id, PID, runtime and IPC-debt identity. After the asynchronous CPU probe, re-snapshot synchronously and skip the restart if the old turn completed, a new query began, activity resumed, or the runner identity changed.
- Restart through the existing replay path so the uncommitted cursor remains durable.

## Verification

- 10 focused files / 87 tests passed, including old-turn idle, fresh activity, new healthy turn, query/PID/generation/debt changes and force-ceiling policy.
- Typecheck, Prettier and git diff --check passed.
- GitHub CI validate passed on the final head.
