### PR TITLE
修复: 飞书 P2P 首条注册与渠道路由 fail-closed

### DIFF
--- a/src/channel-admission.ts
+++ b/src/channel-admission.ts
@@ -119,6 +119,16 @@ export async function evaluateChannelAdmission(
  * A configured resolver owns routing authority. Its null means stale/invalid
  * binding and therefore fail-closed; only standalone connectors without a
  * resolver may persist directly under the source JID.
+ *
+ * im-manager wraps `resolver` per-account and throws ChannelRouteRejectedError
+ * instead of returning null for an unbound/unauthorized chat (see
+ * im-manager.ts). Every channel's own call site used to receive that throw
+ * unfiltered, so a rejected route fell through to whatever generic outer
+ * try/catch happened to wrap the caller instead of this function's own
+ * `null` contract — at best a misleading error log, at worst (Feishu's P2P
+ * bootstrap incident, 2026-08-04) skipping registration side effects that
+ * needed to run first. Catch it here once so every caller's `!resolvedRoute`
+ * branch is reliable regardless of whether the resolver is wrapped.
  */
 export function resolveAdmittedChannelRoute<TContext = undefined>(
   sourceJid: string,
@@ -126,6 +136,12 @@ export function resolveAdmittedChannelRoute<TContext = undefined>(
   context?: TContext,
 ): { targetJid: string; routing: ChannelRouteTarget | null } | null {
   if (!resolver) return { targetJid: sourceJid, routing: null };
-  const routing = resolver(sourceJid, context);
+  let routing: ChannelRouteTarget | null;
+  try {
+    routing = resolver(sourceJid, context);
+  } catch (err) {
+    if (!(err instanceof ChannelRouteRejectedError)) throw err;
+    return null;
+  }
   return routing ? { targetJid: routing.effectiveJid, routing } : null;
 }

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -606,9 +606,19 @@ function assertFeishuApiSuccess(operation: string, response: unknown): void {
     throw new Error(`${operation} returned no acknowledgement`);
   }
   const result = response as { code?: number; msg?: string };
-  if (result.code !== 0) {
+  // Some @larksuiteoapi/node-sdk endpoints (observed on im.v1.file.create)
+  // resolve with the unwrapped `data` payload instead of the {code,msg,data}
+  // envelope, so a missing `code` field is not itself a failure signal.
+  // Only a `code` that is explicitly present and non-zero is a reliable
+  // failure — log the raw response alongside it so a real failure is
+  // diagnosable instead of surfacing as "code=unknown".
+  if (result.code !== undefined && result.code !== 0) {
+    logger.error(
+      { operation, response },
+      'Feishu API call returned a non-zero code',
+    );
     throw new FeishuApiRejectedError(
-      `${operation} failed (code=${result.code ?? 'unknown'}, msg=${result.msg || 'unknown'})`,
+      `${operation} failed (code=${result.code}, msg=${result.msg || 'unknown'})`,
     );
   }
 }

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -35,7 +35,10 @@ import {
   stripLeadingBotMention,
   type MentionGateMention,
 } from './feishu-mention-gate.js';
-import { resolveAdmittedChannelRoute } from './channel-admission.js';
+import {
+  resolveAdmittedChannelRoute,
+  ChannelRouteRejectedError,
+} from './channel-admission.js';
 import {
   extractProviderTarget,
   parseChannelAddress,
@@ -2332,14 +2335,25 @@ export function createFeishuConnection(
       // onNewChat/onP2pSender are idempotent no-ops once already
       // registered, so calling them again in their normal position below
       // is safe and keeps this bootstrap narrowly scoped to P2P.
-      if (
-        chatType === 'p2p' &&
-        resolveEffectiveChatJid &&
-        !resolveEffectiveChatJid(chatJid)
-      ) {
-        onNewChat?.(chatJid, resolvedChatName);
-        if (senderOpenId && onP2pSender) {
-          onP2pSender(senderOpenId);
+      //
+      // resolveEffectiveChatJid is wrapped per-account by im-manager, which
+      // throws ChannelRouteRejectedError instead of returning null for an
+      // unbound chat (see im-manager.ts). A bare `!resolveEffectiveChatJid(...)`
+      // check never observes that falsy case — the throw unwinds straight to
+      // the outer catch below, onNewChat never runs, and the chat can never
+      // register. Treat that specific rejection the same as a null return.
+      if (chatType === 'p2p' && resolveEffectiveChatJid) {
+        let alreadyBound = false;
+        try {
+          alreadyBound = !!resolveEffectiveChatJid(chatJid);
+        } catch (err) {
+          if (!(err instanceof ChannelRouteRejectedError)) throw err;
+        }
+        if (!alreadyBound) {
+          onNewChat?.(chatJid, resolvedChatName);
+          if (senderOpenId && onP2pSender) {
+            onP2pSender(senderOpenId);
+          }
         }
       }
 
@@ -3280,6 +3294,30 @@ export function createFeishuConnection(
             logger.error(
               { err },
               'Error handling bot removed from group event',
+            );
+          }
+        },
+        // 用户点开与 bot 的单聊窗口时触发，早于第一条消息。趁这个事件预注册
+        // chat + owner，第一条 DM 到达时 resolveEffectiveChatJid 就已能正常
+        // 解析，不必再依赖 handleIncomingMessage 里的 P2P bootstrap 兜底
+        // （事件可能因权限未开通/漏投而不触发，bootstrap 兜底仍然保留）。
+        'im.chat.access_event.bot_p2p_chat_entered_v1': async (data) => {
+          try {
+            const chatId = data.chat_id;
+            if (!chatId) return;
+            const rawJid = `feishu:${chatId}`;
+            const chatJid =
+              connectOptions?.normalizeIncomingJid?.(rawJid) ?? rawJid;
+            logger.info({ chatJid }, 'User entered Feishu P2P chat with bot');
+            connectOptions?.onNewChat?.(chatJid, '飞书私聊');
+            const operatorOpenId = data.operator_id?.open_id;
+            if (operatorOpenId && connectOptions?.onP2pSender) {
+              connectOptions.onP2pSender(operatorOpenId);
+            }
+          } catch (err) {
+            logger.error(
+              { err },
+              'Error handling P2P chat entered event',
             );
           }
         },

--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -606,16 +606,14 @@ function assertFeishuApiSuccess(operation: string, response: unknown): void {
     throw new Error(`${operation} returned no acknowledgement`);
   }
   const result = response as { code?: number; msg?: string };
-  // Some @larksuiteoapi/node-sdk endpoints (observed on im.v1.file.create)
-  // resolve with the unwrapped `data` payload instead of the {code,msg,data}
-  // envelope, so a missing `code` field is not itself a failure signal.
-  // Only a `code` that is explicitly present and non-zero is a reliable
-  // failure — log the raw response alongside it so a real failure is
-  // diagnosable instead of surfacing as "code=unknown".
-  if (result.code !== undefined && result.code !== 0) {
+  // Message create/reply use the regular Feishu response envelope. Require an
+  // explicit success code so malformed or partial acknowledgements can never
+  // make the durable outbox believe an unsent message was delivered. Upload
+  // endpoints have a separate unwrapped-payload contract below.
+  if (result.code !== 0) {
     logger.error(
       { operation, response },
-      'Feishu API call returned a non-zero code',
+      'Feishu API acknowledgement did not contain an explicit success code',
     );
     throw new FeishuApiRejectedError(
       `${operation} failed (code=${result.code}, msg=${result.msg || 'unknown'})`,
@@ -3304,30 +3302,6 @@ export function createFeishuConnection(
             logger.error(
               { err },
               'Error handling bot removed from group event',
-            );
-          }
-        },
-        // 用户点开与 bot 的单聊窗口时触发，早于第一条消息。趁这个事件预注册
-        // chat + owner，第一条 DM 到达时 resolveEffectiveChatJid 就已能正常
-        // 解析，不必再依赖 handleIncomingMessage 里的 P2P bootstrap 兜底
-        // （事件可能因权限未开通/漏投而不触发，bootstrap 兜底仍然保留）。
-        'im.chat.access_event.bot_p2p_chat_entered_v1': async (data) => {
-          try {
-            const chatId = data.chat_id;
-            if (!chatId) return;
-            const rawJid = `feishu:${chatId}`;
-            const chatJid =
-              connectOptions?.normalizeIncomingJid?.(rawJid) ?? rawJid;
-            logger.info({ chatJid }, 'User entered Feishu P2P chat with bot');
-            connectOptions?.onNewChat?.(chatJid, '飞书私聊');
-            const operatorOpenId = data.operator_id?.open_id;
-            if (operatorOpenId && connectOptions?.onP2pSender) {
-              connectOptions.onP2pSender(operatorOpenId);
-            }
-          } catch (err) {
-            logger.error(
-              { err },
-              'Error handling P2P chat entered event',
             );
           }
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -18913,7 +18913,11 @@ function isGroupOwnerMessage(chatJid: string, senderImId?: string): boolean {
  * sender_allowlist 为 null/undefined 时不限制（默认），为空数组时无人可触发，
  * 为字符串数组时仅列表中的 open_id 可触发。
  */
-function isSenderAllowedInGroup(chatJid: string, senderImId?: string): boolean {
+function isSenderAllowedInGroup(
+  chatJid: string,
+  senderImId?: string,
+  getCurrentFeishuOwner?: () => string | undefined,
+): boolean {
   const conversationJid = channelConversationJid(
     stripVirtualJidSuffix(chatJid),
   );
@@ -18926,9 +18930,14 @@ function isSenderAllowedInGroup(chatJid: string, senderImId?: string): boolean {
     if (getChannelType(conversationJid) !== 'feishu') return false;
     const accountId = parseChannelAddress(conversationJid)?.channelAccountId;
     const account = accountId ? getChannelAccount(accountId) : undefined;
-    const knownOwner = account
-      ? getUserFeishuConfig(account.owner_user_id)?.ownerOpenId
-      : undefined;
+    // First-class and legacy connections pass the live account-local owner
+    // resolver. Falling back to a user-level owner for every Bot lets one
+    // account's identity leak into another account's first-DM admission.
+    const knownOwner = getCurrentFeishuOwner
+      ? getCurrentFeishuOwner()
+      : account?.is_legacy_default
+        ? getUserFeishuConfig(account.owner_user_id)?.ownerOpenId
+        : undefined;
     return isUnknownFeishuSenderAllowed(knownOwner, senderImId);
   }
 
@@ -19155,7 +19164,12 @@ async function reloadChannelAccountById(accountId: string): Promise<boolean> {
           resolveFeishuConversationPlan:
             resolveFeishuConversationPlanForMessage,
           isGroupOwnerMessage,
-          isSenderAllowedInGroup,
+          isSenderAllowedInGroup: (jid: string, sender?: string) =>
+            isSenderAllowedInGroup(
+              jid,
+              sender,
+              () => secret.ownerOpenId || undefined,
+            ),
           onFollowUpMessage: handleIncomingFollowUp,
           onFollowUpCardAction: handleFollowUpCardAction,
           onCardInterrupt: handleCardInterrupt,
@@ -20017,7 +20031,8 @@ async function main(): Promise<void> {
             resolveFeishuConversationPlan:
               resolveFeishuConversationPlanForMessage,
             isGroupOwnerMessage,
-            isSenderAllowedInGroup,
+            isSenderAllowedInGroup: (jid: string, sender?: string) =>
+              isSenderAllowedInGroup(jid, sender, getReloadOwnerOpenId),
             onFollowUpMessage: handleIncomingFollowUp,
             onFollowUpCardAction: handleFollowUpCardAction,
             onCardInterrupt: handleCardInterrupt,

--- a/tests/channel-admission.test.ts
+++ b/tests/channel-admission.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import { ChannelType } from 'discord.js';
 import {
+  ChannelRouteRejectedError,
   evaluateChannelAdmission,
   matchesChannelAccountAuthorization,
   matchesChannelPairTarget,
@@ -81,6 +82,30 @@ describe('channel admission', () => {
         agentId: 'session',
       },
     });
+  });
+
+  // Regression (2026-08-04): im-manager wraps a channel's resolveEffectiveChatJid
+  // per-account and throws ChannelRouteRejectedError instead of returning null
+  // for an unbound/unauthorized chat. Every channel calls this function
+  // directly with that wrapped resolver and branches on `!resolvedRoute` —
+  // if the throw isn't translated to null here, it escapes past that branch
+  // entirely and falls into whatever generic outer catch happens to wrap the
+  // caller (misleading "intake failed" logs, and in Feishu's P2P bootstrap
+  // path, skipped registration side effects — see feishu.ts commit fc828b4).
+  test('translates a wrapped resolver rejection into the same null contract as a direct null return', () => {
+    expect(
+      resolveAdmittedChannelRoute('discord:source', () => {
+        throw new ChannelRouteRejectedError('discord:source');
+      }),
+    ).toBeNull();
+  });
+
+  test('does not swallow errors unrelated to route rejection', () => {
+    expect(() =>
+      resolveAdmittedChannelRoute('discord:source', () => {
+        throw new Error('database unavailable');
+      }),
+    ).toThrow('database unavailable');
   });
 
   test('passes native context metadata to an authoritative resolver', () => {

--- a/tests/feishu-channel-account-owner.test.ts
+++ b/tests/feishu-channel-account-owner.test.ts
@@ -181,6 +181,9 @@ describe('Feishu owner discovery is per channel account', () => {
       'const ownerOpenId = secret.ownerOpenId ?? senderOpenId',
     );
     expect(reload).toMatch(
+      /isSenderAllowedInGroup:\s*\(jid: string, sender\?: string\) =>\s*isSenderAllowedInGroup\(\s*jid,\s*sender,\s*\(\) => secret\.ownerOpenId \|\| undefined,\s*\)/,
+    );
+    expect(reload).toMatch(
       /backfillEmptyAllowlistsForChannelAccount\(\s*account\.owner_user_id,\s*account\.id,\s*ownerOpenId,\s*\)/,
     );
     expect(reload).not.toContain('saveUserFeishuConfig');

--- a/tests/feishu-durable-inbox.test.ts
+++ b/tests/feishu-durable-inbox.test.ts
@@ -91,6 +91,8 @@ vi.mock('../src/logger.js', () => ({
 
 const db = await import('../src/db.js');
 const { createFeishuConnection } = await import('../src/feishu.js');
+const { ChannelRouteRejectedError } =
+  await import('../src/channel-admission.js');
 const { getChannelCursor, recordChannelInbox } =
   await import('../src/channel-reliability-store.js');
 
@@ -211,10 +213,115 @@ async function connect(
   const handler =
     controls.dispatchers[dispatcherIndex]?.['im.message.receive_v1'];
   expect(handler).toBeTypeOf('function');
-  return { connection, handler };
+  return {
+    connection,
+    handler,
+    handlers: controls.dispatchers[dispatcherIndex]!,
+  };
 }
 
 describe('Feishu durable Inbox and cursor integration', () => {
+  test('bootstraps the first P2P DM after an account-scoped route rejection', async () => {
+    const accountId = `account-first-dm-${Date.now()}`;
+    const executed = vi.fn();
+    const onNewChat = vi.fn();
+    const onP2pSender = vi.fn();
+    let registered = false;
+    onNewChat.mockImplementation(() => {
+      registered = true;
+    });
+    const resolveEffectiveChatJid = vi.fn((jid: string) => {
+      if (!registered) throw new ChannelRouteRejectedError(jid);
+      return {
+        effectiveJid: 'web:durable-feishu-test',
+        agentId: null,
+        sourceJid: jid,
+      };
+    });
+    const connected = await connect(accountId, executed, {
+      normalizeIncomingJid: (jid) => `${jid}#account:${accountId}`,
+      resolveEffectiveChatJid,
+      isSenderAllowedInGroup: () => true,
+      onNewChat,
+      onP2pSender,
+    });
+
+    await connected.handler(event('om_first_dm', Date.now(), 'hello'));
+
+    expect(resolveEffectiveChatJid).toHaveBeenCalledTimes(2);
+    expect(resolveEffectiveChatJid).toHaveBeenNthCalledWith(
+      1,
+      `feishu:ou_durable_user#account:${accountId}`,
+    );
+    expect(onNewChat).toHaveBeenCalledWith(
+      `feishu:ou_durable_user#account:${accountId}`,
+      '飞书私聊',
+    );
+    expect(onP2pSender).toHaveBeenCalledWith('ou_durable_user');
+    expect(executed).toHaveBeenCalledWith('om_first_dm');
+  });
+
+  test('rejects a known-owner mismatch before P2P registration or routing', async () => {
+    const accountId = `account-owner-gate-${Date.now()}`;
+    const executed = vi.fn();
+    const onNewChat = vi.fn();
+    const onP2pSender = vi.fn();
+    const resolveEffectiveChatJid = vi.fn();
+    const connected = await connect(accountId, executed, {
+      normalizeIncomingJid: (jid) => `${jid}#account:${accountId}`,
+      resolveEffectiveChatJid,
+      isSenderAllowedInGroup: (_jid, sender) => sender === 'ou_owner',
+      onNewChat,
+      onP2pSender,
+    });
+
+    await connected.handler(
+      event('om_non_owner_first_dm', Date.now(), 'not the owner'),
+    );
+
+    expect(onNewChat).not.toHaveBeenCalled();
+    expect(onP2pSender).not.toHaveBeenCalled();
+    expect(resolveEffectiveChatJid).not.toHaveBeenCalled();
+    expect(executed).not.toHaveBeenCalled();
+  });
+
+  test('does not bootstrap P2P registration after an unrelated route failure', async () => {
+    const accountId = `account-route-error-${Date.now()}`;
+    const executed = vi.fn();
+    const onNewChat = vi.fn();
+    const onP2pSender = vi.fn();
+    const resolveEffectiveChatJid = vi.fn(() => {
+      throw new Error('route storage unavailable');
+    });
+    const connected = await connect(accountId, executed, {
+      resolveEffectiveChatJid,
+      isSenderAllowedInGroup: () => true,
+      onNewChat,
+      onP2pSender,
+    });
+
+    await connected.handler(
+      event('om_route_error', Date.now(), 'do not register'),
+    );
+
+    expect(resolveEffectiveChatJid).toHaveBeenCalledTimes(1);
+    expect(onNewChat).not.toHaveBeenCalled();
+    expect(onP2pSender).not.toHaveBeenCalled();
+    expect(executed).not.toHaveBeenCalled();
+  });
+
+  test('does not register an owner merely because a user opens the P2P chat', async () => {
+    const accountId = `account-no-enter-claim-${Date.now()}`;
+    const connected = await connect(accountId, vi.fn(), {
+      onNewChat: vi.fn(),
+      onP2pSender: vi.fn(),
+    });
+
+    expect(
+      connected.handlers['im.chat.access_event.bot_p2p_chat_entered_v1'],
+    ).toBeUndefined();
+  });
+
   test('recovery gate queues a live event and executes it only after the gate opens', async () => {
     const accountId = `account-recovery-gate-${Date.now()}`;
     const executed = vi.fn();

--- a/tests/feishu-route-safety.test.ts
+++ b/tests/feishu-route-safety.test.ts
@@ -30,7 +30,7 @@ describe('Feishu route safety integration', () => {
     // forever. See channel-admission.ts's "pairing establishes ownership
     // before routing" contract.
     const bootstrapIdx = source.indexOf(
-      "chatType === 'p2p' &&\n        resolveEffectiveChatJid &&\n        !resolveEffectiveChatJid(chatJid)",
+      "if (chatType === 'p2p' && resolveEffectiveChatJid) {",
     );
     const routeCheckIdx = source.indexOf(
       'resolveAdmittedChannelRoute<FeishuMessageMeta>',
@@ -39,5 +39,33 @@ describe('Feishu route safety integration', () => {
     expect(bootstrapIdx).toBeGreaterThan(-1);
     expect(routeCheckIdx).toBeGreaterThan(-1);
     expect(bootstrapIdx).toBeLessThan(routeCheckIdx);
+  });
+
+  test('bootstrap swallows only ChannelRouteRejectedError from the per-account resolveEffectiveChatJid wrapper', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/feishu.ts'),
+      'utf8',
+    );
+
+    // im-manager wraps resolveEffectiveChatJid per-account and throws
+    // ChannelRouteRejectedError instead of returning null for an unbound
+    // chat. A bare `!resolveEffectiveChatJid(...)` truthiness check never
+    // observes that case — the throw unwinds past the bootstrap block
+    // straight to the outer catch, onNewChat never runs, and the chat can
+    // never register (every first DM permanently fails-closed). The
+    // bootstrap must catch that specific error and treat it as "not yet
+    // registered", while still rethrowing anything else.
+    expect(source).toContain(
+      "import {\n  resolveAdmittedChannelRoute,\n  ChannelRouteRejectedError,\n} from './channel-admission.js';",
+    );
+    const bootstrapIdx = source.indexOf(
+      "if (chatType === 'p2p' && resolveEffectiveChatJid) {",
+    );
+    expect(bootstrapIdx).toBeGreaterThan(-1);
+    const catchIdx = source.indexOf(
+      'if (!(err instanceof ChannelRouteRejectedError)) throw err;',
+      bootstrapIdx,
+    );
+    expect(catchIdx).toBeGreaterThan(bootstrapIdx);
   });
 });

--- a/tests/im-send-strict-ack.test.ts
+++ b/tests/im-send-strict-ack.test.ts
@@ -410,6 +410,26 @@ describe('IM strict send acknowledgement', () => {
     ).rejects.toThrow('document denied');
   });
 
+  test('message create and reply require an explicit code=0 acknowledgement', async () => {
+    const { feishu } = await connectedTransports();
+
+    controls.feishuMessageCreate.mockResolvedValueOnce({});
+    await expect(
+      feishu.sendMessage('oc_1', 'create', undefined, {
+        presentation: 'native',
+      }),
+    ).rejects.toThrow('code=undefined');
+
+    controls.feishuMessageReply.mockResolvedValueOnce({
+      data: { message_id: 'om_unwrapped_reply' },
+    });
+    await expect(
+      feishu.sendMessage('oc_1#root:om_root', 'reply', undefined, {
+        presentation: 'native',
+      }),
+    ).rejects.toThrow('code=undefined');
+  });
+
   test('accepts SDK-unwrapped upload acknowledgements without code=0', async () => {
     const { feishu } = await connectedTransports();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'strict-im-ack-'));


### PR DESCRIPTION
## 修复内容

1. `resolveAdmittedChannelRoute` 将 `ChannelRouteRejectedError` 统一转换为 `null`，让各渠道调用方按 fail-closed 路径丢弃未授权消息，同时继续抛出非路由异常。
2. 飞书首条有效 P2P 消息遇到账号作用域 resolver 拒绝时，先完成安全 bootstrap，再重新解析路由，避免新私聊永久无法注册。
3. 未注册私聊的 audience 判断使用当前 channel account 自己的 owner；已配置 owner 的其他发送者会在注册、owner 学习和路由之前被拒绝，owner 未知时才允许首条有效 DM 认领。
4. 保持 `message.create/reply` 的严格 ACK 契约：必须显式返回 `code=0`；file/image 上传仍由独立的 upload-key 校验接受 SDK unwrapped payload。

## Review 修复

- 移除 `bot_p2p_chat_entered` 预注册，避免仅打开聊天窗口就抢占 owner。
- 增加真实 EventDispatcher/消息 handler 行为测试，覆盖首条 P2P bootstrap、普通路由异常不注册、known-owner 拒绝、entered 事件不认领。
- 增加 message create/reply 缺失 `code` 的严格拒绝测试。
- 修复 Prettier 格式错误。

## 本地验证

- `npm run format:check`
- `npm run typecheck`
- 6 个相关测试文件，57 条测试通过
- `npm run build:all`
- 完整套件并行运行 2913/2916 通过；3 条无关既有时序/超时用例单独串行复跑 93/93 通过，最终以 GitHub CI 干净环境为准。