### PR TITLE
fix(files): 允许 Web 编辑工作区 CLAUDE.md

### DIFF
--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -20,6 +20,12 @@ export interface FileEntry {
   size: number;
   modifiedAt: string;
   isSystem: boolean;
+  /**
+   * 是否允许通过 Web 编辑内容。系统文件默认为 false，但 EDITABLE_SYSTEM_PATHS
+   * 中的例外（工作区 CLAUDE.md）仍可编辑——它受保护是为了防删除/覆盖上传，
+   * 不是为了禁止用户维护自己的工作区指令。
+   */
+  editable: boolean;
   absolutePath?: string; // Agent 视角的绝对路径（container 模式为 /workspace/group/...，host 模式为宿主机路径）
 }
 
@@ -30,6 +36,14 @@ export { MAX_FILE_SIZE };
 const SYSTEM_PATHS = ['logs', 'CLAUDE.md', '.claude', 'conversations'];
 // 预先转小写一次，匹配大小写不敏感文件系统（macOS APFS / Windows NTFS）。
 const SYSTEM_PATHS_LOWER = SYSTEM_PATHS.map((p) => p.toLowerCase());
+
+// 系统路径中允许编辑内容的例外。工作区根部的 CLAUDE.md 是用户自己维护的项目
+// 指令文件（早期由已下线的文件式记忆模块提供编辑入口，那个入口消失后编辑能力
+// 一并丢失）。它继续留在 SYSTEM_PATHS 中以保留「禁删除、禁覆盖上传」保护。
+const EDITABLE_SYSTEM_PATHS = ['CLAUDE.md'];
+const EDITABLE_SYSTEM_PATHS_LOWER = EDITABLE_SYSTEM_PATHS.map((p) =>
+  p.toLowerCase(),
+);
 
 // 仅在大小写不敏感的平台启用 lowercased 比较。case-sensitive Linux 上
 // 'Logs/' 与 'logs/' 是不同 inode，全局 toLowerCase 会误杀合法文件名。
