### PR TITLE
fix(container): preserve non-root session access

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -65,6 +65,7 @@ RUN printf '%s\n' "$TOOL_REFRESH" > /etc/happyclaw-tool-refresh \
     # --- Process & system ---
     procps \
     lsof \
+    inotify-tools \
     # --- Text search & dev ---
     ripgrep \
     fd-find \
@@ -210,8 +211,8 @@ RUN npm run build
 # scoped; legacy global/memory filesystem roots must not exist in the runtime.
 RUN mkdir -p /workspace/group /workspace/extra /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input
 
-# Copy entrypoint script (runs as root, drops to node user via runuser)
-COPY entrypoint.sh /app/entrypoint.sh
+# Copy entrypoint scripts (run as root, then drop to node via runuser)
+COPY entrypoint.sh session-permissions.sh /app/
 RUN chmod +x /app/entrypoint.sh
 
 # Set ownership to node user (non-root) for writable directories

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -6,13 +6,25 @@ set -e
 # Without this, the host cannot delete/modify files created by the container.
 umask 0000
 
-# Fix ownership on mounted volumes.
-# Host uid may differ from container node user (uid 1000), especially in
-# rootless podman where uid remapping causes EACCES on bind mounts.
-# Running as root here so chown works regardless of host uid.
-chown -R node:node /home/node/.claude 2>/dev/null || true
-chown -R node:node /home/node/.feishu-cli 2>/dev/null || true
-chown -R node:node /workspace/group /workspace/ipc 2>/dev/null || true
+# A rootful Linux daemon can safely align node with a non-root host uid. For
+# rootless/userns, host-root and Docker Desktop the helper deliberately avoids
+# assuming that numeric ids have the same meaning on both sides of the mount.
+source /app/session-permissions.sh
+happyclaw_configure_node_identity
+
+# Fix access to the explicit writable mounts. Direct identity mapping touches
+# only mount roots, namespace/VM fallback shares only mount roots, and host-root
+# recursively prepares only these explicit mounts. No path recursively chowns
+# the image's /home/node directory.
+happyclaw_prepare_mounted_path /home/node/.claude
+happyclaw_prepare_mounted_path /home/node/.feishu-cli
+happyclaw_prepare_mounted_path /workspace/group
+happyclaw_prepare_mounted_path /workspace/ipc
+# Repair restrictive session files only when numeric host identity cannot be
+# represented. Direct and host-root modes retain their narrower ownership model.
+if [ "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" = 1 ]; then
+  happyclaw_relax_session_permissions
+fi
 
 # Mark mounted directories as safe for git (CVE-2022-24765 ownership check).
 # Host uid may differ from container node user, causing git to refuse operations.
