### PR TITLE
fix(providers): unbreak macOS host mode — Keychain payload truncation and ownership deadlock

### DIFF
--- a/src/macos-keychain-credentials.ts
+++ b/src/macos-keychain-credentials.ts
@@ -526,9 +526,30 @@ export class MacosKeychainCredentialStore {
           return desired;
         }
         if (!sharesCredentialLineage(existingOauth, desired)) {
-          throw new MacosKeychainCredentialError(
-            'Keychain OAuth ownership is unknown and does not match the selected provider',
+          // No ownership item means this is the first reconcile after the
+          // upgrade that introduced ownership tracking, so an unrelated
+          // credential is the expected state rather than a suspicious one.
+          //
+          // Failing closed here is unrecoverable for a multi-account provider
+          // pool: the item holds whichever account was seeded last, the pool
+          // keeps rotating, and no selected provider can ever match it — so
+          // host mode stays blocked for every provider, forever, with no
+          // supported way to clear the item.
+          //
+          // There is also no third party to protect. The service name is
+          // derived from HappyClaw's own CLAUDE_CONFIG_DIR, so HappyClaw is the
+          // only writer of that item. Adopt the selected provider and record
+          // ownership; this is a one-shot migration that reproduces the
+          // pre-ownership behaviour, and every later reconcile takes the
+          // rotation-aware branches below.
+          const migrated = mergeClaudeKeychainPayload(existingJson, desired);
+          if (migrated !== null) await this.write(service, migrated);
+          await this.writeOwnership(
+            service,
+            options.providerId,
+            desiredFingerprint,
           );
+          return desired;
         }
         if (existingOauth.expiresAt > desired.expiresAt) {
           await this.persistRefresh(options, desired, existingOauth);

--- a/src/macos-keychain-credentials.ts
+++ b/src/macos-keychain-credentials.ts
@@ -18,6 +18,16 @@ const SECURITY_BIN = '/usr/bin/security';
 const SECURITY_TIMEOUT_MS = 10_000;
 const NOT_FOUND_MARKER = 'could not be found';
 const OWNERSHIP_SUFFIX = '.happyclaw-provider-owner';
+/**
+ * `security -i` reads each command through a fixed 4096-byte line buffer.
+ * Overflowing it is not a clean failure: security runs the truncated prefix —
+ * storing a mangled payload — and only then rejects the remainder as an unknown
+ * command. A Keychain item that also carries `mcpOAuth` for a handful of MCP
+ * servers passes 4KB easily, so any command at risk of crossing this boundary
+ * has to go through argv instead. Kept below the real 4096-byte cutoff so the
+ * check never depends on counting the trailing newline exactly.
+ */
+const SECURITY_INTERACTIVE_LINE_LIMIT = 4000;
 
 export interface KeychainClaudeAiOauth {
   accessToken: string;
@@ -409,12 +419,33 @@ export class MacosKeychainCredentialStore {
     ].join(' ');
     try {
       // `security -i` reads the command from stdin, so OAuth/MCP payloads never
-      // appear in process argv or the process environment.
-      await this.runSecurity({
-        args: ['-i'],
-        stdin: `${input}\n`,
-        timeoutMs: SECURITY_TIMEOUT_MS,
-      });
+      // appear in process argv or the process environment. Prefer it whenever
+      // the command fits, and fall back to argv rather than let the payload be
+      // silently truncated (see SECURITY_INTERACTIVE_LINE_LIMIT). The fallback
+      // trades argv exposure for correctness: a corrupted credential item locks
+      // the user out of host mode, and the value is only readable by processes
+      // already running as the same user.
+      const request: SecurityCommandRequest =
+        Buffer.byteLength(input, 'utf8') + 1 <= SECURITY_INTERACTIVE_LINE_LIMIT
+          ? {
+              args: ['-i'],
+              stdin: `${input}\n`,
+              timeoutMs: SECURITY_TIMEOUT_MS,
+            }
+          : {
+              args: [
+                'add-generic-password',
+                '-U',
+                '-s',
+                service,
+                '-a',
+                account,
+                '-w',
+                payload,
+              ],
+              timeoutMs: SECURITY_TIMEOUT_MS,
+            };
+      await this.runSecurity(request);
     } catch {
       throw new MacosKeychainCredentialError(
         `Unable to write macOS Keychain item ${service}`,

--- a/tests/macos-keychain-credentials.test.ts
+++ b/tests/macos-keychain-credentials.test.ts
@@ -69,8 +69,22 @@ class FakeKeychain {
       return { stdout: value, stderr: '' };
     }
     if (this.failWrites) throw new Error('keychain locked');
-    expect(request.args).toEqual(['-i']);
-    const { service, payload } = parseInteractiveWrite(request.stdin ?? '');
+    // Writes arrive either as `security -i` (command on stdin) or, when the
+    // payload would overflow security's 4096-byte stdin line buffer, as a plain
+    // argv invocation. Model both, and reproduce the real truncation so a
+    // regression cannot pass silently.
+    if (request.args[0] === '-i') {
+      const line = request.stdin ?? '';
+      if (Buffer.byteLength(line, 'utf8') > 4096) {
+        throw new Error('security: unknown command (line truncated at 4096)');
+      }
+      const { service, payload } = parseInteractiveWrite(line);
+      this.items.set(service, payload);
+      return { stdout: '', stderr: '' };
+    }
+    expect(request.args[0]).toBe('add-generic-password');
+    const service = request.args[request.args.indexOf('-s') + 1];
+    const payload = request.args[request.args.indexOf('-w') + 1];
     this.items.set(service, payload);
     return { stdout: '', stderr: '' };
   };
@@ -264,6 +278,41 @@ describe('MacosKeychainCredentialStore', () => {
     expect(JSON.parse(fake.items.get(service)!).claudeAiOauth).toEqual(
       normalizeClaudeAiOauth(updated),
     );
+  });
+
+  // A real Keychain item carrying mcpOAuth for ~10 MCP servers is >5KB, which
+  // overflows security's 4096-byte stdin line buffer. Overflow there is
+  // silently destructive: security runs the truncated prefix, storing a mangled
+  // item, and only then rejects the rest.
+  test('writes oversized payloads through argv instead of security -i', async () => {
+    const fake = new FakeKeychain();
+    const service = claudeKeychainServiceName(CONFIG_DIR);
+    const bulkyMcpOAuth = { blob: 'y'.repeat(6000) };
+    fake.items.set(
+      service,
+      JSON.stringify({ claudeAiOauth: OAUTH, mcpOAuth: bulkyMcpOAuth }),
+    );
+    await fake.store().reconcile(CONFIG_DIR, {
+      providerId: 'official-a',
+      claudeAiOauth: OAUTH,
+    });
+    await fake.store().reconcile(CONFIG_DIR, {
+      providerId: 'official-b',
+      claudeAiOauth: REFRESHED,
+    });
+
+    const stored = JSON.parse(fake.items.get(service)!);
+    expect(stored.claudeAiOauth).toEqual(normalizeClaudeAiOauth(REFRESHED));
+    expect(stored.mcpOAuth).toEqual(bulkyMcpOAuth);
+    expect(
+      fake.requests.some((r) => r.args[0] === 'add-generic-password'),
+    ).toBe(true);
+    // the short ownership item still takes the argv-hiding interactive path
+    expect(
+      fake.requests.some(
+        (r) => r.args[0] === '-i' && r.stdin?.includes('provider-owner'),
+      ),
+    ).toBe(true);
   });
 
   test('fails closed on unknown ownership, concurrent changes, and failed persistence', async () => {

--- a/tests/macos-keychain-credentials.test.ts
+++ b/tests/macos-keychain-credentials.test.ts
@@ -315,20 +315,39 @@ describe('MacosKeychainCredentialStore', () => {
     ).toBe(true);
   });
 
-  test('fails closed on unknown ownership, concurrent changes, and failed persistence', async () => {
+  // Without an ownership item there is nothing to reconcile against, and a
+  // multi-account pool can never satisfy a match check — so adopt the selected
+  // provider and record ownership instead of blocking host mode permanently.
+  test('adopts the selected provider when ownership is unknown', async () => {
     const fake = new FakeKeychain();
     const service = claudeKeychainServiceName(CONFIG_DIR);
     fake.items.set(
       service,
-      JSON.stringify({ claudeAiOauth: REFRESHED, mcpOAuth: {} }),
-    );
-    await expect(
-      fake.store().reconcile(CONFIG_DIR, {
-        providerId: 'official-a',
-        claudeAiOauth: OAUTH,
+      JSON.stringify({
+        claudeAiOauth: REFRESHED,
+        mcpOAuth: { 'some-server': 'keep-me' },
       }),
-    ).rejects.toThrow('ownership is unknown');
+    );
 
+    const migrated = await fake.store().reconcile(CONFIG_DIR, {
+      providerId: 'official-a',
+      claudeAiOauth: OAUTH,
+    });
+
+    expect(migrated).toEqual(normalizeClaudeAiOauth(OAUTH));
+    const stored = JSON.parse(fake.items.get(service)!);
+    expect(stored.claudeAiOauth).toEqual(normalizeClaudeAiOauth(OAUTH));
+    expect(stored.mcpOAuth).toEqual({ 'some-server': 'keep-me' });
+    expect(
+      JSON.parse(
+        fake.items.get(claudeKeychainOwnershipServiceName(CONFIG_DIR))!,
+      ).providerId,
+    ).toBe('official-a');
+  });
+
+  test('fails closed on concurrent changes and failed persistence', async () => {
+    const fake = new FakeKeychain();
+    const service = claudeKeychainServiceName(CONFIG_DIR);
     fake.items.clear();
     fake.items.set(service, JSON.stringify({ claudeAiOauth: OAUTH }));
     const store = fake.store();


### PR DESCRIPTION
## Summary

Host mode is unusable on macOS after 42ae89b for anyone whose Keychain item exceeds ~4KB or who runs more than one official OAuth provider. Two independent defects; either one alone blocks it, so both are fixed here.

Reproduced on macOS 26.6, Node 26, with 3 official OAuth providers in a `weighted-round-robin` pool and a 5387-byte Keychain payload.

## 1. `security -i` truncates at 4096 bytes, destructively

`write()` moved to `security -i` so payloads stay out of argv — a good goal, but `security`'s interactive mode reads through a fixed 4096-byte line buffer, and overflow is **not** a clean failure. It executes the truncated prefix, storing a mangled payload, then rejects the remainder:

```
security: unknown command ":"","discoveryState":{"authorizationServerUrl":...
```

Measured on the real binary (payload starts at offset 63 of the command line):

| payload written | payload stored |
|---|---|
| 1000 | 1000 |
| 4000 | 4000 |
| 4090 | **4032** |
| 5000 | **4032** |

The item is shared with `mcpOAuth`. With ~10 authorized MCP servers that field alone was 5036 bytes here, so **every** reconcile rewrote the credentials item as invalid JSON — losing all MCP OAuth state and leaving Claude Code unable to parse its own credentials. Observed in production, not just in a harness:

```
[18:15:04] ERROR: Failed to reconcile macOS Keychain OAuth credentials
MacosKeychainCredentialError: Unable to write macOS Keychain item Claude Code-credentials-<hash>
```
…after which the item was 3751 bytes of truncated JSON.

Fix: keep `-i` when the command fits — that is what keeps tokens out of argv, and the ownership item always fits — and fall back to argv past `SECURITY_INTERACTIVE_LINE_LIMIT`. This trades argv exposure for correctness only when unavoidable; the value is readable only by processes already running as the same user, whereas a corrupted item locks the user out of host mode entirely.

If you would rather not have argv exposure at any size, the alternative is a native Security-framework binding — happy to follow up, but that seemed too large for a regression fix.

## 2. Unknown ownership deadlocks a provider pool

`reconcile()` threw when the ownership item was absent and the Keychain held a different credential:

```
宿主机模式启动失败：无法安全同步 macOS Keychain OAuth 凭据，已阻止启动
```

On the first run after upgrading, the ownership item is **always** absent — that is the migration path, not an attack. With a multi-account pool the check can never be satisfied: the item holds whichever account was seeded last, the pool rotates every spawn, and no selected provider matches. Host mode fails for every provider, permanently, with no supported way to clear the item.

There is also no third party to protect — the service name derives from HappyClaw's own `CLAUDE_CONFIG_DIR`, so HappyClaw is that item's only writer.

Fix: adopt the selected provider and record ownership, reproducing the pre-ownership behaviour exactly once. Every later reconcile finds ownership present and takes the existing rotation-aware branches, which are **unchanged** — a genuine SDK refresh is still detected and persisted, and the "changed concurrently" and failed-persistence guards still fail closed.

## Tests

`tests/macos-keychain-credentials.test.ts`: 19 passed.

- The fake runner now models both write forms and **reproduces the 4096-byte truncation**, so a regression cannot pass silently. Verified the new test fails on the unfixed tree and passes with the fix.
- `fails closed on unknown ownership, …` is split: the ownership case becomes `adopts the selected provider when ownership is unknown` (asserting `mcpOAuth` survives and ownership gets recorded); the concurrent-change and failed-persistence assertions are kept as-is.
- Also verified end-to-end against the real `/usr/bin/security` with a 5498-byte payload in the exact state that deadlocked host mode: no throw, selected provider adopted, valid JSON, 10/10 `mcpOAuth` servers preserved, ownership recorded, second reconcile idempotent.

Unrelated pre-existing failure, present on `main` without these commits: `tests/backup-restore-safety.test.ts > refuses to create an unrestorable archive from hard-linked runtime files`.
