### PR TITLE
fix(routing): attribute channel output to the bound workspace

### DIFF
--- a/src/channel-outbox-runtime-scope.ts
+++ b/src/channel-outbox-runtime-scope.ts
@@ -11,6 +11,8 @@ export interface ActiveChannelOutboxScope extends ChannelRouteSnapshot {
   turnRunId: string;
   /** External input correlation id used by runner-side MCP output. */
   inputTurnId?: string;
+  /** Logical workspace/session base captured when this input turn was admitted. */
+  logicalBaseChatJid?: string;
   owner: string;
   token: string;
 }

--- a/src/group-broadcast-acl.ts
+++ b/src/group-broadcast-acl.ts
@@ -1,4 +1,5 @@
-import { getJidsByFolder, getRegisteredGroup } from './db.js';
+import { getAgent, getJidsByFolder, getRegisteredGroup } from './db.js';
+import { resolveBoundWorkspaceJid } from './workspace-attribution.js';
 
 const allowedUserIdsCache = new Map<
   string,
@@ -21,7 +22,21 @@ export function getGroupAllowedUserIds(chatJid: string): Set<string> | null {
 
   const group = getRegisteredGroup(baseChatJid);
   if (!group) return null;
-  let ownerId: string | null = group.created_by ?? null;
+
+  // A bound IM chat's audience is the owner of the workspace it is bound to.
+  // The IM row keeps the channel account owner's `created_by` even after the
+  // chat is bound elsewhere, so trusting it directly would deliver another
+  // workspace's conversation to the account owner. Kept consistent with
+  // normalizeHomeJid so the broadcast label and its ACL resolve the same group.
+  const boundJid = resolveBoundWorkspaceJid(baseChatJid, {
+    getRegisteredGroup,
+    getAgent,
+    getJidsByFolder,
+  });
+  const attributionGroup =
+    (boundJid ? getRegisteredGroup(boundJid) : null) ?? group;
+
+  let ownerId: string | null = attributionGroup.created_by ?? null;
   if (!ownerId && !baseChatJid.startsWith('web:')) {
     for (const siblingJid of getJidsByFolder(group.folder)) {
       if (!siblingJid.startsWith('web:')) continue;

--- a/src/group-broadcast-acl.ts
+++ b/src/group-broadcast-acl.ts
@@ -1,11 +1,13 @@
-import { getAgent, getJidsByFolder, getRegisteredGroup } from './db.js';
-import { resolveBoundWorkspaceJid } from './workspace-attribution.js';
-
-const allowedUserIdsCache = new Map<
-  string,
-  { ids: Set<string> | null; expiry: number }
->();
-const ALLOWED_CACHE_TTL = 10_000;
+import {
+  getAgent,
+  getChannelMount,
+  getJidsByFolder,
+  getRegisteredGroup,
+} from './db.js';
+import {
+  hasBoundWorkspaceReference,
+  resolveBoundWorkspaceJid,
+} from './workspace-attribution.js';
 
 export function getGroupAllowedUserIds(chatJid: string): Set<string> | null {
   const virtualSeparator = ['#agent:', '#task:']
@@ -16,28 +18,35 @@ export function getGroupAllowedUserIds(chatJid: string): Set<string> | null {
     virtualSeparator === undefined
       ? chatJid
       : chatJid.slice(0, virtualSeparator);
-  const now = Date.now();
-  const cached = allowedUserIdsCache.get(baseChatJid);
-  if (cached && cached.expiry > now) return cached.ids;
-
   const group = getRegisteredGroup(baseChatJid);
   if (!group) return null;
+
+  const attributionDeps = {
+    getRegisteredGroup,
+    getAgent,
+    getJidsByFolder,
+    getChannelMount,
+  };
 
   // A bound IM chat's audience is the owner of the workspace it is bound to.
   // The IM row keeps the channel account owner's `created_by` even after the
   // chat is bound elsewhere, so trusting it directly would deliver another
   // workspace's conversation to the account owner. Kept consistent with
   // normalizeHomeJid so the broadcast label and its ACL resolve the same group.
-  const boundJid = resolveBoundWorkspaceJid(baseChatJid, {
-    getRegisteredGroup,
-    getAgent,
-    getJidsByFolder,
-  });
+  const boundJid = resolveBoundWorkspaceJid(baseChatJid, attributionDeps);
+  const hasBinding = hasBoundWorkspaceReference(baseChatJid, attributionDeps);
+  // A declared binding whose target is stale is not an unbound chat. Falling
+  // back to the channel row would expose the target workspace's output to the
+  // channel account owner's old home session.
+  if (hasBinding && !boundJid) return null;
   const attributionGroup =
     (boundJid ? getRegisteredGroup(boundJid) : null) ?? group;
 
   let ownerId: string | null = attributionGroup.created_by ?? null;
-  if (!ownerId && !baseChatJid.startsWith('web:')) {
+  // Folder fallback is compatibility-only for genuinely unbound legacy IM
+  // rows. Once a binding resolves, an ownerless target must fail closed rather
+  // than borrowing the channel row's original owner.
+  if (!ownerId && !hasBinding && !baseChatJid.startsWith('web:')) {
     for (const siblingJid of getJidsByFolder(group.folder)) {
       if (!siblingJid.startsWith('web:')) continue;
       const sibling = getRegisteredGroup(siblingJid);
@@ -48,11 +57,8 @@ export function getGroupAllowedUserIds(chatJid: string): Set<string> | null {
     }
   }
   if (!ownerId) return null;
-
-  const allowed = new Set<string>([ownerId]);
-  allowedUserIdsCache.set(baseChatJid, {
-    ids: allowed,
-    expiry: now + ALLOWED_CACHE_TTL,
-  });
-  return allowed;
+  // Ownership and binding are security-sensitive mutable state. Resolve them
+  // on every broadcast instead of retaining a raw-JID cache that can outlive a
+  // rebind or ownership transfer.
+  return new Set<string>([ownerId]);
 }

--- a/src/host-ipc-output-router.ts
+++ b/src/host-ipc-output-router.ts
@@ -35,10 +35,14 @@ export function resolveHostIpcLogicalChatJid(input: {
   agentChatJid?: string | null;
   taskRunId?: string | null;
   scheduledTask: boolean;
+  /** Immutable logical base captured when the input turn was admitted. */
+  runtimeChatJid?: string | null;
   resolveWorkspaceJid?: (chatJid: string) => string | null;
 }): string {
   const baseChatJid =
-    input.resolveWorkspaceJid?.(input.sourceChatJid) || input.sourceChatJid;
+    input.runtimeChatJid ||
+    input.resolveWorkspaceJid?.(input.sourceChatJid) ||
+    input.sourceChatJid;
   if (input.agentId) {
     return `${input.agentChatJid || baseChatJid}#agent:${input.agentId}`;
   }

--- a/src/host-ipc-output-router.ts
+++ b/src/host-ipc-output-router.ts
@@ -16,20 +16,36 @@ export interface HostIpcOutputRouteInput {
   interactionMode?: 'assistant' | 'proactive';
 }
 
+/**
+ * Resolve the logical chat JID an IPC output should be persisted and broadcast
+ * under.
+ *
+ * `sourceChatJid` is the runner's `channelContext.sourceJid`, i.e. the raw IM
+ * JID (`qq:c2c:...`). Inbound routing already folds that JID to the bound
+ * workspace before the turn runs, so without the symmetric fold here a
+ * proactive `send_message` would be stored against the IM row — whose
+ * `folder`/`created_by` still belong to the channel account owner, not to the
+ * workspace that produced the reply. `resolveWorkspaceJid` supplies that fold;
+ * when it is absent or returns null the raw JID is kept, preserving behaviour
+ * for unbound chats.
+ */
 export function resolveHostIpcLogicalChatJid(input: {
   sourceChatJid: string;
   agentId?: string | null;
   agentChatJid?: string | null;
   taskRunId?: string | null;
   scheduledTask: boolean;
+  resolveWorkspaceJid?: (chatJid: string) => string | null;
 }): string {
+  const baseChatJid =
+    input.resolveWorkspaceJid?.(input.sourceChatJid) || input.sourceChatJid;
   if (input.agentId) {
-    return `${input.agentChatJid || input.sourceChatJid}#agent:${input.agentId}`;
+    return `${input.agentChatJid || baseChatJid}#agent:${input.agentId}`;
   }
   if (input.taskRunId && input.scheduledTask) {
-    return `${input.sourceChatJid}#task:${input.taskRunId}`;
+    return `${baseChatJid}#task:${input.taskRunId}`;
   }
-  return input.sourceChatJid;
+  return baseChatJid;
 }
 
 export type HostIpcOutputRoute =

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
   resolveHostIpcLogicalChatJid,
   routeHostIpcOutput,
 } from './host-ipc-output-router.js';
+import { resolveBoundWorkspaceJid } from './workspace-attribution.js';
 import {
   buildInterruptedReply,
   buildSteeredReply,
@@ -10056,6 +10057,20 @@ function getIpcDeliveryTargetGroup(
   );
 }
 
+/**
+ * Fold a runner-supplied IM JID to the workspace it is bound to, so IPC output
+ * is attributed to the same workspace inbound routing selected. Returns null
+ * for unbound chats; callers keep the raw JID in that case.
+ */
+function resolveIpcOutputWorkspaceJid(chatJid: string): string | null {
+  return resolveBoundWorkspaceJid(chatJid, {
+    getRegisteredGroup: (jid) =>
+      registeredGroups[jid] ?? getRegisteredGroup(jid),
+    getAgent,
+    getJidsByFolder,
+  });
+}
+
 // Thin production wrapper around the pure helper in ./task-routing.ts so the
 // internal call sites keep their short signature (deps inferred from the
 // runtime IM manager + DB). Tests should import `broadcastToOwnerIMChannels`
@@ -10383,6 +10398,7 @@ function startIpcWatcher(): void {
                     : undefined,
                   taskRunId: ipcTaskId,
                   scheduledTask: data.isScheduledTask === true,
+                  resolveWorkspaceJid: resolveIpcOutputWorkspaceJid,
                 });
                 // Feishu card JSON: store extracted markdown for web, send raw JSON to IM
                 const cardText = extractFeishuCardText(data.text);
@@ -10933,11 +10949,18 @@ function startIpcWatcher(): void {
 
                   // Conversation agents and isolated scheduled tasks store in
                   // virtual JIDs (agent/task tab), not the main conversation.
-                  const imgChatJid = ipcAgentId
-                    ? `${data.chatJid}#agent:${ipcAgentId}`
-                    : ipcTaskId && data.isScheduledTask
-                      ? `${data.chatJid}#task:${ipcTaskId}`
-                      : data.chatJid;
+                  // Shares the text path's resolver so images are attributed to
+                  // the bound workspace instead of the raw IM row.
+                  const imgChatJid = resolveHostIpcLogicalChatJid({
+                    sourceChatJid: data.chatJid,
+                    agentId: ipcAgentId,
+                    agentChatJid: ipcAgentId
+                      ? getAgent(ipcAgentId)?.chat_jid
+                      : undefined,
+                    taskRunId: ipcTaskId,
+                    scheduledTask: data.isScheduledTask === true,
+                    resolveWorkspaceJid: resolveIpcOutputWorkspaceJid,
+                  });
 
                   // Persist image message to DB and broadcast to WebSocket (same as sendMessage flow)
                   const displayText = caption

--- a/src/index.ts
+++ b/src/index.ts
@@ -2520,6 +2520,7 @@ function bindChannelOutboxScope(
     chatId: string;
     rootId?: string | null;
     threadId?: string | null;
+    logicalBaseChatJid?: string;
   },
   inputTurnId: string | undefined = runtime.inputTurnId,
 ): ActiveChannelOutboxScope {
@@ -6615,6 +6616,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             chatId: nextAddress.externalChatId,
             rootId: nextAddress.rootMessageId,
             threadId: nextAddress.threadId,
+            logicalBaseChatJid: chatJid,
           },
           // The runtime keys durable idempotency off the native message id,
           // but the runner correlates its MCP output with this deliveryId.
@@ -7097,6 +7099,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               chatId: streamingAddress.externalChatId,
               rootId: streamingAddress.rootMessageId,
               threadId: streamingAddress.threadId,
+              logicalBaseChatJid: chatJid,
             },
           )
         : undefined;
@@ -10068,7 +10071,31 @@ function resolveIpcOutputWorkspaceJid(chatJid: string): string | null {
       registeredGroups[jid] ?? getRegisteredGroup(jid),
     getAgent,
     getJidsByFolder,
+    getChannelMount,
   });
+}
+
+/**
+ * Recover the logical workspace captured for the exact input turn. Binding
+ * rows are mutable while a runner is working, so reading them only when IPC
+ * output arrives can attribute workspace A's delayed output to a newly-bound
+ * workspace B. The outbox scope already freezes the physical route; carry the
+ * logical base beside it without changing provider delivery.
+ */
+function resolveIpcOutputRuntimeChatJid(
+  sourceGroup: string,
+  ipcAgentId: string | null | undefined,
+  inputTurnId: unknown,
+  targetJid: string,
+): string | null {
+  if (typeof inputTurnId !== 'string' || !inputTurnId) return null;
+  return (
+    activeChannelOutboxScopes.resolveInput(
+      channelTurnScope(sourceGroup, ipcAgentId),
+      inputTurnId,
+      targetJid,
+    )?.logicalBaseChatJid ?? null
+  );
 }
 
 // Thin production wrapper around the pure helper in ./task-routing.ts so the
@@ -10398,6 +10425,12 @@ function startIpcWatcher(): void {
                     : undefined,
                   taskRunId: ipcTaskId,
                   scheduledTask: data.isScheduledTask === true,
+                  runtimeChatJid: resolveIpcOutputRuntimeChatJid(
+                    sourceGroup,
+                    ipcAgentId,
+                    data.inputTurnId,
+                    data.chatJid,
+                  ),
                   resolveWorkspaceJid: resolveIpcOutputWorkspaceJid,
                 });
                 // Feishu card JSON: store extracted markdown for web, send raw JSON to IM
