### PR TITLE
fix(web): 上传失败自动重试，并暴露真实错误原因

### DIFF
--- a/tests/file-upload-retry.test.ts
+++ b/tests/file-upload-retry.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../web/src/api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+  apiFetch: vi.fn(),
+  computeUploadTimeoutMs: (bytes: number) =>
+    Math.min(600_000, Math.max(120_000, Math.ceil(bytes / (20 * 1024)) * 1000)),
+}));
+
+import { api, apiFetch } from '../web/src/api/client';
+import { useFileStore } from '../web/src/stores/files';
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedGet = vi.mocked(api.get);
+
+/**
+ * apiFetch 抛出的是纯对象形态的 ApiError，不是 Error 实例。这一点是本文件多个
+ * 断言的前提：用 `err instanceof Error` 取信息会退化成默认文案。
+ */
+function apiError(status: number, message = 'boom') {
+  return { status, message };
+}
+
+function makeFile(name = 'paper.pdf', size = 124_758) {
+  const file = new File(['x'], name, { type: 'application/pdf' });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+/**
+ * 重试退避是真实的 2s / 5s。用假定时器推进，否则单个用例要真等 7 秒，
+ * 且超时后挂起的重试会污染后续用例的 mock 计数。
+ */
+async function runUpload(jid: string, files: File[]) {
+  const pending = useFileStore.getState().uploadFiles(jid, files);
+  await vi.advanceTimersByTimeAsync(60_000);
+  return pending;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockedApiFetch.mockReset();
+  mockedGet.mockReset();
+  // loadFiles 在上传成功后刷新列表；给它一个合法响应，避免干扰 error 断言。
+  mockedGet.mockResolvedValue({ files: [], currentPath: '' });
+  useFileStore.setState({
+    files: {},
+    currentPath: {},
+    loading: false,
+    uploading: false,
+    uploadProgress: null,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('文件上传重试', () => {
+  test('408 后重试并最终成功——慢链路上反代读体超时是常见瞬时故障', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(408, 'Request timeout'))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(2);
+    expect(useFileStore.getState().error).toBeNull();
+  });
+
+  test('网络错误（status 0）同样重试', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(0, 'Network error'))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([502, 503, 504])('%i 视为上游瞬时不可用，重试', async (status) => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(status))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('连续失败最多尝试 3 次后放弃', async () => {
+    mockedApiFetch.mockRejectedValue(apiError(408, 'Request timeout'));
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(false);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test.each([
+    [400, '参数错误'],
+    [403, '配额或路径被拒'],
+    [413, '超过大小上限'],
+    [500, '服务端逻辑错误'],
+  ])('%i（%s）不重试，立即失败', async (status) => {
+    mockedApiFetch.mockRejectedValue(apiError(status));
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(false);
+    // 重试这类错误没有意义，只会让用户多等两轮退避才看到真实原因
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('失败时暴露真实原因而非笼统文案', async () => {
+    mockedApiFetch.mockRejectedValue(
+      apiError(413, 'File paper.pdf exceeds maximum size of 100MB'),
+    );
+
+    await runUpload('web:g1', [makeFile()]);
+
+    const { error } = useFileStore.getState();
+    expect(error).toContain('exceeds maximum size of 100MB');
+    expect(error).toContain('413');
+    expect(error).not.toBe('Failed to upload files');
+  });
+
+  test('Error 实例的信息也能正确提取', async () => {
+    mockedApiFetch.mockRejectedValue(new Error('boom from fetch'));
+
+    await runUpload('web:g1', [makeFile()]);
+
+    expect(useFileStore.getState().error).toBe('boom from fetch');
+  });
+
+  test('逐文件独立重试：已成功的文件不会被重传', async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce({ success: true, files: ['a.pdf'] })
+      .mockRejectedValueOnce(apiError(408))
+      .mockResolvedValueOnce({ success: true, files: ['b.pdf'] });
+
+    const ok = await runUpload('web:g1', [
+      makeFile('a.pdf'),
+      makeFile('b.pdf'),
+    ]);
+
+    expect(ok).toBe(true);
+    // a 一次成功；b 失败一次后重试成功 → 共 3 次，a 没有被重传
+    expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('每次重试重建 FormData——body 已被上一次 fetch 消费，不能复用', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(408))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    await runUpload('web:g1', [makeFile()]);
+
+    const bodies = mockedApiFetch.mock.calls.map(
+      ([, init]) => (init as RequestInit | undefined)?.body,
+    );
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toBeInstanceOf(FormData);
+    expect(bodies[1]).toBeInstanceOf(FormData);
+    expect(bodies[0]).not.toBe(bodies[1]);
+  });
+
+  test('整批结束后清理上传状态', async () => {
+    mockedApiFetch.mockRejectedValue(apiError(408));
+
+    await runUpload('web:g1', [makeFile()]);
+
+    expect(useFileStore.getState().uploading).toBe(false);
+    expect(useFileStore.getState().uploadProgress).toBeNull();
+  });
+
+  test('空文件列表直接返回 false，不发请求', async () => {
+    const ok = await useFileStore.getState().uploadFiles('web:g1', []);
+
+    expect(ok).toBe(false);
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/chat/FileUploadZone.tsx
+++ b/web/src/components/chat/FileUploadZone.tsx
@@ -53,7 +53,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
 
   const progressPercent =
     uploadProgress && uploadProgress.totalBytes > 0
-      ? Math.round((uploadProgress.uploadedBytes / uploadProgress.totalBytes) * 100)
+      ? Math.round(
+          (uploadProgress.uploadedBytes / uploadProgress.totalBytes) * 100,
+        )
       : 0;
 
   return (
@@ -64,9 +66,7 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={`relative border-2 border-dashed rounded-lg p-3 transition-all ${
-          isDragging
-            ? 'border-primary bg-brand-50'
-            : 'border-border'
+          isDragging ? 'border-primary bg-brand-50' : 'border-border'
         } ${uploading ? 'pointer-events-none' : ''}`}
       >
         {/* Hidden inputs */}
@@ -92,8 +92,12 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
           /* Upload progress */
           <div className="space-y-2">
             <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span className="truncate max-w-[60%]">{uploadProgress.currentFile || '完成'}</span>
-              <span>{uploadProgress.completed}/{uploadProgress.total} 个文件</span>
+              <span className="truncate max-w-[60%]">
+                {uploadProgress.currentFile || '完成'}
+              </span>
+              <span>
+                {uploadProgress.completed}/{uploadProgress.total} 个文件
+              </span>
             </div>
             <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
               <div
@@ -101,7 +105,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
                 style={{ width: `${progressPercent}%` }}
               />
             </div>
-            <p className="text-[11px] text-muted-foreground text-center">{progressPercent}%</p>
+            <p className="text-[11px] text-muted-foreground text-center">
+              {progressPercent}%
+            </p>
           </div>
         ) : (
           /* Idle state */

--- a/web/src/components/chat/FileUploadZone.tsx
+++ b/web/src/components/chat/FileUploadZone.tsx
@@ -94,6 +94,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span className="truncate max-w-[60%]">
                 {uploadProgress.currentFile || '完成'}
+                {uploadProgress.attempt && uploadProgress.attempt > 1
+                  ? `（网络不稳，重试 ${uploadProgress.attempt}/3）`
+                  : ''}
               </span>
               <span>
                 {uploadProgress.completed}/{uploadProgress.total} 个文件

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -1,6 +1,45 @@
 import { create } from 'zustand';
 import { api, apiFetch, computeUploadTimeoutMs } from '../api/client';
 
+/**
+ * 上传重试。慢速或不稳定链路上单次上传失败非常常见（反代读请求体超时 → 408，
+ * 客户端 abort → 网络错误），此前任何一次失败都会让整批上传中断、用户必须
+ * 手动从头再来。服务端按文件名 O_TRUNC 覆盖写，重传同一文件是幂等的。
+ */
+const UPLOAD_MAX_ATTEMPTS = 3;
+const UPLOAD_RETRY_DELAYS_MS = [2000, 5000];
+
+/**
+ * 只重试传输层的瞬时失败：
+ * - 0：apiFetch 归一化后的网络错误
+ * - 408：客户端超时 abort，或反向代理读请求体超时
+ * - 502/503/504：上游短暂不可用
+ * 其余（400 参数错误、403 配额或路径拒绝、413 超限、500 逻辑错误）重试没有意义，
+ * 立即失败，让用户看到真实原因而不是等三轮。
+ */
+function isRetriableUploadError(err: unknown): boolean {
+  const status = (err as { status?: number } | null)?.status;
+  return (
+    status === 0 ||
+    status === 408 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  );
+}
+
+/** apiFetch 抛出的 ApiError 是纯对象而非 Error，直接用 instanceof 会丢掉真实原因。 */
+function uploadErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  const e = err as { message?: string; status?: number } | null;
+  if (e?.message) {
+    return e.status ? `${e.message} (HTTP ${e.status})` : e.message;
+  }
+  return 'Failed to upload files';
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export interface FileEntry {
   name: string;
   path: string;
@@ -20,6 +59,8 @@ export interface UploadProgress {
   /** bytes for current batch */
   totalBytes: number;
   uploadedBytes: number;
+  /** 当前文件的重试轮次；仅在 >1 时有值，用于让 UI 区分「慢」和「卡死」。 */
+  attempt?: number;
 }
 
 interface FileState {
@@ -139,16 +180,47 @@ export const useFileStore = create<FileState>((set, get) => ({
           },
         });
 
-        const formData = new FormData();
-        formData.append('files', file);
-        if (uploadPath) formData.append('path', uploadPath);
+        // 每轮重建 FormData：body 已被上一次 fetch 消费，不能复用。
+        let lastErr: unknown;
+        for (let attempt = 1; attempt <= UPLOAD_MAX_ATTEMPTS; attempt++) {
+          if (attempt > 1) {
+            set({
+              uploadProgress: {
+                total,
+                completed: i,
+                currentFile: file.name,
+                totalBytes,
+                uploadedBytes,
+                attempt,
+              },
+            });
+          }
 
-        await apiFetch(apiUrl, {
-          method: 'POST',
-          body: formData,
-          headers: {},
-          timeoutMs: computeUploadTimeoutMs(file.size),
-        });
+          const formData = new FormData();
+          formData.append('files', file);
+          if (uploadPath) formData.append('path', uploadPath);
+
+          try {
+            await apiFetch(apiUrl, {
+              method: 'POST',
+              body: formData,
+              headers: {},
+              timeoutMs: computeUploadTimeoutMs(file.size),
+            });
+            lastErr = undefined;
+            break;
+          } catch (err) {
+            lastErr = err;
+            if (
+              attempt === UPLOAD_MAX_ATTEMPTS ||
+              !isRetriableUploadError(err)
+            ) {
+              break;
+            }
+            await sleep(UPLOAD_RETRY_DELAYS_MS[attempt - 1] ?? 5000);
+          }
+        }
+        if (lastErr) throw lastErr;
 
         uploadedBytes += file.size;
 
@@ -167,7 +239,7 @@ export const useFileStore = create<FileState>((set, get) => ({
       await get().loadFiles(jid, targetBase);
       return true;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to upload files';
+      const msg = uploadErrorMessage(err);
       console.error('Failed to upload files:', err);
       set({ error: msg });
       return false;


### PR DESCRIPTION
## 评审提示：本 PR 拆为两个提交

- `style: 格式化本次改动涉及的文件` — **纯格式化，零行为变化**。`check-format-changed` 对被改动的文件整体运行 `prettier --check`，因此改动 `FileUploadZone.tsx` 前必须先让它符合 Prettier。单独成一个提交，避免格式噪音淹没逻辑改动（沿用仓库既有惯例）。
- `fix(web): 上传失败自动重试...` — **只看这个提交即可**。其中 `FileUploadZone.tsx` 仅 3 行新增。

## 用户影响

慢速或不稳定链路上，单次文件上传失败非常常见：反向代理读请求体超时会返回 408，客户端自身超时 abort 则表现为连接中断。此前**任何一次失败都会中断整批上传**，用户必须手动从头再传。

实测一位用户在约 12 分钟内连续 10 次上传中有 8 次失败（6 次 408、2 次客户端中止），两篇文档最终只有一篇落地，而失败的那篇她完全不知道为什么传不上去。

失败时的提示同样无用。`apiFetch` 抛出的 `ApiError` 是纯对象而非 `Error` 实例，而 catch 中用 `err instanceof Error ? err.message : '...'` 取信息，判断恒为假，真实原因一直被吞掉，用户只能看到笼统的 `Failed to upload files`。

## 改动

- 每个文件最多尝试 3 次，退避 2s / 5s。服务端按文件名 `O_TRUNC` 覆盖写，重传同一文件是幂等的，不会产生重复文件。
- 只重试传输层瞬时失败：`0`（网络错误）、`408`（超时）、`502/503/504`（上游短暂不可用）。`400/403/413/500` 立即失败——重试没有意义，只会让用户白等两轮退避才看到真实原因。
- 每轮重建 `FormData`：body 已被上一次 fetch 消费，不能复用。
- 重试期间在进度条显示轮次，避免界面在退避等待时看起来像卡死。
- 修复上述错误信息被吞掉的缺陷，现在展示具体信息与 HTTP 状态码。

上传本就是逐文件独立请求，因此重试作用于单个文件，已成功的文件不会被重传。

## 验证方式

- 新增 16 个单测（`tests/file-upload-retry.test.ts`）：瞬时故障重试后成功、`0`/`408`/`502`/`503`/`504` 均触发重试、`400`/`403`/`413`/`500` 不重试、连续失败 3 次后放弃、逐文件独立重试不重传已成功文件、每轮 `FormData` 为新实例、错误信息同时覆盖 `ApiError` 与 `Error` 两种形态、批次结束后上传状态被清理。退避用假定时器推进，测试耗时不受真实等待影响。
- `make typecheck && make test && make build` 全部通过（356 文件 / 3106 测试），`make format-check` 通过。

## 兼容性

无破坏性变更。仅在失败路径上生效，成功路径的请求次数与行为完全不变；不新增配置项。`UploadProgress` 新增可选字段 `attempt?: number`，现有消费方无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
