### PR TITLE
fix(ci): pass session identity to image smoke

### DIFF
--- a/scripts/smoke-agent-image.sh
+++ b/scripts/smoke-agent-image.sh
@@ -35,11 +35,42 @@ if [ -n "$EXPECTED_ARCHITECTURE" ]; then
   fi
 fi
 
+# GitHub's native Linux runners use a rootful Docker daemon, so the process
+# invoking docker is the authoritative host identity for this no-bind-mount
+# smoke. Pass the same explicit contract as the production container runner:
+# align node to a non-root host uid/gid, or use host-root when the caller is
+# actually root. Leaving the mode unset must remain fail-closed in entrypoint.
+smoke_host_uid="$(id -u)"
+smoke_host_gid="$(id -g)"
+case "$smoke_host_uid:$smoke_host_gid" in
+  *[!0-9:]* | *:*:*)
+    echo "Could not determine a numeric smoke host uid/gid" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$smoke_host_uid" -eq 0 ]; then
+  smoke_identity_args=(
+    --env HAPPYCLAW_HOST_IDENTITY_MODE=host-root
+  )
+else
+  smoke_identity_args=(
+    --env HAPPYCLAW_HOST_IDENTITY_MODE=direct
+    --env "HAPPYCLAW_HOST_UID=$smoke_host_uid"
+    --env "HAPPYCLAW_HOST_GID=$smoke_host_gid"
+  )
+fi
+
 # -i keeps stdin open while detached. The production entrypoint starts Chromium
 # first and then waits for the task JSON on stdin, giving the probe a stable
 # window without bypassing any real startup behavior.
 docker run --detach --interactive \
   --name "$SMOKE_CONTAINER_NAME" \
+  "${smoke_identity_args[@]}" \
+  --tmpfs /home/node/.claude:rw,nosuid,nodev,noexec \
+  --tmpfs /workspace/ipc:rw,nosuid,nodev,noexec \
+  --tmpfs /workspace/group:rw,nosuid,nodev \
+  --tmpfs /workspace/extra:rw,nosuid,nodev \
   "$IMAGE_REF" >/dev/null
 
 for ((attempt = 1; attempt <= SMOKE_TIMEOUT_SECONDS; attempt++)); do

--- a/tests/docker-publish-workflow-contract.test.ts
+++ b/tests/docker-publish-workflow-contract.test.ts
@@ -110,6 +110,21 @@ describe('Docker image distribution contract', () => {
 
     expect(smoke).toContain('docker run --detach --interactive');
     expect(smoke).not.toContain('--entrypoint');
+    expect(smoke).toContain('--env HAPPYCLAW_HOST_IDENTITY_MODE=host-root');
+    expect(smoke).toContain('--env HAPPYCLAW_HOST_IDENTITY_MODE=direct');
+    expect(smoke).toContain('--env "HAPPYCLAW_HOST_UID=$smoke_host_uid"');
+    expect(smoke).toContain('--env "HAPPYCLAW_HOST_GID=$smoke_host_gid"');
+    expect(smoke).toContain('"${smoke_identity_args[@]}"');
+    expect(smoke).not.toContain(
+      '--env HAPPYCLAW_HOST_IDENTITY_MODE=virtualized',
+    );
+    expect(smoke).not.toContain('--env HAPPYCLAW_HOST_IDENTITY_MODE=rootless');
+    expect(smoke).toContain(
+      '--tmpfs /home/node/.claude:rw,nosuid,nodev,noexec',
+    );
+    expect(smoke).toContain('--tmpfs /workspace/ipc:rw,nosuid,nodev,noexec');
+    expect(smoke).toContain('--tmpfs /workspace/group:rw,nosuid,nodev');
+    expect(smoke).toContain('--tmpfs /workspace/extra:rw,nosuid,nodev');
     expect(smoke).toContain(
       "docker image inspect --format '{{.Architecture}}'",
     );


### PR DESCRIPTION
## Summary

- pass the native Linux runner uid/gid to the production entrypoint during the image smoke
- use `host-root` only when the smoke caller is actually uid 0
- provide isolated tmpfs roots for the fixed production session mount layout
- keep an unset/unknown identity fail-closed

## Root cause

The image built and pushed successfully, but `scripts/smoke-agent-image.sh` invoked the hardened entrypoint without `HAPPYCLAW_HOST_IDENTITY_MODE`. Both native platform jobs therefore exited with `container identity could not be determined safely` before Chromium could start. Once identity is supplied, the hardened entrypoint also requires its fixed session roots; tmpfs provides those roots without exposing runner files.

## Verification

- real amd64 candidate `sha256:faa73cf54854eb229b22039e9b29f9e198c5c66c84298ed796807c4402c97c08`: Chromium `/json/version` HTTP probe passed
- same exact image without identity: exit 1 with fail-closed message
- 44 workflow/permission contract tests passed against the exact candidate
- `make typecheck`
- `npm run format:check`
- `bash -n scripts/smoke-agent-image.sh`
- `git diff --check`

The arm64 job uses the identical shell path on a native arm64 runner and remains covered by the workflow matrix; GitHub Actions after merge is the authoritative arm64 and promotion verification.