### PR TITLE
feat: configurable brand icon and banner in appearance settings

### DIFF
--- a/docs/ACL-MATRIX.md
+++ b/docs/ACL-MATRIX.md
@@ -208,6 +208,8 @@ read-only 投影按 host-issued turn ID 精确匹配当前或已接纳的 queued
 | `/api/billing/admin/*`                            | `manage_billing`                                   |
 | `/api/docker/pull`、运行监控管理                  | `manage_system_config`                             |
 | `/api/status/channel-outbox/*` 人工裁决           | `manage_system_config`                             |
+| 系统外观读写（`GET/PUT /api/config/appearance`）  | `manage_system_config`                             |
+| 品牌资源上传/删除（图标、横幅头像文件写入）       | admin（`adminRoleMiddleware`）                     |
 | `POST /api/groups/:jid/reset-owner`               | admin break-glass，同时仍验证目标资源              |
 
 系统 MCP 默认仅 admin 可用；只有显式设置为 shared 后，普通成员的 Agent 才能进入

--- a/src/http-upload-policy.ts
+++ b/src/http-upload-policy.ts
@@ -2,6 +2,7 @@ import { bodyLimit } from 'hono/body-limit';
 
 export const AVATAR_MAX_FILE_BYTES = 3 * 1024 * 1024;
 export const SKILL_ARCHIVE_MAX_FILE_BYTES = 10 * 1024 * 1024;
+export const BRAND_ASSET_MAX_FILE_BYTES = 3 * 1024 * 1024;
 
 // Multipart boundaries and field metadata add a small amount of overhead on
 // top of the file itself. Keep the allowance bounded so chunked uploads are
@@ -20,6 +21,9 @@ export const avatarUploadBodyLimit = createUploadBodyLimit(
 );
 export const skillArchiveUploadBodyLimit = createUploadBodyLimit(
   SKILL_ARCHIVE_MAX_FILE_BYTES,
+);
+export const brandAssetUploadBodyLimit = createUploadBodyLimit(
+  BRAND_ASSET_MAX_FILE_BYTES,
 );
 
 // Exported for focused middleware tests with a tiny byte budget.

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -8,9 +8,12 @@ import { ProxyAgent } from 'proxy-agent';
 import QRCode from 'qrcode';
 import { Hono } from 'hono';
 import { DATA_DIR } from '../config.js';
+import { detectImageMimeTypeStrict } from '../image-detector.js';
 import {
   avatarUploadBodyLimit,
   AVATAR_MAX_FILE_BYTES,
+  brandAssetUploadBodyLimit,
+  BRAND_ASSET_MAX_FILE_BYTES,
 } from '../http-upload-policy.js';
 import type { Variables } from '../web-context.js';
 import { canAccessGroup, canModifyGroup, getWebDeps } from '../web-context.js';
@@ -2189,6 +2192,162 @@ configRoutes.delete(
   },
 );
 