@@ -91,6 +103,7 @@ chmod -R a-w /tmp/dist
 # Chromium process so no browser child survives a cancelled run.
 CHROMIUM_PID=
 cleanup() {
+  happyclaw_stop_session_permission_reconciler
   if [ -n "$CHROMIUM_PID" ] && kill -0 "$CHROMIUM_PID" 2>/dev/null; then
     kill "$CHROMIUM_PID" 2>/dev/null || true
     for ((attempt = 0; attempt < 20; attempt++)); do
@@ -102,10 +115,14 @@ cleanup() {
     fi
     wait "$CHROMIUM_PID" 2>/dev/null || true
   fi
-  chmod -R a+rwX /home/node/.claude 2>/dev/null || true
   chmod -R a+rwX /workspace/group 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Numeric uid alignment makes 0600 files host-readable in direct mode. A
+# rootless/userns daemon cannot do that safely, so reconcile the isolated
+# session mount while Claude is running, not only after container exit.
+happyclaw_start_session_permission_reconciler
 
 # Start one deterministic browser for this task container. Binding to loopback
 # keeps the raw Chrome DevTools Protocol private to the container; a future Web

--- a/container/session-permissions.sh
+++ b/container/session-permissions.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+
+# Container/host identity and session-permission helpers. This file is sourced
+# by entrypoint.sh and is kept side-effect free so its behavior can be tested in
+# an otherwise stock agent image.
+
+HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=0
+HAPPYCLAW_MOUNT_PREPARE_MODE=none
+HAPPYCLAW_SESSION_PERMISSION_PID=
+HAPPYCLAW_SESSION_PERMISSION_PROCESS_GROUP=0
+
+happyclaw_valid_nonroot_id() {
+  local value="$1"
+  case "$value" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  [ "$value" -gt 0 ] 2>/dev/null && [ "$value" -le 2147483647 ] 2>/dev/null
+}
+
+happyclaw_warn_identity() {
+  printf 'happyclaw: %s\n' "$1" >&2
+}
+
+happyclaw_write_runtime_ids() {
+  local runtime_user="$1"
+  local runtime_uid="$2"
+  local runtime_gid="$3"
+  local passwd_file="${HAPPYCLAW_PASSWD_FILE:-/etc/passwd}"
+  local temporary
+
+  temporary=$(mktemp /etc/happyclaw-passwd.XXXXXX) || return 1
+  if ! awk -F: -v OFS=: -v user="$runtime_user" \
+    -v uid="$runtime_uid" -v gid="$runtime_gid" '
+      $1 == user { $3 = uid; $4 = gid; found = 1 }
+      { print }
+      END { if (!found) exit 42 }
+    ' "$passwd_file" > "$temporary"; then
+    rm -f "$temporary"
+    return 1
+  fi
+  chmod 0644 "$temporary"
+  chown root:root "$temporary"
+  mv "$temporary" "$passwd_file"
+}
+
+happyclaw_configure_node_identity() {
+  local runtime_user="${HAPPYCLAW_RUNTIME_USER:-node}"
+  local mode="${HAPPYCLAW_HOST_IDENTITY_MODE:-unknown}"
+  local requested_uid="${HAPPYCLAW_HOST_UID:-}"
+  local requested_gid="${HAPPYCLAW_HOST_GID:-}"
+  local current_uid current_gid target_uid target_gid existing_name
+
+  HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=0
+  HAPPYCLAW_MOUNT_PREPARE_MODE=none
+  case "$mode" in
+    direct) ;;
+    namespaced | virtualized | unknown)
+      # Numeric host ids are not meaningful in a user namespace or Docker
+      # Desktop VM. Keep the image's non-root account and share only the mount
+      # roots; the event-driven reconciler is scoped to the session mount.
+      HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=1
+      HAPPYCLAW_MOUNT_PREPARE_MODE=shared
+      export HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS HAPPYCLAW_MOUNT_PREPARE_MODE
+      return 0
+      ;;
+    host-root)
+      # The host backend can read every uid. Prepare only explicit writable
+      # mounts for node and keep the running agent non-root.
+      HAPPYCLAW_MOUNT_PREPARE_MODE=recursive
+      export HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS HAPPYCLAW_MOUNT_PREPARE_MODE
+      return 0
+      ;;
+    *)
+      happyclaw_warn_identity "unknown host identity mode '$mode'; numeric uid/gid remapping disabled"
+      HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=1
+      HAPPYCLAW_MOUNT_PREPARE_MODE=shared
+      export HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS HAPPYCLAW_MOUNT_PREPARE_MODE
+      return 0
+      ;;
+  esac
+
+  current_uid=$(id -u "$runtime_user")
+  current_gid=$(id -g "$runtime_user")
+  target_uid="$current_uid"
+  target_gid="$current_gid"
+
+  # UID and GID are validated and remapped independently. Never turn the
+  # runtime account into root, even when HappyClaw itself runs as host root.
+  if [ -n "$requested_gid" ]; then
+    if ! happyclaw_valid_nonroot_id "$requested_gid"; then
+      happyclaw_warn_identity "refusing unsafe host gid '$requested_gid'; keeping gid $current_gid"
+    elif [ "$requested_gid" != "$current_gid" ]; then
+      # A numeric gid can already have a different group name (for example
+      # nogroup=65534). Keep node's named primary group aligned with passwd so
+      # setpriv --init-groups and chown node:node remain deterministic.
+      if groupmod --non-unique --gid "$requested_gid" "$runtime_user"; then
+        target_gid="$requested_gid"
+      else
+        happyclaw_warn_identity "could not remap $runtime_user to gid $requested_gid"
+      fi
+    fi
+  fi
+
+  if [ -z "$requested_uid" ]; then
+    happyclaw_warn_identity 'direct identity mode did not provide a host uid; using permission reconciliation'
+    HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=1
+  elif ! happyclaw_valid_nonroot_id "$requested_uid"; then
+    happyclaw_warn_identity "refusing unsafe host uid '$requested_uid'; keeping uid $current_uid"
+    HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=1
+  elif [ "$requested_uid" != "$current_uid" ]; then
+    existing_name=$(getent passwd "$requested_uid" | cut -d: -f1 || true)
+    if [ -n "$existing_name" ]; then
+      happyclaw_warn_identity "uid $requested_uid already belongs to $existing_name; using permission reconciliation"
+      HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=1
+    else
+      target_uid="$requested_uid"
+    fi
+  fi
+
+  # Edit only node's passwd record. usermod recursively changes ownership under
+  # the account home when its uid/gid changes, making startup proportional to
+  # the complete bind-mounted session history.
+  if [ "$target_uid" != "$current_uid" ] || [ "$target_gid" != "$current_gid" ]; then
+    if ! happyclaw_write_runtime_ids "$runtime_user" "$target_uid" "$target_gid"; then
+      happyclaw_warn_identity "could not update passwd identity for $runtime_user; using permission reconciliation"
+      HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS=1
+    fi
+  fi
+
+  if [ "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" = 1 ]; then
+    HAPPYCLAW_MOUNT_PREPARE_MODE=shared
+  else
+    HAPPYCLAW_MOUNT_PREPARE_MODE=root
+  fi
+
+  # Bind-mounted content already has the direct host uid. Only the image home
+  # root needs ownership repair after changing the passwd record.
+  chown --no-dereference "$runtime_user:$(id -gn "$runtime_user")" \
+    "/home/$runtime_user" 2>/dev/null || true
+  export HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS HAPPYCLAW_MOUNT_PREPARE_MODE
+}
+
+happyclaw_prepare_mounted_path() {
+  local path="$1"
+  local runtime_user="${HAPPYCLAW_RUNTIME_USER:-node}"
+  [ -e "$path" ] || return 0
+
+  case "$HAPPYCLAW_MOUNT_PREPARE_MODE" in
+    recursive)
+      chown -R --no-dereference "$runtime_user:$(id -gn "$runtime_user")" \
+        "$path" 2>/dev/null || true
+      ;;
+    root)
+      chown --no-dereference "$runtime_user:$(id -gn "$runtime_user")" \
+        "$path" 2>/dev/null || true
+      ;;
+    shared)
+      # Namespace/VM mappings are intentionally not translated numerically.
+      # The host creates writable mount roots; repair only that root here.
+      if [ -d "$path" ]; then
+        chmod a+rwx "$path" 2>/dev/null || true
+      else
+        chmod a+rw "$path" 2>/dev/null || true
+      fi
+      ;;
+  esac
+}
+
+happyclaw_relax_session_permissions() {
+  local session_root="${HAPPYCLAW_SESSION_ROOT:-/home/node/.claude}"
+  [ -d "$session_root" ] || return 0
+
+  # One startup/cleanup traversal repairs restrictive files left by an older
+  # container. Both predicates share one find walk; nested mounts and symlink
+  # targets are never traversed.
+  find "$session_root" -xdev \
+    \( -type d ! -perm -0007 -exec chmod a+rwx {} + \) -o \
+    \( -type f ! -perm -0006 -exec chmod a+rw {} + \) \
+    2>/dev/null || true
+}
+
+happyclaw_relax_session_path() {
+  local changed_path="$1"
+  local session_root="${HAPPYCLAW_SESSION_ROOT:-/home/node/.claude}"
+  [ -e "$changed_path" ] || return 0
+
+  # inotify supplies paths below session_root. Defend in depth against a
+  # malformed event and avoid following a symlink moved into the session.
+  case "$changed_path" in
+    "$session_root" | "$session_root"/*) ;;
+    *) return 0 ;;
+  esac
+  find "$changed_path" -xdev \
+    \( -type d ! -perm -0007 -exec chmod a+rwx {} + \) -o \
+    \( -type f ! -perm -0006 -exec chmod a+rw {} + \) \
+    2>/dev/null || true
+}
+
+happyclaw_start_session_permission_polling() {
+  (
+    while sleep 30; do
+      happyclaw_relax_session_permissions
+    done
+  ) &
+  HAPPYCLAW_SESSION_PERMISSION_PID=$!
+  HAPPYCLAW_SESSION_PERMISSION_PROCESS_GROUP=0
+}
+
+happyclaw_start_session_permission_reconciler() {
+  local session_root="${HAPPYCLAW_SESSION_ROOT:-/home/node/.claude}"
+  local status_dir attempt watch_ready=0
+
+  [ "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" = 1 ] || return 0
+  [ -d "$session_root" ] || return 0
+
+  if command -v inotifywait >/dev/null 2>&1 && command -v setsid >/dev/null 2>&1; then
+    status_dir=$(mktemp -d /tmp/happyclaw-session-watcher.XXXXXX)
+    export HAPPYCLAW_SESSION_ROOT="$session_root"
+    export HAPPYCLAW_SESSION_PERMISSION_HELPER="${BASH_SOURCE[0]}"
+    export HAPPYCLAW_SESSION_PERMISSION_STATUS_DIR="$status_dir"
+
+    # A dedicated process group lets cleanup terminate inotifywait, the path
+    # consumer, and a degraded polling loop together. NUL-delimited paths are
+    # safe for whitespace/newlines; chmod is event-scoped after the one startup
+    # scan instead of repeatedly traversing the complete session tree.
+    setsid bash -c '
+      set -o pipefail
+      source "$HAPPYCLAW_SESSION_PERMISSION_HELPER"
+      LC_ALL=C inotifywait --monitor --recursive --no-dereference \
+        --event create,moved_to,attrib,close_write \
+        --format "%w%f%0" --no-newline "$HAPPYCLAW_SESSION_ROOT" \
+        2> >(
+          while IFS= read -r line; do
+            if [ "$line" = "Watches established." ]; then
+              : > "$HAPPYCLAW_SESSION_PERMISSION_STATUS_DIR/ready"
+            fi
+          done
+        ) |
+        while IFS= read -r -d "" changed_path; do
+          happyclaw_relax_session_path "$changed_path"
+        done
+
+      : > "$HAPPYCLAW_SESSION_PERMISSION_STATUS_DIR/fallback"
+      while true; do
+        happyclaw_relax_session_permissions
+        sleep 30
+      done
+    ' &
+    HAPPYCLAW_SESSION_PERMISSION_PID=$!
+    HAPPYCLAW_SESSION_PERMISSION_PROCESS_GROUP=1
+
+    # Do not start the unprivileged agent until recursive watches are active;
+    # this closes the startup-scan/watch-registration race. Bound the wait so a
+    # pathological tree degrades to low-frequency polling instead of hanging.
+    for ((attempt = 0; attempt < 500; attempt++)); do
+      if [ -e "$status_dir/ready" ] || [ -e "$status_dir/fallback" ]; then
+        watch_ready=1
+        break
+      fi
+      if ! kill -0 "$HAPPYCLAW_SESSION_PERMISSION_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.02
+    done
+
+    if [ "$watch_ready" != 1 ]; then
+      happyclaw_warn_identity 'session permission watcher did not become ready; using 30s polling fallback'
+      kill -- "-$HAPPYCLAW_SESSION_PERMISSION_PID" 2>/dev/null || true
+      wait "$HAPPYCLAW_SESSION_PERMISSION_PID" 2>/dev/null || true
+      HAPPYCLAW_SESSION_PERMISSION_PID=
+      HAPPYCLAW_SESSION_PERMISSION_PROCESS_GROUP=0
+      happyclaw_start_session_permission_polling
+    fi
+    happyclaw_relax_session_permissions
+    rm -rf -- "$status_dir"
+  else
+    happyclaw_warn_identity 'inotifywait unavailable; using 30s session permission polling fallback'
+    happyclaw_start_session_permission_polling
+    happyclaw_relax_session_permissions
+  fi
+}
+
+happyclaw_stop_session_permission_reconciler() {
+  if [ -n "$HAPPYCLAW_SESSION_PERMISSION_PID" ]; then
+    if [ "$HAPPYCLAW_SESSION_PERMISSION_PROCESS_GROUP" = 1 ]; then
+      kill -- "-$HAPPYCLAW_SESSION_PERMISSION_PID" 2>/dev/null || true
+    else
+      kill "$HAPPYCLAW_SESSION_PERMISSION_PID" 2>/dev/null || true
+    fi
+    wait "$HAPPYCLAW_SESSION_PERMISSION_PID" 2>/dev/null || true
+    HAPPYCLAW_SESSION_PERMISSION_PID=
+    HAPPYCLAW_SESSION_PERMISSION_PROCESS_GROUP=0
+  fi
+  if [ "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" = 1 ]; then
+    happyclaw_relax_session_permissions
+  fi
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -505,7 +505,7 @@ function applyKnownProviderFailureDisposition(
   output.inputTurnCompleted = terminal;
 }
 
-interface VolumeMount {
+export interface VolumeMount {
   hostPath: string;
   containerPath: string;
   readonly: boolean;
@@ -1534,15 +1534,114 @@ export function buildVolumeMounts(
   return mounts;
 }
 
-function buildContainerArgs(
+export type ContainerHostIdentityMode =
+  | 'direct'
+  | 'namespaced'
+  | 'virtualized'
+  | 'host-root'
+  | 'unknown';
+
+export interface ContainerHostIdentity {
+  mode: ContainerHostIdentityMode;
+  uid?: number;
+  gid?: number;
+}
+
+export interface ContainerHostIdentityProbe {
+  platform: NodeJS.Platform;
+  uid?: number;
+  gid?: number;
+  securityOptions: readonly string[] | null;
+}
+
+function isPositiveUnixId(value: number | undefined): value is number {
+  return Number.isSafeInteger(value) && value !== undefined && value > 0;
+}
+
+/**
+ * Decide whether container ids share the host's numeric id namespace.
+ *
+ * Numeric remapping is safe only for a rootful Linux daemon without userns.
+ * Rootless Docker/Podman and userns-remap deliberately translate ids, while
+ * Docker Desktop virtualizes bind-mount ownership. Unknown probes fail closed
+ * to the entrypoint's permission reconciler instead of guessing.
+ */
+export function resolveContainerHostIdentity(
+  probe: ContainerHostIdentityProbe,
+): ContainerHostIdentity {
+  if (probe.platform === 'darwin' || probe.platform === 'win32') {
+    return { mode: 'virtualized' };
+  }
+  if (probe.platform !== 'linux') return { mode: 'unknown' };
+
+  if (probe.uid === 0) return { mode: 'host-root' };
+  if (!isPositiveUnixId(probe.uid)) return { mode: 'unknown' };
+  if (probe.securityOptions === null) return { mode: 'unknown' };
+
+  const hasUserNamespace = probe.securityOptions.some((option) => {
+    const normalized = option.toLowerCase();
+    return normalized.includes('rootless') || normalized.includes('userns');
+  });
+  if (hasUserNamespace) return { mode: 'namespaced' };
+
+  return {
+    mode: 'direct',
+    uid: probe.uid,
+    ...(isPositiveUnixId(probe.gid) ? { gid: probe.gid } : {}),
+  };
+}
+
+let cachedContainerHostIdentity: ContainerHostIdentity | null = null;
+
+function detectContainerHostIdentity(): ContainerHostIdentity {
+  if (cachedContainerHostIdentity) return cachedContainerHostIdentity;
+
+  let securityOptions: readonly string[] | null = null;
+  try {
+    const raw = execFileSync(
+      'docker',
+      ['info', '--format', '{{json .SecurityOptions}}'],
+      { encoding: 'utf8', timeout: 3_000 },
+    ).trim();
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((option) => typeof option === 'string')
+    ) {
+      securityOptions = parsed;
+    }
+  } catch {
+    // A missing/unsupported probe must not enable numeric id remapping.
+  }
+
+  cachedContainerHostIdentity = resolveContainerHostIdentity({
+    platform: process.platform,
+    uid: process.getuid?.(),
+    gid: process.getgid?.(),
+    securityOptions,
+  });
+  return cachedContainerHostIdentity;
+}
+
+export function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   tz: string,
+  hostIdentity: ContainerHostIdentity = detectContainerHostIdentity(),
 ): string[] {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Set timezone so container Node.js processes use local time (Asia/Shanghai)
   args.push('-e', `TZ=${tz}`);
+  args.push('-e', `HAPPYCLAW_HOST_IDENTITY_MODE=${hostIdentity.mode}`);
+  if (hostIdentity.mode === 'direct') {
+    if (isPositiveUnixId(hostIdentity.uid)) {
+      args.push('-e', `HAPPYCLAW_HOST_UID=${hostIdentity.uid}`);
+    }
+    if (isPositiveUnixId(hostIdentity.gid)) {
+      args.push('-e', `HAPPYCLAW_HOST_GID=${hostIdentity.gid}`);
+    }
+  }
 
   // Docker: -v with :ro suffix for readonly
   for (const mount of mounts) {

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -190,6 +190,19 @@ const DANGEROUS_ENV_VARS = new Set([
   'HAPPYCLAW_WORKSPACE_IPC',
   'CLAUDE_CONFIG_DIR',
 ]);
+
+function isDangerousEnvKey(key: string): boolean {
+  return (
+    DANGEROUS_ENV_VARS.has(key) ||
+    key.startsWith('HAPPYCLAW_SESSION_') ||
+    key === 'HAPPYCLAW_HOST_IDENTITY_MODE' ||
+    key === 'HAPPYCLAW_HOST_UID' ||
+    key === 'HAPPYCLAW_HOST_GID' ||
+    key === 'HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS' ||
+    key === 'HAPPYCLAW_MOUNT_PREPARE_MODE' ||
+    key === 'HAPPYCLAW_RUNTIME_USER'
+  );
+}
 const MAX_CUSTOM_ENV_ENTRIES = 50;
 const MAX_THIRD_PARTY_PROFILES = 20;
 
@@ -627,6 +640,9 @@ function sanitizeCustomEnvMap(
   for (const [key, rawValue] of entries) {
     if (!ENV_KEY_RE.test(key)) {
       throw new Error(`Invalid env key: ${key}`);
+    }
+    if (isDangerousEnvKey(key)) {
+      continue;
     }
     if (options?.skipReservedClaudeKeys && RESERVED_CLAUDE_ENV_KEYS.has(key)) {
       continue;
@@ -2606,6 +2622,7 @@ export function buildClaudeEnvLines(
   }
 
   for (const [key, value] of Object.entries(customEnv)) {
+    if (isDangerousEnvKey(key)) continue;
     if (RESERVED_CLAUDE_ENV_KEYS.has(key)) continue;
     if (config.anthropicBaseUrl && THIRD_PARTY_CONFIGURABLE_ENV_KEYS.has(key)) {
       continue;
@@ -2874,7 +2891,7 @@ export function saveContainerEnvConfig(
   if (sanitized.customEnv) {
     const cleanEnv: Record<string, string> = {};
     for (const [k, v] of Object.entries(sanitized.customEnv)) {
-      if (DANGEROUS_ENV_VARS.has(k)) {
+      if (isDangerousEnvKey(k)) {
         logger.warn(
           { key: k },
           'Rejected dangerous env variable in saveContainerEnvConfig',
@@ -3038,7 +3055,7 @@ export function buildContainerEnvLines(
         continue;
       }
       // Block dangerous environment variables
-      if (DANGEROUS_ENV_VARS.has(key)) {
+      if (isDangerousEnvKey(key)) {
         logger.warn(
           { key },
           'Blocked dangerous env variable in buildContainerEnvLines',

--- a/tests/container-session-permissions.test.ts
+++ b/tests/container-session-permissions.test.ts
@@ -1,0 +1,461 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const testRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'happyclaw-container-permissions-'),
+);
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    DATA_DIR: path.join(testRoot, 'data'),
+    GROUPS_DIR: path.join(testRoot, 'data', 'groups'),
+    STORE_DIR: path.join(testRoot, 'data', 'db'),
+    CONTAINER_IMAGE: 'happyclaw-agent:test',
+    TIMEZONE: 'UTC',
+  };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+const { buildContainerArgs, resolveContainerHostIdentity } =
+  await import('../src/container-runner.js');
+
+const mounts = [
+  {
+    hostPath: '/host/session',
+    containerPath: '/home/node/.claude',
+    readonly: false,
+  },
+];
+
+function envArgs(args: string[]): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (args[index] === '-e') values.push(args[index + 1]);
+  }
+  return values;
+}
+
+describe('container host identity resolution', () => {
+  test('uses direct ids only for rootful Linux without user namespaces', () => {
+    expect(
+      resolveContainerHostIdentity({
+        platform: 'linux',
+        uid: 1002,
+        gid: 1234,
+        securityOptions: ['name=seccomp,profile=builtin'],
+      }),
+    ).toEqual({ mode: 'direct', uid: 1002, gid: 1234 });
+  });
+
+  test.each([
+    [['name=rootless'], 'namespaced'],
+    [['name=userns'], 'namespaced'],
+  ] as const)('does not reuse numeric ids for %s', (securityOptions, mode) => {
+    expect(
+      resolveContainerHostIdentity({
+        platform: 'linux',
+        uid: 1002,
+        gid: 1002,
+        securityOptions,
+      }),
+    ).toEqual({ mode });
+  });
+
+  test('keeps a host-root deployment non-root inside the container', () => {
+    expect(
+      resolveContainerHostIdentity({
+        platform: 'linux',
+        uid: 0,
+        gid: 0,
+        securityOptions: [],
+      }),
+    ).toEqual({ mode: 'host-root' });
+  });
+
+  test.each(['darwin', 'win32'] as const)(
+    'uses virtualized mount semantics on %s',
+    (platform) => {
+      expect(
+        resolveContainerHostIdentity({
+          platform,
+          uid: 501,
+          gid: 20,
+          securityOptions: [],
+        }),
+      ).toEqual({ mode: 'virtualized' });
+    },
+  );
+
+  test('fails closed when daemon security options cannot be detected', () => {
+    expect(
+      resolveContainerHostIdentity({
+        platform: 'linux',
+        uid: 1002,
+        gid: 1002,
+        securityOptions: null,
+      }),
+    ).toEqual({ mode: 'unknown' });
+  });
+});
+
+describe('buildContainerArgs identity contract', () => {
+  test('passes independently validated non-root uid and gid in direct mode', () => {
+    const args = buildContainerArgs(mounts, 'identity-test', 'UTC', {
+      mode: 'direct',
+      uid: 1002,
+      gid: 1234,
+    });
+
+    expect(envArgs(args)).toEqual(
+      expect.arrayContaining([
+        'TZ=UTC',
+        'HAPPYCLAW_HOST_IDENTITY_MODE=direct',
+        'HAPPYCLAW_HOST_UID=1002',
+        'HAPPYCLAW_HOST_GID=1234',
+      ]),
+    );
+  });
+
+  test('never forwards uid or gid zero even for a malformed direct identity', () => {
+    const args = buildContainerArgs(mounts, 'identity-test', 'UTC', {
+      mode: 'direct',
+      uid: 0,
+      gid: 0,
+    });
+
+    expect(envArgs(args)).toContain('HAPPYCLAW_HOST_IDENTITY_MODE=direct');
+    expect(envArgs(args)).not.toContain('HAPPYCLAW_HOST_UID=0');
+    expect(envArgs(args)).not.toContain('HAPPYCLAW_HOST_GID=0');
+  });
+
+  test.each(['namespaced', 'virtualized', 'host-root', 'unknown'] as const)(
+    'does not pass numeric host ids in %s mode',
+    (mode) => {
+      const args = buildContainerArgs(mounts, 'identity-test', 'UTC', {
+        mode,
+        uid: 1002,
+        gid: 1002,
+      });
+
+      expect(envArgs(args)).toContain(`HAPPYCLAW_HOST_IDENTITY_MODE=${mode}`);
+      expect(
+        envArgs(args).some((arg) => arg.startsWith('HAPPYCLAW_HOST_UID=')),
+      ).toBe(false);
+      expect(
+        envArgs(args).some((arg) => arg.startsWith('HAPPYCLAW_HOST_GID=')),
+      ).toBe(false);
+    },
+  );
+});
+
+describe('entrypoint session permission contract', () => {
+  const entrypoint = fs.readFileSync(
+    path.join(repoRoot, 'container', 'entrypoint.sh'),
+    'utf8',
+  );
+  const helper = fs.readFileSync(
+    path.join(repoRoot, 'container', 'session-permissions.sh'),
+    'utf8',
+  );
+
+  test('sources identity handling before dropping privileges', () => {
+    expect(entrypoint).toContain('source /app/session-permissions.sh');
+    expect(
+      entrypoint.indexOf('happyclaw_configure_node_identity'),
+    ).toBeLessThan(entrypoint.indexOf('runuser -u node'));
+  });
+
+  test('does not recursively chown the image home', () => {
+    expect(entrypoint).not.toMatch(/chown\s+-R\s+[^\n]*\/home\/node(?:\s|$)/);
+    expect(helper).not.toMatch(/chown\s+-R\s+[^\n]*\/home\/\$runtime_user/);
+  });
+
+  test('rejects id zero and scopes fallback reconciliation to the session root', () => {
+    expect(helper).toContain('[ "$value" -gt 0 ]');
+    expect(helper).toContain('refusing unsafe host uid');
+    expect(helper).toContain('refusing unsafe host gid');
+    expect(helper).toContain('HAPPYCLAW_SESSION_ROOT:-/home/node/.claude');
+    expect(helper).toContain('find "$session_root" -xdev');
+  });
+
+  test('uses event-scoped reconciliation with a low-frequency fallback', () => {
+    expect(helper).toContain('inotifywait --monitor --recursive');
+    expect(helper).toContain('happyclaw_relax_session_path "$changed_path"');
+    expect(helper).toContain('while sleep 30');
+    expect(helper).not.toContain('HAPPYCLAW_SESSION_PERMISSION_INTERVAL');
+    expect(helper).not.toContain(
+      'sleep "${HAPPYCLAW_SESSION_PERMISSION_INTERVAL:-0.5}"',
+    );
+  });
+
+  test('widens modes only for identity modes that cannot be mapped', () => {
+    expect(entrypoint).toContain(
+      'if [ "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" = 1 ]',
+    );
+    expect(helper).toContain('HAPPYCLAW_MOUNT_PREPARE_MODE=shared');
+    expect(helper).toContain('HAPPYCLAW_MOUNT_PREPARE_MODE=root');
+    expect(helper).toContain('HAPPYCLAW_MOUNT_PREPARE_MODE=recursive');
+  });
+});
+
+const integrationImage =
+  process.env.HAPPYCLAW_CONTAINER_PERMISSION_TEST_IMAGE ??
+  'riba2534/happyclaw-agent:latest';
+let integrationImageAvailable = false;
+let integrationImageHasInotify = false;
+try {
+  execFileSync('docker', ['image', 'inspect', integrationImage], {
+    stdio: 'ignore',
+  });
+  integrationImageAvailable = true;
+  execFileSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '--entrypoint',
+      '/bin/sh',
+      integrationImage,
+      '-c',
+      'command -v inotifywait >/dev/null',
+    ],
+    { stdio: 'ignore' },
+  );
+  integrationImageHasInotify = true;
+} catch {
+  // Unit and contract tests still run when Docker is unavailable in CI.
+}
+
+describe.skipIf(!integrationImageAvailable)(
+  'session permission helper container behavior',
+  () => {
+    const helperPath = path.join(
+      repoRoot,
+      'container',
+      'session-permissions.sh',
+    );
+
+    function runHelper(script: string): string {
+      return execFileSync(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '--entrypoint',
+          '/bin/bash',
+          '-v',
+          `${helperPath}:/tmp/session-permissions.sh:ro`,
+          integrationImage,
+          '-ceu',
+          `source /tmp/session-permissions.sh\n${script}`,
+        ],
+        { encoding: 'utf8' },
+      ).trim();
+    }
+
+    test('refuses zero ids and independently remaps a non-zero gid', () => {
+      expect(
+        runHelper(`
+          HAPPYCLAW_HOST_IDENTITY_MODE=direct
+          HAPPYCLAW_HOST_UID=0
+          HAPPYCLAW_HOST_GID=12345
+          happyclaw_configure_node_identity
+          printf '%s:%s:%s' "$(id -u node)" "$(id -g node)" "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS"
+        `),
+      ).toBe('1000:12345:1');
+    });
+
+    test('remaps separate non-zero uid and gid without scanning the image home', () => {
+      expect(
+        runHelper(`
+          HAPPYCLAW_HOST_IDENTITY_MODE=direct
+          HAPPYCLAW_HOST_UID=12346
+          HAPPYCLAW_HOST_GID=12347
+          happyclaw_configure_node_identity
+          printf '%s:%s:%s' "$(id -u node)" "$(id -g node)" "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS"
+        `),
+      ).toBe('12346:12347:0');
+    });
+
+    test('keeps node primary-group metadata aligned when the host gid exists', () => {
+      expect(
+        runHelper(`
+          HAPPYCLAW_HOST_IDENTITY_MODE=direct
+          HAPPYCLAW_HOST_UID=12346
+          HAPPYCLAW_HOST_GID=65534
+          happyclaw_configure_node_identity
+          printf '%s:%s:%s' "$(id -u node)" "$(id -g node)" "$(getent group node | cut -d: -f3)"
+        `),
+      ).toBe('12346:65534:65534');
+    });
+
+    test('keeps image ids in namespace mode and repairs a 0600 transcript', () => {
+      expect(
+        runHelper(`
+          session_root=$(mktemp -d)
+          touch "$session_root/transcript.jsonl"
+          chmod 0600 "$session_root/transcript.jsonl"
+          HAPPYCLAW_HOST_IDENTITY_MODE=namespaced
+          HAPPYCLAW_SESSION_ROOT="$session_root"
+          happyclaw_configure_node_identity
+          happyclaw_relax_session_permissions
+          printf '%s:%s:%s:%s' "$(id -u node)" "$(id -g node)" "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" "$(stat -c %a "$session_root/transcript.jsonl")"
+        `),
+      ).toBe('1000:1000:1:666');
+    });
+
+    test('does not numerically chown namespace or virtualized mounts', () => {
+      for (const mode of ['namespaced', 'virtualized']) {
+        expect(
+          runHelper(`
+            session_root=$(mktemp -d)
+            touch "$session_root/transcript.jsonl"
+            chmod 0700 "$session_root"
+            chmod 0600 "$session_root/transcript.jsonl"
+            before=$(stat -c '%u:%g' "$session_root/transcript.jsonl")
+            HAPPYCLAW_HOST_IDENTITY_MODE=${mode}
+            HAPPYCLAW_SESSION_ROOT="$session_root"
+            happyclaw_configure_node_identity
+            happyclaw_prepare_mounted_path "$session_root"
+            after=$(stat -c '%u:%g' "$session_root/transcript.jsonl")
+            happyclaw_relax_session_permissions
+            printf '%s:%s:%s:%s' "$before" "$after" "$(stat -c %a "$session_root")" "$(stat -c %a "$session_root/transcript.jsonl")"
+          `),
+        ).toBe('0:0:0:0:777:666');
+      }
+    });
+
+    test('keeps host-root agent non-root and prepares only the explicit mount', () => {
+      expect(
+        runHelper(`
+          mounted=$(mktemp -d)
+          mkdir "$mounted/nested"
+          touch "$mounted/nested/transcript.jsonl"
+          HAPPYCLAW_HOST_IDENTITY_MODE=host-root
+          happyclaw_configure_node_identity
+          happyclaw_prepare_mounted_path "$mounted"
+          printf '%s:%s:%s:%s' "$(id -u node)" "$HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS" "$(stat -c %u "$mounted")" "$(stat -c %u "$mounted/nested/transcript.jsonl")"
+        `),
+      ).toBe('1000:0:1000:1000');
+    });
+
+    test('direct-mode cleanup does not widen a private file', () => {
+      expect(
+        runHelper(`
+          session_root=$(mktemp -d)
+          touch "$session_root/private.json"
+          chmod 0600 "$session_root/private.json"
+          HAPPYCLAW_HOST_IDENTITY_MODE=direct
+          HAPPYCLAW_HOST_UID=1000
+          HAPPYCLAW_HOST_GID=1000
+          HAPPYCLAW_SESSION_ROOT="$session_root"
+          happyclaw_configure_node_identity
+          happyclaw_stop_session_permission_reconciler
+          stat -c %a "$session_root/private.json"
+        `),
+      ).toBe('600');
+    });
+
+    test('never follows a session symlink or touches a sibling path', () => {
+      expect(
+        runHelper(`
+          parent=$(mktemp -d)
+          session_root="$parent/session"
+          mkdir "$session_root"
+          touch "$parent/outside" "$session_root/local"
+          chmod 0600 "$parent/outside" "$session_root/local"
+          ln -s "$parent/outside" "$session_root/outside-link"
+          HAPPYCLAW_SESSION_ROOT="$session_root"
+          happyclaw_relax_session_permissions
+          happyclaw_relax_session_path "$session_root/outside-link"
+          printf '%s:%s' "$(stat -c %a "$session_root/local")" "$(stat -c %a "$parent/outside")"
+        `),
+      ).toBe('666:600');
+    });
+
+    test.skipIf(!integrationImageHasInotify)(
+      'repairs new files and moved-in subtrees through inotify events',
+      () => {
+        expect(
+          runHelper(`
+            session_root=$(mktemp -d)
+            HAPPYCLAW_HOST_IDENTITY_MODE=namespaced
+            HAPPYCLAW_SESSION_ROOT="$session_root"
+            happyclaw_configure_node_identity
+            happyclaw_start_session_permission_reconciler
+            install -m 0600 /dev/null "$session_root/live.jsonl"
+            incoming=$(mktemp -d)
+            mkdir -p "$incoming/deep"
+            install -m 0600 /dev/null "$incoming/deep/moved.jsonl"
+            mv "$incoming" "$session_root/moved"
+            for attempt in $(seq 1 250); do
+              if [ "$(stat -c %a "$session_root/live.jsonl")" = 666 ] && \
+                [ "$(stat -c %a "$session_root/moved/deep/moved.jsonl")" = 666 ]; then
+                break
+              fi
+              sleep 0.02
+            done
+            result="$(stat -c %a "$session_root/live.jsonl"):$(stat -c %a "$session_root/moved/deep/moved.jsonl")"
+            happyclaw_stop_session_permission_reconciler
+            printf '%s' "$result"
+          `),
+        ).toBe('666:666');
+      },
+      20_000,
+    );
+
+    test.skipIf(!integrationImageHasInotify)(
+      'does not repeat full-tree scans while a large session is idle or active',
+      () => {
+        expect(
+          runHelper(`
+            session_root=$(mktemp -d)
+            find_log=$(mktemp)
+            wrapper_dir=$(mktemp -d)
+            printf '%s\n' '#!/bin/sh' 'printf "%s\\n" "$1" >> "$HAPPYCLAW_FIND_LOG"' 'exec /usr/bin/find "$@"' > "$wrapper_dir/find"
+            chmod +x "$wrapper_dir/find"
+            for shard in $(seq 1 25); do
+              mkdir "$session_root/$shard"
+              for item in $(seq 1 100); do
+                install -m 0600 /dev/null "$session_root/$shard/$item.jsonl"
+              done
+            done
+            export HAPPYCLAW_FIND_LOG="$find_log"
+            export PATH="$wrapper_dir:$PATH"
+            HAPPYCLAW_HOST_IDENTITY_MODE=namespaced
+            HAPPYCLAW_SESSION_ROOT="$session_root"
+            happyclaw_configure_node_identity
+            happyclaw_start_session_permission_reconciler
+            full_before=$(grep -Fxc "$session_root" "$find_log" || true)
+            sleep 2
+            full_idle=$(grep -Fxc "$session_root" "$find_log" || true)
+            install -m 0600 /dev/null "$session_root/new.jsonl"
+            for attempt in $(seq 1 250); do
+              [ "$(stat -c %a "$session_root/new.jsonl")" = 666 ] && break
+              sleep 0.02
+            done
+            full_active=$(grep -Fxc "$session_root" "$find_log" || true)
+            mode=$(stat -c %a "$session_root/new.jsonl")
+            happyclaw_stop_session_permission_reconciler
+            printf '%s:%s:%s:%s' "$full_before" "$full_idle" "$full_active" "$mode"
+          `),
+        ).toBe('1:1:1:666');
+      },
+      30_000,
+    );
+  },
+);

--- a/tests/runtime-config-env.test.ts
+++ b/tests/runtime-config-env.test.ts
@@ -140,6 +140,32 @@ describe('buildClaudeEnvLines', () => {
     expect(lines).toContain('PROJECT_ENV=kept');
   });
 
+  test('blocks custom env from overriding permission reconciler controls', () => {
+    const blocked = {
+      HAPPYCLAW_SESSION_ROOT: '/',
+      HAPPYCLAW_SESSION_PERMISSION_HELPER: '/tmp/attacker.sh',
+      HAPPYCLAW_HOST_IDENTITY_MODE: 'direct',
+      HAPPYCLAW_HOST_UID: '0',
+      HAPPYCLAW_HOST_GID: '0',
+      HAPPYCLAW_RECONCILE_SESSION_PERMISSIONS: '0',
+      HAPPYCLAW_MOUNT_PREPARE_MODE: 'recursive',
+      HAPPYCLAW_RUNTIME_USER: 'root',
+      PROJECT_ENV: 'kept',
+    };
+    const lines = buildContainerEnvLines(
+      config({ anthropicBaseUrl: '', anthropicModel: '' }),
+      { customEnv: blocked },
+      blocked,
+    );
+
+    for (const key of Object.keys(blocked).filter(
+      (key) => key !== 'PROJECT_ENV',
+    )) {
+      expect(lines.some((line) => line.startsWith(`${key}=`))).toBe(false);
+    }
+    expect(lines).toContain('PROJECT_ENV=kept');
+  });
+
   test('injects an authoritative endpoint kind that custom env cannot replace', () => {
     const thirdParty = buildContainerEnvLines(
       config({ anthropicBaseUrl: 'https://proxy.test' }),


### PR DESCRIPTION
## 背景

这是 #621 的容器 session 权限部分（B）的独立替代 PR。自动压缩看门狗部分已由 #623 独立处理并合入；旧 #621 在最终验收前保持 open。

## 实现

- Linux rootful 且宿主为非 root：分别校验并映射非零 UID/GID，绝不把容器 Agent 提升到 UID/GID 0。
- rootless/userns、Docker Desktop/macOS 与探测失败：不假设宿主和容器数值 ID 等价；保持 `node` 身份，仅对隔离的 session mount 做兼容权限桥接。
- 宿主为 root：Agent 仍以 `node` 运行，只递归准备显式 writable mounts，不递归 chown 整个 `/home/node`。
- 用 inotify 监听 create/moved_to/attrib/close_write，按事件路径定点修复；启动和退出各一次全扫。inotify 不可用/失效时降级为 30 秒一次全扫，不再每 0.5 秒扫描整棵树。
- 单次全扫合并目录/文件 predicates；`-xdev`、不跟随 symlink，事件路径还会校验必须位于 session root 内。
- 阻止 provider/workspace custom env 覆盖 `HAPPYCLAW_SESSION_*`、身份模式、UID/GID、runtime user 等 root 控制变量。

## 平台行为

| 场景 | 容器 Agent | 权限策略 |
| --- | --- | --- |
| Linux rootful、宿主非 root | 映射到宿主非零 UID/GID | direct；只修 mount root |
| Linux rootless/userns | 保持 image `node` | 不做数值 chown；session 内事件式 mode bridge |
| Linux 宿主 root | 保持 image `node` | 只递归准备显式 writable mounts |
| macOS/Windows Docker Desktop | 保持 image `node` | 依赖虚拟化 ownership；session 内事件式 mode bridge |
| 探测失败 | 保持 image `node` | 保守采用隔离 session bridge |

## 隔离与剩余风险

每个容器只挂载其 `data/sessions/{group.folder}/.claude`；子 Agent 使用 `agents/{agentId}/.claude`。监听与 chmod 不跨该 mount、不跨文件系统、不跟随符号链接。direct/host-root 不启用 world-mode。

rootless/userns/Desktop 无法可移植地表达宿主身份，因此兼容路径仍会把该 session 内目录/文件放宽为 `a+rwx`/`a+rw`。容器间隔离由每容器独立 bind mount 保证，但若部署在允许其他本地 OS 用户遍历 HappyClaw data 根目录的多用户宿主，这些用户仍可能读取该 session；部署侧应限制 data 根目录的本地访问。没有假设任意 rootless namespace 的数值映射。

## 验证

- 分支镜像：`docker build --network=host -t happyclaw-agent:pr621-perms-final container`
- 容器内 ShellCheck warning 级：通过
- 聚焦测试：39/39（真实分支镜像），覆盖 UID/GID 0、分离映射、GID 冲突、direct/rootless/userns/host-root/Desktop/unknown、env 注入、symlink 越界、事件修复与 moved-in subtree
- 2500 文件持续运行：启动仅 1 次全树扫描；空闲 2 秒和单文件事件后仍为 1 次，新 0600 文件修复为 0666
- `npm run typecheck`：通过
- `npm run build:all`：通过
- `npm test -- --run`：330 files，2834 passed，2 skipped

## 尚未覆盖

实际构建与集成测试运行在 rootful Linux Docker；rootless daemon/userns-remap 和 macOS Docker Desktop 的分支在真实容器内模拟验证，但没有对应 daemon/宿主的端到端硬件环境测试。