@@ -126,6 +140,34 @@ export function isSystemPath(relativePath: string): boolean {
 }
 
 /**
+ * 系统路径中是否属于「内容可编辑」的例外。
+ *
+ * 只承认工作区根部的单段路径：`logs/CLAUDE.md`、`.claude/CLAUDE.md` 等嵌套
+ * 同名文件必须继续锁定，否则解锁范围会顺着 SYSTEM_PATHS 的首段匹配扩散到
+ * 整个系统目录。
+ */
+export function isEditableSystemPath(relativePath: string): boolean {
+  const normalized = path.normalize(relativePath);
+  const segments = normalized.split(path.sep).filter(Boolean);
+
+  if (segments.length !== 1) return false;
+
+  return CASE_INSENSITIVE_FS
+    ? EDITABLE_SYSTEM_PATHS_LOWER.includes(segments[0].toLowerCase())
+    : EDITABLE_SYSTEM_PATHS.includes(segments[0]);
+}
+
+/**
+ * 判断路径是否禁止通过 Web 编辑内容。
+ *
+ * 与 isSystemPath 的区别：isSystemPath 管「禁删除 / 禁覆盖上传 / 禁建目录」，
+ * 本函数只管内容写入，因此 CLAUDE.md 这类例外可以编辑但依然不能删。
+ */
+export function isEditLockedPath(relativePath: string): boolean {
+  return isSystemPath(relativePath) && !isEditableSystemPath(relativePath);
+}
+
+/**
  * 列出目录内容
  * @param folder 会话流文件夹名
  * @param subPath 可选的子路径
@@ -172,13 +214,15 @@ export function listFiles(
       continue;
     }
 
+    const isDirectory = stats.isDirectory();
     files.push({
       name,
       path: entryRelativePath,
-      type: stats.isDirectory() ? 'directory' : 'file',
+      type: isDirectory ? 'directory' : 'file',
       size: stats.size,
       modifiedAt: stats.mtime.toISOString(),
       isSystem: isSystemPath(entryRelativePath),
+      editable: !isDirectory && !isEditLockedPath(entryRelativePath),
     });
   }
 

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -16,6 +16,7 @@ import {
   deleteFile,
   createDirectory,
   isSystemPath,
+  isEditLockedPath,
   MAX_FILE_SIZE,
   getGroupStorageUsage,
   invalidateGroupStorageUsage,
@@ -792,8 +793,8 @@ fileRoutes.put('/:jid/files/content/:path', authMiddleware, async (c) => {
       'utf-8',
     );
 
-    // 禁止写入系统路径
-    if (isSystemPath(relativePath)) {
+    // 禁止写入系统路径（CLAUDE.md 等例外仍可编辑内容，删除/覆盖上传照旧禁止）
+    if (isEditLockedPath(relativePath)) {
       return c.json({ error: 'Cannot edit system file' }, 403);
     }
 

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -122,7 +122,14 @@ const TEXT_EXTENSIONS = new Set([
 ]);
 
 // 不安全的扩展名（HTML/SVG 有 XSS 风险，压缩包不可预览）
-const UNSAFE_PREVIEW_EXTENSIONS = new Set(['html', 'svg', 'zip', 'tar', 'gz', '7z']);
+const UNSAFE_PREVIEW_EXTENSIONS = new Set([
+  'html',
+  'svg',
+  'zip',
+  'tar',
+  'gz',
+  '7z',
+]);
 
 // 允许 inline 预览的安全 MIME 类型（从 MIME_MAP 中排除不安全扩展名自动推导）
 const SAFE_PREVIEW_MIME_TYPES = new Set(
@@ -382,7 +389,11 @@ fileRoutes.post('/:jid/files', authMiddleware, async (c) => {
           fs.writeFileSync(fd, data);
         } finally {
           if (fd !== null) {
-            try { fs.closeSync(fd); } catch { /* ignore */ }
+            try {
+              fs.closeSync(fd);
+            } catch {
+              /* ignore */
+            }
           }
         }
       } else {
@@ -640,8 +651,7 @@ fileRoutes.get('/:jid/files/preview/:path', authMiddleware, (c) => {
       const rangeHeader = c.req.header('range');
       if (rangeHeader) {
         const normalizedRange = rangeHeader.trim();
-        const isBytesRange =
-          normalizedRange.toLowerCase().startsWith('bytes=');
+        const isBytesRange = normalizedRange.toLowerCase().startsWith('bytes=');
         const isMultiRange = isBytesRange && normalizedRange.includes(',');
 
         if (isBytesRange && !isMultiRange) {
@@ -882,18 +892,30 @@ fileRoutes.put('/:jid/files/content/:path', authMiddleware, async (c) => {
           fs.writeFileSync(fd, body.content, 'utf-8');
         } finally {
           if (fd !== null) {
-            try { fs.closeSync(fd); } catch { /* ignore */ }
+            try {
+              fs.closeSync(fd);
+            } catch {
+              /* ignore */
+            }
           }
         }
       } else {
         // Windows fallback：用 'wx' 等价的 O_EXCL 创建避免覆写预放 symlink。
         try {
-          fs.writeFileSync(tmp, body.content, { encoding: 'utf-8', flag: 'wx', mode: 0o644 });
+          fs.writeFileSync(tmp, body.content, {
+            encoding: 'utf-8',
+            flag: 'wx',
+            mode: 0o644,
+          });
         } catch (err: any) {
           if (err && err.code === 'EEXIST') {
             // 旧 tmp 残留：删后重试一次。
             fs.unlinkSync(tmp);
-            fs.writeFileSync(tmp, body.content, { encoding: 'utf-8', flag: 'wx', mode: 0o644 });
+            fs.writeFileSync(tmp, body.content, {
+              encoding: 'utf-8',
+              flag: 'wx',
+              mode: 0o644,
+            });
           } else {
             throw err;
           }
@@ -903,7 +925,11 @@ fileRoutes.put('/:jid/files/content/:path', authMiddleware, async (c) => {
       renameOk = true;
     } finally {
       if (!renameOk) {
-        try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+        try {
+          fs.unlinkSync(tmp);
+        } catch {
+          /* ignore */
+        }
       }
     }
 

--- a/tests/file-manager-system-paths.test.ts
+++ b/tests/file-manager-system-paths.test.ts
@@ -1,0 +1,128 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-files-'));
+const groupsDir = path.join(tmpRoot, 'groups');
+
+vi.mock('../src/config.js', () => ({
+  DATA_DIR: tmpRoot,
+  GROUPS_DIR: groupsDir,
+  MAX_FILE_SIZE: 50 * 1024 * 1024,
+}));
+
+vi.mock('../src/runtime-config.js', () => ({
+  deleteContainerEnvConfig: vi.fn(),
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Import AFTER the mocks so file-manager picks up the mocked GROUPS_DIR.
+const {
+  isSystemPath,
+  isEditableSystemPath,
+  isEditLockedPath,
+  listFiles,
+  deleteFile,
+} = await import('../src/file-manager.ts');
+
+const FOLDER = 'flow-x';
+const folderRoot = path.join(groupsDir, FOLDER);
+
+beforeEach(() => {
+  fs.rmSync(folderRoot, { recursive: true, force: true });
+  fs.mkdirSync(path.join(folderRoot, 'logs'), { recursive: true });
+  fs.mkdirSync(path.join(folderRoot, 'conversations'), { recursive: true });
+  fs.writeFileSync(path.join(folderRoot, 'CLAUDE.md'), '# workspace rules\n');
+  fs.writeFileSync(path.join(folderRoot, 'notes.md'), 'hello\n');
+  fs.writeFileSync(path.join(folderRoot, 'logs', 'CLAUDE.md'), 'nested\n');
+});
+
+describe('system path protection', () => {
+  test('CLAUDE.md stays a system path so delete/upload protection is unchanged', () => {
+    expect(isSystemPath('CLAUDE.md')).toBe(true);
+    expect(() => deleteFile(FOLDER, 'CLAUDE.md')).toThrow(
+      'Cannot delete system path',
+    );
+    expect(fs.existsSync(path.join(folderRoot, 'CLAUDE.md'))).toBe(true);
+  });
+
+  test('workspace CLAUDE.md is the editable exception', () => {
+    expect(isEditableSystemPath('CLAUDE.md')).toBe(true);
+    expect(isEditLockedPath('CLAUDE.md')).toBe(false);
+    expect(isEditLockedPath('./CLAUDE.md')).toBe(false);
+  });
+
+  test('the exception does not leak into nested system directories', () => {
+    for (const nested of [
+      path.join('logs', 'CLAUDE.md'),
+      path.join('.claude', 'CLAUDE.md'),
+      path.join('conversations', 'CLAUDE.md'),
+    ]) {
+      expect(isEditableSystemPath(nested)).toBe(false);
+      expect(isEditLockedPath(nested)).toBe(true);
+    }
+  });
+
+  test('other system paths remain edit-locked', () => {
+    expect(isEditLockedPath('logs')).toBe(true);
+    expect(isEditLockedPath(path.join('logs', 'agent.log'))).toBe(true);
+    expect(isEditLockedPath(path.join('.claude', 'settings.json'))).toBe(true);
+    expect(isEditLockedPath(path.join('conversations', '2026-08-11.md'))).toBe(
+      true,
+    );
+  });
+
+  test('non-system files are untouched', () => {
+    expect(isEditableSystemPath('notes.md')).toBe(false);
+    expect(isEditLockedPath('notes.md')).toBe(false);
+  });
+});
+
+describe('listFiles editable flag', () => {
+  test('marks workspace CLAUDE.md as system but editable', () => {
+    const { files } = listFiles(FOLDER);
+    const claudeMd = files.find((f) => f.name === 'CLAUDE.md');
+    expect(claudeMd).toMatchObject({
+      isSystem: true,
+      editable: true,
+      type: 'file',
+    });
+  });
+
+  test('keeps system directories non-editable', () => {
+    const { files } = listFiles(FOLDER);
+    expect(files.find((f) => f.name === 'logs')).toMatchObject({
+      isSystem: true,
+      editable: false,
+    });
+    expect(files.find((f) => f.name === 'conversations')).toMatchObject({
+      isSystem: true,
+      editable: false,
+    });
+  });
+
+  test('nested CLAUDE.md under logs is not editable', () => {
+    const { files } = listFiles(FOLDER, 'logs');
+    expect(files.find((f) => f.name === 'CLAUDE.md')).toMatchObject({
+      isSystem: true,
+      editable: false,
+    });
+  });
+
+  test('ordinary files stay editable and non-system', () => {
+    const { files } = listFiles(FOLDER);
+    expect(files.find((f) => f.name === 'notes.md')).toMatchObject({
+      isSystem: false,
+      editable: true,
+    });
+  });
+});

--- a/web/src/components/chat/FilePanel.tsx
+++ b/web/src/components/chat/FilePanel.tsx
@@ -169,10 +169,18 @@ const PREVIEW_BLACKLIST_EXTENSIONS = new Set([
   'cache',
 ]);
 
-/** 判断文件是否可点击预览（排除系统文件和临时文件） */
-function isPreviewableFile(name: string, isSystem: boolean): boolean {
-  if (isSystem) return false;
-  const ext = getFileExt(name);
+/**
+ * 后端是否允许编辑该文件内容。
+ * 旧后端不返回 editable 字段时回退到原有的「非系统文件」判断。
+ */
+function isEntryEditable(item: FileEntry): boolean {
+  return item.type === 'file' && (item.editable ?? !item.isSystem);
+}
+
+/** 判断文件是否可点击预览（排除临时文件；系统文件仅在可编辑例外时开放） */
+function isPreviewableFile(item: FileEntry): boolean {
+  if (item.isSystem && !isEntryEditable(item)) return false;
+  const ext = getFileExt(item.name);
   if (PREVIEW_BLACKLIST_EXTENSIONS.has(ext)) return false;
   return true;
 }
@@ -908,7 +916,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
         setPreview({ kind: 'video', file: item });
       } else if (AUDIO_EXTENSIONS.has(ext)) {
         setPreview({ kind: 'audio', file: item });
-      } else if (ext === 'md' && !item.isSystem) {
+      } else if (ext === 'md' && isEntryEditable(item)) {
         setPreview({ kind: 'markdown', file: item });
       } else {
         setPreview({ kind: 'text', file: item });
@@ -1098,8 +1106,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
             <div className="space-y-0.5">
               {sortedFiles.map((item) => {
                 const clickable =
-                  item.type === 'directory' ||
-                  isPreviewableFile(item.name, !!item.isSystem);
+                  item.type === 'directory' || isPreviewableFile(item);
                 const summary = (
                   <>
                     <div className="flex-shrink-0 w-5 flex items-center justify-center">
@@ -1113,7 +1120,7 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                       <div className="flex items-center gap-1.5">
                         <span
                           className={`text-sm truncate ${
-                            item.isSystem
+                            item.isSystem && !isEntryEditable(item)
                               ? 'text-muted-foreground'
                               : 'text-foreground'
                           }`}
@@ -1173,9 +1180,9 @@ export function FilePanel({ groupJid, onClose }: FilePanelProps) {
                       >
                         <Copy className="w-3.5 h-3.5" />
                       </button>
-                      {/* Edit button for non-system text files */}
-                      {!item.isSystem &&
-                        item.type === 'file' &&
+                      {/* Edit button for editable text files (系统文件里的
+                          CLAUDE.md 例外也可编辑，但仍然没有删除按钮) */}
+                      {isEntryEditable(item) &&
                         TEXT_EXTENSIONS.has(getFileExt(item.name)) && (
                           <button
                             onClick={(e) => {

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -31,12 +31,24 @@ interface FileState {
   error: string | null;
 
   loadFiles: (jid: string, path?: string) => Promise<void>;
-  uploadFiles: (jid: string, files: File[], basePath?: string) => Promise<boolean>;
+  uploadFiles: (
+    jid: string,
+    files: File[],
+    basePath?: string,
+  ) => Promise<boolean>;
   deleteFile: (jid: string, filePath: string) => Promise<boolean>;
-  createDirectory: (jid: string, parentPath: string, name: string) => Promise<void>;
+  createDirectory: (
+    jid: string,
+    parentPath: string,
+    name: string,
+  ) => Promise<void>;
   navigateTo: (jid: string, path: string) => void;
   getFileContent: (jid: string, filePath: string) => Promise<string | null>;
-  saveFileContent: (jid: string, filePath: string, content: string) => Promise<boolean>;
+  saveFileContent: (
+    jid: string,
+    filePath: string,
+    content: string,
+  ) => Promise<boolean>;
 }
 
 export function toBase64Url(str: string): string {
@@ -59,12 +71,13 @@ export const useFileStore = create<FileState>((set, get) => ({
   loadFiles: async (jid: string, path?: string) => {
     set({ loading: true, error: null });
     try {
-      const targetPath = path !== undefined ? path : (get().currentPath[jid] || '');
+      const targetPath =
+        path !== undefined ? path : get().currentPath[jid] || '';
       const params = new URLSearchParams();
       if (targetPath) params.set('path', targetPath);
 
       const data = await api.get<{ files: FileEntry[]; currentPath: string }>(
-        `/api/groups/${encodeURIComponent(jid)}/files?${params}`
+        `/api/groups/${encodeURIComponent(jid)}/files?${params}`,
       );
 
       set((s) => ({
@@ -86,10 +99,17 @@ export const useFileStore = create<FileState>((set, get) => ({
     const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
     set({
       uploading: true,
-      uploadProgress: { total, completed: 0, currentFile: files[0].name, totalBytes, uploadedBytes: 0 },
+      uploadProgress: {
+        total,
+        completed: 0,
+        currentFile: files[0].name,
+        totalBytes,
+        uploadedBytes: 0,
+      },
     });
 
-    const targetBase = basePath !== undefined ? basePath : (get().currentPath[jid] || '');
+    const targetBase =
+      basePath !== undefined ? basePath : get().currentPath[jid] || '';
     const apiUrl = `/api/groups/${encodeURIComponent(jid)}/files`;
     let uploadedBytes = 0;
 
@@ -110,7 +130,13 @@ export const useFileStore = create<FileState>((set, get) => ({
         }
 
         set({
-          uploadProgress: { total, completed: i, currentFile: file.name, totalBytes, uploadedBytes },
+          uploadProgress: {
+            total,
+            completed: i,
+            currentFile: file.name,
+            totalBytes,
+            uploadedBytes,
+          },
         });
 
         const formData = new FormData();
@@ -127,7 +153,13 @@ export const useFileStore = create<FileState>((set, get) => ({
         uploadedBytes += file.size;
 
         set({
-          uploadProgress: { total, completed: i + 1, currentFile: i + 1 < total ? files[i + 1].name : '', totalBytes, uploadedBytes },
+          uploadProgress: {
+            total,
+            completed: i + 1,
+            currentFile: i + 1 < total ? files[i + 1].name : '',
+            totalBytes,
+            uploadedBytes,
+          },
         });
       }
 
@@ -147,7 +179,9 @@ export const useFileStore = create<FileState>((set, get) => ({
   deleteFile: async (jid: string, filePath: string) => {
     try {
       const encoded = toBase64Url(filePath);
-      await api.delete(`/api/groups/${encodeURIComponent(jid)}/files/${encoded}`);
+      await api.delete(
+        `/api/groups/${encodeURIComponent(jid)}/files/${encoded}`,
+      );
 
       const currentPath = get().currentPath[jid] || '';
       await get().loadFiles(jid, currentPath);
@@ -169,7 +203,8 @@ export const useFileStore = create<FileState>((set, get) => ({
 
       await get().loadFiles(jid, parentPath);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to create directory';
+      const msg =
+        err instanceof Error ? err.message : 'Failed to create directory';
       console.error('Failed to create directory:', err);
       set({ error: msg });
     }
@@ -187,7 +222,7 @@ export const useFileStore = create<FileState>((set, get) => ({
     try {
       const encoded = toBase64Url(filePath);
       const data = await api.get<{ content: string }>(
-        `/api/groups/${encodeURIComponent(jid)}/files/content/${encoded}`
+        `/api/groups/${encodeURIComponent(jid)}/files/content/${encoded}`,
       );
       return data.content;
     } catch (err) {
@@ -201,7 +236,10 @@ export const useFileStore = create<FileState>((set, get) => ({
   saveFileContent: async (jid: string, filePath: string, content: string) => {
     try {
       const encoded = toBase64Url(filePath);
-      await api.put(`/api/groups/${encodeURIComponent(jid)}/files/content/${encoded}`, { content });
+      await api.put(
+        `/api/groups/${encodeURIComponent(jid)}/files/content/${encoded}`,
+        { content },
+      );
       return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to save file';

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -8,6 +8,8 @@ export interface FileEntry {
   size: number;
   modifiedAt: string;
   isSystem: boolean;
+  /** 后端是否允许编辑内容。系统文件默认 false，工作区 CLAUDE.md 是例外。 */
+  editable?: boolean;
   absolutePath?: string;
 }
 


### PR DESCRIPTION
## 问题

工作区 CLAUDE.md 在 Web 文件面板里置灰、不可点击、没有编辑按钮，`PUT /api/groups/:jid/files/content/:path` 也返回 403，导致用户无法维护自己工作区的指令文件。

时间线：

- 初始版本起 `CLAUDE.md` 就在 `file-manager.ts` 的 `SYSTEM_PATHS` 里，但当时编辑入口在文件式记忆模块（`routes/memory.ts` 的 `writeMemoryFile`），文件面板不开第二个写入口是合理的。
- `0a5735b feat: redesign memory around workspaces` 把记忆改成结构化 memory item，文件式读写接口整体删除，编辑入口随之消失。
- `SYSTEM_PATHS` 的封禁保留了下来，于是 CLAUDE.md 变成完全不可编辑。runner prompt 现在也明确写着 CLAUDE.md 是 instructions/artifacts 而非自动管理的记忆，按系统文件锁定已无依据。

## 修复

把「系统路径」拆成两层语义：

- `isSystemPath` 保持不变，继续管禁删除、禁覆盖上传、禁在其下建目录。
- 新增 `isEditLockedPath`，只管内容写入；`EDITABLE_SYSTEM_PATHS = ['CLAUDE.md']` 为例外。
- 例外只承认工作区根部的单段路径，`logs/CLAUDE.md`、`.claude/CLAUDE.md` 等嵌套同名文件继续锁定，避免解锁顺着首段匹配扩散到整个系统目录。
- `FileEntry` 增加 `editable` 字段驱动前端：CLAUDE.md 恢复可点击预览、Markdown 编辑器和铅笔按钮，保留「系统」badge，删除按钮仍不渲染。

## 验证

- 新增 `tests/file-manager-system-paths.test.ts`（9 个用例）：CLAUDE.md 仍禁删除、例外可编辑、嵌套路径不泄漏、`listFiles` 的 `editable` 标记。
- `make typecheck` 三个项目通过；手动验证了预览/编辑/保存与删除按钮缺失。
- `tests/container-session-permissions.test.ts` 在本地环境失败，但在未改动的 upstream/main 上同样失败，与本次改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)