+// ─── Brand assets (sidebar mark + wordmark) ────────────────────────
+//
+// Two independently configurable images:
+// - brand-icon:   400x400 square mark shown in the collapsed sidebar rail.
+// - brand-banner: 600x200 left-aligned wordmark shown above the workspace
+//                 list. Only PNG/JPG are accepted for either asset.
+
+const BRAND_ASSETS_DIR = path.join(DATA_DIR, 'brand-assets');
+const BRAND_ASSET_KINDS = {
+  icon: { field: 'brandIconUrl', prefix: 'brand-icon-' },
+  banner: { field: 'brandBannerUrl', prefix: 'brand-banner-' },
+} as const;
+type BrandAssetKind = keyof typeof BRAND_ASSET_KINDS;
+const BRAND_ASSET_EXTENSIONS: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+};
+const BRAND_ASSET_FILENAME_RE =
+  /^brand-(?:icon|banner)-[a-f0-9]{8}\.(?:jpg|png)$/;
+
+// Appearance settings are stored in one JSON file and each asset kind owns a
+// shared directory. Serialize mutations so a stale cleanup from one request
+// cannot remove the file selected by another concurrent request.
+let brandAssetMutation = Promise.resolve();
+
+async function withBrandAssetMutation<T>(
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  const previous = brandAssetMutation;
+  let release!: () => void;
+  brandAssetMutation = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+function removeStaleBrandAssets(prefix: string, keep?: string): void {
+  if (!fs.existsSync(BRAND_ASSETS_DIR)) return;
+  for (const filename of fs.readdirSync(BRAND_ASSETS_DIR)) {
+    if (!filename.startsWith(prefix) || filename === keep) continue;
+    fs.rmSync(path.join(BRAND_ASSETS_DIR, filename), { force: true });
+  }
+}
+
+function registerBrandAssetUploadRoute(kind: BrandAssetKind) {
+  const { field, prefix } = BRAND_ASSET_KINDS[kind];
+  configRoutes.post(
+    `/appearance/brand-${kind}`,
+    authMiddleware,
+    adminRoleMiddleware,
+    brandAssetUploadBodyLimit,
+    async (c) => {
+      if (
+        !(c.req.header('content-type') || '').includes('multipart/form-data')
+      ) {
+        return c.json({ error: 'Expected multipart/form-data' }, 400);
+      }
+      const formData = await c.req.formData();
+      const file = formData.get(kind);
+      if (!file || !(file instanceof File)) {
+        return c.json({ error: `No ${kind} file provided` }, 400);
+      }
+      if (file.size > BRAND_ASSET_MAX_FILE_BYTES) {
+        return c.json({ error: 'File too large (max 3MB)' }, 413);
+      }
+      const bytes = Buffer.from(await file.arrayBuffer());
+      const mimeType = detectImageMimeTypeStrict(bytes);
+      const extension = mimeType ? BRAND_ASSET_EXTENSIONS[mimeType] : undefined;
+      if (!extension) {
+        return c.json({ error: 'Unsupported image type. Use jpg or png' }, 400);
+      }
+
+      try {
+        return await withBrandAssetMutation(() => {
+          fs.mkdirSync(BRAND_ASSETS_DIR, { recursive: true });
+          const filename = `${prefix}${randomBytes(4).toString('hex')}${extension}`;
+          const destination = path.join(BRAND_ASSETS_DIR, filename);
+          const temporary = `${destination}.tmp`;
+          fs.writeFileSync(temporary, bytes);
+          fs.renameSync(temporary, destination);
+          const assetUrl = `/api/config/brand-assets/${filename}`;
+          try {
+            const appearance = saveAppearanceConfig({ [field]: assetUrl });
+            removeStaleBrandAssets(prefix, filename);
+            return c.json({ appearance, assetUrl });
+          } catch (err) {
+            fs.rmSync(destination, { force: true });
+            throw err;
+          }
+        });
+      } catch (err) {
+        logger.error({ err, kind }, 'Failed to save brand asset');
+        return c.json({ error: 'Failed to save brand asset' }, 500);
+      }
+    },
+  );
+
+  configRoutes.delete(
+    `/appearance/brand-${kind}`,
+    authMiddleware,
+    adminRoleMiddleware,
+    async (c) => {
+      try {
+        return await withBrandAssetMutation(() => {
+          const appearance = saveAppearanceConfig({ [field]: null });
+          removeStaleBrandAssets(prefix);
+          return c.json({ appearance });
+        });
+      } catch (err) {
+        logger.error({ err, kind }, 'Failed to remove brand asset');
+        return c.json({ error: 'Failed to remove brand asset' }, 500);
+      }
+    },
+  );
+}
+
+registerBrandAssetUploadRoute('icon');
+registerBrandAssetUploadRoute('banner');
+
+// Public — serves the uploaded brand assets. No auth: the sidebar and the
+// pre-login screens render these images before a session exists.
+configRoutes.get('/brand-assets/:filename', async (c) => {
+  const filename = c.req.param('filename');
+  if (!filename || !BRAND_ASSET_FILENAME_RE.test(filename)) {
+    return c.json({ error: 'Invalid filename' }, 400);
+  }
+
+  const filePath = path.join(BRAND_ASSETS_DIR, filename);
+  let data: Buffer;
+  try {
+    data = fs.readFileSync(filePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return c.json({ error: 'Brand asset not found' }, 404);
+    }
+    logger.error({ err, filename }, 'Failed to read brand asset');
+    return c.json({ error: 'Failed to read brand asset' }, 500);
+  }
+
+  const contentType = filename.endsWith('.png') ? 'image/png' : 'image/jpeg';
+  return new Response(new Uint8Array(data), {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': 'public, max-age=31536000, immutable',
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'none'; sandbox",
+    },
+  });
+});
+
 // Public endpoint — no auth required (like /api/auth/status)
 configRoutes.get('/appearance/public', (c) => {
   try {
@@ -2200,6 +2359,8 @@ configRoutes.get('/appearance/public', (c) => {
       aiAvatarColor: config.aiAvatarColor,
       aiAvatarUrl: config.aiAvatarUrl,
       aiAvatarMode: config.aiAvatarMode,
+      brandIconUrl: config.brandIconUrl,
+      brandBannerUrl: config.brandBannerUrl,
     });
   } catch (err) {
     logger.error({ err }, 'Failed to load public appearance config');

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -3299,6 +3299,10 @@ export interface AppearanceConfig {
   aiAvatarColor: string;
   aiAvatarUrl: string | null;
   aiAvatarMode: 'brand' | 'emoji';
+  // 400x400 square mark shown in the collapsed sidebar rail.
+  brandIconUrl: string | null;
+  // 600x200 left-aligned wordmark shown above the workspace list.
+  brandBannerUrl: string | null;
 }
 
 const DEFAULT_APPEARANCE_CONFIG: AppearanceConfig = {
@@ -3308,6 +3312,8 @@ const DEFAULT_APPEARANCE_CONFIG: AppearanceConfig = {
   aiAvatarColor: '#0d9488',
   aiAvatarUrl: null,
   aiAvatarMode: 'brand',
+  brandIconUrl: null,
+  brandBannerUrl: null,
 };
 
 export function getAppearanceConfig(): AppearanceConfig {
@@ -3340,6 +3346,14 @@ export function getAppearanceConfig(): AppearanceConfig {
           ? raw.aiAvatarUrl
           : null,
       aiAvatarMode: raw.aiAvatarMode === 'emoji' ? 'emoji' : 'brand',
+      brandIconUrl:
+        typeof raw.brandIconUrl === 'string' && raw.brandIconUrl
+          ? raw.brandIconUrl
+          : null,
+      brandBannerUrl:
+        typeof raw.brandBannerUrl === 'string' && raw.brandBannerUrl
+          ? raw.brandBannerUrl
+          : null,
     };
   } catch (err) {
     logger.warn(
@@ -3362,6 +3376,14 @@ export function saveAppearanceConfig(
     aiAvatarUrl:
       next.aiAvatarUrl === undefined ? existing.aiAvatarUrl : next.aiAvatarUrl,
     aiAvatarMode: next.aiAvatarMode ?? existing.aiAvatarMode,
+    brandIconUrl:
+      next.brandIconUrl === undefined
+        ? existing.brandIconUrl
+        : next.brandIconUrl,
+    brandBannerUrl:
+      next.brandBannerUrl === undefined
+        ? existing.brandBannerUrl
+        : next.brandBannerUrl,
     updatedAt: new Date().toISOString(),
   };
   fs.mkdirSync(CLAUDE_CONFIG_DIR, { recursive: true });
@@ -3375,6 +3397,8 @@ export function saveAppearanceConfig(
     aiAvatarColor: config.aiAvatarColor,
     aiAvatarUrl: config.aiAvatarUrl,
     aiAvatarMode: config.aiAvatarMode,
+    brandIconUrl: config.brandIconUrl,
+    brandBannerUrl: config.brandBannerUrl,
   };
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -773,6 +773,18 @@ export const AppearanceConfigSchema = z.object({
     .nullable()
     .optional(),
   aiAvatarMode: z.enum(['brand', 'emoji']).optional(),
+  brandIconUrl: z
+    .string()
+    .regex(/^\/api\/config\/brand-assets\/brand-icon-[a-f0-9]{8}\.(?:jpg|png)$/)
+    .nullable()
+    .optional(),
+  brandBannerUrl: z
+    .string()
+    .regex(
+      /^\/api\/config\/brand-assets\/brand-banner-[a-f0-9]{8}\.(?:jpg|png)$/,
+    )
+    .nullable()
+    .optional(),
 });
 
 export const ChangePasswordSchema = z.object({

--- a/tests/runtime-appearance-config.test.ts
+++ b/tests/runtime-appearance-config.test.ts
@@ -34,6 +34,8 @@ describe('system brand migration', () => {
       aiAvatarColor: '#123456',
       aiAvatarUrl: '/api/auth/avatars/system-agent-before.png',
       aiAvatarMode: 'brand',
+      brandIconUrl: null,
+      brandBannerUrl: null,
     });
   });
 
@@ -43,6 +45,31 @@ describe('system brand migration', () => {
       aiAvatarColor: '#123456',
       aiAvatarUrl: null,
       aiAvatarMode: 'brand',
+    });
+  });
+
+  test('persists brand icon and banner URLs independently of each other', () => {
+    expect(
+      runtime.saveAppearanceConfig({
+        brandIconUrl: '/api/config/brand-assets/brand-icon-abcd1234.png',
+      }),
+    ).toMatchObject({
+      brandIconUrl: '/api/config/brand-assets/brand-icon-abcd1234.png',
+      brandBannerUrl: null,
+    });
+
+    expect(
+      runtime.saveAppearanceConfig({
+        brandBannerUrl: '/api/config/brand-assets/brand-banner-abcd1234.png',
+      }),
+    ).toMatchObject({
+      brandIconUrl: '/api/config/brand-assets/brand-icon-abcd1234.png',
+      brandBannerUrl: '/api/config/brand-assets/brand-banner-abcd1234.png',
+    });
+
+    expect(runtime.saveAppearanceConfig({ brandIconUrl: null })).toMatchObject({
+      brandIconUrl: null,
+      brandBannerUrl: '/api/config/brand-assets/brand-banner-abcd1234.png',
     });
   });
 });

--- a/web/src/components/layout/UnifiedSidebar.tsx
+++ b/web/src/components/layout/UnifiedSidebar.tsx
@@ -233,8 +233,11 @@ export function UnifiedSidebar({
         <nav className="w-[4.5rem] h-full bg-muted/30 flex flex-col items-center py-3 gap-1 flex-shrink-0">
           <div className="w-11 h-11 rounded-xl overflow-hidden mb-3 flex-shrink-0">
             <img
-              src={`${import.meta.env.BASE_URL}icons/icon-192.png`}
-              alt="HappyClaw"
+              src={
+                appearance?.brandIconUrl ||
+                `${import.meta.env.BASE_URL}icons/icon-192.png`
+              }
+              alt={appearance?.appName || 'HappyClaw'}
               className="w-full h-full object-cover"
             />
           </div>
@@ -343,9 +346,12 @@ export function UnifiedSidebar({
           <div className="w-[16.5rem] h-full flex flex-col bg-muted/30">
             <div className="flex items-center gap-2 px-4 pt-6 pb-3 mb-3 flex-shrink-0">
               <img
-                src={`${import.meta.env.BASE_URL}icons/logo-text.svg`}
+                src={
+                  appearance?.brandBannerUrl ||
+                  `${import.meta.env.BASE_URL}icons/logo-text.svg`
+                }
                 alt={appearance?.appName || 'HappyClaw'}
-                className="h-10"
+                className="h-10 max-w-[12.5rem] object-contain object-left"
               />
               <div className="flex-1" />
               <button

--- a/web/src/components/settings/AppearanceSection.tsx
+++ b/web/src/components/settings/AppearanceSection.tsx
@@ -1,24 +1,165 @@
-import { useEffect, useState } from 'react';
-import { AppWindow, Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { AppWindow, Loader2, RotateCcw, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useAuthStore } from '../../stores/auth';
-import { api } from '../../api/client';
+import { api, apiFetch } from '../../api/client';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { getErrorMessage } from './types';
 import { SettingsCard as Section } from './SettingsCard';
+import { withBasePath } from '../../utils/url';
 import type { AppearanceConfig } from '../../stores/auth';
 
+const BRAND_ASSET_MAX_BYTES = 3 * 1024 * 1024;
+const BRAND_ASSET_TYPES = ['image/png', 'image/jpeg'];
+
+interface BrandAssetUploadProps {
+  kind: 'icon' | 'banner';
+  title: string;
+  desc: string;
+  url: string | null;
+  canManageAssets: boolean;
+  onChange: (appearance: AppearanceConfig) => void;
+  previewClassName: string;
+  imageClassName: string;
+}
+
+function BrandAssetUpload({
+  kind,
+  title,
+  desc,
+  url,
+  canManageAssets,
+  onChange,
+  previewClassName,
+  imageClassName,
+}: BrandAssetUploadProps) {
+  const [uploading, setUploading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const fieldName = kind;
+
+  const upload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    if (file.size > BRAND_ASSET_MAX_BYTES) {
+      toast.error('图片文件不能超过 3MB');
+      return;
+    }
+    if (!BRAND_ASSET_TYPES.includes(file.type)) {
+      toast.error('仅支持 png、jpg 格式');
+      return;
+    }
+    const body = new FormData();
+    body.append(fieldName, file);
+    setUploading(true);
+    try {
+      const result = await apiFetch<{
+        assetUrl: string;
+        appearance: AppearanceConfig;
+      }>(`/api/config/appearance/brand-${kind}`, {
+        method: 'POST',
+        body,
+      });
+      onChange(result.appearance);
+      toast.success(`${title}已更新`);
+    } catch (err) {
+      toast.error(getErrorMessage(err, `上传${title}失败`));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const remove = async () => {
+    try {
+      const appearance = await api.delete<AppearanceConfig>(
+        `/api/config/appearance/brand-${kind}`,
+      );
+      onChange(appearance);
+      toast.success(`已恢复默认${title}`);
+    } catch (err) {
+      toast.error(getErrorMessage(err, `移除${title}失败`));
+    }
+  };
+
+  return (
+    <Section icon={AppWindow} title={title} desc={desc}>
+      <div className="flex items-center gap-4">
+        <div
+          className={`flex flex-shrink-0 items-center overflow-hidden rounded-lg border border-dashed border-border bg-muted/30 ${previewClassName}`}
+        >
+          {url ? (
+            <img
+              src={withBasePath(url)}
+              alt={title}
+              className={`object-contain ${imageClassName}`}
+            />
+          ) : (
+            <span className="px-2 text-center text-[11px] text-muted-foreground">
+              使用默认
+            </span>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <input
+            ref={inputRef}
+            type="file"
+            accept={BRAND_ASSET_TYPES.join(',')}
+            className="hidden"
+            onChange={upload}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={uploading || !canManageAssets}
+            onClick={() => inputRef.current?.click()}
+          >
+            {uploading ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Upload className="size-3.5" />
+            )}
+            上传图片
+          </Button>
+          {url && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={!canManageAssets}
+              onClick={remove}
+            >
+              <RotateCcw className="size-3.5" />
+              恢复默认
+            </Button>
+          )}
+        </div>
+      </div>
+      {!canManageAssets && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          品牌资源文件的上传与删除需要管理员权限。
+        </p>
+      )}
+    </Section>
+  );
+}
+
 export function AppearanceSection() {
-  const { hasPermission } = useAuthStore();
+  const { user, hasPermission } = useAuthStore();
 
   const [appName, setAppName] = useState('');
+  const [brandIconUrl, setBrandIconUrl] = useState<string | null>(null);
+  const [brandBannerUrl, setBrandBannerUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
   const canManage = hasPermission('manage_system_config');
+  // Brand asset upload/delete is gated to admin on the backend
+  // (`adminRoleMiddleware`), which is stricter than `manage_system_config`.
+  const canManageAssets = user?.role === 'admin';
 
   useEffect(() => {
     if (!canManage) {
@@ -30,6 +171,8 @@ export function AppearanceSection() {
       try {
         const data = await api.get<AppearanceConfig>('/api/config/appearance');
         setAppName(data.appName);
+        setBrandIconUrl(data.brandIconUrl);
+        setBrandBannerUrl(data.brandBannerUrl);
       } catch (err) {
         toast.error(getErrorMessage(err, '加载外观配置失败'));
       } finally {
@@ -37,6 +180,16 @@ export function AppearanceSection() {
       }
     })();
   }, [canManage]);
+
+  const syncBrandAsset =
+    (
+      setter: (url: string | null) => void,
+      pick: (a: AppearanceConfig) => string | null,
+    ) =>
+    (appearance: AppearanceConfig) => {
+      setter(pick(appearance));
+      useAuthStore.setState({ appearance });
+    };
 
   const handleSave = async () => {
     setSaving(true);
@@ -73,8 +226,8 @@ export function AppearanceSection() {
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground bg-muted rounded-lg px-4 py-3">
-        系统品牌只影响站点标题和欢迎文案，不会改变 HappyClaw 或自定义智能体
-        的名称。
+        系统品牌影响站点标题、欢迎文案和侧边栏 Logo，不会改变 HappyClaw
+        或自定义智能体的名称。
       </p>
 
       <Section
@@ -108,6 +261,28 @@ export function AppearanceSection() {
         {saving && <Loader2 className="size-4 animate-spin" />}
         保存系统品牌
       </Button>
+
+      <BrandAssetUpload
+        kind="icon"
+        title="图形 Logo"
+        desc="建议尺寸 400x400，显示在侧边栏折叠图标位置，支持 PNG/JPG"
+        url={brandIconUrl}
+        canManageAssets={canManageAssets}
+        onChange={syncBrandAsset(setBrandIconUrl, (a) => a.brandIconUrl)}
+        previewClassName="h-16 w-16 justify-center"
+        imageClassName="h-full w-full"
+      />
+
+      <BrandAssetUpload
+        kind="banner"
+        title="文字 Logo"
+        desc="建议尺寸 600x200，左对齐显示在工作区列表上方，支持 PNG/JPG"
+        url={brandBannerUrl}
+        canManageAssets={canManageAssets}
+        onChange={syncBrandAsset(setBrandBannerUrl, (a) => a.brandBannerUrl)}
+        previewClassName="h-[3.35rem] w-[10rem] justify-start px-2"
+        imageClassName="h-full w-full object-left"
+      />
     </div>
   );
 }

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -42,6 +42,10 @@ export interface AppearanceConfig {
   aiAvatarColor: string;
   aiAvatarUrl: string | null;
   aiAvatarMode: 'brand' | 'emoji';
+  // 400x400 square mark shown in the collapsed sidebar rail.
+  brandIconUrl: string | null;
+  // 600x200 left-aligned wordmark shown above the workspace list.
+  brandBannerUrl: string | null;
 }
 
 export interface SetupStatus {


### PR DESCRIPTION
## 概述

在**设置 → 常规与品牌**新增两个可配置的品牌图片，均支持 PNG/JPG：

1. **图形 Logo**（建议 400×400）— 显示在左侧折叠导航栏的图标位置
2. **文字 Logo**（建议 600×200，左对齐）— 显示在工作区列表上方

## 改动范围

**后端**
- `src/runtime-config.ts`：`AppearanceConfig` 新增 `brandIconUrl`/`brandBannerUrl` 字段，纯 JSON 文件持久化
- `src/schemas.ts`：URL 校验限定为本站 `/api/config/brand-assets/...` 路径
- `src/http-upload-policy.ts`：新增 3MB 上传体积限制
- `src/routes/config.ts`：
  - `POST/DELETE /api/config/appearance/brand-icon`、`brand-banner`（仅 admin，服务端 MIME 嗅探、随机文件名、并发安全的旧文件清理）
  - `GET /api/config/brand-assets/:filename`（无需鉴权，文件名白名单正则校验，登录前页面也能渲染）
- `docs/ACL-MATRIX.md`：补充外观读写与品牌资源写入的权限矩阵

**前端**
- `web/src/components/settings/AppearanceSection.tsx`：新增上传/预览/恢复默认组件
- `web/src/components/layout/UnifiedSidebar.tsx`：折叠导航栏图标与工作区列表上方使用配置的品牌图片
- `web/src/stores/auth.ts`：`AppearanceConfig` 类型同步新增字段

## 测试

- `make typecheck`（root / web / agent-runner）
- `npm test -- --run`（2887 passed；5 个测试文件的 22 个失败为该分支引入前即存在的环境问题 `TypeError: act is not a function`，与本次改动无关，已通过 `git stash` 对比基线验证）
- `npm run build:all`
- `npm run docs:check`