@@ -10959,6 +10992,12 @@ function startIpcWatcher(): void {
                       : undefined,
                     taskRunId: ipcTaskId,
                     scheduledTask: data.isScheduledTask === true,
+                    runtimeChatJid: resolveIpcOutputRuntimeChatJid(
+                      sourceGroup,
+                      ipcAgentId,
+                      data.inputTurnId,
+                      data.chatJid,
+                    ),
                     resolveWorkspaceJid: resolveIpcOutputWorkspaceJid,
                   });
 

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { Variables } from '../web-context.js';
 import { authMiddleware } from '../middleware/auth.js';
+import { resolveBoundWorkspaceJid } from '../workspace-attribution.js';
 import {
   GroupAgentProfilePatchSchema,
   GroupCreateSchema,
@@ -2364,6 +2365,9 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
   }
 
   // is_home 群组合并查询：将同一 owner、同 folder 下的 Web 与 IM 消息合并展示。
+  // 已绑定到其它工作区的 IM 会话必须排除：它的 folder/created_by 仍停留在渠道
+  // 账号归属人，若只按 folder + owner 合并，别的工作区的对话会出现在账号归属人
+  // 的 Home 历史里。
   const queryJids = [jid];
   if (group.is_home) {
     const siblingJids = getJidsByFolder(group.folder);
@@ -2373,9 +2377,14 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
       if (!siblingGroup) continue;
       const ownerMatch =
         group.created_by && siblingGroup.created_by === group.created_by;
-      if (ownerMatch) {
-        queryJids.push(siblingJid);
-      }
+      if (!ownerMatch) continue;
+      const boundJid = resolveBoundWorkspaceJid(siblingJid, {
+        getRegisteredGroup,
+        getAgent,
+        getJidsByFolder,
+      });
+      if (boundJid && boundJid !== jid) continue;
+      queryJids.push(siblingJid);
     }
   }
 

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -1,7 +1,10 @@
 import { Hono } from 'hono';
 import type { Variables } from '../web-context.js';
 import { authMiddleware } from '../middleware/auth.js';
