### PR TITLE
fix(agent-runner): bound watchdog during auto-compaction

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -801,6 +801,7 @@ const OUTPUT_START_MARKER = '---HAPPYCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---HAPPYCLAW_OUTPUT_END---';
 const SDK_CONTEXT_USAGE_TIMEOUT_MS = 5_000;
 const SDK_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
+const SDK_COMPACTION_RESPONSE_TIMEOUT_MS = 10 * 60_000;
 const SDK_PROVIDER_FAILURE_EXIT_GRACE_MS = 250;
 
 function writeOutput(output: ContainerOutput): void {
@@ -1029,6 +1030,7 @@ function createPreCompactHook(deps: {
   emit: (output: ContainerOutput) => void;
   getFullText: () => string;
   resetFullText: () => void;
+  onCompactionStart?: () => void;
 }): HookCallback {
   return async (input, _toolUseId, _context) => {
     const preCompact = input as PreCompactHookInput;
@@ -1043,6 +1045,12 @@ function createPreCompactHook(deps: {
       );
       return {};
     }
+
+    // Compaction is a legitimate long model round-trip. Replace the short
+    // first-response watchdog with a longer hard deadline before summarization
+    // starts; the deadline remains bounded if compaction or the response after
+    // it stalls permanently.
+    deps.onCompactionStart?.();
 
     // ── Flush accumulated streaming text as compact_partial ──
     // This ensures users see the partial response even after compaction.
@@ -2660,6 +2668,10 @@ async function runQueryAttempt(
                 emit,
                 getFullText: () => processor.getFullText(),
                 resetFullText: () => processor.resetFullTextAccumulator(),
+                onCompactionStart: () =>
+                  firstResponseWatchdog?.beginCompaction(
+                    SDK_COMPACTION_RESPONSE_TIMEOUT_MS,
+                  ),
               }),
             ],
           },
