### PR TITLE
feat(agent): 支持 Agent Profile 推理努力档位

### DIFF
--- a/container/agent-runner/src/agent-effort.ts
+++ b/container/agent-runner/src/agent-effort.ts
@@ -1,0 +1,32 @@
+export const SDK_AGENT_EFFORT_LEVELS = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
+
+export type SdkAgentEffort = (typeof SDK_AGENT_EFFORT_LEVELS)[number];
+
+const SDK_AGENT_EFFORT_LEVEL_SET = new Set<string>(SDK_AGENT_EFFORT_LEVELS);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Return only an explicit Agent effort. Undefined means inherit: the host has
+ * kept the Provider's CLAUDE_CODE_EFFORT_LEVEL (if any), otherwise the SDK
+ * selects its model-aware default.
+ */
+export function resolveAgentSdkEffort(
+  runtimePolicy: unknown,
+): SdkAgentEffort | undefined {
+  if (!isRecord(runtimePolicy) || !isRecord(runtimePolicy.reasoning)) {
+    return undefined;
+  }
+  const effort = runtimePolicy.reasoning.effort;
+  return typeof effort === 'string' && SDK_AGENT_EFFORT_LEVEL_SET.has(effort)
+    ? (effort as SdkAgentEffort)
+    : undefined;
+}

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -107,6 +107,7 @@ import {
   resolveClaudeProviderRuntime,
   resolveClaudeQueryModelRuntime,
 } from './provider-runtime.js';
