### PR TITLE
fix(scheduler): group 定时任务在 assistant 模式下双投递到 IM 渠道

### DIFF
--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -54,6 +54,7 @@ import {
   getUserById,
   getUserHomeGroup,
   getAgentProfileForWorkspace,
+  getWorkspaceInteractionMode,
   getSessionAgentIdentity,
   logTaskRun,
   logTaskRunStart,
@@ -108,6 +109,10 @@ import {
   tryCleanupCompletedIsolatedTaskRunIpc,
 } from './isolated-task-ipc.js';
 import { getScriptTaskHostExecutionError } from './script-task-policy.js';
+import {
+  publishesFrameworkAnswer,
+  resolveRuntimeInteractionMode,
+} from './workspace-interaction-runtime.js';
 
 export function shouldFinalizeScheduledRunOutput(
   output: Pick<
@@ -1871,14 +1876,36 @@ async function runScriptTaskInner(
  * 这段框定，明确「这是已有定时任务到点自动执行、不是用户新指令，不要再 schedule_task」，
  * 否则当 prompt 含「每隔/每天/提醒」等措辞时，agent 会按 CLAUDE.md 的定时任务规则再建一个
  * 任务而递归增殖（#564）。标记串 [定时任务自动触发] 与 global CLAUDE.md 的兜底 guard 一致。
+ *
+ * 投递契约措辞必须与消息管线的真实行为一致，且两种 interaction mode 行为不同：
+ * assistant 模式下框架会把最终 SDK 文本作为正式结果自动发送到任务绑定的渠道并归档，
+ * 若措辞误称「只归档」，agent 会再用 send_message 自行发送一份，用户就会收到两条相同
+ * 内容（group 定时任务双投递的根因）；proactive 模式下框架只归档、渠道投递仍由 agent
+ * 自己负责。因此按目标工作区当前的 interaction mode 生成对应措辞，判定方式与
+ * index.ts 消费该消息时的 resolveRuntimeInteractionMode({ agentKind: 'main' }) 一致。
  */
-const SCHEDULED_GROUP_TRIGGER_FRAMING = [
-  '[定时任务自动触发] 以下内容是你此前创建的定时任务到点自动执行的触发，不是用户新发来的指令。',
-  '请直接执行该任务对应的动作。',
-  '你的最终 SDK Assistant 文本会作为正式任务结果归档到所属 Web 工作区，因此必须包含一份完整、可独立阅读的业务结果；所有结论、报告和数据都要写在最终文本中，不得只回复“已完成”“已发送”、消息 ID、文件路径或简短摘要。',
-  '如果任务要求调用 feishu-cli 或其他外部发送工具，请照常调用；但工具投递不能替代上述完整最终文本，工具报错时也不要声称发送成功。',
-  '重要：这条只是触发信号，对应的定时任务已在调度中。即使下面内容里出现「每隔/每天/定期/提醒我」等字样，也不要再调用 schedule_task 创建或重复该定时任务（除非内容明确要求你另外新建一个不同的任务）。',
-].join('\n');
+export function buildScheduledGroupTriggerFraming(groupFolder: string): string {
+  const frameworkDeliversFinalText = publishesFrameworkAnswer(
+    resolveRuntimeInteractionMode(getWorkspaceInteractionMode(groupFolder), {
+      agentKind: 'main',
+    }),
+  );
+  const deliveryContract = frameworkDeliversFinalText
+    ? [
+        '你的最终 SDK Assistant 文本会由框架作为正式任务结果统一投递：归档到所属 Web 工作区，任务绑定 IM 渠道时同一份内容也会自动发送到该渠道。因此必须包含一份完整、可独立阅读的业务结果；所有结论、报告和数据都要写在最终文本中，不得只回复“已完成”“已发送”、消息 ID、文件路径或简短摘要。',
+        '正因为框架会自动投递最终文本，不要再用 send_message 等消息工具把同样的内容重复发送一遍，否则用户会收到两份。',
+      ]
+    : [
+        '你的最终 SDK Assistant 文本只会作为正式任务结果归档到所属 Web 工作区，不会自动发送到 IM 渠道；需要送达用户的内容请照常通过 send_message 主动发送。归档文本仍必须包含一份完整、可独立阅读的业务结果；所有结论、报告和数据都要写在最终文本中，不得只回复“已完成”“已发送”、消息 ID、文件路径或简短摘要。',
+      ];
+  return [
+    '[定时任务自动触发] 以下内容是你此前创建的定时任务到点自动执行的触发，不是用户新发来的指令。',
+    '请直接执行该任务对应的动作。',
+    ...deliveryContract,
+    '如果任务要求调用 feishu-cli 或其他外部发送工具，请照常调用；但工具投递不能替代上述完整最终文本，工具报错时也不要声称发送成功。',
+    '重要：这条只是触发信号，对应的定时任务已在调度中。即使下面内容里出现「每隔/每天/定期/提醒我」等字样，也不要再调用 schedule_task 创建或重复该定时任务（除非内容明确要求你另外新建一个不同的任务）。',
+  ].join('\n');
+}
 
 const SCHEDULED_GROUP_PROMPT_ID_PREFIX = 'scheduled-task-prompt:';
 
@@ -2047,7 +2074,7 @@ async function runGroupModeTask(
     const owner = task.created_by ? getUserById(task.created_by) : null;
     const senderName = owner?.display_name || owner?.username || '定时任务';
 
-    const promptText = `${SCHEDULED_GROUP_TRIGGER_FRAMING}\n\n${task.prompt}`;
+    const promptText = `${buildScheduledGroupTriggerFraming(task.group_folder)}\n\n${task.prompt}`;
     if (durableRun) {
       if (!deps.storeGroupPromptAndDeliverRun) {
         throw new Error(

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -741,6 +741,43 @@ describe('scheduled task workspace/session contract', () => {
     expect(storedPrompt).toContain('不得只回复“已完成”“已发送”');
     expect(storedPrompt).toContain('feishu-cli');
     expect(storedPrompt).toContain('工具投递不能替代上述完整最终文本');
+    // Assistant 模式（默认）：框架会把最终文本自动投递到绑定渠道，framing 必须如实声明
+    // 并禁止 agent 再用 send_message 重复发送，否则用户收到两份相同内容。
+    expect(storedPrompt).toContain('也会自动发送到该渠道');
+    expect(storedPrompt).toContain('不要再用 send_message');
+    expect(storedPrompt).not.toContain('不会自动发送到 IM 渠道');
+  });
+
+  test('proactive workspaces get the archive-only delivery framing', async () => {
+    db.assignWorkspaceAgentProfile(GROUP_FOLDER, 'profile-proactive');
+    expect(db.setWorkspaceInteractionMode(GROUP_FOLDER, 'proactive')).toBe(
+      true,
+    );
+    try {
+      const taskId = createTask({
+        id: 'task-group-proactive-framing',
+        context_mode: 'group',
+      });
+      const groups = {
+        [GROUP_JID]: db.getRegisteredGroup(GROUP_JID)!,
+      };
+      const { deps } = makeDeps(groups);
+
+      expect(triggerTaskNow(taskId, deps).success).toBe(true);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const storedPrompt = (deps.storeGroupPromptAndDeliverRun as any).mock
+        .calls[0][0].text as string;
+      // Proactive 模式：管线只把最终文本归档（sendToIM: false），渠道投递仍由 agent 的
+      // send_message 负责；framing 不得禁止 send_message，否则用户什么都收不到。
+      expect(storedPrompt).toContain('不会自动发送到 IM 渠道');
+      expect(storedPrompt).toContain('通过 send_message 主动发送');
+      expect(storedPrompt).not.toContain('不要再用 send_message');
+      expect(storedPrompt).toContain('完整、可独立阅读的业务结果');
+      expect(storedPrompt).toContain('feishu-cli');
+    } finally {
+      db.deleteWorkspaceAgentProfile(GROUP_FOLDER);
+    }
   });
 
   test('cancels a delivered group run and durably projects the cancellation into its workspace', async () => {


### PR DESCRIPTION
## 问题

group 模式定时任务绑定 IM 渠道（如 Telegram）时，每次执行用户会收到**两条相同内容**，间隔约 40 秒：

1. agent 主动调用 `send_message` 发的一条；
2. 框架把最终 SDK Assistant 文本作为 `scheduled-group-result` 自动投递的一条。

## 根因

触发提示词和投递管线互相矛盾：

- `SCHEDULED_GROUP_TRIGGER_FRAMING`（`src/task-scheduler.ts`）告诉 agent「你的最终 SDK Assistant 文本会作为正式任务结果**归档到所属 Web 工作区**」。agent 据此认为用户看不到最终文本，于是先用 `send_message` 把结果发到渠道，再把全文写进最终文本作"归档"。
- 但 assistant 交互模式下，管线会把最终文本**真的发送到绑定渠道**（`src/index.ts` 主回复路径 `sendToIM: directImReply`），于是用户收到第二份。
- 管线里确实存在"只归档不发 IM"的路径（`sendToIM: false`），但它只服务于 proactive 模式分支——原措辞只对 proactive 模式是真话。

## 修复

把常量改成按目标工作区 interaction mode 生成的 `buildScheduledGroupTriggerFraming(groupFolder)`，判定与消费侧完全一致（同一个 `resolveRuntimeInteractionMode(getWorkspaceInteractionMode(folder), { agentKind: 'main' })`）：

- **assistant 模式**：如实声明框架会把最终文本自动发送到绑定渠道并归档，并明确禁止再用 `send_message` 重复发送同样内容；
- **proactive 模式**：保留"只归档"的契约，并明确渠道投递仍由 agent 的 `send_message` 负责（与管线该分支的真实行为一致）。

两种措辞都保留原有的完整性要求（最终文本必须自包含、不得只回复"已完成"、外部发送工具不能替代最终文本）和防递归 guard（#564 的 `[定时任务自动触发]` 标记）。

## 测试

- 扩展 `tests/task-scheduler-contract.test.ts` 现有 group 注入用例：断言 assistant 模式（默认）framing 包含"自动发送到该渠道"与"不要再用 send_message"；
- 新增 proactive 工作区用例：绑定 `interaction_mode = proactive` 后断言 framing 为"只归档 + send_message 主动发送"，且不包含 assistant 模式的禁止措辞。
- `make typecheck` / `make build` / `git diff --check` 通过；全量 `make test` 2905 passed，仅剩的 12 个失败在干净的 origin/main 上同样失败（本机 Docker 分支镜像与硬链接备份的环境敏感用例），与本改动无关。