-import { resolveBoundWorkspaceJid } from '../workspace-attribution.js';
+import {
+  hasBoundWorkspaceReference,
+  resolveBoundWorkspaceJid,
+} from '../workspace-attribution.js';
 import {
   GroupAgentProfilePatchSchema,
   GroupCreateSchema,
@@ -34,6 +37,7 @@ import {
   getAllRegisteredGroups,
   getAllChats,
   getJidsByFolder,
+  getChannelMount,
   updateChatName,
   deleteSession,
   deleteWorkspaceSessions,
@@ -2378,12 +2382,19 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
       const ownerMatch =
         group.created_by && siblingGroup.created_by === group.created_by;
       if (!ownerMatch) continue;
-      const boundJid = resolveBoundWorkspaceJid(siblingJid, {
+      const attributionDeps = {
         getRegisteredGroup,
         getAgent,
         getJidsByFolder,
-      });
-      if (boundJid && boundJid !== jid) continue;
+        getChannelMount,
+      };
+      const boundJid = resolveBoundWorkspaceJid(siblingJid, attributionDeps);
+      if (
+        (boundJid && boundJid !== jid) ||
+        (!boundJid && hasBoundWorkspaceReference(siblingJid, attributionDeps))
+      ) {
+        continue;
+      }
       queryJids.push(siblingJid);
     }
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -89,6 +89,7 @@ import {
   setMessageFollowUp,
 } from './db.js';
 import { getGroupAllowedUserIds } from './group-broadcast-acl.js';
+import { resolveBoundWorkspaceJid } from './workspace-attribution.js';
 import { markdownToPlainText } from './im-utils.js';
 import { isSessionExpired } from './auth.js';
 import type {
@@ -2215,15 +2216,27 @@ function isHostGroupJid(chatJid: string): boolean {
 
 /**
  * Normalize chatJid for WebSocket broadcasts.
- * IM groups (Feishu/Telegram) that share a folder with an is_home group are mapped
- * to that home group's web JID so the frontend can match all home-session events.
+ *
+ * A bound IM chat resolves to the workspace it is actually bound to. The
+ * folder scan below is only a fallback for unbound chats: an IM row keeps the
+ * `folder`/`created_by` of the channel account owner even after it is bound
+ * elsewhere, so scanning by folder would label another workspace's events with
+ * the account owner's home JID and surface them in the wrong client.
  */
 function normalizeHomeJid(chatJid: string): string {
   if (chatJid.startsWith('web:')) return chatJid;
   const group = getRegisteredGroup(chatJid);
   if (!group) return chatJid;
 
-  // Find the web: JID that shares this folder (typically the is_home group)
+  const boundJid = resolveBoundWorkspaceJid(chatJid, {
+    getRegisteredGroup,
+    getAgent,
+    getJidsByFolder,
+  });
+  if (boundJid) return boundJid;
+
+  // Unbound IM chat: fall back to the web: JID sharing this folder (typically
+  // the is_home group), which is where its messages are still attributed.
   const jids = getJidsByFolder(group.folder);
   for (const jid of jids) {
     if (jid.startsWith('web:')) {

--- a/src/web.ts
+++ b/src/web.ts
@@ -77,6 +77,7 @@ import {
 import {
   ensureChatExists,
   getRegisteredGroup,
+  getChannelMount,
   getJidsByFolder,
   storeMessageDirect,
   deleteUserSession,
@@ -89,7 +90,10 @@ import {
   setMessageFollowUp,
 } from './db.js';
 import { getGroupAllowedUserIds } from './group-broadcast-acl.js';
-import { resolveBoundWorkspaceJid } from './workspace-attribution.js';
+import {
+  hasBoundWorkspaceReference,
+  resolveBoundWorkspaceJid,
+} from './workspace-attribution.js';
 import { markdownToPlainText } from './im-utils.js';
 import { isSessionExpired } from './auth.js';
 import type {
@@ -2228,12 +2232,15 @@ function normalizeHomeJid(chatJid: string): string {
   const group = getRegisteredGroup(chatJid);
   if (!group) return chatJid;
 
-  const boundJid = resolveBoundWorkspaceJid(chatJid, {
+  const attributionDeps = {
     getRegisteredGroup,
     getAgent,
     getJidsByFolder,
-  });
+    getChannelMount,
+  };
+  const boundJid = resolveBoundWorkspaceJid(chatJid, attributionDeps);
   if (boundJid) return boundJid;
+  if (hasBoundWorkspaceReference(chatJid, attributionDeps)) return chatJid;
 
   // Unbound IM chat: fall back to the web: JID sharing this folder (typically
   // the is_home group), which is where its messages are still attributed.

--- a/src/workspace-attribution.ts
+++ b/src/workspace-attribution.ts
@@ -1,4 +1,4 @@
-import type { RegisteredGroup } from './types.js';
+import type { ChannelMount, RegisteredGroup } from './types.js';
 
 /**
  * Dependencies for resolving where a channel chat's output belongs.
@@ -8,6 +8,9 @@ export interface WorkspaceAttributionDeps {
   getRegisteredGroup: (jid: string) => RegisteredGroup | null | undefined;
   getAgent: (agentId: string) => { chat_jid: string } | null | undefined;
   getJidsByFolder: (folder: string) => string[];
+  getChannelMount?: (
+    jid: string,
+  ) => Pick<ChannelMount, 'workspace_jid' | 'session_id'> | null | undefined;
 }
 
 /**
@@ -39,9 +42,9 @@ function foldLegacyWorkspaceJid(
  * owner. Unlike the inbound resolver this one never creates native-context
  * mounts or thread sessions — attribution must not mutate routing state.
  *
- * Reads the legacy `target_*` columns rather than `channel_mounts` because both
- * sides are dual-written during the mount migration and the columns are present
- * on the already-loaded group row.
+ * Normalized `channel_mounts` rows take precedence, matching inbound routing.
+ * The legacy `target_*` columns remain as a compatibility fallback while both
+ * projections are dual-written during the mount migration.
  *
  * Returns null when the chat has no binding, so callers keep their own fallback.
  */
@@ -53,6 +56,19 @@ export function resolveBoundWorkspaceJid(
 
   const group = deps.getRegisteredGroup(chatJid);
   if (!group) return null;
+
+  const mount = deps.getChannelMount?.(chatJid);
+  if (mount) {
+    if (mount.session_id) {
+      const session = deps.getAgent(mount.session_id);
+      return session?.chat_jid && deps.getRegisteredGroup(session.chat_jid)
+        ? session.chat_jid
+        : null;
+    }
+    return deps.getRegisteredGroup(mount.workspace_jid)
+      ? mount.workspace_jid
+      : null;
+  }
 
   // Session binding takes priority, matching resolveEffectiveChatJid. The
   // agent's chat_jid is its parent workspace JID; the `#agent:` suffix is
@@ -67,4 +83,15 @@ export function resolveBoundWorkspaceJid(
   }
 
   return null;
+}
+
+/** Whether a chat declares a binding even when its target is currently stale. */
+export function hasBoundWorkspaceReference(
+  chatJid: string,
+  deps: WorkspaceAttributionDeps,
+): boolean {
+  if (chatJid.startsWith('web:')) return false;
+  if (deps.getChannelMount?.(chatJid)) return true;
+  const group = deps.getRegisteredGroup(chatJid);
+  return !!(group?.target_agent_id || group?.target_main_jid);
 }

--- a/src/workspace-attribution.ts
+++ b/src/workspace-attribution.ts
@@ -1,0 +1,70 @@
+import type { RegisteredGroup } from './types.js';
+
+/**
+ * Dependencies for resolving where a channel chat's output belongs.
+ * Injected so this module stays side-effect free and unit-testable.
+ */
+export interface WorkspaceAttributionDeps {
+  getRegisteredGroup: (jid: string) => RegisteredGroup | null | undefined;
+  getAgent: (agentId: string) => { chat_jid: string } | null | undefined;
+  getJidsByFolder: (folder: string) => string[];
+}
+
+/**
+ * Legacy compatibility fold: historical rows sometimes stored `target_main_jid`
+ * as `web:{folder}` instead of the registered `web:{uuid}` workspace JID.
+ * Mirrors `resolveWorkspaceJid` in ./channel-mount-service.ts, duplicated here
+ * so pure output-routing modules do not have to import the mount service.
+ */
+function foldLegacyWorkspaceJid(
+  workspaceJid: string,
+  deps: WorkspaceAttributionDeps,
+): string | null {
+  if (deps.getRegisteredGroup(workspaceJid)) return workspaceJid;
+  if (!workspaceJid.startsWith('web:')) return null;
+  const folder = workspaceJid.slice(4);
+  for (const jid of deps.getJidsByFolder(folder)) {
+    if (jid.startsWith('web:') && deps.getRegisteredGroup(jid)) return jid;
+  }
+  return null;
+}
+
+/**
+ * Resolve the logical workspace JID a channel chat is bound to.
+ *
+ * This is the outbound counterpart of `resolveEffectiveChatJid`: it applies the
+ * same binding precedence (session binding wins over workspace binding) so a
+ * reply is attributed to the workspace that actually produced it, instead of to
+ * the IM row whose `folder`/`created_by` still point at the channel account
+ * owner. Unlike the inbound resolver this one never creates native-context
+ * mounts or thread sessions — attribution must not mutate routing state.
+ *
+ * Reads the legacy `target_*` columns rather than `channel_mounts` because both
+ * sides are dual-written during the mount migration and the columns are present
+ * on the already-loaded group row.
+ *
+ * Returns null when the chat has no binding, so callers keep their own fallback.
+ */
+export function resolveBoundWorkspaceJid(
+  chatJid: string,
+  deps: WorkspaceAttributionDeps,
+): string | null {
+  if (chatJid.startsWith('web:')) return chatJid;
+
+  const group = deps.getRegisteredGroup(chatJid);
+  if (!group) return null;
+
+  // Session binding takes priority, matching resolveEffectiveChatJid. The
+  // agent's chat_jid is its parent workspace JID; the `#agent:` suffix is
+  // composed by the caller so this helper stays suffix-agnostic.
+  if (group.target_agent_id) {
+    const agent = deps.getAgent(group.target_agent_id);
+    return agent?.chat_jid ?? null;
+  }
+
+  if (group.target_main_jid) {
+    return foldLegacyWorkspaceJid(group.target_main_jid, deps);
+  }
+
+  return null;
+}

--- a/tests/channel-outbox-runtime-scope.test.ts
+++ b/tests/channel-outbox-runtime-scope.test.ts
@@ -54,6 +54,7 @@ describe('active channel outbox scope', () => {
       ...base,
       turnRunId: 'turn-current',
       inputTurnId: 'input-current',
+      logicalBaseChatJid: 'web:workspace-at-admission',
       owner: 'owner-current',
     });
 
@@ -71,6 +72,10 @@ describe('active channel outbox scope', () => {
       registry.resolveInput('workspace', 'input-current', base.sourceJid)
         ?.token,
     ).toBe(current.token);
+    expect(
+      registry.resolveInput('workspace', 'input-current', base.sourceJid)
+        ?.logicalBaseChatJid,
+    ).toBe('web:workspace-at-admission');
     expect(
       registry.resolveInput('workspace', 'input-missing', base.sourceJid),
     ).toBeNull();

--- a/tests/group-broadcast-acl.test.ts
+++ b/tests/group-broadcast-acl.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ChannelMount, RegisteredGroup } from '../src/types.js';
+
+const state = vi.hoisted(() => ({
+  groups: new Map<string, RegisteredGroup>(),
+  agents: new Map<string, { chat_jid: string }>(),
+  mounts: new Map<string, Pick<ChannelMount, 'workspace_jid' | 'session_id'>>(),
+}));
+
+vi.mock('../src/db.js', () => ({
+  getRegisteredGroup: (jid: string) => state.groups.get(jid),
+  getAgent: (id: string) => state.agents.get(id),
+  getChannelMount: (jid: string) => state.mounts.get(jid),
+  getJidsByFolder: (folder: string) =>
+    [...state.groups.entries()]
+      .filter(([, group]) => group.folder === folder)
+      .map(([jid]) => jid),
+}));
+
+const { getGroupAllowedUserIds } =
+  await import('../src/group-broadcast-acl.js');
+
+function group(
+  jid: string,
+  folder: string,
+  createdBy?: string,
+  extra: Partial<RegisteredGroup> = {},
+): RegisteredGroup {
+  return {
+    jid,
+    name: jid,
+    folder,
+    added_at: '2026-01-01T00:00:00.000Z',
+    created_by: createdBy,
+    ...extra,
+  } as RegisteredGroup;
+}
+
+describe('group broadcast attribution ACL', () => {
+  beforeEach(() => {
+    state.groups.clear();
+    state.agents.clear();
+    state.mounts.clear();
+  });
+
+  test('observes a workspace rebind and owner transfer immediately', () => {
+    const imJid = 'qq:c2c:rebind';
+    state.groups.set(
+      imJid,
+      group(imJid, 'owner-home', 'channel-owner', {
+        target_main_jid: 'web:workspace-a',
+      }),
+    );
+    state.groups.set(
+      'web:workspace-a',
+      group('web:workspace-a', 'workspace-a', 'owner-a'),
+    );
+    state.groups.set(
+      'web:workspace-b',
+      group('web:workspace-b', 'workspace-b', 'owner-b'),
+    );
+    state.mounts.set(imJid, {
+      workspace_jid: 'web:workspace-a',
+      session_id: null,
+    });
+
+    expect([...getGroupAllowedUserIds(imJid)!]).toEqual(['owner-a']);
+
+    state.mounts.set(imJid, {
+      workspace_jid: 'web:workspace-b',
+      session_id: null,
+    });
+    expect([...getGroupAllowedUserIds(imJid)!]).toEqual(['owner-b']);
+
+    state.groups.set('web:workspace-b', {
+      ...state.groups.get('web:workspace-b')!,
+      created_by: 'owner-b-next',
+    });
+    expect([...getGroupAllowedUserIds(imJid)!]).toEqual(['owner-b-next']);
+  });
+
+  test('fails closed when a bound workspace has no owner', () => {
+    const imJid = 'qq:c2c:ownerless-target';
+    state.groups.set(
+      'web:channel-home',
+      group('web:channel-home', 'channel-home', 'channel-owner', {
+        is_home: true,
+      }),
+    );
+    state.groups.set(
+      imJid,
+      group(imJid, 'channel-home', 'channel-owner', {
+        target_main_jid: 'web:legacy-target',
+      }),
+    );
+    state.groups.set(
+      'web:legacy-target',
+      group('web:legacy-target', 'legacy-target'),
+    );
+
+    expect(getGroupAllowedUserIds(imJid)).toBeNull();
+  });
+
+  test('fails closed for a stale declared binding', () => {
+    const imJid = 'qq:c2c:stale-target';
+    state.groups.set(
+      'web:channel-home',
+      group('web:channel-home', 'channel-home', 'channel-owner', {
+        is_home: true,
+      }),
+    );
+    state.groups.set(
+      imJid,
+      group(imJid, 'channel-home', 'channel-owner', {
+        target_main_jid: 'web:deleted-workspace',
+      }),
+    );
+
+    expect(getGroupAllowedUserIds(imJid)).toBeNull();
+  });
+
+  test('keeps the folder fallback for genuinely unbound legacy IM rows', () => {
+    const imJid = 'qq:c2c:legacy-unbound';
+    state.groups.set(
+      'web:legacy-home',
+      group('web:legacy-home', 'legacy-home', 'legacy-owner', {
+        is_home: true,
+      }),
+    );
+    state.groups.set(imJid, group(imJid, 'legacy-home'));
+
+    expect([...getGroupAllowedUserIds(imJid)!]).toEqual(['legacy-owner']);
+  });
+});

--- a/tests/host-ipc-output-router.test.ts
+++ b/tests/host-ipc-output-router.test.ts
@@ -79,6 +79,28 @@ describe('host IPC primary output routing', () => {
     ).toBe('qq:c2c:CHAT_UNBOUND');
   });
 
+  test('keeps delayed text and image output in the workspace frozen for the turn', () => {
+    // The chat was admitted under ws-a, then rebound to ws-b while the model
+    // was still working. Both IPC paths call this helper and must prefer the
+    // immutable runtime scope over the output-time binding lookup.
+    const reboundWorkspace = () => 'web:ws-b';
+    const delayedTextJid = resolveHostIpcLogicalChatJid({
+      sourceChatJid: 'qq:c2c:CHAT_A',
+      scheduledTask: false,
+      runtimeChatJid: 'web:ws-a',
+      resolveWorkspaceJid: reboundWorkspace,
+    });
+    const delayedImageJid = resolveHostIpcLogicalChatJid({
+      sourceChatJid: 'qq:c2c:CHAT_A',
+      scheduledTask: false,
+      runtimeChatJid: 'web:ws-a',
+      resolveWorkspaceJid: reboundWorkspace,
+    });
+
+    expect(delayedTextJid).toBe('web:ws-a');
+    expect(delayedImageJid).toBe('web:ws-a');
+  });
+
   test('stages a custom-agent final in its exact scope without a separate provider send', async () => {
     const activeTurnOutputs = new ActiveTurnOutputRegistry();
     const projectedFinal = vi.fn(() => true);

--- a/tests/host-ipc-output-router.test.ts
+++ b/tests/host-ipc-output-router.test.ts
@@ -28,6 +28,57 @@ describe('host IPC primary output routing', () => {
     ).toBe('web:workspace#task:task-run-1');
   });
 
+  test('attributes a bound IM chat output to its workspace, not the IM row', () => {
+    // The runner reports channelContext.sourceJid, so without the fold this
+    // reply would be stored under the IM row whose folder/created_by still
+    // belong to the channel account owner.
+    const resolveWorkspaceJid = (chatJid: string) =>
+      chatJid === 'qq:c2c:CHAT_A' ? 'web:ws-b' : null;
+
+    expect(
+      resolveHostIpcLogicalChatJid({
+        sourceChatJid: 'qq:c2c:CHAT_A',
+        scheduledTask: false,
+        resolveWorkspaceJid,
+      }),
+    ).toBe('web:ws-b');
+    expect(
+      resolveHostIpcLogicalChatJid({
+        sourceChatJid: 'qq:c2c:CHAT_A',
+        taskRunId: 'task-run-2',
+        scheduledTask: true,
+        resolveWorkspaceJid,
+      }),
+    ).toBe('web:ws-b#task:task-run-2');
+    // An explicit agent JID still wins over the folded source.
+    expect(
+      resolveHostIpcLogicalChatJid({
+        sourceChatJid: 'qq:c2c:CHAT_A',
+        agentId: 'agent-1',
+        agentChatJid: 'web:ws-c',
+        scheduledTask: false,
+        resolveWorkspaceJid,
+      }),
+    ).toBe('web:ws-c#agent:agent-1');
+  });
+
+  test('keeps the raw source JID when the chat has no workspace binding', () => {
+    expect(
+      resolveHostIpcLogicalChatJid({
+        sourceChatJid: 'qq:c2c:CHAT_UNBOUND',
+        scheduledTask: false,
+        resolveWorkspaceJid: () => null,
+      }),
+    ).toBe('qq:c2c:CHAT_UNBOUND');
+    // No resolver injected at all (legacy call sites) must not change.
+    expect(
+      resolveHostIpcLogicalChatJid({
+        sourceChatJid: 'qq:c2c:CHAT_UNBOUND',
+        scheduledTask: false,
+      }),
+    ).toBe('qq:c2c:CHAT_UNBOUND');
+  });
+
   test('stages a custom-agent final in its exact scope without a separate provider send', async () => {
     const activeTurnOutputs = new ActiveTurnOutputRegistry();
     const projectedFinal = vi.fn(() => true);

--- a/tests/warm-channel-outbox-scope-correlation.test.ts
+++ b/tests/warm-channel-outbox-scope-correlation.test.ts
@@ -88,6 +88,7 @@ describe('warm channel outbox scope correlation', () => {
         turnRunId: runtime.runId,
         // What the fixed warm call sites pass explicitly.
         inputTurnId: ipcDeliveryId,
+        logicalBaseChatJid: 'web:workspace-at-admission',
         owner: 'owner-warm',
       });
 
@@ -97,6 +98,10 @@ describe('warm channel outbox scope correlation', () => {
       expect(registry.resolveToken('workspace', scope.token, c2cJid)).toEqual(
         scope,
       );
+      expect(
+        registry.resolveInput('workspace', ipcDeliveryId, c2cJid)
+          ?.logicalBaseChatJid,
+      ).toBe('web:workspace-at-admission');
     } finally {
       runtime.dispose();
     }
@@ -174,6 +179,7 @@ describe('warm channel outbox scope wiring contract', () => {
     expect(mainAdmission).toMatch(
       /bindChannelOutboxScope\(\s*mainAdmissionKey,[\s\S]*?\n\s*inputTurnId,\n\s*\);/,
     );
+    expect(mainAdmission).toMatch(/logicalBaseChatJid:\s*chatJid/);
     // The runtime itself stays on the native message id (durable idempotency).
     expect(mainAdmission).toMatch(
       /externalMessageId:\s*inputCursor\?\.id \?\? inputTurnId/,
@@ -230,5 +236,15 @@ describe('warm channel outbox scope wiring contract', () => {
     // `missing:<inputTurnId>` is the token shape that makes a correlation-key
     // mismatch distinguishable from a genuinely expired scope.
     expect(host).toMatch(/scopeToken:\s*scope\?\.token \?\? `missing:\$\{/);
+  });
+
+  test('text and image IPC projection both recover the frozen logical base', () => {
+    const host = read('src/index.ts');
+    expect(
+      host.match(/runtimeChatJid:\s*resolveIpcOutputRuntimeChatJid\(/g),
+    ).toHaveLength(2);
+    expect(host).toMatch(
+      /logicalBaseChatJid:\s*chatJid[\s\S]*?function resolveIpcOutputRuntimeChatJid/,
+    );
   });
 });

--- a/tests/workspace-attribution.test.ts
+++ b/tests/workspace-attribution.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'vitest';
+
+import { resolveBoundWorkspaceJid } from '../src/workspace-attribution.js';
+import type { RegisteredGroup } from '../src/types.js';
+
+const WORKSPACE_JID = 'web:ws-b';
+const HOME_JID = 'web:main';
+const IM_JID = 'qq:c2c:CHAT_A';
+
+function group(partial: Partial<RegisteredGroup>): RegisteredGroup {
+  return {
+    jid: 'web:unused',
+    name: 'unused',
+    folder: 'main',
+    ...partial,
+  } as RegisteredGroup;
+}
+
+/**
+ * The IM row deliberately keeps `folder: 'main'` and `created_by: 'u1'` — the
+ * channel account owner — while being bound to another user's workspace. That
+ * split is exactly the state the resolver has to see through.
+ */
+function makeDeps(overrides?: {
+  groups?: Record<string, RegisteredGroup>;
+  agents?: Record<string, { chat_jid: string }>;
+}) {
+  const groups: Record<string, RegisteredGroup> = overrides?.groups ?? {
+    [HOME_JID]: group({
+      jid: HOME_JID,
+      folder: 'main',
+      created_by: 'u1',
+      is_home: true,
+    }),
+    [WORKSPACE_JID]: group({
+      jid: WORKSPACE_JID,
+      folder: 'flow-x',
+      created_by: 'u2',
+    }),
+    [IM_JID]: group({
+      jid: IM_JID,
+      folder: 'main',
+      created_by: 'u1',
+      target_main_jid: WORKSPACE_JID,
+    }),
+  };
+  const agents = overrides?.agents ?? {};
+  return {
+    getRegisteredGroup: (jid: string) => groups[jid] ?? null,
+    getAgent: (agentId: string) => agents[agentId] ?? null,
+    getJidsByFolder: (folder: string) =>
+      Object.values(groups)
+        .filter((g) => g.folder === folder)
+        .map((g) => g.jid),
+  };
+}
+
+describe('resolveBoundWorkspaceJid', () => {
+  test('returns web JIDs unchanged without touching the registry', () => {
+    expect(resolveBoundWorkspaceJid(HOME_JID, makeDeps())).toBe(HOME_JID);
+  });
+
+  test('returns null for an unregistered chat', () => {
+    expect(resolveBoundWorkspaceJid('qq:c2c:UNKNOWN', makeDeps())).toBeNull();
+  });
+
+  test('follows a workspace binding instead of the IM row folder/owner', () => {
+    expect(resolveBoundWorkspaceJid(IM_JID, makeDeps())).toBe(WORKSPACE_JID);
+  });
+
+  test('returns null for an unbound IM chat so callers keep their fallback', () => {
+    const deps = makeDeps({
+      groups: {
+        [HOME_JID]: group({ jid: HOME_JID, created_by: 'u1', is_home: true }),
+        [IM_JID]: group({ jid: IM_JID, created_by: 'u1' }),
+      },
+    });
+    expect(resolveBoundWorkspaceJid(IM_JID, deps)).toBeNull();
+  });
+
+  test('folds a legacy web:{folder} binding to the registered workspace JID', () => {
+    const deps = makeDeps({
+      groups: {
+        [WORKSPACE_JID]: group({
+          jid: WORKSPACE_JID,
+          folder: 'flow-x',
+          created_by: 'u2',
+        }),
+        [IM_JID]: group({
+          jid: IM_JID,
+          created_by: 'u1',
+          // Historical shape: web:{folder} rather than the registered JID.
+          target_main_jid: 'web:flow-x',
+        }),
+      },
+    });
+    expect(resolveBoundWorkspaceJid(IM_JID, deps)).toBe(WORKSPACE_JID);
+  });
+
+  test('session binding wins over workspace binding', () => {
+    const deps = makeDeps({
+      groups: {
+        [WORKSPACE_JID]: group({ jid: WORKSPACE_JID, folder: 'flow-x' }),
+        'web:ws-c': group({ jid: 'web:ws-c', folder: 'flow-y' }),
+        [IM_JID]: group({
+          jid: IM_JID,
+          created_by: 'u1',
+          target_agent_id: 'agent-1',
+          target_main_jid: WORKSPACE_JID,
+        }),
+      },
+      agents: { 'agent-1': { chat_jid: 'web:ws-c' } },
+    });
+    expect(resolveBoundWorkspaceJid(IM_JID, deps)).toBe('web:ws-c');
+  });
+
+  test('returns null when the bound session no longer exists', () => {
+    const deps = makeDeps({
+      groups: {
+        [IM_JID]: group({
+          jid: IM_JID,
+          created_by: 'u1',
+          target_agent_id: 'agent-gone',
+          target_main_jid: WORKSPACE_JID,
+        }),
+      },
+      agents: {},
+    });
+    expect(resolveBoundWorkspaceJid(IM_JID, deps)).toBeNull();
+  });
+
+  test('returns null when the workspace binding is stale', () => {
+    const deps = makeDeps({
+      groups: {
+        [IM_JID]: group({
+          jid: IM_JID,
+          created_by: 'u1',
+          target_main_jid: 'web:deleted-workspace',
+        }),
+      },
+    });
+    expect(resolveBoundWorkspaceJid(IM_JID, deps)).toBeNull();
+  });
+});

--- a/tests/workspace-attribution.test.ts
+++ b/tests/workspace-attribution.test.ts
@@ -114,6 +114,47 @@ describe('resolveBoundWorkspaceJid', () => {
     expect(resolveBoundWorkspaceJid(IM_JID, deps)).toBe('web:ws-c');
   });
 
+  test('normalized channel mount takes precedence over legacy target columns', () => {
+    const deps = makeDeps({
+      groups: {
+        [WORKSPACE_JID]: group({ jid: WORKSPACE_JID, folder: 'flow-x' }),
+        'web:ws-c': group({ jid: 'web:ws-c', folder: 'flow-y' }),
+        [IM_JID]: group({
+          jid: IM_JID,
+          target_main_jid: WORKSPACE_JID,
+        }),
+      },
+    });
+    expect(
+      resolveBoundWorkspaceJid(IM_JID, {
+        ...deps,
+        getChannelMount: (jid) =>
+          jid === IM_JID
+            ? { workspace_jid: 'web:ws-c', session_id: null }
+            : null,
+      }),
+    ).toBe('web:ws-c');
+  });
+
+  test('normalized-only session mount resolves through the session owner workspace', () => {
+    const deps = makeDeps({
+      groups: {
+        [WORKSPACE_JID]: group({ jid: WORKSPACE_JID, folder: 'flow-x' }),
+        [IM_JID]: group({ jid: IM_JID, folder: 'channel-owner-home' }),
+      },
+      agents: { 'agent-1': { chat_jid: WORKSPACE_JID } },
+    });
+    expect(
+      resolveBoundWorkspaceJid(IM_JID, {
+        ...deps,
+        getChannelMount: (jid) =>
+          jid === IM_JID
+            ? { workspace_jid: WORKSPACE_JID, session_id: 'agent-1' }
+            : null,
+      }),
+    ).toBe(WORKSPACE_JID);
+  });
+
   test('returns null when the bound session no longer exists', () => {
     const deps = makeDeps({
       groups: {


### PR DESCRIPTION
## Problem

Binding an IM chat to another workspace routes **inbound** messages correctly, but the reply comes back attributed to the wrong workspace: a proactive `send_message` is persisted and broadcast under the IM row, so the conversation surfaces in the *channel account owner's* home session instead of the workspace that produced it.

## Root cause

Binding moves only `target_main_jid` (or `target_agent_id`). The IM chat row keeps the `folder` and `created_by` of the channel account owner. Inbound routing folds the IM JID to the bound workspace via `resolveEffectiveChatJid`, but nothing on the outbound or read side applied the symmetric fold — those paths derived attribution from `folder`/`created_by` directly:

- `resolveHostIpcLogicalChatJid` composed virtual suffixes straight onto the runner-supplied `channelContext.sourceJid`, i.e. the raw IM JID.
- The image path in the IPC watcher rebuilt the same suffix logic inline, so it drifted from the text path.
- `normalizeHomeJid` scanned by folder for a `web:` sibling, labelling the broadcast with the account owner's home JID.
- `getGroupAllowedUserIds` took `created_by` off the IM row, so the broadcast ACL was derived independently of the label — the two could disagree.
- The `is_home` sibling merge in `GET /:jid/messages` pulled in any same-folder, same-owner chat, including ones bound away.

## Change

New `src/workspace-attribution.ts` exports `resolveBoundWorkspaceJid`, the side-effect-free outbound counterpart of `resolveEffectiveChatJid`. It applies the same binding precedence (session binding wins over workspace binding) and carries the same legacy `web:{folder}` → `web:{uuid}` fold, but never creates native-context mounts or thread sessions — attribution must not mutate routing state. It returns `null` for unbound chats so every caller keeps its existing fallback.

Applied on both sides:

- `resolveHostIpcLogicalChatJid` takes an optional `resolveWorkspaceJid` callback and folds the source JID before composing `#agent:` / `#task:` suffixes. Dependency is injected rather than imported so the router stays pure.
- The image path now calls that same helper instead of rebuilding the suffix inline, removing the drift.
- `normalizeHomeJid` and `getGroupAllowedUserIds` both resolve the bound workspace first, so the broadcast label and its ACL come from one group.
- The home sibling merge skips chats bound to a different workspace.

Physical IM delivery is unchanged — it still routes through `resolveImRoute`. This only affects which logical workspace the output is stored and broadcast under. It reads the legacy `target_*` columns rather than `channel_mounts` because both sides are dual-written during the mount migration and the columns are already on the loaded group row.

## Tests

- New `tests/workspace-attribution.test.ts` — binding precedence, the legacy folder fold, `web:` passthrough, unknown/deleted groups, and unbound chats returning `null`.
- `tests/host-ipc-output-router.test.ts` gains cases for a bound chat with agent, task and plain suffixes, plus an unbound chat keeping the raw JID.

Verified the router case fails against unfixed source: checking `src/` out at `upstream/main` and re-running gives `expected 'qq:c2c:CHAT_A' to be 'web:ws-b'`.

## Verification

- `make typecheck`, `npm run docs:check`, `make build` pass.
- Full suite green: 330 files, 2817 tests.
- Rebuilt and restarted a live host-mode instance running in Proactive mode over an IM channel; proactive replies keep delivering normally against the rebuilt code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
