### PR TITLE
fix(wecom): isolate each chat so DM/group reply to their own conversation

### DIFF
--- a/src/im-context-isolation.ts
+++ b/src/im-context-isolation.ts
@@ -23,6 +23,14 @@ export function getUserContextIsolationConfig(
     };
   }
 
+  // WeCom (企业微信) is a single-bot channel with no per-workspace binding UI.
+  // Isolate every chat into its own conversation so a DM and a group each get
+  // their own session channel owner — otherwise all chats collapse to web:main
+  // and share one owner slot, sending private (1:1) replies to the group.
+  if (channelType === 'wecom') {
+    return { enabled: true, sourceKind: 'auto_im' };
+  }
+
   return { enabled: false, sourceKind: 'auto_im' };
 }
 


### PR DESCRIPTION
WeCom chats were not eligible for per-chat context isolation (only feishu was), so every WeCom chat collapsed into the shared `web:main` workspace and shared one session channel owner slot (`channel_session_owner:main:main`). A private 1:1 DM and a group then contended for that single owner, causing **private replies to be delivered to the group**.

This enables per-chat isolation for `wecom` in `getUserContextIsolationConfig` — the same mechanism feishu uses — so each WeCom chat gets its own conversation + owner slot. A DM replies to the DM, a group replies to the group.

Follow-up to the WeCom channel (#641). Verified on a live tenant: 1:1 and group replies now route to their own chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)