### PR TITLE
fix(im): 存量可判定私聊不再与群聊争用 workspace main owner

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -70,6 +70,7 @@ import {
 } from './types.js';
 import { getDefaultPermissions, normalizePermissions } from './permissions.js';
 import { channelConversationJid } from './channel-address.js';
+import { resolveChannelConversationKind } from './channel-conversation-kind.js';
 import { getChannelFromJid } from './channel-prefixes.js';
 import { parseAudienceMode } from './im-audience-policy.js';
 import { parseContainerConfig } from './mount-security.js';
@@ -103,7 +104,7 @@ let db: InstanceType<typeof Database>;
  * restating the number. Hardcoding it meant every schema bump edited a dozen
  * unrelated test files, which is churn that hides real assertion changes.
  */
-export const CURRENT_SCHEMA_VERSION = 72;
+export const CURRENT_SCHEMA_VERSION = 73;
 
 export function isDatabaseInitialized(): boolean {
   return Boolean(db?.open);
@@ -2513,6 +2514,20 @@ export function initDatabase(): void {
     migrateWecomDirectWorkspaceMountsToSessions();
   }
 
+  // v72 -> v73: #654 already made new registration kind-aware and migrated
+  // leftover WeCom DMs. Pre-#654 chats on other JID-classifiable channels
+  // (QQ / DingTalk / Discord / WhatsApp / Telegram / WeChat) can still sit
+  // on target_main_jid and share channel_session_owner:{folder}:main with a
+  // group in the same workspace — including a WeChat DM stealing owner from
+  // a group on another channel. Classify from the JID only; Feishu stays
+  // unknown here and is not migrated. Do not rewrite the v72 WeCom block.
+  const classifiableDirectMountSchemaVersion = Number(
+    getRouterStateInternal('schema_version') ?? '0',
+  );
+  if (classifiableDirectMountSchemaVersion < 73) {
+    migrateClassifiableDirectWorkspaceMountsToSessions();
+  }
+
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', String(CURRENT_SCHEMA_VERSION));
@@ -2596,6 +2611,92 @@ export function migrateWecomDirectWorkspaceMountsToSessions(): number {
         logger.info(
           { migrated },
           'Migrated WeCom direct chats off shared workspace main mounts',
+        );
+      }
+      return migrated;
+    })
+    .immediate();
+}
+
+/**
+ * Move leftover JID-classifiable DMs off a shared workspace main mount.
+ * Same skip rules as v72: already-bound sessions (manual or v72 WeCom),
+ * groups, unknown/unclassifiable JIDs (including Feishu without metadata),
+ * and missing workspaces stay untouched. If the workspace main owner still
+ * points at the DM, clear it so a later group message cannot keep
+ * delivering into that private chat.
+ */
+export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
+  return db
+    .transaction(() => {
+      const groups = getAllRegisteredGroups();
+      let migrated = 0;
+
+      for (const [jid, group] of Object.entries(groups)) {
+        if (resolveChannelConversationKind(jid) !== 'direct') continue;
+        if (!group.target_main_jid || group.target_agent_id) continue;
+
+        const workspaceJid = resolveWorkspaceJidForMount(group.target_main_jid);
+        if (!workspaceJid) continue;
+        const workspace = getRegisteredGroup(workspaceJid);
+        if (!workspace) continue;
+
+        const conversationJid = channelConversationJid(jid);
+        const reusable = listAgentsByJid(workspaceJid).find(
+          (agent) =>
+            agent.source_kind === 'channel_direct' &&
+            agent.last_im_jid &&
+            (agent.last_im_jid === conversationJid ||
+              channelConversationJid(agent.last_im_jid) === conversationJid),
+        );
+
+        const now = new Date().toISOString();
+        const agent =
+          reusable ??
+          (() => {
+            const created: SubAgent = {
+              id: crypto.randomUUID(),
+              group_folder: workspace.folder,
+              chat_jid: workspaceJid,
+              name: group.name || conversationJid,
+              prompt: '',
+              status: 'idle',
+              kind: 'conversation',
+              created_by: group.created_by ?? workspace.created_by ?? null,
+              created_at: now,
+              completed_at: null,
+              result_summary: null,
+              last_im_jid: conversationJid,
+              spawned_from_jid: null,
+              source_kind: 'channel_direct',
+              last_active_at: now,
+            };
+            createAgent(created);
+            const virtualChatJid = `${workspaceJid}#agent:${created.id}`;
+            ensureChatExists(virtualChatJid);
+            updateChatName(virtualChatJid, created.name);
+            return created;
+          })();
+
+        setRegisteredGroup(jid, {
+          ...group,
+          target_agent_id: agent.id,
+          target_main_jid: undefined,
+          binding_mode: 'single_context',
+        });
+
+        const ownerJid = getSessionChannelOwner(workspace.folder, null);
+        if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
+          clearSessionChannelOwner(workspace.folder, null);
+        }
+
+        migrated += 1;
+      }
+
+      if (migrated > 0) {
+        logger.info(
+          { migrated },
+          'Migrated classifiable direct chats off shared workspace main mounts',
         );
       }
       return migrated;

--- a/tests/db-upgrade-safety.test.ts
+++ b/tests/db-upgrade-safety.test.ts
@@ -171,8 +171,10 @@ describe('schema version head', () => {
     // one assertion that fails when the head moves, forcing whoever bumps it
     // to confirm the matching migration block — and a test covering it —
     // actually landed. Update the literal in the same commit as the migration.
-    // v72: moves WeCom DMs off a shared workspace main owner slot; see
-    // tests/schema-v72-wecom-direct-mount.test.ts for migration coverage.
-    expect(db.CURRENT_SCHEMA_VERSION).toBe(72);
+    // v73: generalizes the v72 WeCom DM remount to other JID-classifiable
+    // DMs (QQ / DingTalk / Discord / WhatsApp / Telegram / WeChat leftover
+    // target_main_jid collisions). See
+    // tests/schema-v73-classifiable-direct-mount.test.ts. Do not rewrite v72.
+    expect(db.CURRENT_SCHEMA_VERSION).toBe(73);
   });
 });

