### PR TITLE
fix(feishu): enable lark SDK WS liveness watchdog so silently-stale long connections reconnect

### DIFF
--- a/src/feishu.ts
+++ b/src/feishu.ts
@@ -240,6 +240,14 @@ const FEISHU_WS_READY_STATE_OPEN = 1;
 const WS_HEALTH_CHECK_INTERVAL_MS = 15_000;
 const WS_RECONNECT_CHECK_THRESHOLD = 4;
 const WS_RECONNECT_MIN_INTERVAL_MS = 30_000;
+// Enable the lark SDK's ping/pong liveness watchdog. After the SDK sends a
+// keepalive ping it waits this many seconds for a pong (or any inbound frame);
+// if none arrives the socket is terminated so the normal reconnect flow runs.
+// Without it, a silently half-dead connection keeps readyState === OPEN forever
+// and the readyState-based health check never reconnects — the bot goes quiet
+// with no error until the process is restarted. Any inbound frame clears the
+// watchdog, so healthy idle connections are never terminated.
+const FEISHU_WS_PING_TIMEOUT_SEC = 10;
 const BACKFILL_LOOKBACK_MS = 5 * 60 * 1000;
 const BACKFILL_PAGE_SIZE = 50;
 const BACKFILL_MAX_PAGES_PER_CHAT = 5;
@@ -3366,6 +3374,9 @@ export function createFeishuConnection(
         appId: config.appId,
         appSecret: config.appSecret,
         loggerLevel: lark.LoggerLevel.info,
+        // Detect silently-dead long connections instead of hanging on a
+        // stale-but-OPEN socket (see FEISHU_WS_PING_TIMEOUT_SEC).
+        wsConfig: { pingTimeout: FEISHU_WS_PING_TIMEOUT_SEC },
       });
       await wsClient.start({ eventDispatcher });
 
@@ -3627,6 +3638,9 @@ export function createFeishuConnection(
         appId: config.appId,
         appSecret: config.appSecret,
         loggerLevel: lark.LoggerLevel.info,
+        // Detect silently-dead long connections instead of hanging on a
+        // stale-but-OPEN socket (see FEISHU_WS_PING_TIMEOUT_SEC).
+        wsConfig: { pingTimeout: FEISHU_WS_PING_TIMEOUT_SEC },
       });
 
       try {


### PR DESCRIPTION
## Problem

The Feishu long connection only reconnects when the underlying socket's `readyState` leaves `OPEN`. A **silently half-dead** connection — the server stops pushing events, but the socket still reports `OPEN` — is invisible to the readyState-based health check: `disconnectedChecks` stays `0` and the client never reconnects.

**Symptom:** the bot silently stops receiving any messages (`im.message.receive_v1` never arrives) with **no error in the logs**, and only a process restart recovers it. Observed in production on a self-hosted deployment: the WS reported connected for 30+ min while zero events flowed.

## Fix

The lark SDK already ships a ping/pong liveness watchdog (`armLiveness`/`clearLiveness`), but it is a **no-op unless `wsConfig.pingTimeout` is set** (`this.pingTimeoutSec = userWsConfig?.pingTimeout ?? 0`).

This PR passes `wsConfig: { pingTimeout: 10 }` when constructing the `WSClient`. After each keepalive ping the SDK waits `pingTimeout` seconds for a pong (or any inbound frame) and `terminate()`s the socket if none arrives, letting the existing `close`-handler reconnect flow run. Any inbound frame clears the watchdog, so **healthy idle connections are never terminated** (the SDK deliberately does not re-arm on inbound).

- No new dependency; `@larksuiteoapi/node-sdk` already vendored (>=1.71.x has the watchdog).
- No behavior change when the connection is healthy.
- Complements the existing readyState-based reconnect (which still handles truly-closed sockets).

## Test

- `tsc --noEmit` passes.
- Deployed to the affected instance; WS connects normally with the watchdog armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)