### PR TITLE
fix(ci): authenticate before booting BuildKit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,14 +34,30 @@ jobs:
       - name: Check out source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull BuildKit image
+        run: |
+          set -euo pipefail
+          for attempt in {1..5}; do
+            if docker pull moby/buildkit:buildx-stable-1; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "Failed to pull BuildKit after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       # docker/github-builder finalizes image tags in its reusable workflow.
       # Build by digest here so no user-facing tag can move before both native
@@ -98,14 +114,30 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull BuildKit image
+        run: |
+          set -euo pipefail
+          for attempt in {1..5}; do
+            if docker pull moby/buildkit:buildx-stable-1; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "Failed to pull BuildKit after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Download verified digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## What changed

- authenticate to Docker Hub before initializing Buildx in both image-publishing jobs
- pre-pull `moby/buildkit:buildx-stable-1` with bounded retries
- configure Buildx to use the authenticated, pre-pulled BuildKit image

## Root cause

The AMD64 publisher failed while `docker/setup-buildx-action` booted its builder because it anonymously pulled BuildKit before the existing Docker Hub login step. Docker Hub returned `unauthorized: authentication required`, so the platform build stopped and promotion was skipped.

## Impact

Image publication no longer depends on an unauthenticated BuildKit pull and tolerates short registry interruptions. Both native platform images must still pass their existing Chromium smoke test before signed multi-platform promotion.

## Validation

- `git diff --check`
- `npx prettier --check .github/workflows/docker-publish.yml`
- `FORMAT_BASE_REF=main npm run format:check`