--- a/tests/schema-v73-classifiable-direct-mount.test.ts
+++ b/tests/schema-v73-classifiable-direct-mount.test.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'schema-v73-classifiable-mount-'),
+);
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const dataDir = path.join(root, 'data');
+const databasePath = path.join(storeDir, 'messages.db');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+fs.mkdirSync(dataDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  ASSISTANT_NAME: 'HappyClaw Test',
+  DATA_DIR: dataDir,
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+
+const now = '2026-08-18T00:00:00.000Z';
+const workspaceJid = 'web:legacy-shared-ws';
+const legacyFolderJid = 'web:legacy-shared-ws';
+
+const qqDmJid = 'qq:c2c:alice#account:bot-a';
+const qqGroupJid = 'qq:group:sales#account:bot-a';
+const telegramDmJid = 'telegram:123456#account:bot-a';
+const telegramGroupJid = 'telegram:-100123#account:bot-a';
+const wechatDmJid = 'wechat:wxid_alice#account:bot-a';
+const wecomMigratedJid = 'wecom:c2c:already#account:bot-a';
+const wecomLeftoverJid = 'wecom:c2c:leftover#account:bot-a';
+const manualDmJid = 'qq:c2c:bob#account:bot-a';
+const missingWsDmJid = 'dingtalk:c2c:carol#account:bot-a';
+const feishuUnknownJid = 'feishu:oc_opaque#account:bot-a';
+const malformedTelegramJid = 'telegram:not-a-number#account:bot-a';
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('schema v73 classifiable direct workspace-mount migration', () => {
+  test('moves leftover classifiable DMs off a shared workspace owner and skips groups/manual/unknown', () => {
+    db.initDatabase();
+    db.setRegisteredGroup(workspaceJid, {
+      name: 'Legacy shared workspace',
+      folder: 'legacy-shared-ws',
+      added_at: now,
+      created_by: 'owner-a',
+    });
+    db.createAgent({
+      id: 'manual-session',
+      group_folder: 'legacy-shared-ws',
+      chat_jid: workspaceJid,
+      name: 'Manual QQ DM session',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: 'owner-a',
+      created_at: now,
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: manualDmJid,
+      spawned_from_jid: null,
+      source_kind: 'manual',
+    });
+    db.createAgent({
+      id: 'wecom-v72-session',
+      group_folder: 'legacy-shared-ws',
+      chat_jid: workspaceJid,
+      name: 'Already migrated WeCom DM',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: 'owner-a',
+      created_at: now,
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: wecomMigratedJid,
+      spawned_from_jid: null,
+      source_kind: 'channel_direct',
+    });
+
+    db.setRegisteredGroup(qqDmJid, {
+      name: 'Alice QQ DM',
+      folder: 'qq-alice',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: legacyFolderJid,
+    });
+    db.setRegisteredGroup(qqGroupJid, {
+      name: 'QQ sales group',
+      folder: 'qq-sales',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(telegramDmJid, {
+      name: 'Telegram DM',
+      folder: 'tg-dm',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(telegramGroupJid, {
+      name: 'Telegram group',
+      folder: 'tg-group',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(wechatDmJid, {
+      name: 'WeChat DM',
+      folder: 'wechat-alice',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(wecomMigratedJid, {
+      name: 'WeCom already migrated',
+      folder: 'wecom-already',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_agent_id: 'wecom-v72-session',
+    });
+    db.setRegisteredGroup(wecomLeftoverJid, {
+      name: 'WeCom leftover',
+      folder: 'wecom-leftover',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(manualDmJid, {
+      name: 'Bob QQ DM',
+      folder: 'qq-bob',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_agent_id: 'manual-session',
+    });
+    db.setRegisteredGroup(missingWsDmJid, {
+      name: 'Carol DingTalk DM',
+      folder: 'dt-carol',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: 'web:deleted-workspace',
+    });
+    db.setRegisteredGroup(feishuUnknownJid, {
+      name: 'Feishu opaque chat',
+      folder: 'feishu-opaque',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(malformedTelegramJid, {
+      name: 'Malformed Telegram',
+      folder: 'tg-bad',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+
+    expect(
+      db.setSessionChannelOwnerOnce('legacy-shared-ws', null, qqDmJid),
+    ).toBe(qqDmJid);
+
+    const failureInjector = new Database(databasePath);
+    failureInjector.exec(`
+      CREATE TRIGGER fail_classifiable_direct_mount_update
+      BEFORE UPDATE OF target_agent_id ON registered_groups
+      WHEN OLD.jid = '${qqDmJid}'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected migration failure');
+      END;
+    `);
+    failureInjector.close();
+
+    expect(() =>
+      db.migrateClassifiableDirectWorkspaceMountsToSessions(),
+    ).toThrow('injected migration failure');
+    expect(db.getRegisteredGroup(qqDmJid)).toMatchObject({
+      target_main_jid: legacyFolderJid,
+    });
+    expect(
+      db
+        .listAgentsByJid(workspaceJid)
+        .filter(
+          (agent) =>
+            agent.source_kind === 'channel_direct' &&
+            agent.id !== 'wecom-v72-session',
+        ),
+    ).toHaveLength(0);
+    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBe(qqDmJid);
+
+    const triggerCleanup = new Database(databasePath);
+    triggerCleanup.exec('DROP TRIGGER fail_classifiable_direct_mount_update');
+    triggerCleanup.close();
+
+    expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(4);
+    expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(0);
+
+    const migratedQq = db.getRegisteredGroup(qqDmJid)!;
+    expect(migratedQq.target_main_jid).toBeUndefined();
+    expect(migratedQq.target_agent_id).toBeTruthy();
+    expect(db.getAgent(migratedQq.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
+    expect(db.getChannelMount(qqDmJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: migratedQq.target_agent_id,
+    });
+
+    const migratedTelegram = db.getRegisteredGroup(telegramDmJid)!;
+    expect(migratedTelegram.target_main_jid).toBeUndefined();
+    expect(migratedTelegram.target_agent_id).toBeTruthy();
+    expect(migratedTelegram.target_agent_id).not.toBe(
+      migratedQq.target_agent_id,
+    );
+    expect(db.getAgent(migratedTelegram.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
+
+    const migratedWechat = db.getRegisteredGroup(wechatDmJid)!;
+    expect(migratedWechat.target_main_jid).toBeUndefined();
+    expect(migratedWechat.target_agent_id).toBeTruthy();
+    expect(db.getAgent(migratedWechat.target_agent_id!)?.last_im_jid).toBe(
+      wechatDmJid,
+    );
+
+    const migratedWecomLeftover = db.getRegisteredGroup(wecomLeftoverJid)!;
+    expect(migratedWecomLeftover.target_main_jid).toBeUndefined();
+    expect(migratedWecomLeftover.target_agent_id).toBeTruthy();
+
+    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBeUndefined();
+
+    expect(db.getRegisteredGroup(qqGroupJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+    expect(db.getRegisteredGroup(qqGroupJid)?.target_agent_id).toBeUndefined();
+    expect(db.getChannelMount(qqGroupJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: null,
+    });
+    expect(db.getRegisteredGroup(telegramGroupJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+
+    expect(db.getRegisteredGroup(wecomMigratedJid)).toMatchObject({
+      target_agent_id: 'wecom-v72-session',
+    });
+    expect(db.getRegisteredGroup(wecomMigratedJid)?.target_main_jid).toBe(
+      undefined,
+    );
+
+    expect(db.getRegisteredGroup(manualDmJid)).toMatchObject({
+      target_agent_id: 'manual-session',
+    });
+    expect(db.getRegisteredGroup(missingWsDmJid)).toMatchObject({
+      target_main_jid: 'web:deleted-workspace',
+    });
+    expect(db.getRegisteredGroup(feishuUnknownJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+    expect(db.getRegisteredGroup(malformedTelegramJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+
+    db.closeDatabase();
+    const stamped = new Database(databasePath);
+    stamped
+      .prepare(
+        "UPDATE router_state SET value = '72' WHERE key = 'schema_version'",
+      )
+      .run();
+    stamped.close();
+
+    db.initDatabase();
+    expect(db.getRouterState('schema_version')).toBe(
+      String(db.CURRENT_SCHEMA_VERSION),
+    );
+    expect(db.getRegisteredGroup(qqDmJid)?.target_agent_id).toBe(
+      migratedQq.target_agent_id,
+    );
+    expect(db.getRegisteredGroup(wecomMigratedJid)?.target_agent_id).toBe(
+      'wecom-v72-session',
+    );
+    expect(db.getRegisteredGroup(qqGroupJid)?.target_main_jid).toBe(
+      workspaceJid,
+    );
+    expect(db.getRegisteredGroup(feishuUnknownJid)?.target_main_jid).toBe(
+      workspaceJid,
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #654. New registration is already kind-aware; leftover pre-#654 QQ/DingTalk/Discord/WhatsApp/Telegram/WeChat DMs can still share channel_session_owner:{folder}:main with a group. Schema v73 remounts JID-classifiable DMs onto channel_direct sessions. v72 WeCom block untouched. Feishu unknown JIDs not migrated. Tests: 3141 passed, 23 skipped.