### PR TITLE
fix(web): integrate resilient heartbeat and file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,33 @@ HappyClaw 会执行代码和访问第三方消息平台，部署前请理解以�
 
 完整接口权限见 [ACL 权限矩阵](docs/ACL-MATRIX.md)。
 
+### 反向代理配置
+
+Web 界面依赖 `/ws` 上的 WebSocket 推送流式输出和运行状态。反向代理必须放行
+Upgrade 并把该连接的读超时设得足够长，否则前端会周期性弹出「连接中断，正在重连...」。
+
+服务端已内置 30 秒心跳（ping/pong），既用于保活，也用于回收半开的死连接，
+因此代理侧只需把读超时设得高于心跳间隔即可。nginx 示例：
+
+```nginx
+location /ws {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 3600s;   # 默认 60s 会掐断长连接
+    proxy_send_timeout 3600s;
+}
+```
+
+注意 `Connection` 应固定为 `"upgrade"`，不要写成 `$http_connection`——后者依赖
+客户端如实发送该头部，行为不稳定。
+
+若代理位于 Cloudflare 等平台之后，还需确认其空闲超时高于 30 秒心跳间隔。
+上传大文件时另需放宽 `client_max_body_size`（不小于 `MAX_FILE_SIZE_MB`，并预留
+multipart 开销）与 `client_body_timeout`。
+
 ## 开发与测试
 
 ### 常用命令

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -33,6 +33,41 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+// Serialize Web uploads per workspace so two concurrent requests cannot both
+// pass a quota check against the same pre-upload usage. The secure write helper
+// still revalidates paths descriptor-relatively against non-HTTP writers.
+const uploadMutationTails = new Map<string, Promise<void>>();
+
+async function withUploadMutationLock<T>(
+  workspaceRoot: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = uploadMutationTails.get(workspaceRoot) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.then(() => current);
+  uploadMutationTails.set(workspaceRoot, tail);
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (uploadMutationTails.get(workspaceRoot) === tail) {
+      uploadMutationTails.delete(workspaceRoot);
+    }
+  }
+}
+
+function uploadTargetKey(absolutePath: string): string {
+  const normalized = path.resolve(absolutePath);
+  return process.platform === 'darwin' || process.platform === 'win32'
+    ? normalized.toLowerCase()
+    : normalized;
+}
+
 // MIME 类型映射（预览和编辑端点共用）
 const MIME_MAP: Record<string, string> = {
   // 图片
@@ -309,70 +344,118 @@ fileRoutes.post('/:jid/files', authMiddleware, async (c) => {
       return c.json({ error: 'No files provided' }, 400);
     }
 
-    // 支持单文件和多文件上传
+    // 支持单文件和多文件上传。锁内先验证整批并计算最终净增量，再开始写入：
+    // 配额拒绝或后续文件路径非法时，不会留下半批文件。
     const fileList = Array.isArray(files) ? files : [files];
-    const uploadedFiles: string[] = [];
+    const workspaceRoot = path.resolve(getFileRoot(group.folder, rootOverride));
 
-    // Billing: check storage limit before uploading
-    if (isBillingEnabled() && group.created_by) {
-      const totalUploadSize = fileList.reduce(
-        (sum, f) => sum + (f instanceof File ? f.size : 0),
-        0,
-      );
-      const currentUsage = getGroupStorageUsage(group.folder, rootOverride);
-      const storageCheck = checkStorageLimit(
-        group.created_by,
-        authUser.role,
-        currentUsage,
-        totalUploadSize,
-      );
-      if (!storageCheck.allowed) {
-        return c.json({ error: storageCheck.reason }, 403);
-      }
-    }
+    return await withUploadMutationLock(workspaceRoot, async () => {
+      const uploads: Array<{ file: File; relativePath: string }> = [];
+      const quotaTargets = new Map<
+        string,
+        { existingSize: number; finalSize: number }
+      >();
 
-    for (const file of fileList) {
-      if (!(file instanceof File)) continue;
+      for (const file of fileList) {
+        if (!(file instanceof File)) continue;
 
-      // 检查文件大小
-      if (file.size > MAX_FILE_SIZE) {
-        return c.json(
-          {
-            error: `File ${file.name} exceeds maximum size of ${MAX_FILE_SIZE_MB}MB`,
-          },
-          400,
+        if (file.size > MAX_FILE_SIZE) {
+          return c.json(
+            {
+              error: `File ${file.name} exceeds maximum size of ${MAX_FILE_SIZE_MB}MB`,
+            },
+            400,
+          );
+        }
+
+        // 保留原有文件名、系统路径与 symlink 防护；配额只能在这些验证之后计算。
+        if (file.name.includes('..') || file.name.startsWith('/')) {
+          return c.json({ error: `Invalid file name: ${file.name}` }, 400);
+        }
+
+        const fullRelativePath = path.join(targetPath, file.name);
+        if (isSystemPath(targetPath) || isSystemPath(fullRelativePath)) {
+          return c.json({ error: 'Cannot upload to system path' }, 403);
+        }
+
+        const absolutePath = validateAndResolvePath(
+          group.folder,
+          fullRelativePath,
+          rootOverride,
         );
+        let existingSize = 0;
+        try {
+          const stats = fs.lstatSync(absolutePath);
+          if (stats.isSymbolicLink()) {
+            return c.json({ error: 'Cannot overwrite symbolic link' }, 403);
+          }
+          if (!stats.isFile()) {
+            return c.json(
+              { error: `Upload target is not a regular file: ${file.name}` },
+              400,
+            );
+          }
+          existingSize = stats.size;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        }
+
+        uploads.push({ file, relativePath: fullRelativePath });
+        const key = uploadTargetKey(absolutePath);
+        const prior = quotaTargets.get(key);
+        quotaTargets.set(key, {
+          // Repeated names in one multipart batch replace the same original
+          // inode; charge only the size of the final value, never each part.
+          existingSize: prior?.existingSize ?? existingSize,
+          finalSize: file.size,
+        });
       }
 
-      // 验证文件名，防止路径遍历攻击
-      if (file.name.includes('..') || file.name.startsWith('/')) {
-        return c.json({ error: `Invalid file name: ${file.name}` }, 400);
+      if (isBillingEnabled() && group.created_by) {
+        const totalDelta = Array.from(quotaTargets.values()).reduce(
+          (sum, target) => sum + target.finalSize - target.existingSize,
+          0,
+        );
+        const additionalBytes = Math.max(0, totalDelta);
+        if (additionalBytes > 0) {
+          const currentUsage = getGroupStorageUsage(group.folder, rootOverride);
+          const storageCheck = checkStorageLimit(
+            group.created_by,
+            authUser.role,
+            currentUsage,
+            additionalBytes,
+          );
+          if (!storageCheck.allowed) {
+            return c.json({ error: storageCheck.reason }, 403);
+          }
+        }
       }
 
-      // 禁止写入系统路径
-      const relativeFilePath = path.join(targetPath, file.name);
-      if (isSystemPath(targetPath) || isSystemPath(relativeFilePath)) {
-        return c.json({ error: 'Cannot upload to system path' }, 403);
+      const uploadedFiles: string[] = [];
+      let wroteAnyFile = false;
+      try {
+        for (const { file, relativePath } of uploads) {
+          const data = Buffer.from(await file.arrayBuffer());
+          safeWriteWorkspaceFile(
+            group.folder,
+            relativePath,
+            data,
+            { mustExist: false, createParents: true },
+            rootOverride,
+          );
+          wroteAnyFile = true;
+          uploadedFiles.push(file.name);
+        }
+      } finally {
+        // The batch is not transactional: if a later read/write fails, earlier
+        // files remain on disk. Never leave the pre-upload quota snapshot cached.
+        if (wroteAnyFile) {
+          invalidateGroupStorageUsage(group.folder, rootOverride);
+        }
       }
 
-      // 验证目标路径 + 文件名的完整路径（防止 file.name 含 ../../ 绕过）
-      const fullRelativePath = path.join(targetPath, file.name);
-      validateAndResolvePath(group.folder, fullRelativePath, rootOverride);
-      const buffer = await file.arrayBuffer();
-      const data = Buffer.from(buffer);
-      safeWriteWorkspaceFile(
-        group.folder,
-        fullRelativePath,
-        data,
-        { mustExist: false, createParents: true },
-        rootOverride,
-      );
-
-      uploadedFiles.push(file.name);
-    }
-
-    invalidateGroupStorageUsage(group.folder, rootOverride);
-    return c.json({ success: true, files: uploadedFiles });
+      return c.json({ success: true, files: uploadedFiles });
+    });
   } catch (error) {
     logger.error({ err: error }, `Failed to upload files for ${jid}`);
     return c.json({ error: 'Failed to upload files' }, 500);

--- a/src/web.ts
+++ b/src/web.ts
@@ -123,7 +123,10 @@ import type { ExpandContext } from './plugin-expander-context.js';
 import { PLUGIN_EXPANSION_ATTACHMENT_TYPE } from './plugin-expander-sentinel.js';
 import { persistPluginExpansion } from './plugin-expander-store.js';
 import { logger } from './logger.js';
-import { createWebSocketHeartbeat } from './ws-heartbeat.js';
+import {
+  createWebSocketHeartbeat,
+  startWebSocketHeartbeat,
+} from './ws-heartbeat.js';
 import { recordRunContextSnapshot } from './run-context-snapshot.js';
 import { RunStreamFence } from './run-stream-fence.js';
 import {
@@ -1390,18 +1393,24 @@ function setupWebSocket(server: any): WebSocketServer {
   // 注意：此前死连接是靠反代的读超时（nginx 默认 60s）兜底回收的——调大
   // proxy_read_timeout 必须在心跳上线之后做，否则死连接会堆积到新的超时时长。
   const heartbeat = createWebSocketHeartbeat();
-  const heartbeatTimer = setInterval(() => {
-    const terminated = heartbeat.sweep(wss.clients);
+  startWebSocketHeartbeat(wss, heartbeat, (result) => {
+    for (const failure of result.failures) {
+      const context = { operation: failure.operation, err: failure.error };
+      if (failure.operation === 'terminate') {
+        logger.error(context, 'WebSocket heartbeat operation failed');
+      } else {
+        logger.warn(context, 'WebSocket heartbeat operation failed');
+      }
+    }
+
+    const { terminated } = result;
     if (terminated > 0) {
       logger.info(
         { terminated, maxMissedPongs: heartbeat.maxMissedPongs },
         'WebSocket heartbeat timeout, terminated dead connections',
       );
     }
-  }, heartbeat.intervalMs);
-  // 不阻止进程退出；正常关闭走下面的 wss 'close'。
-  heartbeatTimer.unref?.();
-  wss.on('close', () => clearInterval(heartbeatTimer));
+  });
 
   server.on('upgrade', (request: any, socket: any, head: any) => {
     const { pathname } = new URL(request.url, `http://${request.headers.host}`);

--- a/src/web.ts
+++ b/src/web.ts
@@ -123,6 +123,7 @@ import type { ExpandContext } from './plugin-expander-context.js';
 import { PLUGIN_EXPANSION_ATTACHMENT_TYPE } from './plugin-expander-sentinel.js';
 import { persistPluginExpansion } from './plugin-expander-store.js';
 import { logger } from './logger.js';
+import { createWebSocketHeartbeat } from './ws-heartbeat.js';
 import { recordRunContextSnapshot } from './run-context-snapshot.js';
 import { RunStreamFence } from './run-stream-fence.js';
 import {
@@ -1384,6 +1385,24 @@ function setupWebSocket(server: any): WebSocketServer {
     maxPayload: 8 * 1024 * 1024,
   });
 
+  // 心跳：保活反代/NAT 会掐掉的空闲 upgraded 连接，并回收 TCP 半开的死连接。
+  // 取值与完整背景见 src/ws-heartbeat.ts。
+  // 注意：此前死连接是靠反代的读超时（nginx 默认 60s）兜底回收的——调大
+  // proxy_read_timeout 必须在心跳上线之后做，否则死连接会堆积到新的超时时长。
+  const heartbeat = createWebSocketHeartbeat();
+  const heartbeatTimer = setInterval(() => {
+    const terminated = heartbeat.sweep(wss.clients);
+    if (terminated > 0) {
+      logger.info(
+        { terminated, maxMissedPongs: heartbeat.maxMissedPongs },
+        'WebSocket heartbeat timeout, terminated dead connections',
+      );
+    }
+  }, heartbeat.intervalMs);
+  // 不阻止进程退出；正常关闭走下面的 wss 'close'。
+  heartbeatTimer.unref?.();
+  wss.on('close', () => clearInterval(heartbeatTimer));
+
   server.on('upgrade', (request: any, socket: any, head: any) => {
     const { pathname } = new URL(request.url, `http://${request.headers.host}`);
 
@@ -1495,6 +1514,8 @@ function setupWebSocket(server: any): WebSocketServer {
   wss.on('connection', (ws, request: any) => {
     const sessionId = request?.__happyclawSessionId as string | undefined;
     logger.info('WebSocket client connected');
+    // 心跳状态：浏览器由协议栈自动回 pong，前端无需改动。
+    heartbeat.track(ws);
     const connSession = sessionId
       ? getCachedSessionWithUser(sessionId)
       : undefined;

--- a/src/ws-heartbeat.ts
+++ b/src/ws-heartbeat.ts
@@ -1,0 +1,93 @@
+/**
+ * WebSocket 心跳：保活 + 死连接回收。
+ *
+ * 解决两个问题：
+ *
+ * 1) 保活。反向代理与 NAT 会掐掉空闲的 upgraded 连接（nginx proxy_read_timeout
+ *    默认 60s，Cloudflare 100s，运营商 NAT 常见 30~120s）。没有心跳时前端会被
+ *    动辄每分钟断开一次，反复弹出「连接中断，正在重连...」。服务端定期 ping 让
+ *    连接始终有真实流量，读超时不会触发；浏览器由协议栈自动回 pong，前端无需
+ *    任何改动。
+ *
+ * 2) 死连接回收。客户端非正常消失（合盖、切网、进程被杀）时 TCP 半开，'close'
+ *    永不触发，连接表条目与终端会话会一直泄漏，广播持续写入黑洞。只有 ping/pong
+ *    探测能发现这种连接。
+ *
+ * 关于 maxMissedPongs 的取值：代价高度不对称。误杀活连接会让用户看到
+ * 「连接中断，正在重连...」——正是本心跳要消除的现象；而晚回收死连接只是多留
+ * 一个条目和几 KB 无效广播。主服务是单进程，存在同步写盘（如文件上传）与 GC
+ * 停顿，事件循环被阻塞时 pong 帧虽已到达却来不及处理，取 1（ws 库 README 示例
+ * 的经典写法）会把这种停顿误判成死连接并踢掉全部客户端。因此默认取 3。
+ */
+
+/** 心跳只需要这三个能力，用结构类型以便测试替身注入。 */
+export interface HeartbeatSocket {
+  ping(): void;
+  terminate(): void;
+  on(event: 'pong', listener: () => void): unknown;
+}
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const DEFAULT_MAX_MISSED_PONGS = 3;
+
+export interface HeartbeatOptions {
+  intervalMs?: number;
+  /** 连续多少轮收不到 pong 判定连接已死。必须 >= 1。 */
+  maxMissedPongs?: number;
+}
+
+export interface WebSocketHeartbeat {
+  readonly intervalMs: number;
+  readonly maxMissedPongs: number;
+  /** 登记一条新连接，并挂上 pong 监听。 */
+  track(socket: HeartbeatSocket): void;
+  /** 执行一轮探测，返回本轮被判定为死连接并已 terminate 的数量。 */
+  sweep(sockets: Iterable<HeartbeatSocket>): number;
+}
+
+export function createWebSocketHeartbeat(
+  options: HeartbeatOptions = {},
+): WebSocketHeartbeat {
+  const intervalMs = options.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const maxMissedPongs = Math.max(
+    1,
+    options.maxMissedPongs ?? DEFAULT_MAX_MISSED_PONGS,
+  );
+  // WeakMap：连接被回收后条目自动消失，不会成为新的泄漏点。
+  const missedPongs = new WeakMap<HeartbeatSocket, number>();
+
+  return {
+    intervalMs,
+    maxMissedPongs,
+
+    track(socket) {
+      missedPongs.set(socket, 0);
+      socket.on('pong', () => missedPongs.set(socket, 0));
+    },
+
+    sweep(sockets) {
+      let terminated = 0;
+      for (const socket of sockets) {
+        const missed = (missedPongs.get(socket) ?? 0) + 1;
+        if (missed >= maxMissedPongs) {
+          // terminate() 会触发 'close'，由调用方既有的 close handler 完成
+          // 连接表与终端会话清理。
+          terminated += 1;
+          try {
+            socket.terminate();
+          } catch {
+            /* ignore */
+          }
+          continue;
+        }
+        missedPongs.set(socket, missed);
+        try {
+          socket.ping();
+        } catch {
+          /* ignore */
+        }
+      }
+      return terminated;
+    },
+  };
+}

--- a/src/ws-heartbeat.ts
+++ b/src/ws-heartbeat.ts
@@ -20,8 +20,10 @@
  * 的经典写法）会把这种停顿误判成死连接并踢掉全部客户端。因此默认取 3。
  */
 
-/** 心跳只需要这三个能力，用结构类型以便测试替身注入。 */
+/** 心跳只需要这些能力，用结构类型以便测试替身注入。 */
 export interface HeartbeatSocket {
+  /** ws.OPEN === 1；测试替身可省略，此时按可用连接处理。 */
+  readonly readyState?: number;
   ping(): void;
   terminate(): void;
   on(event: 'pong', listener: () => void): unknown;
@@ -32,8 +34,26 @@ export const DEFAULT_MAX_MISSED_PONGS = 3;
 
 export interface HeartbeatOptions {
   intervalMs?: number;
-  /** 连续多少轮收不到 pong 判定连接已死。必须 >= 1。 */
+  /** 发出多少次 ping 仍收不到 pong 后判定连接已死。必须 >= 1。 */
   maxMissedPongs?: number;
+}
+
+export type HeartbeatOperation = 'ping' | 'terminate';
+
+export interface HeartbeatOperationFailure {
+  readonly operation: HeartbeatOperation;
+  readonly error: unknown;
+}
+
+export interface HeartbeatSweepResult {
+  /** 本轮成功调用 ping 的连接数。 */
+  readonly pinged: number;
+  /** 本轮成功调用 terminate 的连接数。 */
+  readonly terminated: number;
+  /** 已处于 CONNECTING/CLOSING/CLOSED 或已开始终止，因而跳过的连接数。 */
+  readonly skipped: number;
+  /** 单连接操作失败；调用方负责记录，失败不会阻断同一轮的其他连接。 */
+  readonly failures: readonly HeartbeatOperationFailure[];
 }
 
 export interface WebSocketHeartbeat {
@@ -41,8 +61,15 @@ export interface WebSocketHeartbeat {
   readonly maxMissedPongs: number;
   /** 登记一条新连接，并挂上 pong 监听。 */
   track(socket: HeartbeatSocket): void;
-  /** 执行一轮探测，返回本轮被判定为死连接并已 terminate 的数量。 */
-  sweep(sockets: Iterable<HeartbeatSocket>): number;
+  /** 执行一轮探测，返回成功计数与可观测的逐操作失败。 */
+  sweep(sockets: Iterable<HeartbeatSocket>): HeartbeatSweepResult;
+}
+
+/** WebSocketServer 心跳调度所需的最小结构。 */
+export interface HeartbeatSocketServer {
+  readonly clients: Iterable<HeartbeatSocket>;
+  once(event: 'close', listener: () => void): unknown;
+  off(event: 'close', listener: () => void): unknown;
 }
 
 export function createWebSocketHeartbeat(
@@ -55,6 +82,10 @@ export function createWebSocketHeartbeat(
   );
   // WeakMap：连接被回收后条目自动消失，不会成为新的泄漏点。
   const missedPongs = new WeakMap<HeartbeatSocket, number>();
+  // track 可能被上层重复调用；只挂一个 pong listener，避免监听器随重连路径累积。
+  const trackedSockets = new WeakSet<HeartbeatSocket>();
+  // terminate 成功后到 'close' 事件之间仍可能短暂留在 wss.clients，避免重复终止。
+  const terminatingSockets = new WeakSet<HeartbeatSocket>();
 
   return {
     intervalMs,
@@ -62,32 +93,82 @@ export function createWebSocketHeartbeat(
 
     track(socket) {
       missedPongs.set(socket, 0);
+      if (trackedSockets.has(socket)) return;
+      trackedSockets.add(socket);
       socket.on('pong', () => missedPongs.set(socket, 0));
     },
 
     sweep(sockets) {
       let terminated = 0;
+      let pinged = 0;
+      let skipped = 0;
+      const failures: HeartbeatOperationFailure[] = [];
+
       for (const socket of sockets) {
-        const missed = (missedPongs.get(socket) ?? 0) + 1;
+        // WebSocket.OPEN === 1。connection 事件交付的连接均为 OPEN；显式跳过
+        // CONNECTING/CLOSING/CLOSED，避免 close 事件尚未从 clients 移除时误报失败。
+        if (
+          (socket.readyState !== undefined && socket.readyState !== 1) ||
+          terminatingSockets.has(socket)
+        ) {
+          skipped += 1;
+          continue;
+        }
+
+        const missed = missedPongs.get(socket) ?? 0;
         if (missed >= maxMissedPongs) {
           // terminate() 会触发 'close'，由调用方既有的 close handler 完成
           // 连接表与终端会话清理。
-          terminated += 1;
           try {
             socket.terminate();
-          } catch {
-            /* ignore */
+            terminatingSockets.add(socket);
+            terminated += 1;
+          } catch (error) {
+            failures.push({ operation: 'terminate', error });
           }
           continue;
         }
-        missedPongs.set(socket, missed);
+
+        // 先记录 outstanding ping，再调用 ping：如果测试替身/实现同步触发 pong，
+        // pong listener 的清零不能被随后一次 set 覆盖。
+        missedPongs.set(socket, missed + 1);
         try {
           socket.ping();
-        } catch {
-          /* ignore */
+          pinged += 1;
+        } catch (error) {
+          failures.push({ operation: 'ping', error });
         }
       }
-      return terminated;
+
+      return { pinged, terminated, skipped, failures };
     },
   };
+}
+
+/**
+ * 启动心跳调度，并在 WebSocketServer 关闭时同步清除 interval。
+ * 返回的 stop 可用于提前停止；重复调用安全。
+ */
+export function startWebSocketHeartbeat(
+  server: HeartbeatSocketServer,
+  heartbeat: WebSocketHeartbeat,
+  onSweep: (result: HeartbeatSweepResult) => void,
+): () => void {
+  let stopped = false;
+  const timer = setInterval(() => {
+    onSweep(heartbeat.sweep(server.clients));
+  }, heartbeat.intervalMs);
+
+  // 心跳不能阻止 Node 进程自然退出。
+  timer.unref?.();
+
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+    server.off('close', stop);
+  };
+
+  server.once('close', stop);
+  return stop;
 }

--- a/tests/file-upload-quota.test.ts
+++ b/tests/file-upload-quota.test.ts
@@ -1,0 +1,256 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const tmpDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'happyclaw-upload-quota-'),
+);
+const groupsDir = path.join(tmpDir, 'groups');
+const workspaceDir = path.join(groupsDir, 'quota-workspace');
+fs.mkdirSync(workspaceDir, { recursive: true });
+
+const billingMocks = vi.hoisted(() => ({
+  checkStorageLimit: vi.fn(),
+}));
+
+vi.mock('../src/config.js', async (importOriginal) => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    DATA_DIR: tmpDir,
+    GROUPS_DIR: groupsDir,
+    STORE_DIR: path.join(tmpDir, 'db'),
+  };
+});
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+vi.mock('../src/middleware/auth.ts', () => ({
+  authMiddleware: async (c: any, next: any) => {
+    c.set('user', {
+      id: 'quota-user',
+      username: 'quota-user',
+      role: 'member',
+      status: 'active',
+      permissions: [],
+    });
+    return next();
+  },
+}));
+
+vi.mock('../src/db.js', () => ({
+  getRegisteredGroup: (jid: string) =>
+    jid === 'web:quota'
+      ? {
+          jid,
+          name: 'Quota workspace',
+          folder: 'quota-workspace',
+          added_at: '2026-08-17T00:00:00.000Z',
+          executionMode: 'container',
+          created_by: 'quota-user',
+          is_home: false,
+        }
+      : undefined,
+}));
+
+vi.mock('../src/web-context.js', () => ({
+  canAccessGroup: () => true,
+  isHostExecutionGroup: () => false,
+  hasHostExecutionPermission: () => true,
+}));
+
+vi.mock('../src/billing.js', () => ({
+  isBillingEnabled: () => true,
+  checkStorageLimit: billingMocks.checkStorageLimit,
+}));
+
+const routes = (await import('../src/routes/files.js')).default;
+const { invalidateGroupStorageUsage } = await import('../src/file-manager.js');
+
+const LIMIT_BYTES = 1_000_000;
+
+function uploadRequest(files: File[]): Request {
+  const body = new FormData();
+  for (const file of files) body.append('files', file);
+  return new Request('http://localhost/web%3Aquota/files', {
+    method: 'POST',
+    body,
+  });
+}
+
+function makeFile(name: string, size: number): File {
+  return new File([Buffer.alloc(size, 0x61)], name, {
+    type: 'application/octet-stream',
+  });
+}
+
+async function upload(files: File[]) {
+  return routes.request(uploadRequest(files));
+}
+
+beforeEach(() => {
+  fs.rmSync(workspaceDir, { recursive: true, force: true });
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  invalidateGroupStorageUsage('quota-workspace');
+  billingMocks.checkStorageLimit.mockReset();
+  billingMocks.checkStorageLimit.mockImplementation(
+    (_userId, _role, currentBytes: number, additionalBytes: number) =>
+      currentBytes + additionalBytes > LIMIT_BYTES
+        ? { allowed: false, reason: 'quota exceeded' }
+        : { allowed: true },
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('上传存储配额按净增量计费', () => {
+  test('相同大小覆盖及响应丢失后的完整重试均不重复占用配额', async () => {
+    fs.writeFileSync(
+      path.join(workspaceDir, 'large.bin'),
+      Buffer.alloc(900_000),
+    );
+
+    const first = await upload([makeFile('large.bin', 900_000)]);
+    const retryAfterLostResponse = await upload([
+      makeFile('large.bin', 900_000),
+    ]);
+
+    expect(first.status).toBe(200);
+    expect(retryAfterLostResponse.status).toBe(200);
+    expect(billingMocks.checkStorageLimit).not.toHaveBeenCalled();
+    expect(fs.statSync(path.join(workspaceDir, 'large.bin')).size).toBe(
+      900_000,
+    );
+  });
+
+  test('覆盖变大时只计新旧大小之差', async () => {
+    fs.writeFileSync(
+      path.join(workspaceDir, 'large.bin'),
+      Buffer.alloc(900_000),
+    );
+
+    const response = await upload([makeFile('large.bin', 950_000)]);
+
+    expect(response.status).toBe(200);
+    expect(billingMocks.checkStorageLimit).toHaveBeenCalledWith(
+      'quota-user',
+      'member',
+      900_000,
+      50_000,
+    );
+  });
+
+  test('同批缩小旧文件可抵扣新增文件，只按整批最终净增量计费', async () => {
+    fs.writeFileSync(
+      path.join(workspaceDir, 'existing.bin'),
+      Buffer.alloc(900_000),
+    );
+
+    const response = await upload([
+      makeFile('existing.bin', 500_000),
+      makeFile('new.bin', 500_000),
+    ]);
+
+    expect(response.status).toBe(200);
+    expect(billingMocks.checkStorageLimit).toHaveBeenCalledWith(
+      'quota-user',
+      'member',
+      900_000,
+      100_000,
+    );
+  });
+
+  test('同一批次内的同名文件只按最终值相对原文件计费', async () => {
+    fs.writeFileSync(
+      path.join(workspaceDir, 'same.bin'),
+      Buffer.alloc(900_000),
+    );
+
+    const response = await upload([
+      makeFile('same.bin', 950_000),
+      makeFile('same.bin', 910_000),
+    ]);
+
+    expect(response.status).toBe(200);
+    expect(billingMocks.checkStorageLimit).toHaveBeenCalledWith(
+      'quota-user',
+      'member',
+      900_000,
+      10_000,
+    );
+    expect(fs.statSync(path.join(workspaceDir, 'same.bin')).size).toBe(910_000);
+  });
+
+  test('整批安全校验先于写入，目录目标会拒绝且不留下前面的文件', async () => {
+    fs.mkdirSync(path.join(workspaceDir, 'occupied'));
+
+    const response = await upload([
+      makeFile('would-have-been-written.bin', 10),
+      makeFile('occupied', 10),
+    ]);
+
+    expect(response.status).toBe(400);
+    expect(
+      fs.existsSync(path.join(workspaceDir, 'would-have-been-written.bin')),
+    ).toBe(false);
+  });
+
+  test('拒绝覆盖 symlink', async () => {
+    fs.writeFileSync(path.join(workspaceDir, 'real.bin'), Buffer.alloc(10));
+    fs.symlinkSync('real.bin', path.join(workspaceDir, 'linked.bin'));
+
+    const response = await upload([makeFile('linked.bin', 10)]);
+
+    expect(response.status).toBe(403);
+    expect(
+      fs.lstatSync(path.join(workspaceDir, 'linked.bin')).isSymbolicLink(),
+    ).toBe(true);
+  });
+
+  test('并发请求串行检查配额，只有一个 600KB 新文件可通过', async () => {
+    const [a, b] = await Promise.all([
+      upload([makeFile('a.bin', 600_000)]),
+      upload([makeFile('b.bin', 600_000)]),
+    ]);
+
+    expect([a.status, b.status].sort()).toEqual([200, 403]);
+    const written = ['a.bin', 'b.bin'].filter((name) =>
+      fs.existsSync(path.join(workspaceDir, name)),
+    );
+    expect(written).toHaveLength(1);
+  });
+
+  test('部分写入后续文件读取失败时失效配额缓存', async () => {
+    const originalArrayBuffer = File.prototype.arrayBuffer;
+    const arrayBufferSpy = vi
+      .spyOn(File.prototype, 'arrayBuffer')
+      .mockImplementation(function (this: File) {
+        if (this.name === 'fail.bin') {
+          return Promise.reject(new Error('simulated file read failure'));
+        }
+        return originalArrayBuffer.call(this);
+      });
+
+    try {
+      const partial = await upload([
+        makeFile('written.bin', 600_000),
+        makeFile('fail.bin', 1),
+      ]);
+      expect(partial.status).toBe(500);
+      expect(fs.statSync(path.join(workspaceDir, 'written.bin')).size).toBe(
+        600_000,
+      );
+
+      const next = await upload([makeFile('next.bin', 600_000)]);
+      expect(next.status).toBe(403);
+      expect(fs.existsSync(path.join(workspaceDir, 'next.bin'))).toBe(false);
+    } finally {
+      arrayBufferSpy.mockRestore();
+    }
+  });
+});

--- a/tests/file-upload-retry.test.ts
+++ b/tests/file-upload-retry.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+const showToastMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../web/src/utils/toast', () => ({
+  showToast: showToastMock,
+}));
+
 vi.mock('../web/src/api/client', () => ({
   api: {
     get: vi.fn(),
@@ -47,6 +53,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   mockedApiFetch.mockReset();
   mockedGet.mockReset();
+  showToastMock.mockReset();
   // loadFiles 在上传成功后刷新列表；给它一个合法响应，避免干扰 error 断言。
   mockedGet.mockResolvedValue({ files: [], currentPath: '' });
   useFileStore.setState({
@@ -105,6 +112,55 @@ describe('文件上传重试', () => {
 
     expect(ok).toBe(false);
     expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenCalledWith(
+      '上传失败',
+      '上传超时，请检查网络后重试',
+    );
+  });
+
+  test('首次失败后立即进入第 2 次退避状态，sleep 前即可见', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(408))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const pending = useFileStore.getState().uploadFiles('web:g1', [makeFile()]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useFileStore.getState().uploadProgress).toMatchObject({
+      attempt: 1,
+      maxAttempts: 3,
+      retrying: true,
+      nextAttempt: 2,
+      retryDelayMs: 2000,
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect(pending).resolves.toBe(true);
+  });
+
+  test('第二次失败后准确显示即将进行第 3 次重试', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(408))
+      .mockRejectedValueOnce(apiError(503))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const pending = useFileStore.getState().uploadFiles('web:g1', [makeFile()]);
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(useFileStore.getState().uploadProgress).toMatchObject({
+      attempt: 2,
+      maxAttempts: 3,
+      retrying: true,
+      nextAttempt: 3,
+      retryDelayMs: 5000,
+    });
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(pending).resolves.toBe(true);
   });
 
   test.each([
@@ -133,6 +189,20 @@ describe('文件上传重试', () => {
     expect(error).toContain('exceeds maximum size of 100MB');
     expect(error).toContain('413');
     expect(error).not.toBe('Failed to upload files');
+    expect(showToastMock).toHaveBeenCalledWith('上传失败', error);
+  });
+
+  test('新上传会同步清除旧错误，且同一失败只通知一次', async () => {
+    useFileStore.setState({ error: '上一次失败' });
+    mockedApiFetch.mockRejectedValue(apiError(413, '文件太大'));
+
+    const pending = useFileStore.getState().uploadFiles('web:g1', [makeFile()]);
+    expect(useFileStore.getState().error).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(pending).resolves.toBe(false);
+    expect(useFileStore.getState().error).toBe('文件太大 (HTTP 413)');
+    expect(showToastMock).toHaveBeenCalledTimes(1);
   });
 
   test('Error 实例的信息也能正确提取', async () => {
@@ -182,6 +252,48 @@ describe('文件上传重试', () => {
 
     expect(useFileStore.getState().uploading).toBe(false);
     expect(useFileStore.getState().uploadProgress).toBeNull();
+  });
+
+  test('可取消正在进行的请求，且取消不重试、不报错、不弹失败提示', async () => {
+    mockedApiFetch.mockImplementation((_path, options) => {
+      const signal = options?.signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          'abort',
+          () => reject(apiError(499, 'Request cancelled')),
+          { once: true },
+        );
+      });
+    });
+
+    const pending = useFileStore.getState().uploadFiles('web:g1', [makeFile()]);
+    await Promise.resolve();
+    const signal = mockedApiFetch.mock.calls[0]?.[1]?.signal;
+
+    useFileStore.getState().cancelUpload();
+
+    await expect(pending).resolves.toBe(false);
+    expect(signal?.aborted).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+    expect(useFileStore.getState().error).toBeNull();
+    expect(useFileStore.getState().uploading).toBe(false);
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  test('可取消退避等待，不会继续下一轮请求', async () => {
+    mockedApiFetch.mockRejectedValueOnce(apiError(408, 'Request timeout'));
+
+    const pending = useFileStore.getState().uploadFiles('web:g1', [makeFile()]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useFileStore.getState().uploadProgress?.retrying).toBe(true);
+
+    useFileStore.getState().cancelUpload();
+
+    await expect(pending).resolves.toBe(false);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+    expect(useFileStore.getState().error).toBeNull();
+    expect(showToastMock).not.toHaveBeenCalled();
   });
 
   test('空文件列表直接返回 false，不发请求', async () => {

--- a/tests/file-upload-retry.test.ts
+++ b/tests/file-upload-retry.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../web/src/api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+  apiFetch: vi.fn(),
+  computeUploadTimeoutMs: (bytes: number) =>
+    Math.min(600_000, Math.max(120_000, Math.ceil(bytes / (20 * 1024)) * 1000)),
+}));
+
+import { api, apiFetch } from '../web/src/api/client';
+import { useFileStore } from '../web/src/stores/files';
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedGet = vi.mocked(api.get);
+
+/**
+ * apiFetch 抛出的是纯对象形态的 ApiError，不是 Error 实例。这一点是本文件多个
+ * 断言的前提：用 `err instanceof Error` 取信息会退化成默认文案。
+ */
+function apiError(status: number, message = 'boom') {
+  return { status, message };
+}
+
+function makeFile(name = 'paper.pdf', size = 124_758) {
+  const file = new File(['x'], name, { type: 'application/pdf' });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+/**
+ * 重试退避是真实的 2s / 5s。用假定时器推进，否则单个用例要真等 7 秒，
+ * 且超时后挂起的重试会污染后续用例的 mock 计数。
+ */
+async function runUpload(jid: string, files: File[]) {
+  const pending = useFileStore.getState().uploadFiles(jid, files);
+  await vi.advanceTimersByTimeAsync(60_000);
+  return pending;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockedApiFetch.mockReset();
+  mockedGet.mockReset();
+  // loadFiles 在上传成功后刷新列表；给它一个合法响应，避免干扰 error 断言。
+  mockedGet.mockResolvedValue({ files: [], currentPath: '' });
+  useFileStore.setState({
+    files: {},
+    currentPath: {},
+    loading: false,
+    uploading: false,
+    uploadProgress: null,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('文件上传重试', () => {
+  test('408 后重试并最终成功——慢链路上反代读体超时是常见瞬时故障', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(408, 'Request timeout'))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(2);
+    expect(useFileStore.getState().error).toBeNull();
+  });
+
+  test('网络错误（status 0）同样重试', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(0, 'Network error'))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([502, 503, 504])('%i 视为上游瞬时不可用，重试', async (status) => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(status))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(true);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('连续失败最多尝试 3 次后放弃', async () => {
+    mockedApiFetch.mockRejectedValue(apiError(408, 'Request timeout'));
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(false);
+    expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test.each([
+    [400, '参数错误'],
+    [403, '配额或路径被拒'],
+    [413, '超过大小上限'],
+    [500, '服务端逻辑错误'],
+  ])('%i（%s）不重试，立即失败', async (status) => {
+    mockedApiFetch.mockRejectedValue(apiError(status));
+
+    const ok = await runUpload('web:g1', [makeFile()]);
+
+    expect(ok).toBe(false);
+    // 重试这类错误没有意义，只会让用户多等两轮退避才看到真实原因
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('失败时暴露真实原因而非笼统文案', async () => {
+    mockedApiFetch.mockRejectedValue(
+      apiError(413, 'File paper.pdf exceeds maximum size of 100MB'),
+    );
+
+    await runUpload('web:g1', [makeFile()]);
+
+    const { error } = useFileStore.getState();
+    expect(error).toContain('exceeds maximum size of 100MB');
+    expect(error).toContain('413');
+    expect(error).not.toBe('Failed to upload files');
+  });
+
+  test('Error 实例的信息也能正确提取', async () => {
+    mockedApiFetch.mockRejectedValue(new Error('boom from fetch'));
+
+    await runUpload('web:g1', [makeFile()]);
+
+    expect(useFileStore.getState().error).toBe('boom from fetch');
+  });
+
+  test('逐文件独立重试：已成功的文件不会被重传', async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce({ success: true, files: ['a.pdf'] })
+      .mockRejectedValueOnce(apiError(408))
+      .mockResolvedValueOnce({ success: true, files: ['b.pdf'] });
+
+    const ok = await runUpload('web:g1', [
+      makeFile('a.pdf'),
+      makeFile('b.pdf'),
+    ]);
+
+    expect(ok).toBe(true);
+    // a 一次成功；b 失败一次后重试成功 → 共 3 次，a 没有被重传
+    expect(mockedApiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('每次重试重建 FormData——body 已被上一次 fetch 消费，不能复用', async () => {
+    mockedApiFetch
+      .mockRejectedValueOnce(apiError(408))
+      .mockResolvedValueOnce({ success: true, files: ['paper.pdf'] });
+
+    await runUpload('web:g1', [makeFile()]);
+
+    const bodies = mockedApiFetch.mock.calls.map(
+      ([, init]) => (init as RequestInit | undefined)?.body,
+    );
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toBeInstanceOf(FormData);
+    expect(bodies[1]).toBeInstanceOf(FormData);
+    expect(bodies[0]).not.toBe(bodies[1]);
+  });
+
+  test('整批结束后清理上传状态', async () => {
+    mockedApiFetch.mockRejectedValue(apiError(408));
+
+    await runUpload('web:g1', [makeFile()]);
+
+    expect(useFileStore.getState().uploading).toBe(false);
+    expect(useFileStore.getState().uploadProgress).toBeNull();
+  });
+
+  test('空文件列表直接返回 false，不发请求', async () => {
+    const ok = await useFileStore.getState().uploadFiles('web:g1', []);
+
+    expect(ok).toBe(false);
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ws-heartbeat.test.ts
+++ b/tests/ws-heartbeat.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_MAX_MISSED_PONGS,
+  createWebSocketHeartbeat,
+  type HeartbeatSocket,
+} from '../src/ws-heartbeat.js';
+
+/** 测试替身：记录 ping/terminate 次数，并能按需回 pong。 */
+function fakeSocket() {
+  let pongListener: (() => void) | undefined;
+  const socket = {
+    ping: vi.fn(),
+    terminate: vi.fn(),
+    on: vi.fn((event: 'pong', listener: () => void) => {
+      if (event === 'pong') pongListener = listener;
+      return socket;
+    }),
+    /** 模拟对端回 pong */
+    respond: () => pongListener?.(),
+  };
+  return socket;
+}
+
+type FakeSocket = ReturnType<typeof fakeSocket>;
+
+const asSockets = (...sockets: FakeSocket[]): HeartbeatSocket[] =>
+  sockets as unknown as HeartbeatSocket[];
+
+describe('createWebSocketHeartbeat', () => {
+  test('默认 30s 间隔、容忍 3 轮——刻意宽于 ws 库示例的 1 轮', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    expect(heartbeat.intervalMs).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+    expect(heartbeat.intervalMs).toBe(30_000);
+    // 单进程服务存在同步写盘与 GC 停顿，取 1 会把事件循环阻塞误判成死连接
+    // 并踢掉全部客户端。这个下限是回归保护，不要调回 1。
+    expect(heartbeat.maxMissedPongs).toBe(DEFAULT_MAX_MISSED_PONGS);
+    expect(heartbeat.maxMissedPongs).toBe(3);
+  });
+
+  test('track 会登记连接并挂上 pong 监听', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    expect(socket.on).toHaveBeenCalledWith('pong', expect.any(Function));
+  });
+
+  test('每轮对存活连接发 ping，且不终止它们', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    const terminated = heartbeat.sweep(asSockets(socket));
+
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(terminated).toBe(0);
+  });
+
+  test('持续回 pong 的连接永远不会被终止', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    for (let round = 0; round < 20; round++) {
+      expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+      socket.respond();
+    }
+
+    expect(socket.terminate).not.toHaveBeenCalled();
+    expect(socket.ping).toHaveBeenCalledTimes(20);
+  });
+
+  test('连续 3 轮无 pong 才终止——前两轮只探测', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.terminate).not.toHaveBeenCalled();
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.terminate).not.toHaveBeenCalled();
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(1);
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+    // 判定为死连接后不再浪费一次 ping
+    expect(socket.ping).toHaveBeenCalledTimes(2);
+  });
+
+  test('中途恢复 pong 会清零计数，不会累积到终止', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    heartbeat.sweep(asSockets(socket)); // missed = 1
+    heartbeat.sweep(asSockets(socket)); // missed = 2
+    socket.respond(); // 事件循环恢复，pong 被处理 → 清零
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  test('未经 track 的连接同样被计数，不会因缺省状态被立即终止', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const socket = fakeSocket();
+
+    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+  });
+
+  test('maxMissedPongs 可配置，且下限被钳制为 1', () => {
+    const eager = createWebSocketHeartbeat({ maxMissedPongs: 1 });
+    const socket = fakeSocket();
+    eager.track(socket as unknown as HeartbeatSocket);
+    expect(eager.sweep(asSockets(socket))).toBe(1);
+
+    // 0 / 负数会让每一轮都立即终止全部连接，钳制到 1 是安全下限
+    expect(createWebSocketHeartbeat({ maxMissedPongs: 0 }).maxMissedPongs).toBe(
+      1,
+    );
+    expect(
+      createWebSocketHeartbeat({ maxMissedPongs: -5 }).maxMissedPongs,
+    ).toBe(1);
+  });
+
+  test('单个连接 ping 抛错不影响同一轮的其他连接', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const broken = fakeSocket();
+    broken.ping.mockImplementation(() => {
+      throw new Error('socket already closed');
+    });
+    const healthy = fakeSocket();
+    heartbeat.track(broken as unknown as HeartbeatSocket);
+    heartbeat.track(healthy as unknown as HeartbeatSocket);
+
+    expect(() => heartbeat.sweep(asSockets(broken, healthy))).not.toThrow();
+    expect(healthy.ping).toHaveBeenCalledTimes(1);
+  });
+
+  test('terminate 抛错不影响同一轮的其他连接', () => {
+    const heartbeat = createWebSocketHeartbeat({ maxMissedPongs: 1 });
+    const broken = fakeSocket();
+    broken.terminate.mockImplementation(() => {
+      throw new Error('already destroyed');
+    });
+    const healthy = fakeSocket();
+
+    expect(() => heartbeat.sweep(asSockets(broken, healthy))).not.toThrow();
+    expect(healthy.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  test('多连接独立计数：死连接被清理，活连接不受牵连', () => {
+    const heartbeat = createWebSocketHeartbeat();
+    const dead = fakeSocket();
+    const alive = fakeSocket();
+    heartbeat.track(dead as unknown as HeartbeatSocket);
+    heartbeat.track(alive as unknown as HeartbeatSocket);
+
+    for (let round = 0; round < 2; round++) {
+      heartbeat.sweep(asSockets(dead, alive));
+      alive.respond();
+    }
+    const terminated = heartbeat.sweep(asSockets(dead, alive));
+
+    expect(terminated).toBe(1);
+    expect(dead.terminate).toHaveBeenCalledTimes(1);
+    expect(alive.terminate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ws-heartbeat.test.ts
+++ b/tests/ws-heartbeat.test.ts
@@ -1,8 +1,10 @@
+import { EventEmitter } from 'node:events';
 import { describe, expect, test, vi } from 'vitest';
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
   DEFAULT_MAX_MISSED_PONGS,
   createWebSocketHeartbeat,
+  startWebSocketHeartbeat,
   type HeartbeatSocket,
 } from '../src/ws-heartbeat.js';
 
@@ -10,6 +12,7 @@ import {
 function fakeSocket() {
   let pongListener: (() => void) | undefined;
   const socket = {
+    readyState: 1,
     ping: vi.fn(),
     terminate: vi.fn(),
     on: vi.fn((event: 'pong', listener: () => void) => {
@@ -28,7 +31,7 @@ const asSockets = (...sockets: FakeSocket[]): HeartbeatSocket[] =>
   sockets as unknown as HeartbeatSocket[];
 
 describe('createWebSocketHeartbeat', () => {
-  test('默认 30s 间隔、容忍 3 轮——刻意宽于 ws 库示例的 1 轮', () => {
+  test('默认 30s 间隔、容忍 3 次 ping——刻意宽于 ws 库示例的 1 次', () => {
     const heartbeat = createWebSocketHeartbeat();
     expect(heartbeat.intervalMs).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
     expect(heartbeat.intervalMs).toBe(30_000);
@@ -52,11 +55,16 @@ describe('createWebSocketHeartbeat', () => {
     const socket = fakeSocket();
     heartbeat.track(socket as unknown as HeartbeatSocket);
 
-    const terminated = heartbeat.sweep(asSockets(socket));
+    const result = heartbeat.sweep(asSockets(socket));
 
     expect(socket.ping).toHaveBeenCalledTimes(1);
     expect(socket.terminate).not.toHaveBeenCalled();
-    expect(terminated).toBe(0);
+    expect(result).toEqual({
+      pinged: 1,
+      terminated: 0,
+      skipped: 0,
+      failures: [],
+    });
   });
 
   test('持续回 pong 的连接永远不会被终止', () => {
@@ -65,7 +73,7 @@ describe('createWebSocketHeartbeat', () => {
     heartbeat.track(socket as unknown as HeartbeatSocket);
 
     for (let round = 0; round < 20; round++) {
-      expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+      expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(0);
       socket.respond();
     }
 
@@ -73,21 +81,20 @@ describe('createWebSocketHeartbeat', () => {
     expect(socket.ping).toHaveBeenCalledTimes(20);
   });
 
-  test('连续 3 轮无 pong 才终止——前两轮只探测', () => {
+  test('发出 3 次 ping 均无 pong 后，下一轮才终止', () => {
     const heartbeat = createWebSocketHeartbeat();
     const socket = fakeSocket();
     heartbeat.track(socket as unknown as HeartbeatSocket);
 
-    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
-    expect(socket.terminate).not.toHaveBeenCalled();
+    for (let round = 0; round < 3; round++) {
+      expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(0);
+      expect(socket.terminate).not.toHaveBeenCalled();
+    }
 
-    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
-    expect(socket.terminate).not.toHaveBeenCalled();
-
-    expect(heartbeat.sweep(asSockets(socket))).toBe(1);
+    expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(1);
     expect(socket.terminate).toHaveBeenCalledTimes(1);
-    // 判定为死连接后不再浪费一次 ping
-    expect(socket.ping).toHaveBeenCalledTimes(2);
+    // 达到容忍次数后，终止轮不再浪费一次 ping。
+    expect(socket.ping).toHaveBeenCalledTimes(3);
   });
 
   test('中途恢复 pong 会清零计数，不会累积到终止', () => {
@@ -95,12 +102,12 @@ describe('createWebSocketHeartbeat', () => {
     const socket = fakeSocket();
     heartbeat.track(socket as unknown as HeartbeatSocket);
 
-    heartbeat.sweep(asSockets(socket)); // missed = 1
-    heartbeat.sweep(asSockets(socket)); // missed = 2
+    heartbeat.sweep(asSockets(socket)); // outstanding = 1
+    heartbeat.sweep(asSockets(socket)); // outstanding = 2
     socket.respond(); // 事件循环恢复，pong 被处理 → 清零
 
-    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
-    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(0);
+    expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(0);
     expect(socket.terminate).not.toHaveBeenCalled();
   });
 
@@ -108,7 +115,7 @@ describe('createWebSocketHeartbeat', () => {
     const heartbeat = createWebSocketHeartbeat();
     const socket = fakeSocket();
 
-    expect(heartbeat.sweep(asSockets(socket))).toBe(0);
+    expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(0);
     expect(socket.ping).toHaveBeenCalledTimes(1);
   });
 
@@ -116,9 +123,12 @@ describe('createWebSocketHeartbeat', () => {
     const eager = createWebSocketHeartbeat({ maxMissedPongs: 1 });
     const socket = fakeSocket();
     eager.track(socket as unknown as HeartbeatSocket);
-    expect(eager.sweep(asSockets(socket))).toBe(1);
 
-    // 0 / 负数会让每一轮都立即终止全部连接，钳制到 1 是安全下限
+    expect(eager.sweep(asSockets(socket)).terminated).toBe(0);
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+    expect(eager.sweep(asSockets(socket)).terminated).toBe(1);
+
+    // 0 / 负数会让所有连接零次探测后立即终止，钳制到 1 是安全下限。
     expect(createWebSocketHeartbeat({ maxMissedPongs: 0 }).maxMissedPongs).toBe(
       1,
     );
@@ -127,30 +137,41 @@ describe('createWebSocketHeartbeat', () => {
     ).toBe(1);
   });
 
-  test('单个连接 ping 抛错不影响同一轮的其他连接', () => {
+  test('单个连接 ping 抛错会被报告且不影响同一轮的其他连接', () => {
     const heartbeat = createWebSocketHeartbeat();
     const broken = fakeSocket();
+    const pingError = new Error('socket already closed');
     broken.ping.mockImplementation(() => {
-      throw new Error('socket already closed');
+      throw pingError;
     });
     const healthy = fakeSocket();
     heartbeat.track(broken as unknown as HeartbeatSocket);
     heartbeat.track(healthy as unknown as HeartbeatSocket);
 
-    expect(() => heartbeat.sweep(asSockets(broken, healthy))).not.toThrow();
+    const result = heartbeat.sweep(asSockets(broken, healthy));
+
     expect(healthy.ping).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ pinged: 1, terminated: 0, skipped: 0 });
+    expect(result.failures).toEqual([{ operation: 'ping', error: pingError }]);
   });
 
-  test('terminate 抛错不影响同一轮的其他连接', () => {
+  test('terminate 抛错会被报告且不计成功，也不影响其他连接', () => {
     const heartbeat = createWebSocketHeartbeat({ maxMissedPongs: 1 });
     const broken = fakeSocket();
+    const terminateError = new Error('already destroyed');
     broken.terminate.mockImplementation(() => {
-      throw new Error('already destroyed');
+      throw terminateError;
     });
     const healthy = fakeSocket();
 
-    expect(() => heartbeat.sweep(asSockets(broken, healthy))).not.toThrow();
+    heartbeat.sweep(asSockets(broken, healthy));
+    const result = heartbeat.sweep(asSockets(broken, healthy));
+
     expect(healthy.terminate).toHaveBeenCalledTimes(1);
+    expect(result.terminated).toBe(1);
+    expect(result.failures).toEqual([
+      { operation: 'terminate', error: terminateError },
+    ]);
   });
 
   test('多连接独立计数：死连接被清理，活连接不受牵连', () => {
@@ -160,14 +181,76 @@ describe('createWebSocketHeartbeat', () => {
     heartbeat.track(dead as unknown as HeartbeatSocket);
     heartbeat.track(alive as unknown as HeartbeatSocket);
 
-    for (let round = 0; round < 2; round++) {
+    for (let round = 0; round < 3; round++) {
       heartbeat.sweep(asSockets(dead, alive));
       alive.respond();
     }
-    const terminated = heartbeat.sweep(asSockets(dead, alive));
+    const result = heartbeat.sweep(asSockets(dead, alive));
 
-    expect(terminated).toBe(1);
+    expect(result.terminated).toBe(1);
     expect(dead.terminate).toHaveBeenCalledTimes(1);
     expect(alive.terminate).not.toHaveBeenCalled();
+  });
+
+  test('跳过非 OPEN 和已经开始终止的连接', () => {
+    const heartbeat = createWebSocketHeartbeat({ maxMissedPongs: 1 });
+    const closing = fakeSocket();
+    closing.readyState = 2;
+    const dead = fakeSocket();
+
+    heartbeat.sweep(asSockets(dead));
+    const terminated = heartbeat.sweep(asSockets(closing, dead));
+    const afterTerminate = heartbeat.sweep(asSockets(dead));
+
+    expect(closing.ping).not.toHaveBeenCalled();
+    expect(closing.terminate).not.toHaveBeenCalled();
+    expect(terminated).toMatchObject({ terminated: 1, skipped: 1 });
+    expect(afterTerminate).toMatchObject({ terminated: 0, skipped: 1 });
+  });
+
+  test('重复 track 只挂一个 pong listener，并重置未响应计数', () => {
+    const heartbeat = createWebSocketHeartbeat({ maxMissedPongs: 1 });
+    const socket = fakeSocket();
+
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+    heartbeat.sweep(asSockets(socket));
+    heartbeat.track(socket as unknown as HeartbeatSocket);
+
+    expect(socket.on).toHaveBeenCalledTimes(1);
+    expect(heartbeat.sweep(asSockets(socket)).terminated).toBe(0);
+    expect(socket.ping).toHaveBeenCalledTimes(2);
+  });
+
+  test('调度器按 interval sweep，并在 WebSocketServer close 时清理 timer', () => {
+    vi.useFakeTimers();
+    try {
+      const socket = fakeSocket();
+      const server = Object.assign(new EventEmitter(), {
+        clients: new Set(asSockets(socket)),
+      });
+      const heartbeat = createWebSocketHeartbeat({
+        intervalMs: 100,
+        maxMissedPongs: 1,
+      });
+      const onSweep = vi.fn();
+
+      startWebSocketHeartbeat(server, heartbeat, onSweep);
+      expect(vi.getTimerCount()).toBe(1);
+
+      vi.advanceTimersByTime(100);
+      expect(socket.ping).toHaveBeenCalledTimes(1);
+      expect(onSweep).toHaveBeenCalledWith(
+        expect.objectContaining({ pinged: 1, terminated: 0 }),
+      );
+
+      server.emit('close');
+      expect(vi.getTimerCount()).toBe(0);
+
+      vi.advanceTimersByTime(500);
+      expect(onSweep).toHaveBeenCalledTimes(1);
+      expect(socket.terminate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { apiFetch } from './client';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+});
+
+describe('apiFetch cancellation', () => {
+  test('调用方 AbortSignal 会中断底层 fetch，并与请求超时区分', async () => {
+    globalThis.fetch = vi.fn((_input, init) => {
+      const signal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+    const controller = new AbortController();
+
+    const pending = apiFetch('/api/upload-test', {
+      method: 'POST',
+      signal: controller.signal,
+      timeoutMs: 60_000,
+    });
+    const rejection = expect(pending).rejects.toEqual({
+      status: 499,
+      message: 'Request cancelled',
+    });
+    controller.abort();
+
+    await rejection;
+  });
+
+  test('内部超时仍映射为 408', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn((_input, init) => {
+      const signal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+
+    const pending = apiFetch('/api/upload-test', { timeoutMs: 10 });
+    const rejection = expect(pending).rejects.toEqual({
+      status: 408,
+      message: 'Request timeout',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejection;
+  });
+
+  test('超时先发生时，随后调用方取消仍保持 408', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn((_input, init) => {
+      const signal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          'abort',
+          () =>
+            queueMicrotask(() =>
+              reject(new DOMException('Aborted', 'AbortError')),
+            ),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+    const controller = new AbortController();
+
+    const pending = apiFetch('/api/upload-test', {
+      signal: controller.signal,
+      timeoutMs: 10,
+    });
+    const rejection = expect(pending).rejects.toEqual({
+      status: 408,
+      message: 'Request timeout',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    controller.abort();
+
+    await rejection;
+  });
+
+  test('调用方使用自定义 abort reason 时仍归一化为 499', async () => {
+    globalThis.fetch = vi.fn((_input, init) => {
+      const signal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          'abort',
+          () => reject(new Error('custom abort reason')),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+    const controller = new AbortController();
+
+    const pending = apiFetch('/api/upload-test', {
+      signal: controller.signal,
+      timeoutMs: 60_000,
+    });
+    const rejection = expect(pending).rejects.toEqual({
+      status: 499,
+      message: 'Request cancelled',
+    });
+    controller.abort(new Error('caller-specific reason'));
+
+    await rejection;
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -15,12 +15,28 @@ export async function apiFetch<T>(
   const requestPath = /^https?:\/\//i.test(path)
     ? path
     : withBasePath(path.startsWith('/') ? path : `/${path}`);
-  const { timeoutMs: customTimeout, ...fetchOptions } = options ?? {};
+  const {
+    timeoutMs: customTimeout,
+    signal: externalSignal,
+    ...fetchOptions
+  } = options ?? {};
   const controller = new AbortController();
   const isFormData = fetchOptions.body instanceof FormData;
   const timeoutMs =
     customTimeout ?? (isFormData ? 120_000 : REQUEST_TIMEOUT_MS);
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let abortCause: 'caller' | 'timeout' | null = null;
+  const abortRequest = (cause: 'caller' | 'timeout') => {
+    if (controller.signal.aborted) return;
+    abortCause = cause;
+    controller.abort();
+  };
+  const timeout = setTimeout(() => abortRequest('timeout'), timeoutMs);
+  const abortFromCaller = () => abortRequest('caller');
+  if (externalSignal?.aborted) {
+    abortFromCaller();
+  } else {
+    externalSignal?.addEventListener('abort', abortFromCaller, { once: true });
+  }
 
   // FormData 时不设 Content-Type，让浏览器自动加 multipart boundary
   const headers = isFormData
@@ -36,12 +52,16 @@ export async function apiFetch<T>(
       signal: controller.signal,
     });
   } catch (err) {
-    if (err instanceof DOMException && err.name === 'AbortError') {
+    if (abortCause === 'caller') {
+      throw { status: 499, message: 'Request cancelled' } as ApiError;
+    }
+    if (abortCause === 'timeout') {
       throw { status: 408, message: 'Request timeout' } as ApiError;
     }
     throw { status: 0, message: 'Network error' } as ApiError;
   } finally {
     clearTimeout(timeout);
+    externalSignal?.removeEventListener('abort', abortFromCaller);
   }
 
   if (res.status === 401) {

--- a/web/src/components/chat/FileUploadProgress.test.tsx
+++ b/web/src/components/chat/FileUploadProgress.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../../stores/chat', () => {
+  const state = {
+    drafts: {},
+    saveDraft: vi.fn(),
+    clearDraft: vi.fn(),
+  };
+  return {
+    useChatStore: (selector: (value: typeof state) => unknown) =>
+      selector(state),
+  };
+});
+
+vi.mock('../../hooks/useDisplayMode', () => ({
+  useDisplayMode: () => ({ mode: 'default' }),
+}));
+
+vi.mock('../../hooks/useMediaQuery', () => ({
+  useMediaQuery: () => false,
+}));
+
+vi.mock('@/hooks/useKeyboardHeight', () => ({
+  useKeyboardHeight: () => 0,
+}));
+
+vi.mock('../../lib/follow-up-preferences', () => ({
+  FOLLOW_UP_MODE_KEY: 'test-follow-up-mode',
+  FOLLOW_UP_MODE_CHANGED_EVENT: 'test-follow-up-mode-changed',
+  getDefaultFollowUpMode: () => 'queue',
+  alternateFollowUpMode: (mode: 'queue' | 'steer') =>
+    mode === 'queue' ? 'steer' : 'queue',
+}));
+
+import { useFileStore, type UploadProgress } from '../../stores/files';
+import { FileUploadZone } from './FileUploadZone';
+import { MessageInput } from './MessageInput';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+const cancelUpload = vi.fn();
+
+const baseProgress: UploadProgress = {
+  total: 1,
+  completed: 0,
+  currentFile: 'paper.pdf',
+  totalBytes: 100,
+  uploadedBytes: 0,
+  attempt: 1,
+  maxAttempts: 3,
+  retrying: true,
+  nextAttempt: 2,
+  retryDelayMs: 2000,
+};
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useFileStore.setState({
+    uploading: true,
+    uploadProgress: baseProgress,
+    error: null,
+    cancelUpload,
+  });
+  cancelUpload.mockReset();
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  useFileStore.setState({
+    uploading: false,
+    uploadProgress: null,
+    error: null,
+    cancelUpload,
+  });
+});
+
+function retryTexts(): string[] {
+  return Array.from(
+    container?.querySelectorAll('[data-upload-retry-status]') ?? [],
+    (node) => node.textContent ?? '',
+  );
+}
+
+describe('上传重试状态 UI', () => {
+  test('文件面板与主消息输入框一致展示首个退避状态', async () => {
+    await act(async () => {
+      root?.render(
+        <>
+          <FileUploadZone groupJid="web:g1" />
+          <MessageInput groupJid="web:g1" onSend={vi.fn()} />
+        </>,
+      );
+    });
+
+    expect(retryTexts()).toEqual(['（2 秒后重试 2/3）', '（2 秒后重试 2/3）']);
+    const cancelButtons = container?.querySelectorAll('[data-upload-cancel]');
+    expect(cancelButtons).toHaveLength(2);
+    await act(async () => {
+      cancelButtons?.forEach((button) =>
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+      );
+    });
+    expect(cancelUpload).toHaveBeenCalledTimes(2);
+  });
+
+  test('两个入口同步展示第二个退避和实际重试轮次', async () => {
+    await act(async () => {
+      root?.render(
+        <>
+          <FileUploadZone groupJid="web:g1" />
+          <MessageInput groupJid="web:g1" onSend={vi.fn()} />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      useFileStore.setState({
+        uploadProgress: {
+          ...baseProgress,
+          attempt: 2,
+          nextAttempt: 3,
+          retryDelayMs: 5000,
+        },
+      });
+    });
+    expect(retryTexts()).toEqual(['（5 秒后重试 3/3）', '（5 秒后重试 3/3）']);
+
+    await act(async () => {
+      useFileStore.setState({
+        uploadProgress: {
+          ...baseProgress,
+          attempt: 3,
+          retrying: false,
+          nextAttempt: undefined,
+          retryDelayMs: undefined,
+        },
+      });
+    });
+    expect(retryTexts()).toEqual(['（正在重试 3/3）', '（正在重试 3/3）']);
+  });
+});

--- a/web/src/components/chat/FileUploadZone.tsx
+++ b/web/src/components/chat/FileUploadZone.tsx
@@ -53,7 +53,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
 
   const progressPercent =
     uploadProgress && uploadProgress.totalBytes > 0
-      ? Math.round((uploadProgress.uploadedBytes / uploadProgress.totalBytes) * 100)
+      ? Math.round(
+          (uploadProgress.uploadedBytes / uploadProgress.totalBytes) * 100,
+        )
       : 0;
 
   return (
@@ -64,9 +66,7 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={`relative border-2 border-dashed rounded-lg p-3 transition-all ${
-          isDragging
-            ? 'border-primary bg-brand-50'
-            : 'border-border'
+          isDragging ? 'border-primary bg-brand-50' : 'border-border'
         } ${uploading ? 'pointer-events-none' : ''}`}
       >
         {/* Hidden inputs */}
@@ -92,8 +92,12 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
           /* Upload progress */
           <div className="space-y-2">
             <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span className="truncate max-w-[60%]">{uploadProgress.currentFile || '完成'}</span>
-              <span>{uploadProgress.completed}/{uploadProgress.total} 个文件</span>
+              <span className="truncate max-w-[60%]">
+                {uploadProgress.currentFile || '完成'}
+              </span>
+              <span>
+                {uploadProgress.completed}/{uploadProgress.total} 个文件
+              </span>
             </div>
             <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
               <div
@@ -101,7 +105,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
                 style={{ width: `${progressPercent}%` }}
               />
             </div>
-            <p className="text-[11px] text-muted-foreground text-center">{progressPercent}%</p>
+            <p className="text-[11px] text-muted-foreground text-center">
+              {progressPercent}%
+            </p>
           </div>
         ) : (
           /* Idle state */

--- a/web/src/components/chat/FileUploadZone.tsx
+++ b/web/src/components/chat/FileUploadZone.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, DragEvent } from 'react';
-import { Upload, FolderUp } from 'lucide-react';
-import { useFileStore } from '../../stores/files';
+import { Upload, FolderUp, X } from 'lucide-react';
+import { formatUploadRetryStatus, useFileStore } from '../../stores/files';
 
 interface FileUploadZoneProps {
   groupJid: string;
@@ -10,7 +10,8 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
-  const { uploadFiles, uploading, uploadProgress } = useFileStore();
+  const { uploadFiles, cancelUpload, uploading, uploadProgress } =
+    useFileStore();
 
   const handleDragOver = (e: DragEvent) => {
     e.preventDefault();
@@ -57,6 +58,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
           (uploadProgress.uploadedBytes / uploadProgress.totalBytes) * 100,
         )
       : 0;
+  const retryStatus = uploadProgress
+    ? formatUploadRetryStatus(uploadProgress)
+    : null;
 
   return (
     <div className="space-y-2">
@@ -67,7 +71,7 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
         onDrop={handleDrop}
         className={`relative border-2 border-dashed rounded-lg p-3 transition-all ${
           isDragging ? 'border-primary bg-brand-50' : 'border-border'
-        } ${uploading ? 'pointer-events-none' : ''}`}
+        }`}
       >
         {/* Hidden inputs */}
         <input
@@ -94,9 +98,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span className="truncate max-w-[60%]">
                 {uploadProgress.currentFile || '完成'}
-                {uploadProgress.attempt && uploadProgress.attempt > 1
-                  ? `（网络不稳，重试 ${uploadProgress.attempt}/3）`
-                  : ''}
+                {retryStatus ? (
+                  <span data-upload-retry-status>（{retryStatus}）</span>
+                ) : null}
               </span>
               <span>
                 {uploadProgress.completed}/{uploadProgress.total} 个文件
@@ -108,9 +112,20 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
                 style={{ width: `${progressPercent}%` }}
               />
             </div>
-            <p className="text-[11px] text-muted-foreground text-center">
-              {progressPercent}%
-            </p>
+            <div className="flex items-center justify-center gap-2">
+              <p className="text-[11px] text-muted-foreground">
+                {progressPercent}%
+              </p>
+              <button
+                type="button"
+                data-upload-cancel
+                onClick={cancelUpload}
+                className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+              >
+                <X className="w-3 h-3" />
+                取消
+              </button>
+            </div>
           </div>
         ) : (
           /* Idle state */

--- a/web/src/components/chat/FileUploadZone.tsx
+++ b/web/src/components/chat/FileUploadZone.tsx
@@ -94,6 +94,9 @@ export function FileUploadZone({ groupJid }: FileUploadZoneProps) {
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span className="truncate max-w-[60%]">
                 {uploadProgress.currentFile || '完成'}
+                {uploadProgress.attempt && uploadProgress.attempt > 1
+                  ? `（网络不稳，重试 ${uploadProgress.attempt}/3）`
+                  : ''}
               </span>
               <span>
                 {uploadProgress.completed}/{uploadProgress.total} 个文件

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -27,7 +27,7 @@ import {
   Check,
   Trash2,
 } from 'lucide-react';
-import { useFileStore } from '../../stores/files';
+import { formatUploadRetryStatus, useFileStore } from '../../stores/files';
 import {
   useChatStore,
   type FollowUpMode,
@@ -131,6 +131,7 @@ export function MessageInput({
   // 窄 selector：这是 1200+ 行常驻组件，无 selector 的整 store 订阅会让它在
   // 流式输出的每一帧（rAF 级 set()）都重渲染一次。actions 引用稳定。
   const uploadFiles = useFileStore((s) => s.uploadFiles);
+  const cancelUpload = useFileStore((s) => s.cancelUpload);
   const uploading = useFileStore((s) => s.uploading);
   const uploadProgress = useFileStore((s) => s.uploadProgress);
   const drafts = useChatStore((s) => s.drafts);
@@ -787,6 +788,9 @@ export function MessageInput({
           (uploadProgress.uploadedBytes / uploadProgress.totalBytes) * 100,
         )
       : 0;
+  const uploadRetryStatus = uploadProgress
+    ? formatUploadRetryStatus(uploadProgress)
+    : null;
 
   return (
     <div
@@ -822,10 +826,22 @@ export function MessageInput({
             <div className="flex items-center justify-between mb-1.5">
               <span className="text-xs text-foreground/70 truncate max-w-[65%]">
                 {uploadProgress.currentFile || '完成'}
+                {uploadRetryStatus ? (
+                  <span data-upload-retry-status>（{uploadRetryStatus}）</span>
+                ) : null}
               </span>
-              <span className="text-xs text-muted-foreground">
+              <span className="flex items-center gap-2 text-xs text-muted-foreground">
                 {uploadProgress.completed}/{uploadProgress.total} ·{' '}
                 {progressPercent}%
+                <button
+                  type="button"
+                  data-upload-cancel
+                  onClick={cancelUpload}
+                  className="inline-flex items-center gap-0.5 hover:text-foreground"
+                >
+                  <X className="h-3 w-3" />
+                  取消
+                </button>
               </span>
             </div>
             <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden">

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api, apiFetch, computeUploadTimeoutMs } from '../api/client';
+import { showToast } from '../utils/toast';
 
 /**
  * 上传重试。慢速或不稳定链路上单次上传失败非常常见（反代读请求体超时 → 408，
@@ -8,6 +9,8 @@ import { api, apiFetch, computeUploadTimeoutMs } from '../api/client';
  */
 const UPLOAD_MAX_ATTEMPTS = 3;
 const UPLOAD_RETRY_DELAYS_MS = [2000, 5000];
+const UPLOAD_CANCELLED = Symbol('upload-cancelled');
+let activeUploadController: AbortController | null = null;
 
 /**
  * 只重试传输层的瞬时失败：
@@ -30,15 +33,40 @@ function isRetriableUploadError(err: unknown): boolean {
 
 /** apiFetch 抛出的 ApiError 是纯对象而非 Error，直接用 instanceof 会丢掉真实原因。 */
 function uploadErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
   const e = err as { message?: string; status?: number } | null;
-  if (e?.message) {
-    return e.status ? `${e.message} (HTTP ${e.status})` : e.message;
+  if (e?.status === 0) return '网络连接失败，请检查网络后重试';
+  if (e?.status === 408) return '上传超时，请检查网络后重试';
+  if (e?.status && [502, 503, 504].includes(e.status)) {
+    return '上传服务暂时不可用，请稍后重试';
   }
-  return 'Failed to upload files';
+  if (typeof e?.message === 'string' && e.message.trim()) {
+    const message = e.message.trim().slice(0, 200);
+    return e.status ? `${message} (HTTP ${e.status})` : message;
+  }
+  if (err instanceof Error && err.message.trim()) {
+    return err.message.trim().slice(0, 200);
+  }
+  return '文件上传失败，请稍后重试';
 }
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+function waitForUploadRetry(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(UPLOAD_CANCELLED);
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(UPLOAD_CANCELLED);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
 
 export interface FileEntry {
   name: string;
@@ -59,8 +87,27 @@ export interface UploadProgress {
   /** bytes for current batch */
   totalBytes: number;
   uploadedBytes: number;
-  /** 当前文件的重试轮次；仅在 >1 时有值，用于让 UI 区分「慢」和「卡死」。 */
-  attempt?: number;
+  /** 当前实际请求轮次（首轮为 1）。 */
+  attempt: number;
+  maxAttempts: number;
+  /** true 表示上轮已失败，正在等待 nextAttempt。 */
+  retrying: boolean;
+  nextAttempt?: number;
+  retryDelayMs?: number;
+}
+
+/** 两个上传入口共用此文案，避免重试轮次或最大次数展示不一致。 */
+export function formatUploadRetryStatus(
+  progress: UploadProgress,
+): string | null {
+  if (progress.retrying && progress.nextAttempt) {
+    const seconds = Math.max(1, Math.ceil((progress.retryDelayMs ?? 0) / 1000));
+    return `${seconds} 秒后重试 ${progress.nextAttempt}/${progress.maxAttempts}`;
+  }
+  if (progress.attempt > 1) {
+    return `正在重试 ${progress.attempt}/${progress.maxAttempts}`;
+  }
+  return null;
 }
 
 interface FileState {
@@ -77,6 +124,7 @@ interface FileState {
     files: File[],
     basePath?: string,
   ) => Promise<boolean>;
+  cancelUpload: () => void;
   deleteFile: (jid: string, filePath: string) => Promise<boolean>;
   createDirectory: (
     jid: string,
@@ -109,6 +157,8 @@ export const useFileStore = create<FileState>((set, get) => ({
   uploadProgress: null,
   error: null,
 
+  cancelUpload: () => activeUploadController?.abort(),
+
   loadFiles: async (jid: string, path?: string) => {
     set({ loading: true, error: null });
     try {
@@ -134,18 +184,25 @@ export const useFileStore = create<FileState>((set, get) => ({
   },
 
   uploadFiles: async (jid: string, files: File[], basePath?: string) => {
-    if (files.length === 0) return false;
+    if (files.length === 0 || get().uploading) return false;
+
+    const uploadController = new AbortController();
+    activeUploadController = uploadController;
 
     const total = files.length;
     const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
     set({
       uploading: true,
+      error: null,
       uploadProgress: {
         total,
         completed: 0,
         currentFile: files[0].name,
         totalBytes,
         uploadedBytes: 0,
+        attempt: 1,
+        maxAttempts: UPLOAD_MAX_ATTEMPTS,
+        retrying: false,
       },
     });
 
@@ -156,6 +213,7 @@ export const useFileStore = create<FileState>((set, get) => ({
 
     try {
       for (let i = 0; i < files.length; i++) {
+        if (uploadController.signal.aborted) throw UPLOAD_CANCELLED;
         const file = files[i];
 
         // For folder uploads, webkitRelativePath = "folderName/sub/file.txt"
@@ -177,24 +235,28 @@ export const useFileStore = create<FileState>((set, get) => ({
             currentFile: file.name,
             totalBytes,
             uploadedBytes,
+            attempt: 1,
+            maxAttempts: UPLOAD_MAX_ATTEMPTS,
+            retrying: false,
           },
         });
 
         // 每轮重建 FormData：body 已被上一次 fetch 消费，不能复用。
         let lastErr: unknown;
         for (let attempt = 1; attempt <= UPLOAD_MAX_ATTEMPTS; attempt++) {
-          if (attempt > 1) {
-            set({
-              uploadProgress: {
-                total,
-                completed: i,
-                currentFile: file.name,
-                totalBytes,
-                uploadedBytes,
-                attempt,
-              },
-            });
-          }
+          if (uploadController.signal.aborted) throw UPLOAD_CANCELLED;
+          set({
+            uploadProgress: {
+              total,
+              completed: i,
+              currentFile: file.name,
+              totalBytes,
+              uploadedBytes,
+              attempt,
+              maxAttempts: UPLOAD_MAX_ATTEMPTS,
+              retrying: false,
+            },
+          });
 
           const formData = new FormData();
           formData.append('files', file);
@@ -206,10 +268,15 @@ export const useFileStore = create<FileState>((set, get) => ({
               body: formData,
               headers: {},
               timeoutMs: computeUploadTimeoutMs(file.size),
+              signal: uploadController.signal,
             });
+            if (uploadController.signal.aborted) throw UPLOAD_CANCELLED;
             lastErr = undefined;
             break;
           } catch (err) {
+            if (uploadController.signal.aborted || err === UPLOAD_CANCELLED) {
+              throw UPLOAD_CANCELLED;
+            }
             lastErr = err;
             if (
               attempt === UPLOAD_MAX_ATTEMPTS ||
@@ -217,7 +284,22 @@ export const useFileStore = create<FileState>((set, get) => ({
             ) {
               break;
             }
-            await sleep(UPLOAD_RETRY_DELAYS_MS[attempt - 1] ?? 5000);
+            const retryDelayMs = UPLOAD_RETRY_DELAYS_MS[attempt - 1] ?? 5000;
+            set({
+              uploadProgress: {
+                total,
+                completed: i,
+                currentFile: file.name,
+                totalBytes,
+                uploadedBytes,
+                attempt,
+                maxAttempts: UPLOAD_MAX_ATTEMPTS,
+                retrying: true,
+                nextAttempt: attempt + 1,
+                retryDelayMs,
+              },
+            });
+            await waitForUploadRetry(retryDelayMs, uploadController.signal);
           }
         }
         if (lastErr) throw lastErr;
@@ -231,20 +313,34 @@ export const useFileStore = create<FileState>((set, get) => ({
             currentFile: i + 1 < total ? files[i + 1].name : '',
             totalBytes,
             uploadedBytes,
+            attempt: 1,
+            maxAttempts: UPLOAD_MAX_ATTEMPTS,
+            retrying: false,
           },
         });
       }
 
+      // All request bodies are complete now, so hide the cancel control while
+      // retaining `uploading` as a guard against a concurrent refresh/upload.
+      set({ uploadProgress: null });
       // Reload file list
       await get().loadFiles(jid, targetBase);
       return true;
     } catch (err) {
+      if (err === UPLOAD_CANCELLED || uploadController.signal.aborted) {
+        if (uploadedBytes > 0) await get().loadFiles(jid, targetBase);
+        return false;
+      }
       const msg = uploadErrorMessage(err);
       console.error('Failed to upload files:', err);
       set({ error: msg });
+      showToast('上传失败', msg);
       return false;
     } finally {
-      set({ uploading: false, uploadProgress: null });
+      if (activeUploadController === uploadController) {
+        activeUploadController = null;
+        set({ uploading: false, uploadProgress: null });
+      }
     }
   },
 

--- a/web/src/stores/files.ts
+++ b/web/src/stores/files.ts
@@ -1,6 +1,45 @@
 import { create } from 'zustand';
 import { api, apiFetch, computeUploadTimeoutMs } from '../api/client';
 
+/**
+ * 上传重试。慢速或不稳定链路上单次上传失败非常常见（反代读请求体超时 → 408，
+ * 客户端 abort → 网络错误），此前任何一次失败都会让整批上传中断、用户必须
+ * 手动从头再来。服务端按文件名 O_TRUNC 覆盖写，重传同一文件是幂等的。
+ */
+const UPLOAD_MAX_ATTEMPTS = 3;
+const UPLOAD_RETRY_DELAYS_MS = [2000, 5000];
+
+/**
+ * 只重试传输层的瞬时失败：
+ * - 0：apiFetch 归一化后的网络错误
+ * - 408：客户端超时 abort，或反向代理读请求体超时
+ * - 502/503/504：上游短暂不可用
+ * 其余（400 参数错误、403 配额或路径拒绝、413 超限、500 逻辑错误）重试没有意义，
+ * 立即失败，让用户看到真实原因而不是等三轮。
+ */
+function isRetriableUploadError(err: unknown): boolean {
+  const status = (err as { status?: number } | null)?.status;
+  return (
+    status === 0 ||
+    status === 408 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  );
+}
+
+/** apiFetch 抛出的 ApiError 是纯对象而非 Error，直接用 instanceof 会丢掉真实原因。 */
+function uploadErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  const e = err as { message?: string; status?: number } | null;
+  if (e?.message) {
+    return e.status ? `${e.message} (HTTP ${e.status})` : e.message;
+  }
+  return 'Failed to upload files';
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export interface FileEntry {
   name: string;
   path: string;
@@ -20,6 +59,8 @@ export interface UploadProgress {
   /** bytes for current batch */
   totalBytes: number;
   uploadedBytes: number;
+  /** 当前文件的重试轮次；仅在 >1 时有值，用于让 UI 区分「慢」和「卡死」。 */
+  attempt?: number;
 }
 
 interface FileState {
@@ -139,16 +180,47 @@ export const useFileStore = create<FileState>((set, get) => ({
           },
         });
 
-        const formData = new FormData();
-        formData.append('files', file);
-        if (uploadPath) formData.append('path', uploadPath);
+        // 每轮重建 FormData：body 已被上一次 fetch 消费，不能复用。
+        let lastErr: unknown;
+        for (let attempt = 1; attempt <= UPLOAD_MAX_ATTEMPTS; attempt++) {
+          if (attempt > 1) {
+            set({
+              uploadProgress: {
+                total,
+                completed: i,
+                currentFile: file.name,
+                totalBytes,
+                uploadedBytes,
+                attempt,
+              },
+            });
+          }
 
-        await apiFetch(apiUrl, {
-          method: 'POST',
-          body: formData,
-          headers: {},
-          timeoutMs: computeUploadTimeoutMs(file.size),
-        });
+          const formData = new FormData();
+          formData.append('files', file);
+          if (uploadPath) formData.append('path', uploadPath);
+
+          try {
+            await apiFetch(apiUrl, {
+              method: 'POST',
+              body: formData,
+              headers: {},
+              timeoutMs: computeUploadTimeoutMs(file.size),
+            });
+            lastErr = undefined;
+            break;
+          } catch (err) {
+            lastErr = err;
+            if (
+              attempt === UPLOAD_MAX_ATTEMPTS ||
+              !isRetriableUploadError(err)
+            ) {
+              break;
+            }
+            await sleep(UPLOAD_RETRY_DELAYS_MS[attempt - 1] ?? 5000);
+          }
+        }
+        if (lastErr) throw lastErr;
 
         uploadedBytes += file.size;
 
@@ -167,7 +239,7 @@ export const useFileStore = create<FileState>((set, get) => ({
       await get().loadFiles(jid, targetBase);
       return true;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to upload files';
+      const msg = uploadErrorMessage(err);
       console.error('Failed to upload files:', err);
       set({ error: msg });
       return false;


### PR DESCRIPTION
## Summary

Integrates and hardens the work from #651 and #652 on one validation branch.

- make WebSocket heartbeat tolerant of transient stalls, observable on per-socket failures, and bound to server lifecycle
- make uploads retry/cancel cleanly with consistent progress and safe user-facing errors
- make upload quota checks concurrency-safe and based on final net storage growth
- preflight unsafe upload targets and cover retry, cancellation, quota, and heartbeat edge cases

## Validation

- `npm run format:check`
- `npm run audit:prod`
- `make typecheck`
- `npm test -- --run` (3112 passed, 23 skipped)
- `npm run build:all`
- `npm --prefix web run test:e2e` (9 passed)
- `npm run self-test:agent-runner`
- post-review targeted regression suite (49 passed)

This PR remains draft until deployment and real validation on the Mac mini complete.