### PR TITLE
fix: make feishu-cli binary executable for the node runtime user

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -196,6 +196,8 @@ RUN set -eu && \
       > "$DOWNLOAD_TMP/checksum.txt" && \
     (cd "$DOWNLOAD_TMP" && sha256sum -c checksum.txt) && \
     tar -xzf "$DOWNLOAD_TMP/$ARCHIVE" --strip-components=1 -C /usr/local/bin && \
+    chown root:root /usr/local/bin/feishu-cli && \
+    chmod 755 /usr/local/bin/feishu-cli && \
     feishu-cli --version && \
     printf '%s\n' "$RELEASE_TAG" > /usr/local/share/feishu-cli-version && \
     rm -rf "$DOWNLOAD_TMP"


### PR DESCRIPTION
## Problem

`container/Dockerfile` installs `feishu-cli` by downloading and extracting the upstream release tarball as `root` during the image build. The release archive itself ships the binary owned by the CI build user (`uid 1001`) with mode `700` (owner-only read/execute).

- During build, `feishu-cli --version` is run as `root`, which bypasses file permission checks, so the build succeeds and hides the problem.
- At runtime, `entrypoint.sh` drops privileges to the `node` user (`uid 1000`) before running the agent. `node` is neither the file owner nor root, so it cannot read or execute `/usr/local/bin/feishu-cli` — every in-session `feishu-cli` invocation fails silently for agents.

Confirmed by inspecting the built image:

```
$ docker run --rm --entrypoint sh happyclaw-agent:latest -c "ls -la /usr/local/bin/feishu-cli"
-rwx------ 1 1001 1001 28829594 Jul 11 16:20 /usr/local/bin/feishu-cli
```

## Fix

Explicitly `chown root:root` + `chmod 755` the binary right after extraction, so its permissions no longer depend on whatever the upstream release archive happens to ship:

```
tar -xzf "$DOWNLOAD_TMP/$ARCHIVE" --strip-components=1 -C /usr/local/bin && \
chown root:root /usr/local/bin/feishu-cli && \
chmod 755 /usr/local/bin/feishu-cli && \
feishu-cli --version && \
...
```

## Test plan

- [x] Built the image with this Dockerfile change and confirmed `/usr/local/bin/feishu-cli` is now `755` / `root:root`
- [x] `su node -s /bin/sh -c 'feishu-cli --version'` succeeds inside the built image (previously failed with permission denied)
- [ ] CI image build/smoke test