### PR TITLE
fix(web): 增加 WebSocket 心跳，修复反代下每分钟断线与死连接泄漏

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,33 @@ HappyClaw 会执行代码和访问第三方消息平台，部署前请理解以�
 
 完整接口权限见 [ACL 权限矩阵](docs/ACL-MATRIX.md)。
 
+### 反向代理配置
+
+Web 界面依赖 `/ws` 上的 WebSocket 推送流式输出和运行状态。反向代理必须放行
+Upgrade 并把该连接的读超时设得足够长，否则前端会周期性弹出「连接中断，正在重连...」。
+
+服务端已内置 30 秒心跳（ping/pong），既用于保活，也用于回收半开的死连接，
+因此代理侧只需把读超时设得高于心跳间隔即可。nginx 示例：
+
+```nginx
+location /ws {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 3600s;   # 默认 60s 会掐断长连接
+    proxy_send_timeout 3600s;
+}
+```
+
+注意 `Connection` 应固定为 `"upgrade"`，不要写成 `$http_connection`——后者依赖
+客户端如实发送该头部，行为不稳定。
+
+若代理位于 Cloudflare 等平台之后，还需确认其空闲超时高于 30 秒心跳间隔。
+上传大文件时另需放宽 `client_max_body_size`（不小于 `MAX_FILE_SIZE_MB`，并预留
+multipart 开销）与 `client_body_timeout`。
+
 ## 开发与测试
 
 ### 常用命令

--- a/src/web.ts
+++ b/src/web.ts
@@ -123,6 +123,7 @@ import type { ExpandContext } from './plugin-expander-context.js';
 import { PLUGIN_EXPANSION_ATTACHMENT_TYPE } from './plugin-expander-sentinel.js';
 import { persistPluginExpansion } from './plugin-expander-store.js';
 import { logger } from './logger.js';
+import { createWebSocketHeartbeat } from './ws-heartbeat.js';
 import { recordRunContextSnapshot } from './run-context-snapshot.js';
 import { RunStreamFence } from './run-stream-fence.js';
 import {
@@ -1384,6 +1385,24 @@ function setupWebSocket(server: any): WebSocketServer {
     maxPayload: 8 * 1024 * 1024,
   });
 
