### PR TITLE
fix(providers): sync macOS Keychain claudeAiOauth with pool-selected provider

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -43,7 +43,12 @@ import {
   resolveProviderById,
   shellQuoteEnvLines,
   writeCredentialsFile,
+  buildClaudeAiOauthPayload,
 } from './runtime-config.js';
+import {
+  removeClaudeKeychainOAuth,
+  syncClaudeKeychainOAuth,
+} from './macos-keychain-credentials.js';
 import { providerModelTier, providerPool } from './provider-pool.js';
 import type { ProviderTier } from './provider-pool.js';
 import {
@@ -2895,6 +2900,16 @@ export async function runHostAgent(
     }
     if (tierEnv.model) hostEnv['ANTHROPIC_MODEL'] = tierEnv.model;
 
+    // Resolve symlinks up front: this exact string becomes CLAUDE_CONFIG_DIR
+    // below, and the macOS Keychain entry the CLI reads is addressed by a
+    // hash of it — both consumers must see the identical path.
+    let resolvedSessionsDir = groupSessionsDir;
+    try {
+      resolvedSessionsDir = fs.realpathSync(groupSessionsDir);
+    } catch {
+      // Path may not exist yet on first spawn; fall back to the literal path.
+    }
+
     // Third-party provider: unless this provider explicitly injects
     // ANTHROPIC_AUTH_TOKEN (Bearer proxy mode), remove any inherited host token
     // so API-key mode can take effect.
@@ -2947,6 +2962,10 @@ export async function runHostAgent(
           'Failed to remove .credentials.json for third-party provider',
         );
       }
+      // Same forced-OAuth hazard, second store: on macOS the CLI keeps OAuth
+      // credentials in the Keychain and prefers them over the (now removed)
+      // file, so the claudeAiOauth field must be stripped there as well.
+      removeClaudeKeychainOAuth(resolvedSessionsDir);
     }
 
     // Write .credentials.json for OAuth credentials
@@ -2959,6 +2978,14 @@ export async function runHostAgent(
           { folder: group.folder, err },
           'Failed to write .credentials.json for host agent',
         );
+      }
+      // On macOS the CLI reads the Keychain entry for this config dir in
+      // preference to .credentials.json. Without this sync, provider-pool
+      // rotation only ever rewrites the ignored file and every turn keeps
+      // authenticating as whichever account seeded the Keychain first.
+      const claudeAiOauth = buildClaudeAiOauthPayload(mergedConfig);
+      if (claudeAiOauth) {
+        syncClaudeKeychainOAuth(resolvedSessionsDir, claudeAiOauth);
       }
     }
 
