### PR TITLE
fix(wecom): 私聊与群聊不再争用同一 workspace main owner

### DIFF
--- a/src/channel-account-routing.ts
+++ b/src/channel-account-routing.ts
@@ -1,3 +1,4 @@
+import type { ChannelConversationKind } from './channel-conversation-kind.js';
 import type { ChannelAccount, RegisteredGroup } from './types.js';
 
 export interface ChannelAccountFallbackWorkspace {
@@ -30,6 +31,17 @@ export function resolveChannelAccountFallbackWorkspace(
  * Attach an inbound chat to its channel account without changing a binding the
  * user already selected. Account defaults are only a registration fallback;
  * they must never turn every subsequent IM message into a binding update.
+ *
+ * Group and unknown conversations may fall back to the account default
+ * workspace. Direct chats must not: they share that workspace's main owner
+ * slot with every group bound to the same workspace, which is how a WeCom
+ * 1:1 and a group collapsed onto one reply target. Direct chats only receive
+ * the account id here; callers then mount a dedicated session.
+ *
+ * `conversationKind` defaults to `unknown` so existing callers keep the
+ * workspace fallback. Infer kind from the JID only — Feishu P2P metadata
+ * must not silently opt Feishu into this path (that stays `auto_im`).
+ *
  * Returns the input object unchanged when nothing needs to move, so callers
  * can skip persistence — every inbound message funnels through this path, and
  * an unconditional setRegisteredGroup costs ~10 statements per message.
@@ -38,18 +50,21 @@ export function applyChannelAccountRegistrationFallback(
   group: RegisteredGroup,
   accountId: string,
   fallbackWorkspaceJid: string,
+  conversationKind: ChannelConversationKind = 'unknown',
 ): RegisteredGroup {
   const hasExplicitBinding = Boolean(
     group.target_main_jid || group.target_agent_id,
   );
   const nextAccountId = group.channel_account_id ?? accountId;
+  const shouldBindWorkspace =
+    !hasExplicitBinding && conversationKind !== 'direct';
   const changed =
     nextAccountId !== group.channel_account_id ||
-    (!hasExplicitBinding && group.target_main_jid !== fallbackWorkspaceJid);
+    (shouldBindWorkspace && group.target_main_jid !== fallbackWorkspaceJid);
   if (!changed) return group;
   return {
     ...group,
     channel_account_id: nextAccountId,
-    ...(hasExplicitBinding ? {} : { target_main_jid: fallbackWorkspaceJid }),
+    ...(shouldBindWorkspace ? { target_main_jid: fallbackWorkspaceJid } : {}),
   };
 }

--- a/src/channel-mount-service.ts
+++ b/src/channel-mount-service.ts
@@ -27,6 +27,7 @@ import {
   getRegisteredGroup,
   getUserHomeGroup,
   listAgentsByJid,
+  setRegisteredGroupAndClearMatchingMainOwner,
   setRegisteredGroup,
   updateAgentLastImJid,
   updateChatName,
@@ -284,6 +285,13 @@ export function restoreDefaultChannelMount(
   // Infer kind from the JID only. Feishu P2P metadata must not opt Feishu
   // into a channel_direct session; that path stays auto_im.
   if (resolveChannelConversationKind(channelJid) === 'direct') {
+    const previousWorkspaceJid = resolveWorkspaceJid(group.target_main_jid, {
+      getRegisteredGroup,
+      getJidsByFolder,
+    });
+    const previousWorkspaceFolder = previousWorkspaceJid
+      ? getRegisteredGroup(previousWorkspaceJid)?.folder
+      : undefined;
     const mounted = ensureDirectChannelSessionMount({
       sourceJid: channelJid,
       group: {
@@ -300,7 +308,9 @@ export function restoreDefaultChannelMount(
       force: true,
       mountOptions: { replyPolicy: 'source_only' },
     });
-    commitChannelMountUpdate(channelJid, mounted);
+    commitChannelMountUpdate(channelJid, mounted, {
+      clearMatchingMainOwnerFolder: previousWorkspaceFolder,
+    });
     return { ...resolved, updated: mounted };
   }
 
@@ -715,8 +725,17 @@ export function buildUnmountUpdate(
 export function commitChannelMountUpdate(
   channelJid: string,
   updated: RegisteredGroup,
+  options: { clearMatchingMainOwnerFolder?: string } = {},
 ): void {
-  setRegisteredGroup(channelJid, updated);
+  if (options.clearMatchingMainOwnerFolder) {
+    setRegisteredGroupAndClearMatchingMainOwner(
+      channelJid,
+      updated,
+      options.clearMatchingMainOwnerFolder,
+    );
+  } else {
+    setRegisteredGroup(channelJid, updated);
+  }
   const deps = getWebDeps();
   if (!deps) return;
   const groups = deps.getRegisteredGroups();

--- a/src/channel-mount-service.ts
+++ b/src/channel-mount-service.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import type {
   ChannelAccount,
   ChannelProvider,
@@ -7,10 +8,17 @@ import type {
   SubAgent,
 } from './types.js';
 import { getChannelType } from './im-channel.js';
-import { parseChannelAddress } from './channel-address.js';
+import {
+  channelConversationJid,
+  parseChannelAddress,
+} from './channel-address.js';
+import { applyChannelAccountRegistrationFallback } from './channel-account-routing.js';
+import { resolveChannelConversationKind } from './channel-conversation-kind.js';
 import { isThreadMapCapableChat } from './im-channel-capabilities.js';
 import { requiresMention as feishuRequiresMention } from './feishu-conversation-policy.js';
 import {
+  createAgent,
+  ensureChatExists,
   getChannelAccount,
   getAllRegisteredGroups,
   getDefaultChannelAccount,
@@ -18,8 +26,13 @@ import {
   getLegacyChannelAccount,
   getRegisteredGroup,
   getUserHomeGroup,
+  listAgentsByJid,
   setRegisteredGroup,
+  updateAgentLastImJid,
+  updateChatName,
 } from './db.js';
+import { logger } from './logger.js';
+import { ensureAgentDirectories } from './utils.js';
 import { getWebDeps } from './web-context.js';
 
 export interface ChannelMountResolutionDeps {
@@ -266,10 +279,177 @@ export function restoreDefaultChannelMount(
     },
     liveInfo,
   );
-  if (resolved.status === 'resolved') {
-    commitChannelMountUpdate(channelJid, resolved.updated);
+  if (resolved.status !== 'resolved') return resolved;
+
+  // Infer kind from the JID only. Feishu P2P metadata must not opt Feishu
+  // into a channel_direct session; that path stays auto_im.
+  if (resolveChannelConversationKind(channelJid) === 'direct') {
+    const mounted = ensureDirectChannelSessionMount({
+      sourceJid: channelJid,
+      group: {
+        ...group,
+        ...((resolved.accountId ?? group.channel_account_id)
+          ? {
+              channel_account_id:
+                resolved.accountId ?? group.channel_account_id,
+            }
+          : {}),
+      },
+      workspaceJid: resolved.workspaceJid,
+      userId: ownerUserId ?? group.created_by ?? '',
+      force: true,
+      mountOptions: { replyPolicy: 'source_only' },
+    });
+    commitChannelMountUpdate(channelJid, mounted);
+    return { ...resolved, updated: mounted };
   }
+
+  commitChannelMountUpdate(channelJid, resolved.updated);
   return resolved;
+}
+
+export interface EnsureDirectChannelSessionMountParams {
+  sourceJid: string;
+  group: RegisteredGroup;
+  workspaceJid: string;
+  userId: string;
+  /** Remount even when the chat already has a workspace or session bind. */
+  force?: boolean;
+  mountOptions?: ChannelMountUpdateOptions;
+  onCreated?: (agent: SubAgent, workspaceJid: string) => void;
+}
+
+function matchesDirectConversationJid(
+  lastImJid: string | null,
+  conversationJid: string,
+): boolean {
+  if (!lastImJid) return false;
+  return (
+    lastImJid === conversationJid ||
+    channelConversationJid(lastImJid) === conversationJid
+  );
+}
+
+/**
+ * Mount an unbound (or force-restored) direct chat onto a dedicated
+ * conversation session in the fallback workspace. Reuses an existing
+ * `channel_direct` session for the same conversation JID when one exists.
+ */
+export function ensureDirectChannelSessionMount(
+  params: EnsureDirectChannelSessionMountParams,
+): RegisteredGroup {
+  if (
+    !params.force &&
+    (params.group.target_agent_id || params.group.target_main_jid)
+  ) {
+    return params.group;
+  }
+
+  const workspace = getRegisteredGroup(params.workspaceJid);
+  if (!workspace) return params.group;
+
+  const conversationJid = channelConversationJid(params.sourceJid);
+  const reusable = listAgentsByJid(params.workspaceJid).find(
+    (agent) =>
+      agent.source_kind === 'channel_direct' &&
+      matchesDirectConversationJid(agent.last_im_jid, conversationJid),
+  );
+
+  if (
+    reusable &&
+    params.group.target_agent_id === reusable.id &&
+    !params.group.target_main_jid
+  ) {
+    return params.group;
+  }
+
+  const now = new Date().toISOString();
+  const agent =
+    reusable ??
+    (() => {
+      const created: SubAgent = {
+        id: crypto.randomUUID(),
+        group_folder: workspace.folder,
+        chat_jid: params.workspaceJid,
+        name: params.group.name || conversationJid,
+        prompt: '',
+        status: 'idle',
+        kind: 'conversation',
+        created_by: params.userId || workspace.created_by || null,
+        created_at: now,
+        completed_at: null,
+        result_summary: null,
+        last_im_jid: conversationJid,
+        spawned_from_jid: null,
+        source_kind: 'channel_direct',
+        last_active_at: now,
+      };
+      createAgent(created);
+      ensureAgentDirectories(workspace.folder, created.id);
+      const virtualChatJid = `${params.workspaceJid}#agent:${created.id}`;
+      ensureChatExists(virtualChatJid);
+      updateChatName(virtualChatJid, created.name);
+      params.onCreated?.(created, params.workspaceJid);
+      logger.info(
+        {
+          sourceJid: params.sourceJid,
+          agentId: created.id,
+          workspaceJid: params.workspaceJid,
+        },
+        'Created channel_direct session mount for direct chat',
+      );
+      return created;
+    })();
+
+  if (reusable) {
+    updateAgentLastImJid(reusable.id, conversationJid);
+  }
+
+  return buildSessionMountUpdate(params.group, agent.id, params.mountOptions);
+}
+
+/**
+ * Account-aware first-registration attach. Groups and unknown chats fall
+ * back to the account default workspace. Direct chats get a dedicated
+ * session in that workspace so they do not share the main owner slot.
+ */
+export function attachDefaultChannelAccountMount(params: {
+  sourceJid: string;
+  group: RegisteredGroup;
+  accountId?: string;
+  fallbackWorkspaceJid: string;
+  userId: string;
+  onCreated?: (agent: SubAgent, workspaceJid: string) => void;
+}): RegisteredGroup {
+  const conversationKind = resolveChannelConversationKind(params.sourceJid);
+  const withAccount = params.accountId
+    ? applyChannelAccountRegistrationFallback(
+        params.group,
+        params.accountId,
+        params.fallbackWorkspaceJid,
+        conversationKind,
+      )
+    : conversationKind === 'direct' ||
+        params.group.target_main_jid ||
+        params.group.target_agent_id
+      ? params.group
+      : { ...params.group, target_main_jid: params.fallbackWorkspaceJid };
+
+  if (
+    conversationKind !== 'direct' ||
+    withAccount.target_main_jid ||
+    withAccount.target_agent_id
+  ) {
+    return withAccount;
+  }
+
+  return ensureDirectChannelSessionMount({
+    sourceJid: params.sourceJid,
+    group: withAccount,
+    workspaceJid: params.fallbackWorkspaceJid,
+    userId: params.userId,
+    onCreated: params.onCreated,
+  });
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -2526,77 +2526,81 @@ export function initDatabase(): void {
  * message cannot keep delivering into that private chat.
  */
 export function migrateWecomDirectWorkspaceMountsToSessions(): number {
-  const groups = getAllRegisteredGroups();
-  let migrated = 0;
+  return db
+    .transaction(() => {
+      const groups = getAllRegisteredGroups();
+      let migrated = 0;
 
-  for (const [jid, group] of Object.entries(groups)) {
-    if (!jid.startsWith('wecom:c2c:')) continue;
-    if (!group.target_main_jid || group.target_agent_id) continue;
+      for (const [jid, group] of Object.entries(groups)) {
+        if (!jid.startsWith('wecom:c2c:')) continue;
+        if (!group.target_main_jid || group.target_agent_id) continue;
 
-    const workspaceJid = resolveWorkspaceJidForMount(group.target_main_jid);
-    if (!workspaceJid) continue;
-    const workspace = getRegisteredGroup(workspaceJid);
-    if (!workspace) continue;
+        const workspaceJid = resolveWorkspaceJidForMount(group.target_main_jid);
+        if (!workspaceJid) continue;
+        const workspace = getRegisteredGroup(workspaceJid);
+        if (!workspace) continue;
 
-    const conversationJid = channelConversationJid(jid);
-    const reusable = listAgentsByJid(workspaceJid).find(
-      (agent) =>
-        agent.source_kind === 'channel_direct' &&
-        agent.last_im_jid &&
-        (agent.last_im_jid === conversationJid ||
-          channelConversationJid(agent.last_im_jid) === conversationJid),
-    );
+        const conversationJid = channelConversationJid(jid);
+        const reusable = listAgentsByJid(workspaceJid).find(
+          (agent) =>
+            agent.source_kind === 'channel_direct' &&
+            agent.last_im_jid &&
+            (agent.last_im_jid === conversationJid ||
+              channelConversationJid(agent.last_im_jid) === conversationJid),
+        );
 
-    const now = new Date().toISOString();
-    const agent =
-      reusable ??
-      (() => {
-        const created: SubAgent = {
-          id: crypto.randomUUID(),
-          group_folder: workspace.folder,
-          chat_jid: workspaceJid,
-          name: group.name || conversationJid,
-          prompt: '',
-          status: 'idle',
-          kind: 'conversation',
-          created_by: group.created_by ?? workspace.created_by ?? null,
-          created_at: now,
-          completed_at: null,
-          result_summary: null,
-          last_im_jid: conversationJid,
-          spawned_from_jid: null,
-          source_kind: 'channel_direct',
-          last_active_at: now,
-        };
-        createAgent(created);
-        const virtualChatJid = `${workspaceJid}#agent:${created.id}`;
-        ensureChatExists(virtualChatJid);
-        updateChatName(virtualChatJid, created.name);
-        return created;
-      })();
+        const now = new Date().toISOString();
+        const agent =
+          reusable ??
+          (() => {
+            const created: SubAgent = {
+              id: crypto.randomUUID(),
+              group_folder: workspace.folder,
+              chat_jid: workspaceJid,
+              name: group.name || conversationJid,
+              prompt: '',
+              status: 'idle',
+              kind: 'conversation',
+              created_by: group.created_by ?? workspace.created_by ?? null,
+              created_at: now,
+              completed_at: null,
+              result_summary: null,
+              last_im_jid: conversationJid,
+              spawned_from_jid: null,
+              source_kind: 'channel_direct',
+              last_active_at: now,
+            };
+            createAgent(created);
+            const virtualChatJid = `${workspaceJid}#agent:${created.id}`;
+            ensureChatExists(virtualChatJid);
+            updateChatName(virtualChatJid, created.name);
+            return created;
+          })();
 
-    setRegisteredGroup(jid, {
-      ...group,
-      target_agent_id: agent.id,
-      target_main_jid: undefined,
-      binding_mode: 'single_context',
-    });
+        setRegisteredGroup(jid, {
+          ...group,
+          target_agent_id: agent.id,
+          target_main_jid: undefined,
+          binding_mode: 'single_context',
+        });
 
-    const ownerJid = getSessionChannelOwner(workspace.folder, null);
-    if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
-      clearSessionChannelOwner(workspace.folder, null);
-    }
+        const ownerJid = getSessionChannelOwner(workspace.folder, null);
+        if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
+          clearSessionChannelOwner(workspace.folder, null);
+        }
 
-    migrated += 1;
-  }
+        migrated += 1;
+      }
 
-  if (migrated > 0) {
-    logger.info(
-      { migrated },
-      'Migrated WeCom direct chats off shared workspace main mounts',
-    );
-  }
-  return migrated;
+      if (migrated > 0) {
+        logger.info(
+          { migrated },
+          'Migrated WeCom direct chats off shared workspace main mounts',
+        );
+      }
+      return migrated;
+    })
+    .immediate();
 }
 
 /**
@@ -11111,6 +11115,28 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
 }
 
 /**
+ * Persist a channel reroute and release a stale workspace-main owner in one
+ * transaction. The owner is cleared only when it belongs to the same canonical
+ * direct conversation, so unrelated channels cannot lose their sticky route.
+ */
+export function setRegisteredGroupAndClearMatchingMainOwner(
+  jid: string,
+  group: RegisteredGroup,
+  previousWorkspaceFolder: string,
+): void {
+  db.transaction(() => {
+    setRegisteredGroup(jid, group);
+    const ownerJid = getSessionChannelOwner(previousWorkspaceFolder, null);
+    if (
+      ownerJid &&
+      channelConversationJid(ownerJid) === channelConversationJid(jid)
+    ) {
+      clearSessionChannelOwner(previousWorkspaceFolder, null);
+    }
+  })();
+}
+
+/**
  * Refresh the provider-hosted avatar for an already registered external chat.
  * Discovery invokes onNewChat first, so a missing row means the chat was not
  * admitted and must not be created as a side effect of avatar synchronization.
@@ -12086,12 +12112,18 @@ export function deleteGroupData(
      * Callers update their live routing cache only after this transaction
      * succeeds.
      */
-    channelUpdates?: Array<{ jid: string; group: RegisteredGroup }>;
+    channelUpdates?:
+      | Array<{ jid: string; group: RegisteredGroup }>
+      | (() => Array<{ jid: string; group: RegisteredGroup }>);
   } = {},
 ): void {
   const tx = db.transaction(() => {
     const legacyMainJid = `web:${folder}`;
-    for (const update of options.channelUpdates ?? []) {
+    const channelUpdates =
+      typeof options.channelUpdates === 'function'
+        ? options.channelUpdates()
+        : (options.channelUpdates ?? []);
+    for (const update of channelUpdates) {
       setRegisteredGroup(update.jid, update.group);
     }
     db.prepare(

--- a/src/db.ts
+++ b/src/db.ts
@@ -103,7 +103,7 @@ let db: InstanceType<typeof Database>;
  * restating the number. Hardcoding it meant every schema bump edited a dozen
  * unrelated test files, which is churn that hides real assertion changes.
  */
-export const CURRENT_SCHEMA_VERSION = 71;
+export const CURRENT_SCHEMA_VERSION = 72;
 
 export function isDatabaseInitialized(): boolean {
   return Boolean(db?.open);
@@ -2501,9 +2501,102 @@ export function initDatabase(): void {
     }
   }
 
+  // v71 -> v72: WeCom 1:1 chats that were registration-fallback bound to a
+  // workspace main session shared that workspace's channel-owner slot with
+  // any group in the same workspace. Move those DMs onto dedicated
+  // channel_direct sessions. Groups, manual session binds, and missing
+  // workspaces are left untouched. Idempotent for already-migrated rows.
+  const wecomDirectMountSchemaVersion = Number(
+    getRouterStateInternal('schema_version') ?? '0',
+  );
+  if (wecomDirectMountSchemaVersion < 72) {
+    migrateWecomDirectWorkspaceMountsToSessions();
+  }
+
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', String(CURRENT_SCHEMA_VERSION));
+}
+
+/**
+ * Move WeCom DMs off a shared workspace main mount onto a dedicated
+ * conversation session. Existing `target_agent_id` binds (manual or
+ * already-migrated) and every group chat are left alone. If the workspace
+ * main owner slot still points at the DM, clear it so a later group
+ * message cannot keep delivering into that private chat.
+ */
+export function migrateWecomDirectWorkspaceMountsToSessions(): number {
+  const groups = getAllRegisteredGroups();
+  let migrated = 0;
+
+  for (const [jid, group] of Object.entries(groups)) {
+    if (!jid.startsWith('wecom:c2c:')) continue;
+    if (!group.target_main_jid || group.target_agent_id) continue;
+
+    const workspaceJid = resolveWorkspaceJidForMount(group.target_main_jid);
+    if (!workspaceJid) continue;
+    const workspace = getRegisteredGroup(workspaceJid);
+    if (!workspace) continue;
+
+    const conversationJid = channelConversationJid(jid);
+    const reusable = listAgentsByJid(workspaceJid).find(
+      (agent) =>
+        agent.source_kind === 'channel_direct' &&
+        agent.last_im_jid &&
+        (agent.last_im_jid === conversationJid ||
+          channelConversationJid(agent.last_im_jid) === conversationJid),
+    );
+
+    const now = new Date().toISOString();
+    const agent =
+      reusable ??
+      (() => {
+        const created: SubAgent = {
+          id: crypto.randomUUID(),
+          group_folder: workspace.folder,
+          chat_jid: workspaceJid,
+          name: group.name || conversationJid,
+          prompt: '',
+          status: 'idle',
+          kind: 'conversation',
+          created_by: group.created_by ?? workspace.created_by ?? null,
+          created_at: now,
+          completed_at: null,
+          result_summary: null,
+          last_im_jid: conversationJid,
+          spawned_from_jid: null,
+          source_kind: 'channel_direct',
+          last_active_at: now,
+        };
+        createAgent(created);
+        const virtualChatJid = `${workspaceJid}#agent:${created.id}`;
+        ensureChatExists(virtualChatJid);
+        updateChatName(virtualChatJid, created.name);
+        return created;
+      })();
+
+    setRegisteredGroup(jid, {
+      ...group,
+      target_agent_id: agent.id,
+      target_main_jid: undefined,
+      binding_mode: 'single_context',
+    });
+
+    const ownerJid = getSessionChannelOwner(workspace.folder, null);
+    if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
+      clearSessionChannelOwner(workspace.folder, null);
+    }
+
+    migrated += 1;
+  }
+
+  if (migrated > 0) {
+    logger.info(
+      { migrated },
+      'Migrated WeCom direct chats off shared workspace main mounts',
+    );
+  }
+  return migrated;
 }
 
 /**
@@ -13568,7 +13661,8 @@ function mapAgentRow(row: Record<string, unknown>): SubAgent {
             | 'manual'
             | 'native_thread'
             | 'feishu_thread'
-            | 'auto_im')
+            | 'auto_im'
+            | 'channel_direct')
         : null,
     thread_id: typeof row.thread_id === 'string' ? row.thread_id : null,
     root_message_id:

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,7 @@ import {
   isNativeContextContainer,
   resolveChannelMountTarget,
   restoreDefaultChannelMount,
+  attachDefaultChannelAccountMount,
   upgradeNativeContextChannelMount,
 } from './channel-mount-service.js';
 import { isThreadMapCapableChat } from './im-channel-capabilities.js';
@@ -400,10 +401,7 @@ import {
   ensureLegacyDefaultChannelAccount,
   syncDefaultChannelAccountCredentials,
 } from './channel-account-migration.js';
-import {
-  applyChannelAccountRegistrationFallback,
-  resolveChannelAccountFallbackWorkspace,
-} from './channel-account-routing.js';
+import { resolveChannelAccountFallbackWorkspace } from './channel-account-routing.js';
 import { testChannelAccountCredentials } from './channel-account-connectivity.js';
 import {
   buildAgentProfilePrompt,
@@ -18630,18 +18628,24 @@ function buildOnPairAttempt(
     const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
     if (group) {
       const fallbackWorkspaceJid = defaultWorkspaceJid ?? pairingUserHome.jid;
-      const updated = accountId
-        ? applyChannelAccountRegistrationFallback(
-            group,
-            accountId,
-            fallbackWorkspaceJid,
-          )
-        : {
-            ...group,
-            ...(group.target_main_jid || group.target_agent_id
-              ? {}
-              : { target_main_jid: fallbackWorkspaceJid }),
-          };
+      const updated = attachDefaultChannelAccountMount({
+        sourceJid: jid,
+        group,
+        accountId,
+        fallbackWorkspaceJid,
+        userId: result.userId,
+        onCreated: (agent, workspaceJid) => {
+          broadcastAgentStatus(
+            workspaceJid,
+            agent.id,
+            'idle',
+            agent.name,
+            '',
+            undefined,
+            'conversation',
+          );
+        },
+      });
       const pairedOwnerImId = ownerImIdFromDirectConversationJid(jid);
       const paired = pairedOwnerImId
         ? claimOwner(
@@ -19624,11 +19628,24 @@ async function reloadChannelAccountById(accountId: string): Promise<boolean> {
     baseOnNewChat(jid, name);
     const group = registeredGroups[jid] ?? getRegisteredGroup(jid);
     if (!group) return;
-    const updated = applyChannelAccountRegistrationFallback(
+    const updated = attachDefaultChannelAccountMount({
+      sourceJid: jid,
       group,
-      account.id,
-      workspace.jid,
-    );
+      accountId: account.id,
+      fallbackWorkspaceJid: workspace.jid,
+      userId: account.owner_user_id,
+      onCreated: (agent, workspaceJid) => {
+        broadcastAgentStatus(
+          workspaceJid,
+          agent.id,
+          'idle',
+          agent.name,
+          '',
+          undefined,
+          'conversation',
+        );
+      },
+    });
     // Steady-state inbound messages resolve to an already-attached group;
     // rewriting an identical row on every message was pure write amplification.
     if (updated === group) return;

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -94,8 +94,10 @@ import { getChannelType } from '../im-channel.js';
 import {
   buildNativeThreadWorkspaceUpdate,
   buildUnmountUpdate,
+  ensureDirectChannelSessionMount,
   resolveDefaultChannelMountForWorkspaceDeletion,
 } from '../channel-mount-service.js';
+import { resolveChannelConversationKind } from '../channel-conversation-kind.js';
 import {
   AdditionalMountValidationError,
   loadMountAllowlist,
@@ -1790,37 +1792,51 @@ groupRoutes.delete('/:jid', authMiddleware, async (c) => {
       group: RegisteredGroup;
     }> = [];
     const nativeThreadTargets = new Set<string>();
-    if (confirmedChannelUnbind) {
-      for (const channelJid of freshBindingSummary.mountedChannelJids) {
-        const channelGroup = getRegisteredGroup(channelJid);
-        if (!channelGroup) continue;
-        const restored = resolveDefaultChannelMountForWorkspaceDeletion(
-          channelJid,
-          channelGroup,
-          channelGroup.created_by ?? authUser.id,
-          excludedWorkspaceJids,
-        );
-        if (restored.status === 'resolved') {
-          channelUpdates.push({
-            jid: channelJid,
-            group: restored.updated,
-          });
-          if (restored.routingMode === 'thread_map') {
-            nativeThreadTargets.add(restored.workspaceJid);
-          }
-        } else {
-          // A damaged legacy account may have no viable default workspace.
-          // Clearing its route is still safer than leaving a dangling pointer
-          // to the workspace that is about to disappear.
-          channelUpdates.push({
-            jid: channelJid,
-            group: buildUnmountUpdate(channelGroup),
-          });
-        }
-      }
-    }
 
-    deleteGroupData(jid, freshExisting.folder, { channelUpdates });
+    deleteGroupData(jid, freshExisting.folder, {
+      // Resolve and create any fallback direct sessions inside the same SQLite
+      // transaction as the workspace deletion. A crash must not leave a DM on
+      // a shared main mount or publish a half-created session route.
+      channelUpdates: () => {
+        if (!confirmedChannelUnbind) return channelUpdates;
+        for (const channelJid of freshBindingSummary.mountedChannelJids) {
+          const channelGroup = getRegisteredGroup(channelJid);
+          if (!channelGroup) continue;
+          const restored = resolveDefaultChannelMountForWorkspaceDeletion(
+            channelJid,
+            channelGroup,
+            channelGroup.created_by ?? authUser.id,
+            excludedWorkspaceJids,
+          );
+          if (restored.status === 'resolved') {
+            const updated =
+              resolveChannelConversationKind(channelJid) === 'direct'
+                ? ensureDirectChannelSessionMount({
+                    sourceJid: channelJid,
+                    group: restored.updated,
+                    workspaceJid: restored.workspaceJid,
+                    userId: channelGroup.created_by ?? authUser.id,
+                    force: true,
+                    mountOptions: { replyPolicy: 'source_only' },
+                  })
+                : restored.updated;
+            channelUpdates.push({ jid: channelJid, group: updated });
+            if (restored.routingMode === 'thread_map') {
+              nativeThreadTargets.add(restored.workspaceJid);
+            }
+          } else {
+            // A damaged legacy account may have no viable default workspace.
+            // Clearing its route is still safer than leaving a dangling pointer
+            // to the workspace that is about to disappear.
+            channelUpdates.push({
+              jid: channelJid,
+              group: buildUnmountUpdate(channelGroup),
+            });
+          }
+        }
+        return channelUpdates;
+      },
+    });
     deleteCommitted = true;
 
     const registeredGroups = deps.getRegisteredGroups();

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,8 +193,9 @@ export interface RegisteredGroup {
   target_agent_id?: string;
   /**
    * Binding target stored as the canonical workspace JID.
-   * - group chats: the workspace itself owns the channel context;
-   * - direct chats: the workspace's main session owns the channel context.
+   * Group chats own the workspace main context. Direct chats must not use
+   * this slot — they bind through `target_agent_id` so they do not share
+   * the workspace main channel-owner key with a group.
    */
   target_main_jid?: string;
   reply_policy?: 'source_only' | 'mirror'; // IM 绑定的回复策略
@@ -841,7 +842,13 @@ export interface SubAgent {
   last_im_jid: string | null;
   /** 发起 /spawn 命令的源会话 JID，用于完成后结果回注 */
   spawned_from_jid: string | null;
-  source_kind?: 'manual' | 'native_thread' | 'feishu_thread' | 'auto_im' | null;
+  source_kind?:
+    | 'manual'
+    | 'native_thread'
+    | 'feishu_thread'
+    | 'auto_im'
+    | 'channel_direct'
+    | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?:

--- a/tests/channel-account-routing.test.ts
+++ b/tests/channel-account-routing.test.ts
@@ -83,6 +83,71 @@ describe('channel account registration fallback', () => {
     ).toBe(fallbackBound);
   });
 
+  test('does not bind an unbound direct chat to the account default workspace', () => {
+    expect(
+      applyChannelAccountRegistrationFallback(
+        baseGroup,
+        'bot-a',
+        'web:account-default',
+        'direct',
+      ),
+    ).toMatchObject({
+      channel_account_id: 'bot-a',
+    });
+    expect(
+      applyChannelAccountRegistrationFallback(
+        baseGroup,
+        'bot-a',
+        'web:account-default',
+        'direct',
+      ).target_main_jid,
+    ).toBeUndefined();
+  });
+
+  test('still binds an unbound group chat to the account default workspace', () => {
+    expect(
+      applyChannelAccountRegistrationFallback(
+        baseGroup,
+        'bot-a',
+        'web:account-default',
+        'group',
+      ),
+    ).toMatchObject({
+      channel_account_id: 'bot-a',
+      target_main_jid: 'web:account-default',
+    });
+  });
+
+  test('preserves a manual workspace or session bind on a direct chat', () => {
+    const workspaceBound = {
+      ...baseGroup,
+      channel_account_id: 'bot-a',
+      target_main_jid: 'web:user-selected',
+    };
+    expect(
+      applyChannelAccountRegistrationFallback(
+        workspaceBound,
+        'bot-a',
+        'web:account-default',
+        'direct',
+      ),
+    ).toBe(workspaceBound);
+
+    const sessionBound = {
+      ...baseGroup,
+      channel_account_id: 'bot-a',
+      target_agent_id: 'conversation-123',
+    };
+    expect(
+      applyChannelAccountRegistrationFallback(
+        sessionBound,
+        'bot-a',
+        'web:account-default',
+        'direct',
+      ),
+    ).toBe(sessionBound);
+  });
+
   test('uses explicit workspace then home, never an Agent first-workspace fallback', () => {
     const account = {
       owner_user_id: 'owner',

--- a/tests/channel-binding-rest-contract.test.ts
+++ b/tests/channel-binding-rest-contract.test.ts
@@ -37,7 +37,7 @@ describe('channel binding REST contract', () => {
       'Channel account has no default or owner home workspace',
     );
     expect(service).toMatch(
-      /if \(resolved\.status === 'resolved'\) \{[\s\S]*commitChannelMountUpdate/,
+      /if \(resolved\.status !== 'resolved'\) return resolved;[\s\S]*commitChannelMountUpdate/,
     );
   });
 

--- a/tests/db-upgrade-safety.test.ts
+++ b/tests/db-upgrade-safety.test.ts
@@ -171,8 +171,8 @@ describe('schema version head', () => {
     // one assertion that fails when the head moves, forcing whoever bumps it
     // to confirm the matching migration block — and a test covering it —
     // actually landed. Update the literal in the same commit as the migration.
-    // v71: persists provider message identity/order for WeChat token replay; see
-    // tests/schema-v70-wechat-context-token.test.ts for migration coverage.
-    expect(db.CURRENT_SCHEMA_VERSION).toBe(71);
+    // v72: moves WeCom DMs off a shared workspace main owner slot; see
+    // tests/schema-v72-wecom-direct-mount.test.ts for migration coverage.
+    expect(db.CURRENT_SCHEMA_VERSION).toBe(72);
   });
 });

--- a/tests/im-context-isolation.test.ts
+++ b/tests/im-context-isolation.test.ts
@@ -54,6 +54,14 @@ describe('getUserContextIsolationConfig', () => {
       enabled: false,
       sourceKind: 'auto_im',
     });
+    expect(getUserContextIsolationConfig('u1', 'wecom', deps)).toEqual({
+      enabled: false,
+      sourceKind: 'auto_im',
+    });
+    expect(getUserContextIsolationConfig('u1', 'qq', deps)).toEqual({
+      enabled: false,
+      sourceKind: 'auto_im',
+    });
   });
 });
 

--- a/tests/routes-agents-acl.test.ts
+++ b/tests/routes-agents-acl.test.ts
@@ -1152,7 +1152,7 @@ describe('agents IM-binding ACL (owner-only, mirrors CRUD)', () => {
     }
   });
 
-  test('deleting a session binding restores the account default workspace', async () => {
+  test('deleting a session binding remounts a direct chat onto a default-workspace session', async () => {
     seedTestGroup();
     asUser(OWNER_ID);
     const created = await postSession({ name: 'Temporary session' });
@@ -1186,15 +1186,20 @@ describe('agents IM-binding ACL (owner-only, mirrors CRUD)', () => {
     );
     expect(status).toBe(200);
     expect(body.target_main_jid).toBe(GROUP_JID);
-    expect(db.getRegisteredGroup(imJid)).toMatchObject({
-      target_main_jid: GROUP_JID,
-      target_agent_id: undefined,
+    const restored = db.getRegisteredGroup(imJid);
+    expect(restored).toMatchObject({
+      target_main_jid: undefined,
       binding_mode: 'single_context',
       activation_mode: 'when_mentioned',
       owner_im_id: 'owner-im',
       sender_allowlist: ['owner-im'],
       reply_policy: 'source_only',
     });
+    expect(restored?.target_agent_id).toBeTruthy();
+    expect(restored?.target_agent_id).not.toBe(sessionId);
+    expect(db.getAgent(restored!.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
   });
 
   test('unbinding one of multiple chats keeps the agent fallback route on a remaining chat', async () => {

--- a/tests/routes-groups-owner-acl.test.ts
+++ b/tests/routes-groups-owner-acl.test.ts
@@ -435,6 +435,99 @@ describe('DELETE /:jid blocks channel_mounts-bound workspaces', () => {
       db.deleteChannelAccount(accountId, OWNER_ID);
     }
   });
+
+  test('confirmed delete keeps a WeCom DM on an isolated fallback session', async () => {
+    const accountId = 'delete-workspace-wecom-account';
+    const dmJid = `wecom:c2c:delete-workspace-user#account:${accountId}`;
+    const oldAgentId = 'delete-workspace-wecom-old-session';
+    let fallbackAgentId: string | undefined;
+    db.createChannelAccount({
+      id: accountId,
+      owner_user_id: OWNER_ID,
+      provider: 'wecom',
+      name: 'Delete workspace WeCom Bot',
+      secret_ref: 'test-secret',
+      default_workspace_jid: JID,
+    });
+    db.createAgent({
+      id: oldAgentId,
+      group_folder: FOLDER,
+      chat_jid: JID,
+      name: 'Legacy direct session',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: OWNER_ID,
+      created_at: new Date().toISOString(),
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: dmJid,
+      spawned_from_jid: null,
+      source_kind: 'channel_direct',
+    });
+    db.setRegisteredGroup(dmJid, {
+      name: 'Mounted WeCom DM',
+      folder: HOME_FOLDER,
+      added_at: new Date().toISOString(),
+      created_by: OWNER_ID,
+      channel_account_id: accountId,
+      target_agent_id: oldAgentId,
+      binding_mode: 'single_context',
+    });
+    for (const jid of [JID, IM_JID, HOME_JID, dmJid]) {
+      webDepsCache[jid] = db.getRegisteredGroup(jid)!;
+    }
+    webContext.setWebDeps({
+      getRegisteredGroups: () => webDepsCache,
+      getSessions: () => ({}),
+      setLastAgentTimestamp: vi.fn(),
+      queue: {
+        pauseGroupsForMutation: () => ({ id: 1 }),
+        resumeGroupsAfterMutation: vi.fn(),
+        discardGroupsAfterMutation: vi.fn(),
+        listDescendantJids: () => [],
+        stopGroup: vi.fn(async () => {}),
+      },
+    } as unknown as Parameters<typeof webContext.setWebDeps>[0]);
+
+    try {
+      asUser(OWNER_ID, 'member');
+      const response = await groupRoutes.request(
+        `/${encodeURIComponent(JID)}?unbind_channels=true`,
+        { method: 'DELETE' },
+      );
+      expect(response.status).toBe(200);
+
+      const rerouted = db.getRegisteredGroup(dmJid)!;
+      fallbackAgentId = rerouted.target_agent_id;
+      expect(rerouted.target_main_jid).toBeUndefined();
+      expect(fallbackAgentId).toBeTruthy();
+      expect(fallbackAgentId).not.toBe(oldAgentId);
+      expect(db.getAgent(oldAgentId)).toBeUndefined();
+      expect(db.getAgent(fallbackAgentId!)).toMatchObject({
+        chat_jid: HOME_JID,
+        group_folder: HOME_FOLDER,
+        source_kind: 'channel_direct',
+        last_im_jid: dmJid,
+      });
+      expect(db.getChannelMount(dmJid)).toMatchObject({
+        workspace_jid: HOME_JID,
+        session_id: fallbackAgentId,
+      });
+      expect(db.getChannelAccount(accountId)?.default_workspace_jid).toBe(
+        HOME_JID,
+      );
+    } finally {
+      delete webDepsCache[dmJid];
+      try {
+        db.deleteRegisteredGroup(dmJid);
+      } catch {
+        /* ignore */
+      }
+      if (fallbackAgentId) db.deleteAgent(fallbackAgentId);
+      db.deleteChannelAccount(accountId, OWNER_ID);
+    }
+  });
 });
 
 describe('DELETE /:jid mutation pause', () => {

--- a/tests/schema-v70-wechat-context-token.test.ts
+++ b/tests/schema-v70-wechat-context-token.test.ts
@@ -64,7 +64,9 @@ describe.sequential('schema v71 WeChat context_token generations', () => {
     legacy.close();
 
     db.initDatabase();
-    expect(db.getRouterState('schema_version')).toBe('71');
+    expect(db.getRouterState('schema_version')).toBe(
+      String(db.CURRENT_SCHEMA_VERSION),
+    );
     expect(db.listWeChatContextTokens(account.id)[0]).toMatchObject({
       context_token: 'legacy-token',
       send_count: 9,
@@ -185,7 +187,9 @@ describe.sequential('schema v71 WeChat context_token generations', () => {
     `);
     v69.close();
     db.initDatabase();
-    expect(db.getRouterState('schema_version')).toBe('71');
+    expect(db.getRouterState('schema_version')).toBe(
+      String(db.CURRENT_SCHEMA_VERSION),
+    );
     const probe = new Database(databasePath, { readonly: true });
     const columns = probe
       .prepare('PRAGMA table_info(wechat_context_tokens)')

--- a/tests/schema-v72-wecom-direct-mount.test.ts
+++ b/tests/schema-v72-wecom-direct-mount.test.ts
@@ -1,0 +1,152 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-v72-wecom-mount-'));
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const dataDir = path.join(root, 'data');
+const databasePath = path.join(storeDir, 'messages.db');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+fs.mkdirSync(dataDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  ASSISTANT_NAME: 'HappyClaw Test',
+  DATA_DIR: dataDir,
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+
+const now = '2026-08-17T00:00:00.000Z';
+const workspaceJid = 'web:wecom-legacy-ws';
+const legacyFolderJid = 'web:wecom-legacy-ws';
+const dmJid = 'wecom:c2c:alice#account:bot-a';
+const groupJid = 'wecom:group:sales#account:bot-a';
+const manualDmJid = 'wecom:c2c:bob#account:bot-a';
+const missingWsDmJid = 'wecom:c2c:carol#account:bot-a';
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('schema v72 WeCom direct workspace-mount migration', () => {
+  test('moves existing WeCom DMs off a shared workspace owner and keeps groups/manual binds', () => {
+    db.initDatabase();
+    db.setRegisteredGroup(workspaceJid, {
+      name: 'Legacy workspace',
+      folder: 'wecom-legacy-ws',
+      added_at: now,
+      created_by: 'owner-a',
+    });
+    db.createAgent({
+      id: 'manual-session',
+      group_folder: 'wecom-legacy-ws',
+      chat_jid: workspaceJid,
+      name: 'Manual DM session',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: 'owner-a',
+      created_at: now,
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: manualDmJid,
+      spawned_from_jid: null,
+      source_kind: 'manual',
+    });
+    db.setRegisteredGroup(dmJid, {
+      name: 'Alice DM',
+      folder: 'wecom-alice',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: legacyFolderJid,
+    });
+    db.setRegisteredGroup(groupJid, {
+      name: 'Sales group',
+      folder: 'wecom-sales',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(manualDmJid, {
+      name: 'Bob DM',
+      folder: 'wecom-bob',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_agent_id: 'manual-session',
+    });
+    db.setRegisteredGroup(missingWsDmJid, {
+      name: 'Carol DM',
+      folder: 'wecom-carol',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: 'web:deleted-workspace',
+    });
+    expect(db.setSessionChannelOwnerOnce('wecom-legacy-ws', null, dmJid)).toBe(
+      dmJid,
+    );
+
+    expect(db.migrateWecomDirectWorkspaceMountsToSessions()).toBe(1);
+    expect(db.migrateWecomDirectWorkspaceMountsToSessions()).toBe(0);
+
+    const migratedDm = db.getRegisteredGroup(dmJid)!;
+    expect(migratedDm.target_main_jid).toBeUndefined();
+    expect(migratedDm.target_agent_id).toBeTruthy();
+    expect(db.getAgent(migratedDm.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
+    expect(db.getChannelMount(dmJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: migratedDm.target_agent_id,
+    });
+    expect(db.getSessionChannelOwner('wecom-legacy-ws')).toBeUndefined();
+
+    expect(db.getRegisteredGroup(groupJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+    expect(db.getRegisteredGroup(groupJid)?.target_agent_id).toBeUndefined();
+    expect(db.getChannelMount(groupJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: null,
+    });
+
+    expect(db.getRegisteredGroup(manualDmJid)).toMatchObject({
+      target_agent_id: 'manual-session',
+    });
+    expect(db.getRegisteredGroup(missingWsDmJid)).toMatchObject({
+      target_main_jid: 'web:deleted-workspace',
+    });
+
+    db.closeDatabase();
+    const stamped = new Database(databasePath);
+    stamped
+      .prepare(
+        "UPDATE router_state SET value = '71' WHERE key = 'schema_version'",
+      )
+      .run();
+    stamped.close();
+
+    db.initDatabase();
+    expect(db.getRouterState('schema_version')).toBe(
+      String(db.CURRENT_SCHEMA_VERSION),
+    );
+    expect(db.getRegisteredGroup(dmJid)?.target_agent_id).toBe(
+      migratedDm.target_agent_id,
+    );
+    expect(db.getRegisteredGroup(groupJid)?.target_main_jid).toBe(workspaceJid);
+  });
+});

--- a/tests/schema-v72-wecom-direct-mount.test.ts
+++ b/tests/schema-v72-wecom-direct-mount.test.ts
@@ -100,6 +100,34 @@ describe('schema v72 WeCom direct workspace-mount migration', () => {
       dmJid,
     );
 
+    const failureInjector = new Database(databasePath);
+    failureInjector.exec(`
+      CREATE TRIGGER fail_wecom_direct_mount_update
+      BEFORE UPDATE OF target_agent_id ON registered_groups
+      WHEN OLD.jid = '${dmJid}'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected migration failure');
+      END;
+    `);
+    failureInjector.close();
+
+    expect(() => db.migrateWecomDirectWorkspaceMountsToSessions()).toThrow(
+      'injected migration failure',
+    );
+    expect(db.getRegisteredGroup(dmJid)).toMatchObject({
+      target_main_jid: legacyFolderJid,
+    });
+    expect(
+      db
+        .listAgentsByJid(workspaceJid)
+        .filter((agent) => agent.source_kind === 'channel_direct'),
+    ).toHaveLength(0);
+    expect(db.getSessionChannelOwner('wecom-legacy-ws')).toBe(dmJid);
+
+    const triggerCleanup = new Database(databasePath);
+    triggerCleanup.exec('DROP TRIGGER fail_wecom_direct_mount_update');
+    triggerCleanup.close();
+
     expect(db.migrateWecomDirectWorkspaceMountsToSessions()).toBe(1);
     expect(db.migrateWecomDirectWorkspaceMountsToSessions()).toBe(0);
 

--- a/tests/wecom-direct-mount.test.ts
+++ b/tests/wecom-direct-mount.test.ts
@@ -160,6 +160,37 @@ describe.sequential('WeCom DM / group channel-account mounts', () => {
     expect(rebound.target_agent_id).toBe(first.target_agent_id);
   });
 
+  test('keeps the same native DM isolated across WeCom accounts', () => {
+    db.createChannelAccount({
+      id: 'bot-b',
+      owner_user_id: 'owner-a',
+      provider: 'wecom',
+      name: 'Second WeCom bot',
+      secret_ref: 'channel-account:bot-b',
+      default_workspace_jid: workspaceJid,
+    });
+    let secondAgentId: string | undefined;
+    try {
+      const first = db.getRegisteredGroup(dmJid)!;
+      const second = attachDefaultChannelAccountMount({
+        sourceJid: 'wecom:c2c:user-1#account:bot-b',
+        group: chatGroup('Private DM on second bot'),
+        accountId: 'bot-b',
+        fallbackWorkspaceJid: workspaceJid,
+        userId: 'owner-a',
+      });
+      secondAgentId = second.target_agent_id;
+      expect(secondAgentId).toBeTruthy();
+      expect(secondAgentId).not.toBe(first.target_agent_id);
+      expect(db.getAgent(secondAgentId!)?.last_im_jid).toBe(
+        'wecom:c2c:user-1#account:bot-b',
+      );
+    } finally {
+      if (secondAgentId) db.deleteAgent(secondAgentId);
+      db.deleteChannelAccount('bot-b', 'owner-a');
+    }
+  });
+
   test('does not overwrite a manual session or workspace bind', () => {
     const sessionBound = chatGroup('Manual session', {
       channel_account_id: 'bot-a',
@@ -199,6 +230,10 @@ describe.sequential('WeCom DM / group channel-account mounts', () => {
         target_main_jid: workspaceJid,
       }),
     );
+    db.clearSessionChannelOwner('wecom-ws', null);
+    expect(db.setSessionChannelOwnerOnce('wecom-ws', null, restoreJid)).toBe(
+      restoreJid,
+    );
     const restored = restoreDefaultChannelMount(
       restoreJid,
       db.getRegisteredGroup(restoreJid)!,
@@ -216,5 +251,6 @@ describe.sequential('WeCom DM / group channel-account mounts', () => {
     expect(db.getAgent(restored.updated.target_agent_id!)?.source_kind).toBe(
       'channel_direct',
     );
+    expect(db.getSessionChannelOwner('wecom-ws')).toBeUndefined();
   });
 });

--- a/tests/wecom-direct-mount.test.ts
+++ b/tests/wecom-direct-mount.test.ts
@@ -1,0 +1,220 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wecom-direct-mount-'));
+const store = path.join(tmp, 'db');
+const groups = path.join(tmp, 'groups');
+const dataDir = path.join(tmp, 'data');
+fs.mkdirSync(store, { recursive: true });
+fs.mkdirSync(groups, { recursive: true });
+fs.mkdirSync(dataDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  ASSISTANT_NAME: 'HappyClaw Test',
+  DATA_DIR: dataDir,
+  STORE_DIR: store,
+  GROUPS_DIR: groups,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+const {
+  attachDefaultChannelAccountMount,
+  restoreDefaultChannelMount,
+  resolveChannelMountTarget,
+} = await import('../src/channel-mount-service.js');
+
+const now = '2026-08-17T00:00:00.000Z';
+const workspaceJid = 'web:wecom-ws';
+const dmJid = 'wecom:c2c:user-1#account:bot-a';
+const groupJid = 'wecom:group:chat-1#account:bot-a';
+
+function workspaceGroup() {
+  return {
+    name: 'WeCom workspace',
+    folder: 'wecom-ws',
+    added_at: now,
+    created_by: 'owner-a',
+  };
+}
+
+function chatGroup(name: string, overrides: Record<string, unknown> = {}) {
+  return {
+    name,
+    folder: 'wecom-chat',
+    added_at: now,
+    created_by: 'owner-a',
+    ...overrides,
+  };
+}
+
+beforeAll(() => {
+  db.initDatabase();
+  db.setRegisteredGroup(workspaceJid, workspaceGroup());
+  db.createChannelAccount({
+    id: 'bot-a',
+    owner_user_id: 'owner-a',
+    provider: 'wecom',
+    name: 'WeCom bot',
+    secret_ref: 'channel-account:bot-a',
+    default_workspace_jid: workspaceJid,
+  });
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe.sequential('WeCom DM / group channel-account mounts', () => {
+  test('binds a new DM to a dedicated session and a group to workspace main', () => {
+    const dm = attachDefaultChannelAccountMount({
+      sourceJid: dmJid,
+      group: chatGroup('Private DM'),
+      accountId: 'bot-a',
+      fallbackWorkspaceJid: workspaceJid,
+      userId: 'owner-a',
+    });
+    expect(dm.channel_account_id).toBe('bot-a');
+    expect(dm.target_main_jid).toBeUndefined();
+    expect(dm.target_agent_id).toBeTruthy();
+
+    db.setRegisteredGroup(dmJid, dm);
+    const dmMount = db.getChannelMount(dmJid);
+    expect(dmMount).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: dm.target_agent_id,
+      routing_mode: 'single_session',
+    });
+    const dmTarget = resolveChannelMountTarget(dmMount!, {
+      getAgent: db.getAgent,
+      getRegisteredGroup: db.getRegisteredGroup,
+    });
+    expect(dmTarget).toMatchObject({
+      status: 'resolved',
+      effectiveJid: `${workspaceJid}#agent:${dm.target_agent_id}`,
+      agentId: dm.target_agent_id,
+    });
+
+    const group = attachDefaultChannelAccountMount({
+      sourceJid: groupJid,
+      group: chatGroup('Team group'),
+      accountId: 'bot-a',
+      fallbackWorkspaceJid: workspaceJid,
+      userId: 'owner-a',
+    });
+    expect(group).toMatchObject({
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    expect(group.target_agent_id).toBeUndefined();
+    db.setRegisteredGroup(groupJid, group);
+    expect(db.getChannelMount(groupJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: null,
+    });
+
+    const groupOwner = db.setSessionChannelOwnerOnce(
+      'wecom-ws',
+      null,
+      groupJid,
+    );
+    const dmOwner = db.setSessionChannelOwnerOnce(
+      'wecom-ws',
+      dm.target_agent_id,
+      dmJid,
+    );
+    expect(groupOwner).toBe(groupJid);
+    expect(dmOwner).toBe(dmJid);
+    expect(db.setSessionChannelOwnerOnce('wecom-ws', null, dmJid)).toBe(
+      groupJid,
+    );
+    expect(
+      db.setSessionChannelOwnerOnce('wecom-ws', dm.target_agent_id, groupJid),
+    ).toBe(dmJid);
+  });
+
+  test('reuses the channel_direct session for the same DM conversation', () => {
+    const first = db.getRegisteredGroup(dmJid)!;
+    const again = attachDefaultChannelAccountMount({
+      sourceJid: dmJid,
+      group: first,
+      accountId: 'bot-a',
+      fallbackWorkspaceJid: workspaceJid,
+      userId: 'owner-a',
+    });
+    expect(again).toBe(first);
+
+    const rebound = attachDefaultChannelAccountMount({
+      sourceJid: dmJid,
+      group: chatGroup('Private DM replay'),
+      accountId: 'bot-a',
+      fallbackWorkspaceJid: workspaceJid,
+      userId: 'owner-a',
+    });
+    expect(rebound.target_agent_id).toBe(first.target_agent_id);
+  });
+
+  test('does not overwrite a manual session or workspace bind', () => {
+    const sessionBound = chatGroup('Manual session', {
+      channel_account_id: 'bot-a',
+      target_agent_id: 'manual-session',
+    });
+    expect(
+      attachDefaultChannelAccountMount({
+        sourceJid: 'wecom:c2c:user-2#account:bot-a',
+        group: sessionBound,
+        accountId: 'bot-a',
+        fallbackWorkspaceJid: workspaceJid,
+        userId: 'owner-a',
+      }),
+    ).toBe(sessionBound);
+
+    const workspaceBound = chatGroup('Manual workspace', {
+      channel_account_id: 'bot-a',
+      target_main_jid: 'web:user-selected',
+    });
+    expect(
+      attachDefaultChannelAccountMount({
+        sourceJid: 'wecom:group:chat-2#account:bot-a',
+        group: workspaceBound,
+        accountId: 'bot-a',
+        fallbackWorkspaceJid: workspaceJid,
+        userId: 'owner-a',
+      }),
+    ).toBe(workspaceBound);
+  });
+
+  test('restore default remounts a WeCom DM onto a session, not workspace main', () => {
+    const restoreJid = 'wecom:c2c:user-3#account:bot-a';
+    db.setRegisteredGroup(
+      restoreJid,
+      chatGroup('Legacy DM', {
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      }),
+    );
+    const restored = restoreDefaultChannelMount(
+      restoreJid,
+      db.getRegisteredGroup(restoreJid)!,
+      'owner-a',
+    );
+    expect(restored.status).toBe('resolved');
+    if (restored.status !== 'resolved') return;
+    expect(restored.workspaceJid).toBe(workspaceJid);
+    expect(restored.updated.target_main_jid).toBeUndefined();
+    expect(restored.updated.target_agent_id).toBeTruthy();
+    expect(db.getChannelMount(restoreJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: restored.updated.target_agent_id,
+    });
+    expect(db.getAgent(restored.updated.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
+  });
+});

--- a/tests/wecom-registration.test.ts
+++ b/tests/wecom-registration.test.ts
@@ -6,6 +6,16 @@ const read = (file: string) =>
   fs.readFileSync(path.join(process.cwd(), file), 'utf8');
 
 describe('WeCom full-stack provider registration', () => {
+  test('uses channel-account session mounts for DMs instead of Feishu auto_im isolation', () => {
+    const isolation = read('src/im-context-isolation.ts');
+    expect(isolation).toContain("if (channelType === 'feishu')");
+    expect(isolation).not.toContain('wecom');
+
+    const runtime = read('src/index.ts');
+    expect(runtime).toContain('attachDefaultChannelAccountMount(');
+    expect(runtime).not.toContain('applyChannelAccountRegistrationFallback(');
+  });
+
   test('registers account-scoped admission and transport status in runtime', () => {
     const source = read('src/index.ts');
     const start = source.indexOf("} else if (account.provider === 'wecom') {");

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -353,7 +353,13 @@ export interface AgentInfo {
   completed_at?: string;
   result_summary?: string;
   linked_im_groups?: Array<{ jid: string; name: string }>;
-  source_kind?: 'manual' | 'native_thread' | 'feishu_thread' | 'auto_im' | null;
+  source_kind?:
+    | 'manual'
+    | 'native_thread'
+    | 'feishu_thread'
+    | 'auto_im'
+    | 'channel_direct'
+    | null;
   thread_id?: string | null;
   root_message_id?: string | null;
   title_source?:


### PR DESCRIPTION
## 背景

#641 接入企业微信后，私聊（wecom:c2c）和群聊（wecom:group）都会走账号默认工作区的 workspace main 绑定。setSessionChannelOwnerOnce 的 key 是 channel_session_owner:{folder}:main，先到的会话占住 owner，后到的回复被投递到对方。

#642 试图把 WeCom 加回 getUserContextIsolationConfig。维护者关闭了它：那套 force-isolation 在多账号 + workspace/session 绑定落地后是故意拿掉的；只影响新配对未绑定会话，存量 target_main_jid 会被跳过。

本 PR 是 #641 / #642 的后续，不把 WeCom 加回 getUserContextIsolationConfig。

## 根因

1. applyChannelAccountRegistrationFallback 对所有未绑定会话写 target_main_jid，不区分 direct/group。
2. pairing 和 onNewChat 都走这条 fallback。
3. WeCom JID 已能区分 c2c/group。
4. 产品策略是群绑 workspace、私聊绑 session，但 fallback 把私聊也绑到 workspace main。
5. 两条会话共用 channel_session_owner:{folder}:main。

## 做法

沿用 channel-account / mount 模型：
- 注册 fallback：direct 只挂 channel_account_id，不写 target_main_jid；group/unknown（含飞书）保持 workspace fallback
- attachDefaultChannelAccountMount 为私聊创建或复用 source_kind=channel_direct session
- /unbind restore 把 JID 可判定 DM 挂回 session，避免再次撞 owner
- schema v72 迁移已有 wecom:c2c 且仅有 target_main_jid 的行；群、手工绑定、缺失工作区跳过；若 main owner 仍指向该 DM 则清除

## 用户影响

- 未绑定企业微信私聊不再和同工作区群聊串线
- 存量 WeCom 私聊在 v72 迁到独立 session
- 手工绑定保持原样；飞书行为不变

## 验证

- make typecheck: pass
- make test: 362 files, 3128 passed, 23 skipped
- make build: pass
- format check: Prettier clean

## 兼容性

- 不把 WeCom 加回 isolation config，不复用 auto_im
- 不为 QQ / WeChat 存量 DM 做迁移