@@ -2676,9 +2688,9 @@ async function runQueryAttempt(
     queryRef = q;
     firstResponseWatchdog = new SdkFirstResponseWatchdog(
       SDK_FIRST_RESPONSE_TIMEOUT_MS,
-      () => {
+      (phase, timeoutMs) => {
         log(
-          `No model response event within ${SDK_FIRST_RESPONSE_TIMEOUT_MS}ms; marking provider unhealthy`,
+          `No model response event within ${timeoutMs}ms (${phase}); marking provider unhealthy`,
         );
         publishProviderAccountFailure('server_error');
         processor.discardPendingTextOutput();

--- a/container/agent-runner/src/sdk-control.ts
+++ b/container/agent-runner/src/sdk-control.ts
@@ -40,34 +40,58 @@ const FIRST_RESPONSE_MESSAGE_TYPES = new Set([
   'stream_event',
 ]);
 
+export type SdkFirstResponseWatchdogPhase = 'first_response' | 'compaction';
+
 /**
  * Last-resort guard for third-party CLI/provider combinations that persist an
  * API error to the transcript but never forward it through the SDK iterator.
  */
 export class SdkFirstResponseWatchdog {
   private timer: ReturnType<typeof setTimeout> | undefined;
-  private observed = false;
+  private activePhase: SdkFirstResponseWatchdogPhase | undefined;
+  private timedOut = false;
 
   constructor(
     readonly timeoutMs: number,
-    onTimeout: () => void,
+    private readonly onTimeout: (
+      phase: SdkFirstResponseWatchdogPhase,
+      timeoutMs: number,
+    ) => void,
   ) {
-    this.timer = setTimeout(() => {
-      this.timer = undefined;
-      if (this.observed) return;
-      this.observed = true;
-      onTimeout();
-    }, timeoutMs);
+    this.arm(timeoutMs, 'first_response');
   }
 
   observe(messageType: string): void {
     if (!FIRST_RESPONSE_MESSAGE_TYPES.has(messageType)) return;
-    this.observed = true;
     this.clear();
+  }
+
+  /**
+   * Replace the short first-response deadline with one bounded allowance for
+   * SDK auto-compaction. The SDK exposes PreCompact but no matching completion
+   * hook, so this deadline covers both the summarization round-trip and the
+   * first real model response that follows it. Repeated PreCompact callbacks
+   * cannot keep extending the deadline indefinitely.
+   */
+  beginCompaction(timeoutMs: number): void {
+    if (this.timedOut || this.activePhase === 'compaction') return;
+    this.arm(timeoutMs, 'compaction');
   }
 
   clear(): void {
     if (this.timer) clearTimeout(this.timer);
     this.timer = undefined;
+    this.activePhase = undefined;
+  }
+
+  private arm(timeoutMs: number, phase: SdkFirstResponseWatchdogPhase): void {
+    this.clear();
+    this.activePhase = phase;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.activePhase = undefined;
+      this.timedOut = true;
+      this.onTimeout(phase, timeoutMs);
+    }, timeoutMs);
   }
 }

--- a/tests/agent-runner-sdk-control.test.ts
+++ b/tests/agent-runner-sdk-control.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import { describe, expect, test, vi } from 'vitest';
 
 import {
@@ -82,6 +84,99 @@ describe('agent-runner SDK control requests', () => {
       }
     },
   );
+
+  test('allows a long compaction and clears its deadline on the real response', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const watchdog = new SdkFirstResponseWatchdog(60_000, onTimeout);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      watchdog.beginCompaction(10 * 60_000);
+
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      watchdog.observe('assistant');
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('retains a bounded deadline when the post-compaction response stalls', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const watchdog = new SdkFirstResponseWatchdog(60_000, onTimeout);
+
+      watchdog.beginCompaction(10 * 60_000);
+      // Treat the first two minutes as a completed summarization round-trip.
+      // The SDK has no PostCompact callback, so the same absolute deadline must
+      // also bound a provider that never emits the subsequent model response.
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(8 * 60_000 - 1);
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onTimeout).toHaveBeenCalledOnce();
+      expect(onTimeout).toHaveBeenCalledWith('compaction', 10 * 60_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('does not let repeated compactions extend the hard deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const watchdog = new SdkFirstResponseWatchdog(60_000, onTimeout);
+
+      watchdog.beginCompaction(10 * 60_000);
+      await vi.advanceTimersByTimeAsync(9 * 60_000);
+      watchdog.beginCompaction(10 * 60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(onTimeout).toHaveBeenCalledOnce();
+      expect(onTimeout).toHaveBeenCalledWith('compaction', 10 * 60_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('arms a fresh bounded deadline for compaction after an earlier response', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const watchdog = new SdkFirstResponseWatchdog(60_000, onTimeout);
+
+      watchdog.observe('stream_event');
+      watchdog.beginCompaction(10 * 60_000);
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+      expect(onTimeout).toHaveBeenCalledOnce();
+      expect(onTimeout).toHaveBeenCalledWith('compaction', 10 * 60_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('does not arm the main watchdog for a sub-agent compaction', () => {
+    const source = fs.readFileSync(
+      new URL('../container/agent-runner/src/index.ts', import.meta.url),
+      'utf8',
+    );
+    const hookStart = source.indexOf('function createPreCompactHook');
+    const subAgentGuard = source.indexOf('if (preCompact.agent_id)', hookStart);
+    const watchdogArm = source.indexOf('deps.onCompactionStart?.()', hookStart);
+
+    expect(hookStart).toBeGreaterThanOrEqual(0);
+    expect(subAgentGuard).toBeGreaterThan(hookStart);
+    expect(watchdogArm).toBeGreaterThan(subAgentGuard);
+  });
 
   test('does not treat a non-terminal rate-limit warning as a model response', () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Context

This extracts and replaces the auto-compaction watchdog half of #621 so it can be reviewed and merged independently. The original PR remains open pending acceptance of both replacement PRs.

Near-full sessions can spend longer than the normal 60-second first-response budget in SDK auto-compaction without yielding model events. Treating that silence as a dead provider interrupts compaction and can trap the session in a retry loop.

## Change

- Keep the normal first-response deadline at 60 seconds.
- Arm a separate 10-minute hard deadline for each main-session `PreCompact` round trip.
- Do not let repeated callbacks for the same active compaction extend that deadline.
- Allow a later compaction to arm a fresh deadline even if the query emitted earlier model events.
- Ignore sub-agent compactions for the main-session watchdog.
- Clear the active deadline on the first real `assistant`, `result`, or `stream_event` after compaction.
- Include the active phase and timeout in failure logs.

The SDK exposes `PreCompact` but no matching completion hook, so the compaction deadline deliberately covers both summarization and the first real response that follows it. A completed compaction followed by a permanently stalled provider therefore still fails within a bounded window.

## Verification

- `npx vitest run tests/agent-runner-sdk-control.test.ts` — 13/13 passed
- `npm test -- --run` — 324 files, 2768 tests passed
- `npm run typecheck` — passed
- `npm run build:all` — passed
- `npm run self-test:agent-runner` — passed
- Prettier and `git diff --check` — passed

Independent read-only review found no remaining blocker or warning after the follow-up fixes.