+import { resolveAgentSdkEffort } from './agent-effort.js';
 import {
   decideProviderLimitAction,
   isAccountProviderAssistantError,
@@ -2619,6 +2620,14 @@ async function runQueryAttempt(
     : {};
 
   try {
+    const agentEffort = resolveAgentSdkEffort(
+      containerInput.agentProfile?.runtimePolicy,
+    );
+    log(
+      agentEffort
+        ? `Agent effort override: ${agentEffort}`
+        : 'Agent effort: inherit Provider/SDK default',
+    );
     const sdkCompat = withHappyClawSubagentContract({
       ...(pathToClaudeCodeExecutable && { pathToClaudeCodeExecutable }),
       ...queryModelRuntime.queryModelOptions,
@@ -2631,6 +2640,7 @@ async function runQueryAttempt(
         disallowedTools: effectiveDisallowedTools,
       }),
       thinking: { type: 'adaptive' as const, display: 'summarized' as const },
+      ...(agentEffort ? { effort: agentEffort } : {}),
       permissionMode: 'bypassPermissions' as const,
       allowDangerouslySkipPermissions: true,
       agentProgressSummaries: true,

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -2278,6 +2278,18 @@ Returns null if the current chat is a DM (DMs do not belong to a server). Only w
         .default(null),
       runtime_policy: z
         .object({
+          reasoning: z
+            .object({
+              effort: z.enum([
+                'inherit',
+                'low',
+                'medium',
+                'high',
+                'xhigh',
+                'max',
+              ]),
+            })
+            .optional(),
           context: z
             .object({
               source: z.enum(['managed', 'host_claude']),

--- a/src/agent-effort.ts
+++ b/src/agent-effort.ts
@@ -1,0 +1,56 @@
+import type { AgentEffortLevel, AgentProfileRuntimePolicy } from './types.js';
+
+export const AGENT_EFFORT_LEVELS = [
+  'inherit',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const satisfies readonly AgentEffortLevel[];
+
+export const SDK_AGENT_EFFORT_LEVELS = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
+
+export type SdkAgentEffort = (typeof SDK_AGENT_EFFORT_LEVELS)[number];
+
+const AGENT_EFFORT_LEVEL_SET = new Set<string>(AGENT_EFFORT_LEVELS);
+const SDK_AGENT_EFFORT_LEVEL_SET = new Set<string>(SDK_AGENT_EFFORT_LEVELS);
+
+export function normalizeAgentEffort(value: unknown): AgentEffortLevel {
+  return typeof value === 'string' && AGENT_EFFORT_LEVEL_SET.has(value)
+    ? (value as AgentEffortLevel)
+    : 'inherit';
+}
+
+/**
+ * Resolve an Agent-owned SDK effort override. Undefined deliberately means
+ * "inherit": keep the selected Provider's CLAUDE_CODE_EFFORT_LEVEL, or let the
+ * SDK choose its model-aware default when the Provider does not define one.
+ */
+export function resolveAgentSdkEffort(
+  policy: AgentProfileRuntimePolicy | undefined,
+): SdkAgentEffort | undefined {
+  const effort = policy?.reasoning?.effort;
+  return typeof effort === 'string' && SDK_AGENT_EFFORT_LEVEL_SET.has(effort)
+    ? (effort as SdkAgentEffort)
+    : undefined;
+}
+
+/** Remove the Provider-level effort only when an Agent has an explicit value. */
+export function removeProviderEffortEnv(
+  lines: string[],
+  effort: SdkAgentEffort | undefined,
+): void {
+  if (!effort) return;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (lines[index]?.startsWith('CLAUDE_CODE_EFFORT_LEVEL=')) {
+      lines.splice(index, 1);
+    }
+  }
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -117,6 +117,10 @@ import {
 } from './feishu-cli-runtime.js';
 import { assertValidWorkspaceFolderName } from './workspace-folder.js';
 import { resolveRunnerLivenessTimeouts } from './runner-liveness.js';
+import {
+  removeProviderEffortEnv,
+  resolveAgentSdkEffort,
+} from './agent-effort.js';
 
 /**
  * 宿主机的 ~/.claude.json 路径。
@@ -1374,6 +1378,8 @@ export function buildVolumeMounts(
     effectiveContainerOverride,
     resolvedProvider?.customEnv,
   );
+  const agentEffort = resolveAgentSdkEffort(agentProfile?.runtimePolicy);
+  removeProviderEffortEnv(envLines, agentEffort);
   // Agent policy is authoritative; do not inherit global/custom runtime env.
   for (let index = envLines.length - 1; index >= 0; index -= 1) {
     if (
@@ -2457,6 +2463,10 @@ export async function runHostAgent(
         : containerOverride,
       hostPoolResult?.resolved.customEnv,
     );
+    const agentEffort = resolveAgentSdkEffort(
+      input.agentProfile?.runtimePolicy,
+    );
+    removeProviderEffortEnv(envLines, agentEffort);
     const injectsAnthropicAuthToken = envLines.some((line) =>
       line.startsWith('ANTHROPIC_AUTH_TOKEN='),
     );

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { STORE_DIR, GROUPS_DIR } from './config.js';
+import { normalizeAgentEffort } from './agent-effort.js';
 import { logger } from './logger.js';
 import {
   AgentProfile,
@@ -102,7 +103,7 @@ let db: InstanceType<typeof Database>;
  * restating the number. Hardcoding it meant every schema bump edited a dozen
  * unrelated test files, which is churn that hides real assertion changes.
  */
-export const CURRENT_SCHEMA_VERSION = 68;
+export const CURRENT_SCHEMA_VERSION = 69;
 
 export function isDatabaseInitialized(): boolean {
   return Boolean(db?.open);
@@ -1992,6 +1993,16 @@ export function initDatabase(): void {
       ON agent_profiles(model_config_id)
       WHERE model_config_id IS NOT NULL;
   `);
+  // v68 -> v69: make reasoning effort an explicit Agent runtime policy. The
+  // inherited default preserves every existing Provider/SDK behavior, so this
+  // migration normalizes JSON only and deliberately does not bump Agent
+  // identity/version metadata.
+  if (
+    rawSchemaVersionBeforeInit !== null &&
+    Number(rawSchemaVersionBeforeInit) < 69
+  ) {
+    migrateAgentProfileEffortPolicy();
+  }
 
   // v47 → v48: split the legacy all-in-one Agent prompt into the four
   // IDENTITY / SOUL / AGENTS / TOOLS sections. The legacy prompt represented
@@ -7920,6 +7931,7 @@ export function getSessionAgentIdentity(
 }
 
 const DEFAULT_AGENT_PROFILE_RUNTIME_POLICY: AgentProfileRuntimePolicy = {
+  reasoning: { effort: 'inherit' },
   context: {
     source: 'managed',
     auto_compact_window: 0,
@@ -7930,6 +7942,7 @@ const DEFAULT_AGENT_PROFILE_RUNTIME_POLICY: AgentProfileRuntimePolicy = {
 };
 
 type RuntimePolicyInput = Partial<{
+  reasoning: Partial<AgentProfileRuntimePolicy['reasoning']> | null;
   context: Partial<AgentProfileRuntimePolicy['context']> | null;
   skills:
     | (Partial<Omit<AgentProfileRuntimePolicy['skills'], 'host'>> & {
@@ -7968,6 +7981,9 @@ export function normalizeAgentProfileRuntimePolicy(
 ): AgentProfileRuntimePolicy {
   const raw = (input ?? {}) as RuntimePolicyInput | AgentProfileRuntimePolicy;
   const normalized: AgentProfileRuntimePolicy = {
+    reasoning: {
+      effort: normalizeAgentEffort(raw.reasoning?.effort),
+    },
     context: {
       source: normalizeMode(
         raw.context?.source,
@@ -8064,6 +8080,13 @@ export function mergeAgentProfileRuntimePolicy(
   };
 
   return normalizeAgentProfileRuntimePolicy({
+    reasoning: has('reasoning')
+      ? patch.reasoning === null
+        ? DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.reasoning
+        : {
+            effort: patch.reasoning?.effort ?? current.reasoning.effort,
+          }
+      : current.reasoning,
     context: has('context')
       ? patch.context === null
         ? DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.context
@@ -8086,6 +8109,53 @@ export function serializeAgentProfileRuntimePolicy(
   input?: RuntimePolicyInput | AgentProfileRuntimePolicy | null,
 ): string {
   return JSON.stringify(normalizeAgentProfileRuntimePolicy(input));
+}
+
+/** Persist the v69 inherited effort default into legacy runtime-policy JSON. */
+export function migrateAgentProfileEffortPolicy(): number {
+  const rows = db
+    .prepare('SELECT id, runtime_policy FROM agent_profiles')
+    .all() as Array<{ id: string; runtime_policy: unknown }>;
+  const update = db.prepare(
+    'UPDATE agent_profiles SET runtime_policy = ? WHERE id = ?',
+  );
+  let migrated = 0;
+  db.transaction(() => {
+    for (const row of rows) {
+      let next: Record<string, unknown> | AgentProfileRuntimePolicy;
+      try {
+        const parsed =
+          typeof row.runtime_policy === 'string'
+            ? JSON.parse(row.runtime_policy)
+            : row.runtime_policy;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('Legacy Agent runtime policy is not an object');
+        }
+        const raw = parsed as Record<string, unknown>;
+        const rawReasoning =
+          raw.reasoning &&
+          typeof raw.reasoning === 'object' &&
+          !Array.isArray(raw.reasoning)
+            ? (raw.reasoning as Record<string, unknown>)
+            : {};
+        next = {
+          ...raw,
+          reasoning: {
+            ...rawReasoning,
+            effort: normalizeAgentEffort(rawReasoning.effort),
+          },
+        };
+      } catch {
+        // Invalid legacy JSON is normalized to the safe inherited default.
+        next = normalizeAgentProfileRuntimePolicy();
+      }
+      const serialized = JSON.stringify(next);
+      if (serialized === row.runtime_policy) continue;
+      update.run(serialized, row.id);
+      migrated += 1;
+    }
+  })();
+  return migrated;
 }
 
 /**
@@ -8266,11 +8336,13 @@ export function computeAgentProfileIdentityHash(
     name?: string;
   } = { prompts };
   const identityPolicy = {
+    reasoning: normalizedPolicy.reasoning,
     context: { source: normalizedPolicy.context.source },
     skills: normalizedPolicy.skills,
     mcp: normalizedPolicy.mcp,
   };
   const defaultIdentityPolicy = {
+    reasoning: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.reasoning,
     context: { source: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.context.source },
     skills: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.skills,
     mcp: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.mcp,

--- a/src/db.ts
+++ b/src/db.ts
@@ -8336,13 +8336,14 @@ export function computeAgentProfileIdentityHash(
     name?: string;
   } = { prompts };
   const identityPolicy = {
-    reasoning: normalizedPolicy.reasoning,
+    ...(normalizedPolicy.reasoning.effort === 'inherit'
+      ? {}
+      : { reasoning: normalizedPolicy.reasoning }),
     context: { source: normalizedPolicy.context.source },
     skills: normalizedPolicy.skills,
     mcp: normalizedPolicy.mcp,
   };
   const defaultIdentityPolicy = {
-    reasoning: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.reasoning,
     context: { source: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.context.source },
     skills: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.skills,
     mcp: DEFAULT_AGENT_PROFILE_RUNTIME_POLICY.mcp,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,6 +1,7 @@
 // Zod schemas and validation types for API requests
 
 import { z } from 'zod';
+import { AGENT_EFFORT_LEVELS } from './agent-effort.js';
 import { ALL_PERMISSIONS } from './permissions.js';
 import type { Permission } from './types.js';
 import { MAX_GROUP_NAME_LEN } from './web-context.js';
@@ -303,6 +304,11 @@ const AgentProfileRuntimePolicyModeSchema = z.enum([
 
 export const AgentProfileRuntimePolicySchema = z
   .object({
+    reasoning: z
+      .object({
+        effort: z.enum(AGENT_EFFORT_LEVELS).optional(),
+      })
+      .optional(),
     context: z
       .object({
         source: z.enum(['managed', 'host_claude']).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,6 +310,14 @@ export interface AgentProfile {
 
 export type AgentProfilePromptMode = 'append' | 'replace';
 
+export type AgentEffortLevel =
+  | 'inherit'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max';
+
 export interface AgentProfilePrompts {
   identity_prompt: string;
   soul_prompt: string;
@@ -339,6 +347,10 @@ export interface WorkspaceAgentProfileBinding {
 }
 
 export interface AgentProfileRuntimePolicy {
+  reasoning: {
+    /** Inherit Provider customEnv first, then the SDK model-aware default. */
+    effort: AgentEffortLevel;
+  };
   context: {
     source: 'managed' | 'host_claude';
     auto_compact_window: number;

--- a/tests/agent-effort-runtime-contract.test.ts
+++ b/tests/agent-effort-runtime-contract.test.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const root = process.cwd();
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+describe('Agent effort runtime contracts', () => {
+  test('normal conversations and isolated scheduled tasks forward runtime policy', () => {
+    const main = read('src/index.ts');
+    const scheduler = read('src/task-scheduler.ts');
+
+    expect(main).toMatch(
+      /function toContainerAgentProfile[\s\S]*runtimePolicy: profile\.runtime_policy/,
+    );
+    expect(scheduler).toMatch(
+      /function toRunnerAgentProfile[\s\S]*runtimePolicy: profile\.runtime_policy/,
+    );
+  });
+
+  test('host and container starts remove Provider effort only for explicit Agents', () => {
+    const host = read('src/container-runner.ts');
+    const calls = host.match(
+      /removeProviderEffortEnv\(envLines, agentEffort\)/g,
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  test('runner passes the resolved value through the supported SDK option', () => {
+    const runner = read('container/agent-runner/src/index.ts');
+    expect(runner).toContain('...(agentEffort ? { effort: agentEffort } : {})');
+  });
+});

--- a/tests/agent-effort.test.ts
+++ b/tests/agent-effort.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  normalizeAgentEffort,
+  removeProviderEffortEnv,
+  resolveAgentSdkEffort,
+} from '../src/agent-effort.js';
+import { resolveAgentSdkEffort as resolveRunnerAgentSdkEffort } from '../container/agent-runner/src/agent-effort.js';
+import {
+  buildClaudeEnvLines,
+  type ClaudeProviderConfig,
+} from '../src/runtime-config.js';
+
+function providerConfig(
+  patch: Partial<ClaudeProviderConfig>,
+): ClaudeProviderConfig {
+  return {
+    anthropicBaseUrl: '',
+    anthropicAuthToken: '',
+    anthropicApiKey: 'test-key',
+    claudeCodeOauthToken: '',
+    claudeOAuthCredentials: null,
+    anthropicModel: 'claude-test',
+    updatedAt: null,
+    ...patch,
+  };
+}
+
+describe('Agent effort resolution', () => {
+  test('normalizes legacy, missing, and invalid values to inherit', () => {
+    expect(normalizeAgentEffort(undefined)).toBe('inherit');
+    expect(normalizeAgentEffort('inherit')).toBe('inherit');
+    expect(normalizeAgentEffort('turbo')).toBe('inherit');
+    expect(normalizeAgentEffort('xhigh')).toBe('xhigh');
+  });
+
+  test('returns only explicit SDK effort levels in host and runner resolvers', () => {
+    const explicit = { reasoning: { effort: 'high' } } as const;
+    const inherited = { reasoning: { effort: 'inherit' } } as const;
+
+    expect(resolveAgentSdkEffort(explicit as any)).toBe('high');
+    expect(resolveRunnerAgentSdkEffort(explicit)).toBe('high');
+    expect(resolveAgentSdkEffort(inherited as any)).toBeUndefined();
+    expect(resolveRunnerAgentSdkEffort(inherited)).toBeUndefined();
+    expect(
+      resolveRunnerAgentSdkEffort({ reasoning: { effort: 'turbo' } }),
+    ).toBeUndefined();
+  });
+
+  test.each(['low', 'medium', 'high', 'xhigh', 'max'] as const)(
+    'passes %s through without model-side filtering',
+    (effort) => {
+      expect(resolveRunnerAgentSdkEffort({ reasoning: { effort } })).toBe(
+        effort,
+      );
+    },
+  );
+
+  test('explicit Agent effort removes Provider env while inherit preserves it', () => {
+    const inheritedLines = [
+      'ANTHROPIC_MODEL=claude-test',
+      'CLAUDE_CODE_EFFORT_LEVEL=max',
+    ];
+    removeProviderEffortEnv(inheritedLines, undefined);
+    expect(inheritedLines).toContain('CLAUDE_CODE_EFFORT_LEVEL=max');
+
+    const explicitLines = [
+      'CLAUDE_CODE_EFFORT_LEVEL=low',
+      'ANTHROPIC_MODEL=third-party-model',
+      'CLAUDE_CODE_EFFORT_LEVEL=max',
+    ];
+    removeProviderEffortEnv(explicitLines, 'medium');
+    expect(explicitLines).toEqual(['ANTHROPIC_MODEL=third-party-model']);
+  });
+
+  test.each([
+    {
+      name: 'official',
+      config: providerConfig({}),
+      customEnv: { CLAUDE_CODE_EFFORT_LEVEL: 'low' },
+      expectedInherited: 'CLAUDE_CODE_EFFORT_LEVEL=low',
+    },
+    {
+      name: 'third-party',
+      config: providerConfig({
+        anthropicBaseUrl: 'https://models.example.test',
+        anthropicApiKey: '',
+        anthropicAuthToken: 'third-party-token',
+        anthropicModel: 'third-party-model',
+      }),
+      customEnv: { CLAUDE_CODE_EFFORT_LEVEL: 'medium' },
+      expectedInherited: 'CLAUDE_CODE_EFFORT_LEVEL=medium',
+    },
+  ])(
+    '$name Provider env is kept for inherit and removed for an explicit Agent',
+    ({ config, customEnv, expectedInherited }) => {
+      const inherited = buildClaudeEnvLines(config, customEnv);
+      removeProviderEffortEnv(inherited, undefined);
+      expect(inherited).toContain(expectedInherited);
+
+      const explicit = buildClaudeEnvLines(config, customEnv);
+      removeProviderEffortEnv(explicit, 'high');
+      expect(
+        explicit.some((line) => line.startsWith('CLAUDE_CODE_EFFORT_LEVEL=')),
+      ).toBe(false);
+    },
+  );
+});

--- a/tests/agent-profiles-db.test.ts
+++ b/tests/agent-profiles-db.test.ts
@@ -75,6 +75,7 @@ describe('AgentProfile DB model', () => {
     expect(profiles[0].include_claude_preset).toBe(true);
     expect(profiles[0].model_config_id).toBeNull();
     expect(profiles[0].runtime_policy).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'managed',
         auto_compact_window: 0,
@@ -179,6 +180,7 @@ describe('AgentProfile DB model', () => {
         tools: { mode: 'readonly' },
       } as any),
     ).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'managed',
         auto_compact_window: 0,
@@ -379,6 +381,7 @@ describe('AgentProfile DB model', () => {
     });
 
     expect(profile.runtime_policy).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'managed',
         auto_compact_window: 0,
@@ -418,6 +421,7 @@ describe('AgentProfile DB model', () => {
     );
     expect(updated?.version).toBe(profile.version + 1);
     expect(updated?.runtime_policy).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'host_claude',
         auto_compact_window: 0,
@@ -507,6 +511,7 @@ describe('AgentProfile DB model', () => {
     );
 
     expect(updated?.runtime_policy).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'host_claude',
         auto_compact_window: 0,

--- a/tests/agent-tool-policy-removal-migration.test.ts
+++ b/tests/agent-tool-policy-removal-migration.test.ts
@@ -64,6 +64,7 @@ describe('retired Agent tool policy migration', () => {
     db.initDatabase();
     const migrated = db.getAgentProfile(profile.id)!;
     expect(migrated.runtime_policy).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'managed',
         auto_compact_window: 0,

--- a/tests/db-upgrade-safety.test.ts
+++ b/tests/db-upgrade-safety.test.ts
@@ -171,8 +171,8 @@ describe('schema version head', () => {
     // one assertion that fails when the head moves, forcing whoever bumps it
     // to confirm the matching migration block — and a test covering it —
     // actually landed. Update the literal in the same commit as the migration.
-    // v68: adds Agent-level model configuration binding; see
-    // tests/schema-v68-agent-model-config.test.ts for migration coverage.
-    expect(db.CURRENT_SCHEMA_VERSION).toBe(68);
+    // v69: adds Agent-level reasoning effort; see
+    // tests/schema-v69-agent-effort.test.ts for migration coverage.
+    expect(db.CURRENT_SCHEMA_VERSION).toBe(69);
   });
 });

--- a/tests/frontend-agent-capability-experience.test.ts
+++ b/tests/frontend-agent-capability-experience.test.ts
@@ -196,4 +196,21 @@ describe('Agent prompt and capability frontend contract', () => {
       expect(source).toContain("!model.enabled ? '（仅显式使用）' : ''");
     }
   });
+
+  test('lets the main HappyClaw read and persist its reasoning effort', () => {
+    const main = read(
+      'web/src/components/settings/MainAgentCapabilitiesSection.tsx',
+    );
+
+    expect(main).toContain('aria-label="主 HappyClaw 推理努力档位"');
+    expect(main).toContain(
+      "setEffort(profile.runtime_policy.reasoning?.effort ?? 'inherit')",
+    );
+    expect(main).toMatch(
+      /runtime_policy:\s*\{[\s\S]*reasoning: \{ effort \}[\s\S]*skills:/,
+    );
+    for (const effort of ['inherit', 'low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(main).toContain(`value: '${effort}'`);
+    }
+  });
 });

--- a/tests/routes-agent-profiles.test.ts
+++ b/tests/routes-agent-profiles.test.ts
@@ -279,6 +279,22 @@ describe('/api/agent-profiles routes', () => {
   });
 
   test('creates, patches, inherits, and validates Agent effort', async () => {
+    const defaultProfile = db
+      .listAgentProfilesForUser('routes-agent-user')
+      .find((profile) => profile.is_default);
+    expect(defaultProfile).toBeDefined();
+    const defaultPatchRes = await routes.request(`/${defaultProfile!.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        runtime_policy: { reasoning: { effort: 'medium' } },
+      }),
+    });
+    expect(defaultPatchRes.status).toBe(200);
+    expect(
+      (await defaultPatchRes.json()).profile.runtime_policy.reasoning,
+    ).toEqual({ effort: 'medium' });
+
     const createdRes = await routes.request('/', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -323,6 +339,15 @@ describe('/api/agent-profiles routes', () => {
       }),
     });
     expect(invalidRes.status).toBe(400);
+
+    const restoreDefaultRes = await routes.request(`/${defaultProfile!.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        runtime_policy: { reasoning: { effort: 'inherit' } },
+      }),
+    });
+    expect(restoreDefaultRes.status).toBe(200);
   });
 
   test('keeps legacy all-in-one prompt payloads compatible while complete payloads use IDENTITY', async () => {

--- a/tests/routes-agent-profiles.test.ts
+++ b/tests/routes-agent-profiles.test.ts
@@ -139,6 +139,9 @@ describe('/api/agent-profiles routes', () => {
     const body = await res.json();
     expect(body.profiles).toHaveLength(1);
     expect(body.profiles[0].is_default).toBe(true);
+    expect(body.profiles[0].runtime_policy.reasoning).toEqual({
+      effort: 'inherit',
+    });
     expect(body.profiles[0].runtime_policy.context).toEqual({
       source: 'managed',
       auto_compact_window: 0,
@@ -273,6 +276,53 @@ describe('/api/agent-profiles routes', () => {
       mcp: { mode: 'custom', ids: ['github'] },
     });
     expect(patchedBody.profile.version).toBe(2);
+  });
+
+  test('creates, patches, inherits, and validates Agent effort', async () => {
+    const createdRes = await routes.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Effort Agent',
+        runtime_policy: { reasoning: { effort: 'high' } },
+      }),
+    });
+    expect(createdRes.status).toBe(201);
+    const created = (await createdRes.json()).profile;
+    expect(created.runtime_policy.reasoning).toEqual({ effort: 'high' });
+
+    const patchedRes = await routes.request(`/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        runtime_policy: { reasoning: { effort: 'xhigh' } },
+      }),
+    });
+    expect(patchedRes.status).toBe(200);
+    const patched = (await patchedRes.json()).profile;
+    expect(patched.runtime_policy.reasoning).toEqual({ effort: 'xhigh' });
+    expect(patched.version).toBe(created.version + 1);
+
+    const inheritedRes = await routes.request(`/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        runtime_policy: { reasoning: { effort: 'inherit' } },
+      }),
+    });
+    expect(inheritedRes.status).toBe(200);
+    expect(
+      (await inheritedRes.json()).profile.runtime_policy.reasoning,
+    ).toEqual({ effort: 'inherit' });
+
+    const invalidRes = await routes.request(`/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        runtime_policy: { reasoning: { effort: 'turbo' } },
+      }),
+    });
+    expect(invalidRes.status).toBe(400);
   });
 
   test('keeps legacy all-in-one prompt payloads compatible while complete payloads use IDENTITY', async () => {
@@ -470,6 +520,7 @@ describe('/api/agent-profiles routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.profile.runtime_policy).toEqual({
+      reasoning: { effort: 'inherit' },
       context: {
         source: 'managed',
         auto_compact_window: 0,
@@ -1242,6 +1293,57 @@ describe('/api/agent-profiles routes', () => {
     expect(noOpResponse.status).toBe(200);
     expect((await noOpResponse.json()).profile.version).toBe(profile.version);
     expect(stopGroup).not.toHaveBeenCalled();
+  });
+
+  test('effort PATCH invalidates warm workspaces and advances runtime identity', async () => {
+    const profile = db.createAgentProfile({
+      ownerUserId: 'routes-agent-user',
+      name: 'Warm Effort Agent',
+      runtimePolicy: { reasoning: { effort: 'low' } },
+    });
+    const folder = 'warm-effort-workspace';
+    db.setRegisteredGroup('web:warm-effort-workspace', {
+      name: 'Warm Effort Workspace',
+      folder,
+      added_at: '2026-08-01T00:00:00.000Z',
+      created_by: 'routes-agent-user',
+    });
+    db.assignWorkspaceAgentProfile(folder, profile.id);
+    db.setSession(folder, 'sdk-warm-effort', '', {
+      agentProfileId: profile.id,
+      agentProfileVersion: profile.version,
+      identityHash: profile.identity_hash,
+    });
+
+    const stopGroup = vi.fn(async () => {});
+    webContext.setWebDeps({
+      queue: {
+        pauseGroupsForMutation: () => ({ id: 1 }),
+        resumeGroupsAfterMutation: () => {},
+        listDescendantJids: () => [],
+        stopGroup,
+      },
+    } as unknown as Parameters<typeof webContext.setWebDeps>[0]);
+
+    const response = await routes.request(`/${profile.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        runtime_policy: { reasoning: { effort: 'max' } },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      invalidated_runtime_jids: 1,
+      profile: {
+        version: profile.version + 1,
+        runtime_policy: { reasoning: { effort: 'max' } },
+      },
+    });
+    expect(body.profile.identity_hash).not.toBe(profile.identity_hash);
+    expect(stopGroup).toHaveBeenCalledTimes(2);
   });
 
   test('name-only PATCH bumps identity version/hash, quiesces twice, and leaves the old session hash mismatched', async () => {

--- a/tests/schema-v69-agent-effort.test.ts
+++ b/tests/schema-v69-agent-effort.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -6,6 +7,7 @@ import Database from 'better-sqlite3';
 import { afterAll, describe, expect, test, vi } from 'vitest';
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-v69-agent-effort-'));
+const dataDir = path.join(root, 'data');
 const storeDir = path.join(root, 'store');
 const groupsDir = path.join(root, 'groups');
 const databasePath = path.join(storeDir, 'messages.db');
@@ -13,6 +15,8 @@ fs.mkdirSync(storeDir, { recursive: true });
 fs.mkdirSync(groupsDir, { recursive: true });
 
 vi.mock('../src/config.js', () => ({
+  ASSISTANT_NAME: 'HappyClaw Test',
+  DATA_DIR: dataDir,
   STORE_DIR: storeDir,
   GROUPS_DIR: groupsDir,
 }));
@@ -23,17 +27,80 @@ vi.mock('../src/logger.js', () => ({
 const createdAt = '2026-08-01T00:00:00.000Z';
 const legacyPolicy = {
   context: {
-    source: 'managed',
+    source: 'host_claude',
     auto_compact_window: 0,
     auto_compact_percentage: 0,
   },
-  skills: { mode: 'inherit', ids: [] },
-  mcp: { mode: 'inherit', ids: [] },
+  skills: {
+    mode: 'custom',
+    ids: ['legacy-skill'],
+    host: { mode: 'custom', ids: ['legacy-host-skill'] },
+  },
+  mcp: { mode: 'custom', ids: ['legacy-mcp'] },
 };
+const legacyPrompts = {
+  identity_prompt: '',
+  soul_prompt: '',
+  agents_prompt: '',
+  tools_prompt: '',
+  prompt_mode: 'append',
+};
+const legacyIdentityHash = createHash('sha256')
+  .update(
+    JSON.stringify({
+      prompts: legacyPrompts,
+      name: 'Legacy Agent',
+      runtimePolicy: {
+        context: { source: legacyPolicy.context.source },
+        skills: legacyPolicy.skills,
+        mcp: legacyPolicy.mcp,
+      },
+    }),
+  )
+  .digest('hex');
 const legacy = new Database(databasePath);
 legacy.exec(`
   CREATE TABLE router_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
   INSERT INTO router_state VALUES ('schema_version', '68');
+  CREATE TABLE users (
+    id TEXT PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    display_name TEXT NOT NULL DEFAULT '',
+    role TEXT NOT NULL DEFAULT 'member',
+    status TEXT NOT NULL DEFAULT 'active',
+    permissions TEXT NOT NULL DEFAULT '[]',
+    must_change_password INTEGER NOT NULL DEFAULT 0,
+    disable_reason TEXT,
+    notes TEXT,
+    avatar_emoji TEXT,
+    avatar_color TEXT,
+    ai_name TEXT,
+    ai_avatar_emoji TEXT,
+    ai_avatar_color TEXT,
+    ai_avatar_url TEXT,
+    default_require_mention INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    last_login_at TEXT,
+    deleted_at TEXT
+  );
+  INSERT INTO users (
+    id, username, password_hash, display_name, role, status, created_at, updated_at
+  ) VALUES (
+    'legacy-user', 'legacy-user', 'hash', 'Legacy User', 'admin', 'active',
+    '${createdAt}', '${createdAt}'
+  );
+  CREATE TABLE sessions (
+    group_folder TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL DEFAULT '',
+    provider_id TEXT,
+    agent_profile_id TEXT,
+    identity_hash TEXT,
+    agent_profile_version INTEGER,
+    PRIMARY KEY (group_folder, agent_id)
+  );
   CREATE TABLE agent_profiles (
     id TEXT PRIMARY KEY,
     owner_user_id TEXT NOT NULL,
@@ -69,15 +136,31 @@ legacy
     'legacy-user',
     'Legacy Agent',
     JSON.stringify(legacyPolicy),
-    'legacy-hash',
+    legacyIdentityHash,
     7,
-    1,
+    0,
     createdAt,
     createdAt,
+  );
+legacy
+  .prepare(
+    `INSERT INTO sessions (
+       group_folder, session_id, agent_id, agent_profile_id,
+       agent_profile_version, identity_hash
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+  .run(
+    'legacy-workspace',
+    'sdk-session-before-v69',
+    '',
+    'legacy-agent',
+    7,
+    legacyIdentityHash,
   );
 legacy.close();
 
 const db = await import('../src/db.js');
+const agentProfileRuntime = await import('../src/agent-profile-runtime.js');
 
 afterAll(() => {
   db.closeDatabase();
@@ -85,16 +168,31 @@ afterAll(() => {
 });
 
 describe('schema v69 Agent effort migration', () => {
-  test('backfills inherit without changing Agent identity metadata', () => {
+  test('preserves v68 identity and warm session compatibility for inherited effort', () => {
     db.initDatabase();
 
     const profile = db.getAgentProfile('legacy-agent');
     expect(profile?.runtime_policy.reasoning).toEqual({ effort: 'inherit' });
     expect(profile).toMatchObject({
       version: 7,
-      identity_hash: 'legacy-hash',
+      identity_hash: legacyIdentityHash,
       updated_at: createdAt,
     });
+    expect(profile?.runtime_policy).toMatchObject(legacyPolicy);
+
+    const effectiveProfile =
+      agentProfileRuntime.resolveEffectiveAgentProfile(profile);
+    const sessionIdentity = db.getSessionAgentIdentity('legacy-workspace');
+    expect(db.getSession('legacy-workspace')).toBe('sdk-session-before-v69');
+    expect(effectiveProfile?.identity_hash).toBe(legacyIdentityHash);
+    expect(sessionIdentity).toEqual({
+      agent_profile_id: 'legacy-agent',
+      agent_profile_version: 7,
+      identity_hash: legacyIdentityHash,
+    });
+    expect(sessionIdentity?.identity_hash).toBe(
+      effectiveProfile?.identity_hash,
+    );
 
     const probe = new Database(databasePath, { readonly: true });
     const stored = probe
@@ -112,7 +210,7 @@ describe('schema v69 Agent effort migration', () => {
     });
     expect(stored).toMatchObject({
       version: 7,
-      identity_hash: 'legacy-hash',
+      identity_hash: legacyIdentityHash,
       updated_at: createdAt,
     });
     probe.close();

--- a/tests/schema-v69-agent-effort.test.ts
+++ b/tests/schema-v69-agent-effort.test.ts
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-v69-agent-effort-'));
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const databasePath = path.join(storeDir, 'messages.db');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const createdAt = '2026-08-01T00:00:00.000Z';
+const legacyPolicy = {
+  context: {
+    source: 'managed',
+    auto_compact_window: 0,
+    auto_compact_percentage: 0,
+  },
+  skills: { mode: 'inherit', ids: [] },
+  mcp: { mode: 'inherit', ids: [] },
+};
+const legacy = new Database(databasePath);
+legacy.exec(`
+  CREATE TABLE router_state (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  INSERT INTO router_state VALUES ('schema_version', '68');
+  CREATE TABLE agent_profiles (
+    id TEXT PRIMARY KEY,
+    owner_user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    identity_prompt TEXT NOT NULL DEFAULT '',
+    soul_prompt TEXT NOT NULL DEFAULT '',
+    agents_prompt TEXT NOT NULL DEFAULT '',
+    tools_prompt TEXT NOT NULL DEFAULT '',
+    prompt_mode TEXT NOT NULL DEFAULT 'append',
+    include_claude_preset INTEGER NOT NULL DEFAULT 1,
+    avatar_emoji TEXT,
+    avatar_color TEXT,
+    avatar_url TEXT,
+    model_config_id TEXT,
+    runtime_policy TEXT NOT NULL DEFAULT '{}',
+    identity_hash TEXT NOT NULL DEFAULT '',
+    version INTEGER NOT NULL DEFAULT 1,
+    is_default INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+`);
+legacy
+  .prepare(
+    `INSERT INTO agent_profiles (
+       id, owner_user_id, name, runtime_policy, identity_hash, version,
+       is_default, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+  .run(
+    'legacy-agent',
+    'legacy-user',
+    'Legacy Agent',
+    JSON.stringify(legacyPolicy),
+    'legacy-hash',
+    7,
+    1,
+    createdAt,
+    createdAt,
+  );
+legacy.close();
+
+const db = await import('../src/db.js');
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('schema v69 Agent effort migration', () => {
+  test('backfills inherit without changing Agent identity metadata', () => {
+    db.initDatabase();
+
+    const profile = db.getAgentProfile('legacy-agent');
+    expect(profile?.runtime_policy.reasoning).toEqual({ effort: 'inherit' });
+    expect(profile).toMatchObject({
+      version: 7,
+      identity_hash: 'legacy-hash',
+      updated_at: createdAt,
+    });
+
+    const probe = new Database(databasePath, { readonly: true });
+    const stored = probe
+      .prepare(
+        'SELECT runtime_policy, version, identity_hash, updated_at FROM agent_profiles WHERE id = ?',
+      )
+      .get('legacy-agent') as {
+      runtime_policy: string;
+      version: number;
+      identity_hash: string;
+      updated_at: string;
+    };
+    expect(JSON.parse(stored.runtime_policy).reasoning).toEqual({
+      effort: 'inherit',
+    });
+    expect(stored).toMatchObject({
+      version: 7,
+      identity_hash: 'legacy-hash',
+      updated_at: createdAt,
+    });
+    probe.close();
+  });
+});

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -248,6 +248,61 @@ afterAll(() => {
 });
 
 describe('scheduled task workspace/session contract', () => {
+  test('forwards Agent effort to isolated container and host scheduled runs', async () => {
+    const ownerId = 'task-effort-owner';
+    const now = new Date().toISOString();
+    db.createUser({
+      id: ownerId,
+      username: ownerId,
+      password_hash: 'hash',
+      display_name: ownerId,
+      role: 'admin',
+      status: 'active',
+      must_change_password: false,
+      created_at: now,
+      updated_at: now,
+    });
+    db.setRegisteredGroup(GROUP_JID, {
+      name: 'Task Effort Workspace',
+      folder: GROUP_FOLDER,
+      added_at: now,
+      executionMode: 'container',
+      is_home: false,
+      created_by: ownerId,
+    } as any);
+    const defaultProfile = db.getOrCreateDefaultAgentProfile(ownerId);
+    const profile = db.updateAgentProfile(defaultProfile.id, ownerId, {
+      runtimePolicy: { reasoning: { effort: 'xhigh' } },
+    })!;
+    db.assignWorkspaceAgentProfile(GROUP_FOLDER, profile.id);
+    const groups = { [GROUP_JID]: db.getRegisteredGroup(GROUP_JID)! };
+
+    const containerTaskId = createTask({
+      id: 'task-effort-container',
+      execution_mode: 'container',
+    });
+    const containerRun = makeDeps(groups);
+    expect(triggerTaskNow(containerTaskId, containerRun.deps).success).toBe(
+      true,
+    );
+    await containerRun.waitForRun();
+    expect(
+      runContainerAgentMock.mock.calls[0][1].agentProfile.runtimePolicy
+        .reasoning,
+    ).toEqual({ effort: 'xhigh' });
+
+    const hostTaskId = createTask({
+      id: 'task-effort-host',
+      execution_mode: 'host',
+    });
+    const hostRun = makeDeps(groups);
+    expect(triggerTaskNow(hostTaskId, hostRun.deps).success).toBe(true);
+    await hostRun.waitForRun();
+    expect(
+      runHostAgentMock.mock.calls[0][1].agentProfile.runtimePolicy.reasoning,
+    ).toEqual({ effort: 'xhigh' });
+  });
+
   test('finalizes only at a durable scheduled-input boundary', () => {
     expect(
       shouldFinalizeScheduledRunOutput({

--- a/web/src/components/settings/MainAgentCapabilitiesSection.tsx
+++ b/web/src/components/settings/MainAgentCapabilitiesSection.tsx
@@ -6,7 +6,7 @@ import { api } from '../../api/client';
 import { useAgentProfilesStore } from '../../stores/agent-profiles';
 import { useMcpServersStore } from '../../stores/mcp-servers';
 import { useSkillsStore } from '../../stores/skills';
-import type { AgentProfileRuntimePolicy } from '../../types';
+import type { AgentEffortLevel, AgentProfileRuntimePolicy } from '../../types';
 import {
   buildMcpPolicyOptions,
   normalizeMcpPolicyReferences,
@@ -29,6 +29,18 @@ import {
 } from '../../utils/agent-runtime-policy';
 
 type CapabilityMode = 'inherit' | 'custom' | 'disabled';
+
+const AGENT_EFFORT_OPTIONS: Array<{
+  value: AgentEffortLevel;
+  label: string;
+}> = [
+  { value: 'inherit', label: '跟随模型配置' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'XHigh' },
+  { value: 'max', label: 'Max' },
+];
 
 export function MainAgentCapabilitiesSection() {
   const profiles = useAgentProfilesStore((state) => state.profiles);
@@ -64,6 +76,7 @@ export function MainAgentCapabilitiesSection() {
   const [mcpMode, setMcpMode] = useState<CapabilityMode>('inherit');
   const [mcpIds, setMcpIds] = useState<string[]>([]);
   const [modelConfigId, setModelConfigId] = useState('inherit');
+  const [effort, setEffort] = useState<AgentEffortLevel>('inherit');
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -80,6 +93,7 @@ export function MainAgentCapabilitiesSection() {
     setMcpMode(profile.runtime_policy.mcp.mode);
     setMcpIds(normalizeMcpPolicyReferences(profile.runtime_policy.mcp.ids));
     setModelConfigId(profile.model_config_id ?? 'inherit');
+    setEffort(profile.runtime_policy.reasoning?.effort ?? 'inherit');
   }, [profile?.id, profile?.updated_at]);
 
   useEffect(() => {
@@ -155,6 +169,7 @@ export function MainAgentCapabilitiesSection() {
     !!profile &&
     ((modelConfigId === 'inherit' ? null : modelConfigId) !==
       profile.model_config_id ||
+      effort !== (profile.runtime_policy.reasoning?.effort ?? 'inherit') ||
       skillsMode !== profile.runtime_policy.skills.mode ||
       JSON.stringify(skillIds) !==
         JSON.stringify(profile.runtime_policy.skills.ids) ||
@@ -172,6 +187,7 @@ export function MainAgentCapabilitiesSection() {
       profile
         ? {
             ...profile.runtime_policy,
+            reasoning: { effort },
             skills: {
               mode: skillsMode,
               ids: skillIds,
@@ -181,6 +197,7 @@ export function MainAgentCapabilitiesSection() {
           }
         : null,
     [
+      effort,
       hostSkillIds,
       hostSkillsMode,
       mcpIds,
@@ -198,6 +215,7 @@ export function MainAgentCapabilitiesSection() {
       await api.patch(`/api/agent-profiles/${encodeURIComponent(profile.id)}`, {
         model_config_id: modelConfigId === 'inherit' ? null : modelConfigId,
         runtime_policy: {
+          reasoning: { effort },
           skills: {
             mode: skillsMode,
             ids: skillIds,
@@ -207,7 +225,7 @@ export function MainAgentCapabilitiesSection() {
         } satisfies Partial<AgentProfileRuntimePolicy>,
       });
       await loadProfiles();
-      toast.success('主 HappyClaw 模型与能力已保存');
+      toast.success('主 HappyClaw 模型、推理档位与能力已保存');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : '保存能力失败');
     } finally {
@@ -270,6 +288,31 @@ export function MainAgentCapabilitiesSection() {
         <p className="text-[11px] leading-5 text-muted-foreground">
           Home
           工作区、主会话、独立会话与定时任务都会继承该选择。未启用的配置仍可在这里显式使用。
+        </p>
+      </div>
+
+      <div className="max-w-xl space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">
+          推理努力档位
+        </label>
+        <Select
+          value={effort}
+          onValueChange={(next) => setEffort(next as AgentEffortLevel)}
+        >
+          <SelectTrigger aria-label="主 HappyClaw 推理努力档位">
+            <SelectValue placeholder="选择推理努力档位" />
+          </SelectTrigger>
+          <SelectContent>
+            {AGENT_EFFORT_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-[11px] leading-5 text-muted-foreground">
+          跟随模型配置时保留 Provider 环境或 SDK
+          默认值；显式档位会覆盖该默认值。
         </p>
       </div>
 

--- a/web/src/pages/AgentProfilesPage.tsx
+++ b/web/src/pages/AgentProfilesPage.tsx
@@ -64,6 +64,7 @@ import {
 } from '../utils/mcp-servers';
 import {
   getAgentContextSource,
+  type AgentEffortLevel,
   type AgentProfilePromptMode,
   type AgentContextSource,
   type AgentProfileRuntimePolicy,
@@ -84,6 +85,7 @@ import {
 } from '../utils/agent-runtime-policy';
 
 const DEFAULT_RUNTIME_POLICY: AgentProfileRuntimePolicy = {
+  reasoning: { effort: 'inherit' },
   context: {
     source: 'managed',
     auto_compact_window: 0,
@@ -97,10 +99,33 @@ const DEFAULT_RUNTIME_POLICY: AgentProfileRuntimePolicy = {
   mcp: { mode: 'inherit', ids: [] },
 };
 
+const AGENT_EFFORT_OPTIONS: Array<{
+  value: AgentEffortLevel;
+  label: string;
+}> = [
+  { value: 'inherit', label: '跟随模型配置' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'XHigh' },
+  { value: 'max', label: 'Max' },
+];
+
+const AGENT_EFFORT_VALUES = new Set<AgentEffortLevel>(
+  AGENT_EFFORT_OPTIONS.map((option) => option.value),
+);
+
 function normalizeRuntimePolicy(
   policy?: Partial<AgentProfileRuntimePolicy> | null,
 ): AgentProfileRuntimePolicy {
   return {
+    reasoning: {
+      effort: AGENT_EFFORT_VALUES.has(
+        policy?.reasoning?.effort as AgentEffortLevel,
+      )
+        ? (policy?.reasoning?.effort as AgentEffortLevel)
+        : 'inherit',
+    },
     context: {
       source: getAgentContextSource(policy),
       auto_compact_window:
@@ -216,6 +241,7 @@ export function AgentProfilesPage() {
   const [promptMode, setPromptMode] =
     useState<AgentProfilePromptMode>('append');
   const [modelConfigId, setModelConfigId] = useState('inherit');
+  const [effort, setEffort] = useState<AgentEffortLevel>('inherit');
   const [assistantSection, setAssistantSection] =
     useState<AgentPromptSection>('identity');
   const [avatarEmoji, setAvatarEmoji] = useState<string | null>(null);
@@ -359,6 +385,7 @@ export function AgentProfilesPage() {
     policy?: AgentProfileRuntimePolicy | null,
   ) => {
     const normalized = normalizeRuntimePolicy(policy);
+    setEffort(normalized.reasoning.effort);
     setSkillsMode(normalized.skills.mode);
     setSkillIds(normalized.skills.ids);
     const hostPolicy = normalized.skills.host ?? {
@@ -424,6 +451,7 @@ export function AgentProfilesPage() {
   const currentRuntimePolicy = useMemo(
     () =>
       normalizeRuntimePolicy({
+        reasoning: { effort },
         context: {
           source: contextSource,
           auto_compact_window: useSdkCompactDefault
@@ -447,6 +475,7 @@ export function AgentProfilesPage() {
     [
       autoCompactPercentage,
       contextSource,
+      effort,
       hostSkillIds,
       hostSkillsMode,
       legacyAutoCompactWindow,
@@ -1527,6 +1556,38 @@ export function AgentProfilesPage() {
                           该智能体所属的所有工作区、会话和定时任务都会使用这里解析出的完整模型网关环境。未启用的配置不会参与系统自动选择，但仍可由智能体显式使用。
                         </p>
                       </div>
+                      <div>
+                        <label className="mb-2 block text-sm font-medium">
+                          推理努力档位
+                        </label>
+                        <Select
+                          value={effort}
+                          onValueChange={(value) =>
+                            setEffort(value as AgentEffortLevel)
+                          }
+                        >
+                          <SelectTrigger aria-label="智能体推理努力档位">
+                            <SelectValue placeholder="选择推理努力档位" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {AGENT_EFFORT_OPTIONS.map((option) => (
+                              <SelectItem
+                                key={option.value}
+                                value={option.value}
+                              >
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <p className="mt-1.5 text-xs leading-5 text-muted-foreground">
+                          “跟随模型配置”保留 Provider 高级设置中的
+                          CLAUDE_CODE_EFFORT_LEVEL；显式档位通过 Agent SDK
+                          传入并覆盖该环境变量。不支持所选档位的模型会由 Claude
+                          静默降级，实际值可在会话的 CLAUDE_EFFORT
+                          环境变量中查看。
+                        </p>
+                      </div>
                       <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
                         <div className="flex flex-wrap items-center gap-4">
                           <EmojiAvatar
@@ -1798,6 +1859,14 @@ export function AgentProfilesPage() {
                               : (modelConfigs.find(
                                   (item) => item.id === modelConfigId,
                                 )?.name ?? '不可用模型配置')
+                          }
+                        />
+                        <SummaryItem
+                          label="推理努力档位"
+                          value={
+                            AGENT_EFFORT_OPTIONS.find(
+                              (option) => option.value === effort,
+                            )?.label ?? '跟随模型配置'
                           }
                         />
                         <SummaryItem

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -90,6 +90,14 @@ export interface ModelConfigOption {
 
 export type AgentProfilePromptMode = 'append' | 'replace';
 
+export type AgentEffortLevel =
+  | 'inherit'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max';
+
 export interface AgentProfilePrompts {
   identity_prompt: string;
   soul_prompt: string;
@@ -110,6 +118,9 @@ export interface AgentProfilePromptVersion extends AgentProfilePrompts {
 }
 
 export interface AgentProfileRuntimePolicy {
+  reasoning: {
+    effort: AgentEffortLevel;
+  };
   context?: {
     source: 'managed' | 'host_claude';
     auto_compact_window?: number;
@@ -130,6 +141,7 @@ export interface AgentProfileRuntimePolicy {
 }
 
 export interface AgentProfileRuntimePolicyPatch {
+  reasoning?: Partial<AgentProfileRuntimePolicy['reasoning']>;
   context?: Partial<NonNullable<AgentProfileRuntimePolicy['context']>>;
   skills?: {
     mode?: AgentProfileRuntimePolicy['skills']['mode'];


### PR DESCRIPTION
## Summary

- add Agent Profile `reasoning.effort` with `inherit | low | medium | high | xhigh | max` across schema, SQLite migration, REST/API types, Agent Builder schema, and the Chinese web UI
- define precedence as Agent explicit value > Provider `CLAUDE_CODE_EFFORT_LEVEL` customEnv > Agent SDK/model default
- pass explicit values through Agent SDK `options.effort`; `inherit` intentionally omits the option and preserves Provider env
- remove Provider effort env before both host and container runner starts when the Agent value is explicit
- treat effort changes as runtime identity changes and reuse the existing two-phase workspace quiesce/cleanup path, so warm runners restart while cold sessions and scheduled tasks receive the new policy
- document in the UI that unsupported models can silently downgrade and expose the effective value as `CLAUDE_EFFORT`

## Compatibility

- schema v69 backfills existing profile JSON with `reasoning.effort = inherit` without changing profile version, identity hash, or timestamps
- old/partial API payloads normalize to `inherit`
- `inherit` retains current official and third-party Provider behavior, including the third-party `max` default

## Verification

- `npm run format:check`
- `npm run docs:check`
- `npm run typecheck`
- `npm run build:all`
- `npm test -- --run` — 327 files, 2785 tests passed on latest `main`
- real isolated HTTP server: setup + Agent Profile create/read/update/delete; `high -> max` persisted, invalid `turbo` returned HTTP 400
- real Agent SDK process with a recording Claude CLI: explicit `xhigh` emitted `--effort xhigh`; `inherit` emitted no `--effort` and forwarded Provider `CLAUDE_CODE_EFFORT_LEVEL=medium`

Closes #616
