### PR TITLE
fix: keep idle streaming sessions alive until first stream event (#629)

### DIFF
--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -2650,7 +2650,7 @@ export class StreamingCardController {
       this.auxFlushCtrl = new FlushController(1500, 0);
       this.maxPatchFailures = 3;
 
-      logger.debug(
+      logger.info(
         { chatId: this.chatId, messageId, mode: 'streaming' },
         'Streaming card created via streaming mode',
       );
@@ -2685,7 +2685,7 @@ export class StreamingCardController {
       this.flushCtrl = new FlushController(1000, 50);
       this.maxPatchFailures = 3;
 
-      logger.debug(
+      logger.info(
         { chatId: this.chatId, messageId, mode: 'cardkit-v1' },
         'Streaming card created via CardKit v1',
       );
@@ -2738,7 +2738,7 @@ export class StreamingCardController {
         throw new Error('No message_id in response');
       }
 
-      logger.debug(
+      logger.info(
         { chatId: this.chatId, messageId: this.messageId, mode: 'legacy' },
         'Streaming card created via legacy path',
       );

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -92,6 +92,21 @@ export function isStreamingSessionSettled(session: StreamingSession): boolean {
   return (session as { currentState?: string }).currentState !== 'idle';
 }
 
+/**
+ * Append the current main-answer projection while the provider session can
+ * still accept output. Feishu is intentionally inactive while `idle`, so an
+ * `isActive()` guard alone would drop a text-only turn's first visible delta
+ * before `append()` can lazily create the provider card.
+ */
+export function appendStreamingSessionAnswer(
+  session: StreamingSession,
+  text: string,
+): boolean {
+  if (isStreamingSessionSettled(session)) return false;
+  session.append(text);
+  return true;
+}
+
 // ─── Unified Interface ──────────────────────────────────────────
 
 export interface IMChannelConnectOpts {

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -79,6 +79,19 @@ export type StreamingSession =
   | DiscordStreamingEditController
   | QQStreamingController;
 
+/**
+ * Whether a streaming session has settled into a terminal presentation state
+ * and may be rotated out. The Feishu controller reports `isActive() === false`
+ * while still `'idle'` (lazily-created card waiting for its first stream
+ * event); rotating it out at that point orphans the durable card reservation
+ * and the provider card never publishes. Controllers without a `currentState`
+ * accessor treat `'idle'` as active inside `isActive()` already.
+ */
+export function isStreamingSessionSettled(session: StreamingSession): boolean {
+  if (session.isActive()) return false;
+  return (session as { currentState?: string }).currentState !== 'idle';
+}
+
 // ─── Unified Interface ──────────────────────────────────────────
 
 export interface IMChannelConnectOpts {

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,7 @@ import { ChannelTurnRuntime } from './channel-turn-runtime.js';
 import { resolveStickyChannelOwner } from './channel-session-owner.js';
 import { migrateLegacyWhatsAppAuthDir } from './whatsapp.js';
 import {
+  appendStreamingSessionAnswer,
   getChannelType,
   extractChatId,
   isStreamingSessionSettled,
@@ -7329,11 +7330,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             }
             if (streamingSession) {
               const se = result.streamEvent;
-              if (
-                answerProjection?.visibleAnswerChanged &&
-                streamingSession.isActive()
-              ) {
-                streamingSession.append(
+              if (answerProjection?.visibleAnswerChanged) {
+                appendStreamingSessionAnswer(
+                  streamingSession,
                   heldCardBaseText() + answerProjection.visibleAnswerText,
                 );
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,7 @@ import { migrateLegacyWhatsAppAuthDir } from './whatsapp.js';
 import {
   getChannelType,
   extractChatId,
+  isStreamingSessionSettled,
   type StreamingSession,
   type ChannelMessageDeliveryOptions,
 } from './im-channel.js';
@@ -6798,7 +6799,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       // event activates B after A has reached its own terminal output.
       if (acceptedNewInput) return;
       if (newImJid === replySourceImJid) {
-        if (streamingSession && !streamingSession.isActive()) {
+        // 'idle' session 尚未发布任何 provider 卡片，保留给新 turn 懒创建；
+        // 只有已定稿（completed/aborted/error）的 session 才在此轮换（#629）。
+        if (streamingSession && isStreamingSessionSettled(streamingSession)) {
           streamingSession.dispose();
           unregisterStreamingSession(streamingSessionJid);
           streamingSession = undefined;
@@ -7299,9 +7302,13 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               streamingSession &&
               (streamingSession as { currentState?: string }).currentState ===
                 'error';
+            // isStreamingSessionSettled（而非裸 !isActive()）：飞书控制器在
+            // 'idle'（懒创建卡等待首个流事件）时 isActive() 也为 false，用裸
+            // 判断会在首个事件到达时就丢弃 session——beginCreation() 永远不会
+            // 执行，预留记录停在 creating 并在重启时被 fence（#629）。
             if (
               streamingSession &&
-              !streamingSession.isActive() &&
+              isStreamingSessionSettled(streamingSession) &&
               !sessionErrored &&
               !runEnded
             ) {

--- a/tests/streaming-session-idle-rotation.test.ts
+++ b/tests/streaming-session-idle-rotation.test.ts
@@ -1,8 +1,11 @@
 import fs from 'node:fs';
 
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
-import { isStreamingSessionSettled } from '../src/im-channel.js';
+import {
+  appendStreamingSessionAnswer,
+  isStreamingSessionSettled,
+} from '../src/im-channel.js';
 import { StreamingCardController } from '../src/feishu-streaming-card.js';
 
 // Regression coverage for issue #629: a freshly-created Feishu streaming
@@ -47,6 +50,108 @@ describe('isStreamingSessionSettled', () => {
   });
 });
 
+describe('appendStreamingSessionAnswer', () => {
+  test('a first main text delta starts an idle Feishu card and persists provider identity', async () => {
+    const lifecycleEvents: Array<{
+      status: string;
+      messageId: string | null;
+      cardId: string | null;
+      version: number;
+      snapshot: { state: string };
+    }> = [];
+    const cardCreate = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { card_id: 'card_idle_main_text' },
+    });
+    const messageCreate = vi.fn().mockResolvedValue({
+      data: { message_id: 'om_idle_main_text' },
+    });
+    const controller = new StreamingCardController({
+      client: {
+        cardkit: {
+          v1: {
+            card: {
+              create: cardCreate,
+              batchUpdate: vi.fn().mockResolvedValue({ code: 0 }),
+              settings: vi.fn().mockResolvedValue({ code: 0 }),
+              update: vi.fn().mockResolvedValue({ code: 0 }),
+            },
+            cardElement: {
+              content: vi.fn().mockResolvedValue({ code: 0 }),
+              update: vi.fn().mockResolvedValue({ code: 0 }),
+            },
+          },
+        },
+        im: {
+          message: {
+            reply: vi.fn().mockResolvedValue({
+              data: { message_id: 'om_idle_main_text' },
+            }),
+          },
+          v1: {
+            message: {
+              create: messageCreate,
+              patch: vi.fn().mockResolvedValue({}),
+            },
+          },
+        },
+      } as any,
+      chatId: 'oc_idle_main_text',
+      lifecycle: {
+        onEvent: (event) => lifecycleEvents.push(event),
+      },
+    });
+
+    expect(controller.currentState).toBe('idle');
+    expect(controller.isActive()).toBe(false);
+
+    expect(
+      appendStreamingSessionAnswer(controller, 'first visible answer'),
+    ).toBe(true);
+    expect(controller.currentState).toBe('creating');
+
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    expect(cardCreate).toHaveBeenCalledTimes(1);
+    expect(messageCreate).toHaveBeenCalledTimes(1);
+    expect(lifecycleEvents[0]).toMatchObject({
+      status: 'creating',
+      messageId: null,
+      cardId: null,
+      version: 0,
+    });
+    expect(lifecycleEvents).toContainEqual(
+      expect.objectContaining({
+        status: 'streaming',
+        messageId: 'om_idle_main_text',
+        cardId: 'card_idle_main_text',
+        version: 1,
+        snapshot: expect.objectContaining({ state: 'streaming' }),
+      }),
+    );
+    controller.dispose();
+  });
+
+  test('terminal sessions are not reactivated', () => {
+    for (const currentState of ['completed', 'aborted', 'error']) {
+      const append = vi.fn();
+      const session = { isActive: () => false, currentState, append };
+      expect(appendStreamingSessionAnswer(session as any, 'late text')).toBe(
+        false,
+      );
+      expect(append).not.toHaveBeenCalled();
+    }
+  });
+
+  test('other active controllers keep their previous append behavior', () => {
+    const append = vi.fn();
+    const session = { isActive: () => true, append };
+    expect(appendStreamingSessionAnswer(session as any, 'visible text')).toBe(
+      true,
+    );
+    expect(append).toHaveBeenCalledWith('visible text');
+  });
+});
+
 describe('main-runner rotation guards use the settled predicate', () => {
   const main = fs.readFileSync('src/index.ts', 'utf8');
 
@@ -65,6 +170,15 @@ describe('main-runner rotation guards use the settled predicate', () => {
     );
     expect(main).toMatch(
       /if \(streamingSession && isStreamingSessionSettled\(streamingSession\)\) \{\s*streamingSession\.dispose\(\);/,
+    );
+  });
+
+  test('main text projection uses the idle-aware append helper', () => {
+    expect(main).toMatch(
+      /if \(answerProjection\?\.visibleAnswerChanged\) \{\s*appendStreamingSessionAnswer\(\s*streamingSession,/,
+    );
+    expect(main).not.toMatch(
+      /answerProjection\?\.visibleAnswerChanged &&\s*streamingSession\.isActive\(\)/,
     );
   });
 });

--- a/tests/streaming-session-idle-rotation.test.ts
+++ b/tests/streaming-session-idle-rotation.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+
+import { describe, expect, test } from 'vitest';
+
+import { isStreamingSessionSettled } from '../src/im-channel.js';
+import { StreamingCardController } from '../src/feishu-streaming-card.js';
+
+// Regression coverage for issue #629: a freshly-created Feishu streaming
+// session sits in 'idle' (card reserved, provider creation deferred to the
+// first stream event). The main-runner rotation guard used a bare
+// `!isActive()` check, which matched 'idle' too — the session was discarded
+// on the very first stream event, beginCreation() never ran, and the durable
+// reservation stayed at status=creating until restart recovery fenced it.
+
+describe('isStreamingSessionSettled', () => {
+  test('a fresh Feishu controller is idle, inactive, and NOT settled', () => {
+    const controller = new StreamingCardController({
+      client: {} as any,
+      chatId: 'oc_idle_guard',
+    });
+    expect(controller.currentState).toBe('idle');
+    expect(controller.isActive()).toBe(false);
+    expect(isStreamingSessionSettled(controller)).toBe(false);
+    controller.dispose();
+  });
+
+  test('an active session is not settled', () => {
+    const session = {
+      isActive: () => true,
+      currentState: 'streaming',
+    };
+    expect(isStreamingSessionSettled(session as any)).toBe(false);
+  });
+
+  test('a terminal Feishu session is settled and may rotate out', () => {
+    for (const currentState of ['completed', 'aborted', 'error']) {
+      const session = { isActive: () => false, currentState };
+      expect(isStreamingSessionSettled(session as any)).toBe(true);
+    }
+  });
+
+  test('controllers without a currentState accessor keep prior semantics', () => {
+    // DingTalk / Discord / QQ controllers report 'idle' as active inside
+    // isActive() itself, so an inactive session there is genuinely terminal.
+    const session = { isActive: () => false };
+    expect(isStreamingSessionSettled(session as any)).toBe(true);
+  });
+});
+
+describe('main-runner rotation guards use the settled predicate', () => {
+  const main = fs.readFileSync('src/index.ts', 'utf8');
+
+  test('stream-event rotation never discards an idle lazily-created session', () => {
+    expect(main).toMatch(
+      /streamingSession &&\s*isStreamingSessionSettled\(streamingSession\) &&\s*!sessionErrored &&\s*!runEnded/,
+    );
+    expect(main).not.toMatch(
+      /streamingSession &&\s*!streamingSession\.isActive\(\) &&\s*!sessionErrored &&\s*!runEnded/,
+    );
+  });
+
+  test('new-message rotation keeps the idle session for the next turn', () => {
+    expect(main).not.toMatch(
+      /if \(streamingSession && !streamingSession\.isActive\(\)\) \{\s*streamingSession\.dispose\(\);/,
+    );
+    expect(main).toMatch(
+      /if \(streamingSession && isStreamingSessionSettled\(streamingSession\)\) \{\s*streamingSession\.dispose\(\);/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #629

## Root cause

The main-runner has two rotation guards that decide whether the current streaming session has finished and should be rotated out, both using a bare `!streamingSession.isActive()` check:

1. the per-stream-event rotation block (runs before every `feedStreamEventToCard()` call), and
2. the new-message rotation block in the route updater.

The Feishu `StreamingCardController` is the only provider controller whose `isActive()` excludes the `'idle'` state:

```ts
// feishu-streaming-card.ts
isActive(): boolean {
  return this.state === 'streaming' || this.state === 'creating';
}
```

The DingTalk / Discord / QQ controllers all treat `'idle'` as active. A fresh Feishu session starts in `'idle'` — the card is lazily created by `beginCreation()` on the first fed event (`setThinking()` / `appendThinking()` / `append()`). So on the **very first stream event of every run**, guard (1) saw an "inactive" session and discarded it (`streamingSession = undefined`, `activeDurableCardLifecycle = undefined`) before any event could be fed.

This explains every observation in the issue:

- `beginCreation()` never ran → neither its success path nor the `initial create failed` warn ever logged, and no CardKit API errors appeared;
- the durable `streaming_cards` reservation (written by `reserveStreamingCard()` before provider creation) stayed at `status=creating`, `revision=0`, empty `card_id`/`message_id`;
- on every restart, `channel-reliability-recovery.ts` fenced those orphaned reservations with the `no durable provider identity` ERROR;
- replies still arrived via the static terminal-card fallback, so nothing was lost — only the live panel and the meta row.

The regression came from commit 76e6ed9, which removed the session *rebuild* from that block but kept the `!isActive()` condition, silently widening it to cover the fresh `'idle'` state.

## Fix

- Add `isStreamingSessionSettled()` next to the `StreamingSession` union in `src/im-channel.ts`: a session may be rotated out only when it is inactive **and** not `'idle'`. Controllers without a `currentState` accessor (DingTalk / Discord / QQ) keep their previous semantics unchanged.
- Use it at both rotation sites in `src/index.ts`. Feishu `isActive()` itself is left untouched — widening it would break `rollbackIdleMainCardReservation()`, which relies on idle reservations reporting inactive so they can be rolled back after provider failures.
- Promote the three card-creation success logs (streaming mode / CardKit v1 / legacy) from `debug` to `info`, as requested in the issue, so the chosen backend level is visible in production logs.

## Tests

New `tests/streaming-session-idle-rotation.test.ts`:

- a freshly constructed `StreamingCardController` is `idle`, inactive, and **not** settled (the exact regression);
- terminal states (`completed`/`aborted`/`error`) are settled; sessions without `currentState` keep prior behavior;
- source-contract checks that both rotation guards in `src/index.ts` use the settled predicate instead of bare `!isActive()`.

Validation: `make typecheck`, `make build`, `make test` (2850 passed; the single failure, `backup-restore-safety.test.ts` hard-link case, also fails on a clean `upstream/main` checkout in this environment and is unrelated), `npm run docs:check`, `git diff --check`.