### PR TITLE
fix(config): allow promoting a disabled provider to default

### DIFF
--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1412,11 +1412,18 @@ export function getDefaultProviderId(): string | null {
 export function setDefaultProvider(id: string): UnifiedProvider {
   const state = readStoredStateV4();
   if (!state) throw new Error('模型配置不存在');
-  const provider = state.providers.find((item) => item.id === id);
-  if (!provider) throw new Error('未找到指定模型配置');
-  if (!provider.enabled) throw new Error('默认模型配置必须处于启用状态');
-  writeStoredStateV4(state.providers, state.balancing, provider.id);
-  return provider;
+  const idx = state.providers.findIndex((item) => item.id === id);
+  if (idx < 0) throw new Error('未找到指定模型配置');
+  const provider = state.providers[idx];
+  // 默认模型是所有「跟随系统默认」Agent 的运行时兜底，必须处于启用状态。
+  // 这里在提升为默认时自动启用，而不是直接报错：用户可以把一个处于关闭状态
+  // 的备选模型一步设为默认，从而把原默认释放出来去禁用或删除，避免死结。
+  const next = provider.enabled
+    ? provider
+    : { ...provider, enabled: true, updatedAt: new Date().toISOString() };
+  if (!provider.enabled) state.providers[idx] = next;
+  writeStoredStateV4(state.providers, state.balancing, id);
+  return next;
 }
 
 export function getBalancingConfig(): BalancingConfig {

--- a/tests/runtime-config-default-provider.test.ts
+++ b/tests/runtime-config-default-provider.test.ts
@@ -139,4 +139,36 @@ describe('default model configuration', () => {
       defaultProviderId: firstEnabledId,
     });
   });
+
+  test('promoting a disabled provider to default auto-enables it', () => {
+    const primary = runtimeConfig.createProvider({
+      name: 'Auto-enable primary',
+      type: 'third_party',
+      anthropicBaseUrl: 'https://ae-primary.example.test',
+      anthropicAuthToken: 'ae-primary-token',
+      anthropicModel: 'ae-primary-model',
+      enabled: true,
+    });
+    runtimeConfig.setDefaultProvider(primary.id);
+    expect(runtimeConfig.getDefaultProviderId()).toBe(primary.id);
+
+    const alt = runtimeConfig.createProvider({
+      name: 'Auto-enable alt',
+      type: 'third_party',
+      anthropicBaseUrl: 'https://ae-alt.example.test',
+      anthropicAuthToken: 'ae-alt-token',
+      anthropicModel: 'ae-alt-model',
+      enabled: false,
+    });
+    expect(alt.enabled).toBe(false);
+
+    // 旧行为是抛错「默认模型配置必须处于启用状态」；现在应自动启用并设为默认，
+    // 从而把原默认释放出来去禁用或删除，避免死结。
+    const promoted = runtimeConfig.setDefaultProvider(alt.id);
+    expect(promoted.enabled).toBe(true);
+    expect(runtimeConfig.getDefaultProviderId()).toBe(alt.id);
+    expect(() =>
+      runtimeConfig.setProviderEnabled(primary.id, false),
+    ).not.toThrow();
+  });
 });

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -221,12 +221,17 @@ export function ProviderList({
                           provider.enabled ? '禁用模型配置' : '启用模型配置'
                         }
                       />
-                      {provider.enabled && !isDefault && (
+                      {!isDefault && (
                         <Button
                           size="sm"
                           variant="ghost"
                           onClick={() => onSetDefault(provider)}
                           disabled={disabled || toggling || deleting}
+                          title={
+                            provider.enabled
+                              ? undefined
+                              : '设为默认（将同时启用该模型）'
+                          }
                           className="h-7 px-2 text-xs"
                         >
                           <Star className="size-3.5" />


### PR DESCRIPTION
## 背景 / Problem

当前默认模型配置存在一个「死结」：

- `setDefaultProvider` 要求被提升为默认的模型必须已启用，否则抛错 `默认模型配置必须处于启用状态`。
- 但前端「设为默认」按钮的渲染条件是 `provider.enabled && !isDefault` —— **只对已启用的备选显示**。

于是当用户想把默认身份从一个模型转到另一个**处于关闭状态**的备选时：按钮看不到，就算调接口也会报错，无法把原默认释放出来去禁用或删除。

## 解决方案 / Solution

提升为默认时**自动启用**目标模型，而非报错。理由：默认模型是所有「跟随系统默认」(`model_config_id = null`) Agent 的运行时兜底，本就必须启用，自动启用是一步到位、符合直觉的行为。

改动：

- `src/runtime-config.ts` · `setDefaultProvider`：目标未启用时改为自动启用（沿用既有 `updatedAt` 字段，遵循不可变更新）。
- `web/src/components/settings/ProviderList.tsx`：「设为默认」按钮显示条件由 `provider.enabled && !isDefault` 放宽为 `!isDefault`；对关闭状态的备选加 tooltip `设为默认（将同时启用该模型）`。
- `tests/runtime-config-default-provider.test.ts`：新增 `promoting a disabled provider to default auto-enables it`，断言提升后 `enabled=true`、成为默认、且原默认可被正常禁用。

## 验证 / Verification

- 后端 `tsc --noEmit`：0 错误
- web `tsc --noEmit`：0 错误
- `tests/runtime-config-default-provider.test.ts`：5/5 通过

## 改动量

3 files changed, 50 insertions(+), 6 deletions(-)