@@ -2986,15 +3013,10 @@ export async function runHostAgent(
     hostEnv['HAPPYCLAW_WORKSPACE_GROUP'] = groupDir;
     hostEnv['HAPPYCLAW_WORKSPACE_IPC'] = groupIpcDir;
 
-    // Resolve symlinks so CLAUDE_CONFIG_DIR ends up as the real on-disk path.
-    // Host mode also goes through the synchronized session .claude directory so
-    // explicit externalClaudeDir is authoritative for CLAUDE.md/rules/skills.
-    let resolvedSessionsDir = groupSessionsDir;
-    try {
-      resolvedSessionsDir = fs.realpathSync(groupSessionsDir);
-    } catch {
-      // Path may not exist yet on first spawn; fall back to the literal path.
-    }
+    // CLAUDE_CONFIG_DIR is the real on-disk path (resolved above, before the
+    // credential writes). Host mode also goes through the synchronized session
+    // .claude directory so explicit externalClaudeDir is authoritative for
+    // CLAUDE.md/rules/skills.
     hostEnv['CLAUDE_CONFIG_DIR'] = resolvedSessionsDir;
 
     // 让 SDK 捕获 CLI 的 stderr 输出，便于排查启动失败

--- a/src/macos-keychain-credentials.ts
+++ b/src/macos-keychain-credentials.ts
@@ -1,0 +1,187 @@
+/**
+ * macOS Keychain credential sync for host-mode Claude runners.
+ *
+ * On macOS the Claude Code CLI persists its credentials in the login Keychain
+ * under the service name `Claude Code-credentials-<hash>` (hash = first 8 hex
+ * chars of sha256(CLAUDE_CONFIG_DIR)) and PREFERS that entry over the
+ * `.credentials.json` file in the config dir. HappyClaw rewrites the file on
+ * every spawn to follow provider-pool rotation, but once the CLI has seeded a
+ * Keychain entry, the file is ignored — every turn silently authenticates as
+ * whichever account was seeded first, while the pool's health/bindings/UI keep
+ * "rotating". This module keeps the Keychain entry's `claudeAiOauth` field in
+ * lockstep with the provider selected for the current spawn.
+ *
+ * The same Keychain payload also stores MCP OAuth state (`mcpOAuth`), so the
+ * entry must never be deleted or replaced wholesale — only the
+ * `claudeAiOauth` field is merged in or stripped out.
+ */
+import { execFileSync } from 'child_process';
+import crypto from 'crypto';
+import os from 'os';
+
+import { logger } from './logger.js';
+
+const SECURITY_BIN = '/usr/bin/security';
+const SECURITY_TIMEOUT_MS = 10_000;
+/** errSecItemNotFound — "not found" is a normal outcome, not an error. */
+const NOT_FOUND_MARKER = 'could not be found';
+
+export interface KeychainClaudeAiOauth {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  scopes: string[];
+  subscriptionType?: string;
+}
+
+/**
+ * Service name the CLI uses for a non-default CLAUDE_CONFIG_DIR. The dir must
+ * be the exact string passed to the runner as CLAUDE_CONFIG_DIR (realpath'd),
+ * or the hash will address a different entry.
+ */
+export function claudeKeychainServiceName(configDir: string): string {
+  const hash = crypto
+    .createHash('sha256')
+    .update(configDir)
+    .digest('hex')
+    .slice(0, 8);
+  return `Claude Code-credentials-${hash}`;
+}
+
+/**
+ * Merge the selected account's OAuth credentials into an existing Keychain
+ * payload, preserving every other field (mcpOAuth etc).
+ *
+ * Returns the serialized payload to write, or null when no write is needed
+ * (same access token already present, or the existing payload is not JSON —
+ * clobbering an unparseable payload risks destroying MCP OAuth state).
+ */
+export function mergeClaudeKeychainPayload(
+  existingJson: string,
+  claudeAiOauth: KeychainClaudeAiOauth | null,
+): string | null {
+  let payload: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(existingJson) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    payload = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const existing = payload.claudeAiOauth as
+    | { accessToken?: string }
+    | undefined;
+
+  if (claudeAiOauth === null) {
+    if (!('claudeAiOauth' in payload)) return null;
+    delete payload.claudeAiOauth;
+    return JSON.stringify(payload);
+  }
+
+  if (existing?.accessToken === claudeAiOauth.accessToken) return null;
+  payload.claudeAiOauth = claudeAiOauth;
+  return JSON.stringify(payload);
+}
+
+function keychainAccount(): string {
+  return os.userInfo().username;
+}
+
+function readKeychainPayload(service: string): string | null {
+  try {
+    return execFileSync(
+      SECURITY_BIN,
+      ['find-generic-password', '-s', service, '-a', keychainAccount(), '-w'],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: SECURITY_TIMEOUT_MS,
+      },
+    ).trim();
+  } catch (err) {
+    const stderr = (err as { stderr?: string }).stderr ?? '';
+    if (!String(stderr).includes(NOT_FOUND_MARKER)) {
+      logger.warn(
+        { service, err: (err as Error).message },
+        'Keychain read failed; skipping credential sync',
+      );
+    }
+    return null;
+  }
+}
+
+function writeKeychainPayload(service: string, payload: string): boolean {
+  try {
+    // -w on argv mirrors what the CLI itself does for payloads above the
+    // `security -i` stdin limit (it logs "using argv"). The exposure window in
+    // the process list is brief and same-user only.
+    execFileSync(
+      SECURITY_BIN,
+      [
+        'add-generic-password',
+        '-U',
+        '-s',
+        service,
+        '-a',
+        keychainAccount(),
+        '-w',
+        payload,
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: SECURITY_TIMEOUT_MS },
+    );
+    return true;
+  } catch (err) {
+    logger.warn(
+      { service, err: (err as Error).message },
+      'Keychain write failed; runner may authenticate as a stale account',
+    );
+    return false;
+  }
+}
+
+/**
+ * Ensure the Keychain entry for this config dir carries the given OAuth
+ * credentials. No-op off macOS, when no entry exists yet (the CLI seeds one
+ * from .credentials.json on first run), or when the entry already holds the
+ * same access token. Best effort — never throws.
+ */
+export function syncClaudeKeychainOAuth(
+  configDir: string,
+  claudeAiOauth: KeychainClaudeAiOauth,
+): void {
+  if (process.platform !== 'darwin') return;
+  const service = claudeKeychainServiceName(configDir);
+  const existing = readKeychainPayload(service);
+  if (existing === null) return;
+  const merged = mergeClaudeKeychainPayload(existing, claudeAiOauth);
+  if (merged === null) return;
+  if (writeKeychainPayload(service, merged)) {
+    logger.info(
+      { service, configDir },
+      'Keychain claudeAiOauth synced to selected provider',
+    );
+  }
+}
+
+/**
+ * Strip claudeAiOauth from the Keychain entry (third-party provider turns:
+ * leftover OAuth credentials force the CLI onto the OAuth code path even when
+ * the .credentials.json file was removed). Preserves MCP OAuth state.
+ */
+export function removeClaudeKeychainOAuth(configDir: string): void {
+  if (process.platform !== 'darwin') return;
+  const service = claudeKeychainServiceName(configDir);
+  const existing = readKeychainPayload(service);
+  if (existing === null) return;
+  const merged = mergeClaudeKeychainPayload(existing, null);
+  if (merged === null) return;
+  if (writeKeychainPayload(service, merged)) {
+    logger.info(
+      { service, configDir },
+      'Keychain claudeAiOauth removed for third-party provider',
+    );
+  }
+}

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3083,15 +3083,19 @@ export function buildContainerEnvLines(
 // ─── OAuth credentials file management ────────────────────────────
 
 /**
- * Write .credentials.json to a Claude session directory.
- * Format matches what Claude Code CLI/Agent SDK natively reads.
+ * Build the claudeAiOauth object in the exact shape Claude Code CLI reads,
+ * shared by the .credentials.json file and the macOS Keychain entry so the
+ * two credential stores can never disagree on content.
  */
-export function writeCredentialsFile(
-  sessionDir: string,
-  config: ClaudeProviderConfig,
-): void {
+export function buildClaudeAiOauthPayload(config: ClaudeProviderConfig): {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  scopes: string[];
+  subscriptionType?: string;
+} | null {
   const creds = config.claudeOAuthCredentials;
-  if (!creds) return;
+  if (!creds) return null;
 
   // Claude CLI requires scopes to recognize the token as valid.
   // Fall back to a sensible default when the stored credentials lack scopes
@@ -3100,13 +3104,7 @@ export function writeCredentialsFile(
     ? creds.scopes
     : DEFAULT_CREDENTIAL_SCOPES;
 
-  const claudeAiOauth: {
-    accessToken: string;
-    refreshToken: string;
-    expiresAt: number;
-    scopes: string[];
-    subscriptionType?: string;
-  } = {
+  const claudeAiOauth: ReturnType<typeof buildClaudeAiOauthPayload> = {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
@@ -3115,8 +3113,21 @@ export function writeCredentialsFile(
   // Only include subscriptionType when explicitly configured — avoids
   // misleading Claude CLI when the actual subscription tier is unknown.
   if (creds.subscriptionType) {
-    claudeAiOauth.subscriptionType = creds.subscriptionType;
+    claudeAiOauth!.subscriptionType = creds.subscriptionType;
   }
+  return claudeAiOauth;
+}
+
+/**
+ * Write .credentials.json to a Claude session directory.
+ * Format matches what Claude Code CLI/Agent SDK natively reads.
+ */
+export function writeCredentialsFile(
+  sessionDir: string,
+  config: ClaudeProviderConfig,
+): void {
+  const claudeAiOauth = buildClaudeAiOauthPayload(config);
+  if (!claudeAiOauth) return;
 
   const credentialsData = { claudeAiOauth };
 

--- a/tests/macos-keychain-credentials.test.ts
+++ b/tests/macos-keychain-credentials.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, test } from 'vitest';
+import { execFileSync } from 'child_process';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   claudeKeychainServiceName,
   mergeClaudeKeychainPayload,
+  removeClaudeKeychainOAuth,
+  syncClaudeKeychainOAuth,
 } from '../src/macos-keychain-credentials.js';
+
+vi.mock('child_process', () => ({ execFileSync: vi.fn() }));
 
 const OAUTH = {
   accessToken: 'sk-ant-oat01-new',
@@ -76,5 +82,89 @@ describe('mergeClaudeKeychainPayload', () => {
   test('never clobbers an unparseable payload', () => {
     expect(mergeClaudeKeychainPayload('not json', OAUTH)).toBeNull();
     expect(mergeClaudeKeychainPayload('[1,2]', OAUTH)).toBeNull();
+  });
+});
+
+describe('platform guard', () => {
+  const execFileSyncMock = vi.mocked(execFileSync);
+  const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+
+  function setPlatform(platform: string): void {
+    Object.defineProperty(process, 'platform', {
+      value: platform,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', realPlatform);
+    execFileSyncMock.mockReset();
+  });
+
+  // The Keychain store only exists on macOS; on every other platform the CLI
+  // reads .credentials.json directly, which host spawns already rewrite. Both
+  // entry points must return without touching the `security` binary — it does
+  // not exist off macOS.
+  test.each(['linux', 'win32', 'freebsd'])(
+    'syncClaudeKeychainOAuth is a no-op on %s',
+    (platform) => {
+      setPlatform(platform);
+      expect(() =>
+        syncClaudeKeychainOAuth('/home/user/.claude', OAUTH),
+      ).not.toThrow();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['linux', 'win32', 'freebsd'])(
+    'removeClaudeKeychainOAuth is a no-op on %s',
+    (platform) => {
+      setPlatform(platform);
+      expect(() =>
+        removeClaudeKeychainOAuth('/home/user/.claude'),
+      ).not.toThrow();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    },
+  );
+
+  // Positive control: proves the no-op assertions above are not passing
+  // vacuously (i.e. the mock plumbing does observe real `security` calls).
+  test('on darwin, sync reads the entry and writes the merged payload', () => {
+    setPlatform('darwin');
+    execFileSyncMock.mockReturnValueOnce(
+      JSON.stringify({
+        claudeAiOauth: { accessToken: 'sk-ant-oat01-old' },
+        mcpOAuth: { keep: true },
+      }),
+    );
+    execFileSyncMock.mockReturnValueOnce('');
+
+    syncClaudeKeychainOAuth('/home/user/.claude', OAUTH);
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    const [readArgs, writeArgs] = execFileSyncMock.mock.calls.map(
+      (call) => call[1] as string[],
+    );
+    expect(readArgs).toContain('find-generic-password');
+    expect(writeArgs).toContain('add-generic-password');
+    const written = JSON.parse(writeArgs[writeArgs.indexOf('-w') + 1]);
+    expect(written.claudeAiOauth).toEqual(OAUTH);
+    expect(written.mcpOAuth.keep).toBe(true);
+  });
+
+  test('on darwin, a missing Keychain entry skips the write', () => {
+    setPlatform('darwin');
+    execFileSyncMock.mockImplementationOnce(() => {
+      const err = new Error('security: exit 44') as Error & {
+        stderr: string;
+      };
+      err.stderr =
+        'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.';
+      throw err;
+    });
+
+    syncClaudeKeychainOAuth('/home/user/.claude', OAUTH);
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/macos-keychain-credentials.test.ts
+++ b/tests/macos-keychain-credentials.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  claudeKeychainServiceName,
+  mergeClaudeKeychainPayload,
+} from '../src/macos-keychain-credentials.js';
+
+const OAUTH = {
+  accessToken: 'sk-ant-oat01-new',
+  refreshToken: 'sk-ant-ort01-new',
+  expiresAt: 1_800_000_000_000,
+  scopes: ['user:inference', 'user:profile'],
+};
+
+describe('claudeKeychainServiceName', () => {
+  test('matches the CLI derivation: first 8 hex of sha256(configDir)', () => {
+    // Known vector observed from a live Claude Code 2.1.220 install.
+    expect(
+      claudeKeychainServiceName(
+        '/Users/christianlee/Documents/git/happyclaw/data/sessions/main/.claude',
+      ),
+    ).toBe('Claude Code-credentials-b74245f7');
+  });
+
+  test('different config dirs address different entries', () => {
+    expect(claudeKeychainServiceName('/a/.claude')).not.toBe(
+      claudeKeychainServiceName('/b/.claude'),
+    );
+  });
+});
+
+describe('mergeClaudeKeychainPayload', () => {
+  test('replaces claudeAiOauth while preserving unrelated fields', () => {
+    const existing = JSON.stringify({
+      claudeAiOauth: { accessToken: 'sk-ant-oat01-old' },
+      mcpOAuth: { 'plugin:x|abc': { serverName: 'x', clientId: 'c1' } },
+    });
+    const merged = mergeClaudeKeychainPayload(existing, OAUTH);
+    expect(merged).not.toBeNull();
+    const parsed = JSON.parse(merged!);
+    expect(parsed.claudeAiOauth).toEqual(OAUTH);
+    expect(parsed.mcpOAuth['plugin:x|abc'].clientId).toBe('c1');
+  });
+
+  test('returns null when the same access token is already stored', () => {
+    const existing = JSON.stringify({
+      claudeAiOauth: { ...OAUTH },
+      mcpOAuth: {},
+    });
+    expect(mergeClaudeKeychainPayload(existing, OAUTH)).toBeNull();
+  });
+
+  test('adds claudeAiOauth to a payload that lacks it', () => {
+    const existing = JSON.stringify({ mcpOAuth: {} });
+    const merged = mergeClaudeKeychainPayload(existing, OAUTH);
+    expect(JSON.parse(merged!).claudeAiOauth).toEqual(OAUTH);
+  });
+
+  test('null oauth strips claudeAiOauth and keeps the rest', () => {
+    const existing = JSON.stringify({
+      claudeAiOauth: { accessToken: 'sk-ant-oat01-old' },
+      mcpOAuth: { keep: true },
+    });
+    const merged = mergeClaudeKeychainPayload(existing, null);
+    const parsed = JSON.parse(merged!);
+    expect(parsed.claudeAiOauth).toBeUndefined();
+    expect(parsed.mcpOAuth.keep).toBe(true);
+  });
+
+  test('null oauth on a payload without claudeAiOauth is a no-op', () => {
+    expect(
+      mergeClaudeKeychainPayload(JSON.stringify({ mcpOAuth: {} }), null),
+    ).toBeNull();
+  });
+
+  test('never clobbers an unparseable payload', () => {
+    expect(mergeClaudeKeychainPayload('not json', OAUTH)).toBeNull();
+    expect(mergeClaudeKeychainPayload('[1,2]', OAUTH)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 问题

macOS 上 Claude Code CLI 会把 OAuth 凭据存入登录 Keychain（服务名 `Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR) 前 8 位 hex>`），且读取时**优先于** `.credentials.json`。

Host 模式每次 spawn 只重写凭据文件，从不碰 Keychain。结果是：CLI 第一次播种 Keychain 之后，无论 provider 池怎么轮换，每一轮真实认证用的都是最早播种的那个账号——绑定记录、健康统计和前端 UI 的"轮换"全部只是表象。

实测（3 个启用的官方 OAuth 账号、weighted-round-robin）：绑定逐轮轮换正常，但 Anthropic usage API 显示二号、三号账号 7 天用量 **0.0%**，全部消耗集中在一号。

## 修复

- 新增 `src/macos-keychain-credentials.ts`：服务名哈希推导 + 纯函数载荷合并 + `security` CLI 读写；非 darwin 或 Keychain 无条目时 no-op。
- Host spawn 写完 `.credentials.json` 后，把选中 provider 的 `claudeAiOauth` **合并**进对应 config dir 的 Keychain 条目。同一载荷里还存着 `mcpOAuth`（MCP OAuth 状态），因此只替换 `claudeAiOauth` 字段，绝不整条覆盖或删除。
- 第三方 provider（BaseURL/APIKey）回合从 Keychain 条目剥离 `claudeAiOauth`，与删除凭据文件的语义对齐，避免 CLI 从 Keychain 捡回官方 OAuth。

## 验证

- `make typecheck` 通过；新增合并逻辑单测在内的相关测试通过。
- 部署实测：修复后首轮 spawn，`.credentials.json` 与 Keychain 条目的 accessToken 完全一致（sha256 对比），且 `mcpOAuth` 字段原样保留。