+  // 心跳：保活反代/NAT 会掐掉的空闲 upgraded 连接，并回收 TCP 半开的死连接。
+  // 取值与完整背景见 src/ws-heartbeat.ts。
+  // 注意：此前死连接是靠反代的读超时（nginx 默认 60s）兜底回收的——调大
+  // proxy_read_timeout 必须在心跳上线之后做，否则死连接会堆积到新的超时时长。
+  const heartbeat = createWebSocketHeartbeat();
+  const heartbeatTimer = setInterval(() => {
+    const terminated = heartbeat.sweep(wss.clients);
+    if (terminated > 0) {
+      logger.info(
+        { terminated, maxMissedPongs: heartbeat.maxMissedPongs },
+        'WebSocket heartbeat timeout, terminated dead connections',
+      );
+    }
+  }, heartbeat.intervalMs);
+  // 不阻止进程退出；正常关闭走下面的 wss 'close'。
+  heartbeatTimer.unref?.();
+  wss.on('close', () => clearInterval(heartbeatTimer));
+
   server.on('upgrade', (request: any, socket: any, head: any) => {
     const { pathname } = new URL(request.url, `http://${request.headers.host}`);
 
@@ -1495,6 +1514,8 @@ function setupWebSocket(server: any): WebSocketServer {
   wss.on('connection', (ws, request: any) => {
     const sessionId = request?.__happyclawSessionId as string | undefined;
     logger.info('WebSocket client connected');
+    // 心跳状态：浏览器由协议栈自动回 pong，前端无需改动。
+    heartbeat.track(ws);
     const connSession = sessionId
       ? getCachedSessionWithUser(sessionId)
       : undefined;

--- a/src/ws-heartbeat.ts
+++ b/src/ws-heartbeat.ts
@@ -1,0 +1,93 @@
+/**
+ * WebSocket 心跳：保活 + 死连接回收。
+ *
+ * 解决两个问题：
+ *
+ * 1) 保活。反向代理与 NAT 会掐掉空闲的 upgraded 连接（nginx proxy_read_timeout
+ *    默认 60s，Cloudflare 100s，运营商 NAT 常见 30~120s）。没有心跳时前端会被
+ *    动辄每分钟断开一次，反复弹出「连接中断，正在重连...」。服务端定期 ping 让
+ *    连接始终有真实流量，读超时不会触发；浏览器由协议栈自动回 pong，前端无需
+ *    任何改动。
+ *
+ * 2) 死连接回收。客户端非正常消失（合盖、切网、进程被杀）时 TCP 半开，'close'
+ *    永不触发，连接表条目与终端会话会一直泄漏，广播持续写入黑洞。只有 ping/pong
+ *    探测能发现这种连接。
+ *
+ * 关于 maxMissedPongs 的取值：代价高度不对称。误杀活连接会让用户看到
+ * 「连接中断，正在重连...」——正是本心跳要消除的现象；而晚回收死连接只是多留
+ * 一个条目和几 KB 无效广播。主服务是单进程，存在同步写盘（如文件上传）与 GC
+ * 停顿，事件循环被阻塞时 pong 帧虽已到达却来不及处理，取 1（ws 库 README 示例
+ * 的经典写法）会把这种停顿误判成死连接并踢掉全部客户端。因此默认取 3。
+ */
+
+/** 心跳只需要这三个能力，用结构类型以便测试替身注入。 */
+export interface HeartbeatSocket {
+  ping(): void;
+  terminate(): void;
+  on(event: 'pong', listener: () => void): unknown;
+}
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const DEFAULT_MAX_MISSED_PONGS = 3;
+
+export interface HeartbeatOptions {
+  intervalMs?: number;
+  /** 连续多少轮收不到 pong 判定连接已死。必须 >= 1。 */
+  maxMissedPongs?: number;
+}
+
+export interface WebSocketHeartbeat {
+  readonly intervalMs: number;
+  readonly maxMissedPongs: number;
+  /** 登记一条新连接，并挂上 pong 监听。 */
+  track(socket: HeartbeatSocket): void;
+  /** 执行一轮探测，返回本轮被判定为死连接并已 terminate 的数量。 */
+  sweep(sockets: Iterable<HeartbeatSocket>): number;
+}
+
+export function createWebSocketHeartbeat(
+  options: HeartbeatOptions = {},
+): WebSocketHeartbeat {
+  const intervalMs = options.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const maxMissedPongs = Math.max(
+    1,
+    options.maxMissedPongs ?? DEFAULT_MAX_MISSED_PONGS,
+  );
+  // WeakMap：连接被回收后条目自动消失，不会成为新的泄漏点。
+  const missedPongs = new WeakMap<HeartbeatSocket, number>();
+
+  return {
+    intervalMs,
+    maxMissedPongs,
+
+    track(socket) {
+      missedPongs.set(socket, 0);
+      socket.on('pong', () => missedPongs.set(socket, 0));
+    },
+
+    sweep(sockets) {
+      let terminated = 0;
+      for (const socket of sockets) {
+        const missed = (missedPongs.get(socket) ?? 0) + 1;
+        if (missed >= maxMissedPongs) {
+          // terminate() 会触发 'close'，由调用方既有的 close handler 完成
+          // 连接表与终端会话清理。
+          terminated += 1;
+          try {
+            socket.terminate();
+          } catch {
+            /* ignore */
+          }
+          continue;
+        }
+        missedPongs.set(socket, missed);
+        try {
+          socket.ping();
+        } catch {
+          /* ignore */
+        }
+      }
+      return terminated;
+    },
+  };
+}

--- a/tests/ws-heartbeat.test.ts
+++ b/tests/ws-heartbeat.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_MAX_MISSED_PONGS,
+  createWebSocketHeartbeat,
+  type HeartbeatSocket,
+} from '../src/ws-heartbeat.js';
+
+/** 测试替身：记录 ping/terminate 次数，并能按需回 pong。 */
+function fakeSocket() {
+  let pongListener: (() => void) | undefined;
+  const socket = {
+    ping: vi.fn(),
+    terminate: vi.fn(),
+    on: vi.fn((event: 'pong', listener: () => void) => {
+      if (event === 'pong') pongListener = listener;
+      return socket;
+    }),
+    /** 模拟对端回 pong */
+    respond: () => pongListener?.(),
+  };
+  return socket;
+}
+
+type FakeSocket = ReturnType<typeof fakeSocket>;
+
+const asSockets = (...sockets: FakeSocket[]): HeartbeatSocket[] =>
+  sockets as unknown as HeartbeatSocket[];
+
+describe('createWebSocketHeartbeat', () => {
+  test('默认 30s 间隔、容忍 3 轮——刻意宽于 ws 库示例的 1 轮', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    expect(heartbeat.intervalMs).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+    expect(heartbeat.intervalMs).toBe(30_000);
+    // 单进程服务存在同步写盘与 GC 停顿，取 1 会把事件循环阻塞误判成死连接
+    // 并踢掉全部客户端。这个下限是回归保护，不要调回 1。
+    expect(heartbeat.maxMissedPongs).toBe(DEFAULT_MAX_MISSED_PONGS);
+    expect(heartbeat.maxMissedPongs).toBe(3);
+  });
+
+  test('track 会登记连接并挂上 pong 监听', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    expect(socket.on).toHaveBeenCalledWith('pong', expect.any(Function));
+  });
+
+  test('每轮对存活连接发 ping，且不终止它们', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    const terminated = heartbeat.sweep(asSockets(socket));
+
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(terminated).toBe(0);
+  });
+
+  test('持续回 pong 的连接永远不会被终止', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    for (let round = 0; round < 20; round++) {
+      expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+      socket.respond();
+    }
+
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(socket.ping).toHaveBeenCalledTimes(20);
+  });
+
+  test('连续 3 轮无 pong 才终止——前两轮只探测', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.terminate).not.toHaveBeenCalled();
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.terminate).not.toHaveBeenCalled();
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(1);
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+    // 判定为死连接后不再浪费一次 ping
+    expect(socket.ping).toHaveBeenCalledTimes(2);
+  });
+
+  test('中途恢复 pong 会清零计数，不会累积到终止', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    heartbeat.sweep(asSockets(socket)); // missed = 1
+    heartbeat.sweep(asSockets(socket)); // missed = 2
+    socket.respond(); // 事件循环恢复，pong 被处理 → 清零
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  test('未经 track 的连接同样被计数，不会因缺省状态被立即终止', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+  });
+
+  test('maxMissedPongs 可配置，且下限被钳制为 1', () => {
+    const eager = createWebSocketHeartbeat({ maxMissedPongs: 1 });
+    const socket = fakeSocket();
+    eager.track(socket as unknown as HeartbeatSocket);
+    expect(eager.sweep(asSockets(socket))).toBe(1);
+
+    // 0 / 负数会让每一轮都立即终止全部连接，钳制到 1 是安全下限
+    expect(createWebSocketHeartbeat({ maxMissedPongs: 0 }).maxMissedPongs).toBe(
+      1,
+    );
+    expect(
+      createWebSocketHeartbeat({ maxMissedPongs: -5 }).maxMissedPongs,
+    ).toBe(1);
+  });
+
+  test('单个连接 ping 抛错不影响同一轮的其他连接', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const broken = fakeSocket();
+    broken.ping.mockImplementation(() => {
+      throw new Error('socket already closed');
+    });
+    const healthy = fakeSocket();
+    heartbeat.track(broken as unknown as HeartbeatSocket);
+    heartbeat.track(healthy as unknown as HeartbeatSocket);
+
+    expect(() => heartbeat.sweep(asSockets(broken, healthy))).not.toThrow();
+    expect(healthy.ping).toHaveBeenCalledTimes(1);
+  });
+
+  test('terminate 抛错不影响同一轮的其他连接', () => {
+    const heartbeat = createWebSocketHeartbeat({ maxMissedPongs: 1 });
+    const broken = fakeSocket();
+    broken.terminate.mockImplementation(() => {
+      throw new Error('already destroyed');
+    });
+    const healthy = fakeSocket();
+
+    expect(() => heartbeat.sweep(asSockets(broken, healthy))).not.toThrow();
+    expect(healthy.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  test('多连接独立计数：死连接被清理，活连接不受牵连', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const dead = fakeSocket();
+    const alive = fakeSocket();
+    heartbeat.track(dead as unknown as HeartbeatSocket);
+    heartbeat.track(alive as unknown as HeartbeatSocket);
+
+    for (let round = 0; round < 2; round++) {
+      heartbeat.sweep(asSockets(dead, alive));
+      alive.respond();
+    }
+    const terminated = heartbeat.sweep(asSockets(dead, alive));
+
+    expect(terminated).toBe(1);
+    expect(dead.terminate).toHaveBeenCalledTimes(1);
+    expect(alive.terminate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 用户影响

自托管在反向代理后的用户，Web 界面会反复弹出「连接中断，正在重连...」，随后自动恢复，循环往复。

服务端此前既不发 ping 也不检测 pong，因此任何空闲超过代理读超时的 WebSocket 都会被单方面切断。实测在一套 nginx 部署上，多个互不相关的客户端均以约 62 秒的固定节奏重新握手（60s `proxy_read_timeout` 默认值 + 前端 1s 重连退避）。这不是单个用户的网络问题——nginx 默认 60s、Cloudflare 100s、运营商 NAT 常见 30~120s，只要部署在反代或 NAT 之后就会触发。

同一缺陷还导致第二个问题：客户端非正常消失（合盖、切网、进程被杀）时 TCP 半开，`'close'` 永不触发，`wsClients` 条目与终端会话持续泄漏，广播写入黑洞。此前这类死连接实际上是靠反代的读超时被动清理的。

## 改动

新增 `src/ws-heartbeat.ts`：服务端每 30s 主动 ping，连续 3 轮收不到 pong 判定连接已死并 `terminate()`（复用既有 close handler 完成清理）。浏览器由协议栈自动回 pong，前端无需任何改动。

心跳逻辑抽为独立模块而非内联在 `setupWebSocket()` 中，是为了能直接单测，避免为覆盖它而 mock 整个 `web.js`。

**关于容忍轮次取 3 而非 ws 库 README 示例的 1**：代价高度不对称。误杀活连接会产生正是本改动要消除的断线提示；而晚回收死连接只是多留一个条目和几 KB 无效广播。主服务为单进程，存在同步写盘（如文件上传的 `writeFileSync`）与 GC 停顿，事件循环被阻塞时 pong 帧虽已到达却来不及处理，取 1 会把这类停顿误判成死连接并踢掉全部客户端。

README 补充了反向代理配置章节：此前文档建议公网部署使用反向代理，却未说明 WebSocket 所需的超时配置，自托管用户必然踩坑。

## 验证方式

- 新增 11 个单测（`tests/ws-heartbeat.test.ts`）：存活连接持续被 ping 且不被终止、中途恢复 pong 会清零计数、连续 3 轮无响应才终止、多连接独立计数互不牵连、`ping`/`terminate` 抛错不影响同轮其他连接、`maxMissedPongs` 下限钳制。其中默认值 3 有显式回归保护。
- `make typecheck && make test && make build` 全部通过（356 文件 / 3101 测试），`make format-check` 通过。
- 生产环境实测：改动前 `/ws` 每 62 秒重新握手一次；改动后连续 5 分钟零重连，socket 的 `lastrcv` 呈标准锯齿、复位间隔精确 30.0 秒。

## 兼容性

无破坏性变更。不新增配置项，不改变任何现有接口或消息格式；前端无需改动。

**部署顺序提示**：调大 `proxy_read_timeout` 应在本心跳生效之后进行，否则会移除当前唯一在回收死连接的机制。README 已写明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)