### PR TITLE
feat(providers): xAI Grok OAuth + cli-chat-proxy via Anthropic facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ HappyClaw 不是一个简单的聊天 API Wrapper。智能体运行在真实的 
 | **工作区**     | 智能体归属、宿主机/容器执行、独立目录、项目环境变量、项目 Claude 上下文、多会话                                              |
 | **能力治理**   | 用户 Skills、系统/用户 MCP、Claude Code Plugins 与最终生效预览；智能体工具权限完整开放                                       |
 | **消息渠道**   | 飞书、Telegram、QQ、钉钉、微信、企业微信、Discord、WhatsApp，多账号、扫码登录、工作区/会话绑定                               |
-| **模型提供商** | Anthropic 官方、第三方兼容端点与 ChatGPT Codex（本机 Anthropic facade）、多 Provider、轮询/加权/故障转移、健康检查、会话粘性 |
+| **模型提供商** | Anthropic 官方、第三方兼容端点、ChatGPT Codex 与 xAI Grok（本机 Anthropic facade）、多 Provider、轮询/加权/故障转移、健康检查、会话粘性 |
 | **定时任务**   | Cron、固定间隔、一次性任务，智能体/Script 执行，隔离上下文，幂等立即运行，通知重试                                           |
 | **记忆与文件** | Workspace Memory（事实、决策、经验、待跟进）、来源与修订、CAS 编辑、搜索、文件与终端                                         |
 | **用量与计费** | Token 分类统计、智能体/工作区/模型筛选、明细与 CSV 导出、订阅、余额、兑换码与配额                                            |
@@ -189,10 +189,11 @@ HappyClaw 可以同时配置多个 Claude Provider，并为新会话按策略选
 | **Anthropic 官方** | Claude OAuth、一键登录、`setup-token` / `.credentials.json` 或 API Key                   |
 | **第三方兼容端点** | 填写 API Endpoint、Auth Token 和模型名称，可启用 1M 上下文                               |
 | **ChatGPT Codex**  | ChatGPT 设备码登录；Runner 仍走 Anthropic Messages，由本机 facade 翻译到 Codex Responses |
+| **xAI Grok**       | auth.x.ai PKCE 登录；同一 facade 翻译到 cli-chat-proxy Responses，默认 grok-4.5 |
 
 第三方 Provider 会自动预填 Claude Code 兼容环境变量，包括主模型映射、上下文窗口、自动压缩、超时和非必要流量设置。高级设置会展示所有预填值，用户可以编辑、恢复默认值或增加自定义 Header 等环境变量。
 
-Codex 不改写官方或第三方的直连路径。选中 Codex 时，Runner 的 `ANTHROPIC_BASE_URL` 指向本机 `POST /model/v1/messages` facade（仅 runner bearer），由 HappyClaw 翻译到 ChatGPT Codex Responses。同一 facade 也是后续 Grok 等非 Anthropic 上游的接入面。凭据密封保存，API 只返回是否已登录与脱敏邮箱。
+Codex 与 Grok 都不改写官方或第三方的直连路径。选中 Codex 或 Grok 时，Runner 的 `ANTHROPIC_BASE_URL` 指向本机 `POST /model/v1/messages` facade（仅 runner bearer）。Codex 翻译到 ChatGPT Responses；Grok 翻译到 `cli-chat-proxy.grok.com/v1/responses`（`X-XAI-Token-Auth: xai-grok-cli`）。凭据密封保存，API 只返回是否已登录与脱敏邮箱。
 
 负载均衡支持：
 
@@ -518,6 +519,13 @@ Claude Code，并把实际版本写入
 <summary><strong>可以使用 ChatGPT Codex 吗？</strong></summary>
 
 可以。在“设置 → 模型与提供商”添加 Codex 并用 ChatGPT 设备码登录。Claude Agent SDK 仍然只讲 Anthropic Messages；HappyClaw 在本机 facade 上翻译到 Codex Responses。官方 Claude 与第三方兼容端点继续直连，不会经过该 facade。
+
+</details>
+
+<details>
+<summary><strong>可以使用 xAI Grok 吗？</strong></summary>
+
+可以。在“设置 → 模型与提供商”添加 Grok 并用 xAI OAuth 登录（auth.x.ai PKCE，公共 Grok CLI client）。授权后浏览器会跳到 `http://127.0.0.1:<port>/callback`；本机部署自动完成，远端部署把地址栏 URL 粘贴回来即可。Claude Agent SDK 仍然只讲 Anthropic Messages；HappyClaw 在本机 facade 上翻译到 cli-chat-proxy。官方 Claude、第三方兼容端点与 Codex 路径不变。
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ HappyClaw 不是一个简单的聊天 API Wrapper。智能体运行在真实的 
 
 ## 功能总览
 
-| 模块           | 主要能力                                                                                       |
-| -------------- | ---------------------------------------------------------------------------------------------- |
-| **智能体**     | 主 HappyClaw 对话式创建/编辑、自定义智能体、头像、结构化提示词、AI 优化、版本历史与恢复        |
-| **工作区**     | 智能体归属、宿主机/容器执行、独立目录、项目环境变量、项目 Claude 上下文、多会话                |
-| **能力治理**   | 用户 Skills、系统/用户 MCP、Claude Code Plugins 与最终生效预览；智能体工具权限完整开放         |
-| **消息渠道**   | 飞书、Telegram、QQ、钉钉、微信、企业微信、Discord、WhatsApp，多账号、扫码登录、工作区/会话绑定 |
-| **模型提供商** | Anthropic 官方与第三方兼容端点、多 Provider、轮询/加权/故障转移、健康检查、会话粘性            |
-| **定时任务**   | Cron、固定间隔、一次性任务，智能体/Script 执行，隔离上下文，幂等立即运行，通知重试             |
-| **记忆与文件** | Workspace Memory（事实、决策、经验、待跟进）、来源与修订、CAS 编辑、搜索、文件与终端           |
-| **用量与计费** | Token 分类统计、智能体/工作区/模型筛选、明细与 CSV 导出、订阅、余额、兑换码与配额              |
-| **运维与安全** | RBAC、邀请注册、登录设备、审计日志、运行监控、Docker 镜像管理、备份与安全恢复                  |
-| **客户端体验** | 实时流式输出、工具轨迹、Markdown/Mermaid/KaTeX、消息分享图片、响应式布局与 PWA                 |
+| 模块           | 主要能力                                                                                                                     |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **智能体**     | 主 HappyClaw 对话式创建/编辑、自定义智能体、头像、结构化提示词、AI 优化、版本历史与恢复                                      |
+| **工作区**     | 智能体归属、宿主机/容器执行、独立目录、项目环境变量、项目 Claude 上下文、多会话                                              |
+| **能力治理**   | 用户 Skills、系统/用户 MCP、Claude Code Plugins 与最终生效预览；智能体工具权限完整开放                                       |
+| **消息渠道**   | 飞书、Telegram、QQ、钉钉、微信、企业微信、Discord、WhatsApp，多账号、扫码登录、工作区/会话绑定                               |
+| **模型提供商** | Anthropic 官方、第三方兼容端点与 ChatGPT Codex（本机 Anthropic facade）、多 Provider、轮询/加权/故障转移、健康检查、会话粘性 |
+| **定时任务**   | Cron、固定间隔、一次性任务，智能体/Script 执行，隔离上下文，幂等立即运行，通知重试                                           |
+| **记忆与文件** | Workspace Memory（事实、决策、经验、待跟进）、来源与修订、CAS 编辑、搜索、文件与终端                                         |
+| **用量与计费** | Token 分类统计、智能体/工作区/模型筛选、明细与 CSV 导出、订阅、余额、兑换码与配额                                            |
+| **运维与安全** | RBAC、邀请注册、登录设备、审计日志、运行监控、Docker 镜像管理、备份与安全恢复                                                |
+| **客户端体验** | 实时流式输出、工具轨迹、Markdown/Mermaid/KaTeX、消息分享图片、响应式布局与 PWA                                               |
 
 ## 智能体优先工作模型
 
@@ -184,12 +184,15 @@ Bot 的凭据。
 
 HappyClaw 可以同时配置多个 Claude Provider，并为新会话按策略选择健康的 Provider。
 
-| 类型               | 配置方式                                                               |
-| ------------------ | ---------------------------------------------------------------------- |
-| **Anthropic 官方** | Claude OAuth、一键登录、`setup-token` / `.credentials.json` 或 API Key |
-| **第三方兼容端点** | 填写 API Endpoint、Auth Token 和模型名称，可启用 1M 上下文             |
+| 类型               | 配置方式                                                                                 |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| **Anthropic 官方** | Claude OAuth、一键登录、`setup-token` / `.credentials.json` 或 API Key                   |
+| **第三方兼容端点** | 填写 API Endpoint、Auth Token 和模型名称，可启用 1M 上下文                               |
+| **ChatGPT Codex**  | ChatGPT 设备码登录；Runner 仍走 Anthropic Messages，由本机 facade 翻译到 Codex Responses |
 
 第三方 Provider 会自动预填 Claude Code 兼容环境变量，包括主模型映射、上下文窗口、自动压缩、超时和非必要流量设置。高级设置会展示所有预填值，用户可以编辑、恢复默认值或增加自定义 Header 等环境变量。
+
+Codex 不改写官方或第三方的直连路径。选中 Codex 时，Runner 的 `ANTHROPIC_BASE_URL` 指向本机 `POST /model/v1/messages` facade（仅 runner bearer），由 HappyClaw 翻译到 ChatGPT Codex Responses。同一 facade 也是后续 Grok 等非 Anthropic 上游的接入面。凭据密封保存，API 只返回是否已登录与脱敏邮箱。
 
 负载均衡支持：
 
@@ -508,6 +511,13 @@ Claude Code，并把实际版本写入
 <summary><strong>可以使用第三方 Claude 兼容接口吗？</strong></summary>
 
 可以。在“设置 → 模型与提供商”选择第三方，只需填写 Endpoint、Auth Token 和模型名；1M 上下文及 Claude Code 兼容环境变量由系统预填，也允许在高级设置中编辑。
+
+</details>
+
+<details>
+<summary><strong>可以使用 ChatGPT Codex 吗？</strong></summary>
+
+可以。在“设置 → 模型与提供商”添加 Codex 并用 ChatGPT 设备码登录。Claude Agent SDK 仍然只讲 Anthropic Messages；HappyClaw 在本机 facade 上翻译到 Codex Responses。官方 Claude 与第三方兼容端点继续直连，不会经过该 facade。
 
 </details>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -284,7 +284,14 @@ Provider：
 - `POST /api/config/claude/apply`
 - `POST /api/config/claude/oauth/start`
 - `POST /api/config/claude/oauth/callback`
+- `POST /api/config/codex/oauth/start`
+- `GET /api/config/codex/oauth/:id`
 - `PUT /api/config/claude/custom-env`
+
+`type=codex` 走 ChatGPT 设备码登录。Access / refresh token 密封持久化，公开 API 只返回
+`hasCodexOAuthCredentials`、脱敏邮箱和 plan。Runner 在选中 Codex 时使用本机
+`POST /model/v1/messages`（及 `count_tokens`）Anthropic facade；未带 runner bearer
+返回 401 且不会访问上游。官方与第三方 Provider 仍直连 Anthropic / 兼容端点。
 
 系统：
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -286,12 +286,24 @@ Provider：
 - `POST /api/config/claude/oauth/callback`
 - `POST /api/config/codex/oauth/start`
 - `GET /api/config/codex/oauth/:id`
+- `POST /api/config/grok/oauth/start`
+- `GET /api/config/grok/oauth/:id`
+- `POST /api/config/grok/oauth/:id/code`
+- `GET /callback`（xAI 白名单 redirect_uri，无登录态）
 - `PUT /api/config/claude/custom-env`
 
 `type=codex` 走 ChatGPT 设备码登录。Access / refresh token 密封持久化，公开 API 只返回
-`hasCodexOAuthCredentials`、脱敏邮箱和 plan。Runner 在选中 Codex 时使用本机
-`POST /model/v1/messages`（及 `count_tokens`）Anthropic facade；未带 runner bearer
-返回 401 且不会访问上游。官方与第三方 Provider 仍直连 Anthropic / 兼容端点。
+`hasCodexOAuthCredentials`、脱敏邮箱和 plan。
+
+`type=grok` 走 auth.x.ai PKCE（公共 client `b1a00492-073a-47ea-816f-4c329264a828`，
+scopes 含 `grok-cli:access` + `api:access` + `offline_access`）。redirect_uri 固定为
+`http://127.0.0.1:<WEB_PORT>/callback`。本机回调自动换 token；远端把地址栏 URL
+POST 到 `/grok/oauth/:id/code`。公开 API 只返回 `hasGrokOAuthCredentials` 与脱敏邮箱。
+默认模型 `grok-4.5`，reasoning effort 仅 `low|medium|high`。
+
+Runner 在选中 Codex 或 Grok 时使用本机 `POST /model/v1/messages`（及 `count_tokens`）
+Anthropic facade；未带 runner bearer 返回 401 且不会访问上游。官方与第三方 Provider
+仍直连 Anthropic / 兼容端点。
 
 系统：
 

--- a/src/codex-facade.ts
+++ b/src/codex-facade.ts
@@ -1,0 +1,267 @@
+/**
+ * Local Anthropic Messages facade used only by Codex runners.
+ *
+ * Official Claude and third-party Anthropic-compat providers stay direct.
+ * This HTTP surface is the substrate for later Grok (same Anthropic in,
+ * a different upstream out).
+ */
+
+import { Hono } from 'hono';
+
+import { logger } from './logger.js';
+import {
+  anthropicErrorJson,
+  anthropicErrorSse,
+  anthropicMessageJson,
+  anthropicToCodexRequest,
+  CODEX_DEFAULT_MODEL,
+  CODEX_RESPONSES_URL,
+  estimateInputTokens,
+  stripThinkingBlocks,
+  translateCodexSse,
+  type AnthropicMessagesRequest,
+  type CodexCredential,
+} from './codex-translator.js';
+import {
+  codexTokenExpiresSoon,
+  credentialSnapshot,
+  refreshCodexCredential,
+} from './codex-oauth.js';
+import { resolveCodexRunnerProviderId } from './codex-runtime.js';
+import {
+  getProviders,
+  updateProviderCodexCredentialsIfCurrent,
+} from './runtime-config.js';
+
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const refreshLocks = new Map<string, Promise<CodexCredential>>();
+
+export function resetCodexRefreshLocksForTests(): void {
+  refreshLocks.clear();
+}
+
+function readCodexCredential(providerId: string): CodexCredential | null {
+  const provider = getProviders().find((item) => item.id === providerId);
+  if (
+    !provider ||
+    provider.type !== 'codex' ||
+    !provider.codexOAuthCredentials
+  ) {
+    return null;
+  }
+  return { ...provider.codexOAuthCredentials };
+}
+
+async function persistRefreshedCredential(
+  providerId: string,
+  expected: CodexCredential,
+  refreshed: CodexCredential,
+): Promise<boolean> {
+  return updateProviderCodexCredentialsIfCurrent(
+    providerId,
+    expected,
+    refreshed,
+  );
+}
+
+export async function refreshAndPersistCodexCredential(
+  providerId: string,
+  stale: CodexCredential,
+): Promise<CodexCredential> {
+  const inflight = refreshLocks.get(providerId);
+  if (inflight) return inflight;
+
+  const work = (async () => {
+    const latest = readCodexCredential(providerId);
+    if (
+      latest &&
+      credentialSnapshot(latest) !== credentialSnapshot(stale) &&
+      !codexTokenExpiresSoon(latest.accessToken, REFRESH_BUFFER_MS)
+    ) {
+      return latest;
+    }
+    const refreshed = await refreshCodexCredential(latest ?? stale);
+    const persisted = await persistRefreshedCredential(
+      providerId,
+      latest ?? stale,
+      refreshed,
+    );
+    if (!persisted) {
+      const after = readCodexCredential(providerId);
+      if (after) return after;
+    }
+    return refreshed;
+  })();
+
+  refreshLocks.set(providerId, work);
+  try {
+    return await work;
+  } finally {
+    refreshLocks.delete(providerId);
+  }
+}
+
+export async function callCodexResponses(
+  providerId: string,
+  credential: CodexCredential,
+  body: unknown,
+): Promise<{ status: number; text: string }> {
+  let current = credential;
+  if (
+    current.refreshToken &&
+    codexTokenExpiresSoon(current.accessToken, REFRESH_BUFFER_MS)
+  ) {
+    try {
+      current = await refreshAndPersistCodexCredential(providerId, current);
+    } catch (err) {
+      logger.warn({ err, providerId }, 'Codex proactive token refresh failed');
+    }
+  }
+
+  const once = async (cred: CodexCredential) => {
+    const res = await fetch(CODEX_RESPONSES_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cred.accessToken}`,
+        'chatgpt-account-id': cred.accountId,
+        'OpenAI-Beta': 'responses=experimental',
+        originator: 'codex_cli_rs',
+        Origin: 'https://chatgpt.com',
+        Referer: 'https://chatgpt.com/codex',
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    return { status: res.status, text };
+  };
+
+  let first = await once(current);
+  if (first.status === 401 && current.refreshToken) {
+    try {
+      current = await refreshAndPersistCodexCredential(providerId, current);
+      first = await once(current);
+    } catch (err) {
+      logger.warn({ err, providerId }, 'Codex 401 refresh failed');
+    }
+  }
+  return first;
+}
+
+function parseUpstreamSse(text: string): string[] {
+  return text.split(/\r?\n/);
+}
+
+export function createCodexFacadeApp(): Hono {
+  const app = new Hono();
+
+  app.use('/model/*', async (c, next) => {
+    if (!resolveCodexRunnerProviderId(c.req.header('Authorization'))) {
+      return c.json({ error: 'unauthorized' }, 401);
+    }
+    await next();
+  });
+
+  app.post('/model/v1/messages/count_tokens', async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    return c.json({
+      input_tokens: estimateInputTokens(
+        (body as { messages?: unknown }).messages ?? body,
+      ),
+    });
+  });
+
+  app.post('/model/v1/messages', async (c) => {
+    const providerId = resolveCodexRunnerProviderId(
+      c.req.header('Authorization'),
+    );
+    if (!providerId) {
+      return c.json({ error: 'unauthorized' }, 401);
+    }
+    const credential = readCodexCredential(providerId);
+    if (!credential) {
+      return c.json(anthropicErrorJson('Codex account is not authorized'), 400);
+    }
+
+    const raw = (await c.req
+      .json()
+      .catch(() => null)) as AnthropicMessagesRequest | null;
+    if (!raw || typeof raw !== 'object') {
+      return c.json(anthropicErrorJson('bad json'), 400);
+    }
+    if (Array.isArray(raw.messages)) {
+      raw.messages = raw.messages.map((message) => ({
+        ...message,
+        content: stripThinkingBlocks(message.content),
+      }));
+    }
+    raw.model = raw.model?.trim() || CODEX_DEFAULT_MODEL;
+    const streaming = raw.stream === true;
+    const request = anthropicToCodexRequest(raw);
+
+    let upstream: { status: number; text: string };
+    try {
+      upstream = await callCodexResponses(providerId, credential, request);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'codex upstream failed';
+      logger.warn({ err, providerId }, 'Codex upstream call failed');
+      if (streaming) {
+        return new Response(anthropicErrorSse(message), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+            'Cache-Control': 'no-cache',
+          },
+        });
+      }
+      return c.json(anthropicErrorJson(message), 502);
+    }
+
+    if (upstream.status !== 200) {
+      const message = `codex ${upstream.status}: ${upstream.text.slice(0, 800)}`;
+      if (streaming) {
+        return new Response(anthropicErrorSse(message), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+            'Cache-Control': 'no-cache',
+          },
+        });
+      }
+      return c.json(anthropicErrorJson(message), 502);
+    }
+
+    const translated = translateCodexSse(
+      raw.model,
+      parseUpstreamSse(upstream.text),
+    );
+    if (translated.error) {
+      if (streaming) {
+        return new Response(translated.sse, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+            'Cache-Control': 'no-cache',
+          },
+        });
+      }
+      return c.json(anthropicErrorJson(translated.error), 502);
+    }
+
+    if (streaming) {
+      return new Response(translated.sse, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache',
+        },
+      });
+    }
+    return c.json(anthropicMessageJson(raw.model, translated));
+  });
+
+  return app;
+}
+
+export const codexFacadeRoutes = createCodexFacadeApp();

--- a/src/codex-facade.ts
+++ b/src/codex-facade.ts
@@ -1,9 +1,8 @@
 /**
- * Local Anthropic Messages facade used only by Codex runners.
+ * Local Anthropic Messages facade used by Codex and Grok runners.
  *
  * Official Claude and third-party Anthropic-compat providers stay direct.
- * This HTTP surface is the substrate for later Grok (same Anthropic in,
- * a different upstream out).
+ * Same Anthropic in; Codex and Grok are different Responses upstreams.
  */
 
 import { Hono } from 'hono';
@@ -29,19 +28,38 @@ import {
 } from './codex-oauth.js';
 import { resolveCodexRunnerProviderId } from './codex-runtime.js';
 import {
+  grokCredentialExpiresSoon,
+  grokCredentialSnapshot,
+  refreshGrokCredential,
+} from './grok-oauth.js';
+import {
+  anthropicToGrokRequest,
+  GROK_DEFAULT_MODEL,
+  GROK_RESPONSES_URL,
+  grokUpstreamHeaders,
+  type GrokCredential,
+} from './grok-translator.js';
+import {
   getProviders,
   updateProviderCodexCredentialsIfCurrent,
+  updateProviderGrokCredentialsIfCurrent,
 } from './runtime-config.js';
 
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const refreshLocks = new Map<string, Promise<CodexCredential>>();
+const grokRefreshLocks = new Map<string, Promise<GrokCredential>>();
 
 export function resetCodexRefreshLocksForTests(): void {
   refreshLocks.clear();
+  grokRefreshLocks.clear();
+}
+
+function readProvider(providerId: string) {
+  return getProviders().find((item) => item.id === providerId) ?? null;
 }
 
 function readCodexCredential(providerId: string): CodexCredential | null {
-  const provider = getProviders().find((item) => item.id === providerId);
+  const provider = readProvider(providerId);
   if (
     !provider ||
     provider.type !== 'codex' ||
@@ -50,6 +68,30 @@ function readCodexCredential(providerId: string): CodexCredential | null {
     return null;
   }
   return { ...provider.codexOAuthCredentials };
+}
+
+function readGrokCredential(providerId: string): GrokCredential | null {
+  const provider = readProvider(providerId);
+  if (!provider || provider.type !== 'grok' || !provider.grokOAuthCredentials) {
+    return null;
+  }
+  return { ...provider.grokOAuthCredentials };
+}
+
+function resolveGrokEffort(
+  raw: AnthropicMessagesRequest,
+  providerId: string,
+): string {
+  const rec = raw as AnthropicMessagesRequest & {
+    effort?: unknown;
+    thinking?: { effort?: unknown };
+  };
+  if (typeof rec.effort === 'string' && rec.effort.trim()) return rec.effort;
+  if (typeof rec.thinking?.effort === 'string' && rec.thinking.effort.trim()) {
+    return rec.thinking.effort;
+  }
+  const provider = readProvider(providerId);
+  return provider?.customEnv?.CLAUDE_CODE_EFFORT_LEVEL || 'medium';
 }
 
 async function persistRefreshedCredential(
@@ -101,6 +143,43 @@ export async function refreshAndPersistCodexCredential(
   }
 }
 
+export async function refreshAndPersistGrokCredential(
+  providerId: string,
+  stale: GrokCredential,
+): Promise<GrokCredential> {
+  const inflight = grokRefreshLocks.get(providerId);
+  if (inflight) return inflight;
+
+  const work = (async () => {
+    const latest = readGrokCredential(providerId);
+    if (
+      latest &&
+      grokCredentialSnapshot(latest) !== grokCredentialSnapshot(stale) &&
+      !grokCredentialExpiresSoon(latest, REFRESH_BUFFER_MS)
+    ) {
+      return latest;
+    }
+    const refreshed = await refreshGrokCredential(latest ?? stale);
+    const persisted = updateProviderGrokCredentialsIfCurrent(
+      providerId,
+      latest ?? stale,
+      refreshed,
+    );
+    if (!persisted) {
+      const after = readGrokCredential(providerId);
+      if (after) return after;
+    }
+    return refreshed;
+  })();
+
+  grokRefreshLocks.set(providerId, work);
+  try {
+    return await work;
+  } finally {
+    grokRefreshLocks.delete(providerId);
+  }
+}
+
 export async function callCodexResponses(
   providerId: string,
   credential: CodexCredential,
@@ -148,8 +227,64 @@ export async function callCodexResponses(
   return first;
 }
 
+export async function callGrokResponses(
+  providerId: string,
+  credential: GrokCredential,
+  body: unknown,
+): Promise<{ status: number; text: string }> {
+  let current = credential;
+  if (
+    current.refreshToken &&
+    grokCredentialExpiresSoon(current, REFRESH_BUFFER_MS)
+  ) {
+    try {
+      current = await refreshAndPersistGrokCredential(providerId, current);
+    } catch (err) {
+      logger.warn({ err, providerId }, 'Grok proactive token refresh failed');
+    }
+  }
+
+  const once = async (cred: GrokCredential) => {
+    const res = await fetch(GROK_RESPONSES_URL, {
+      method: 'POST',
+      headers: grokUpstreamHeaders(cred.accessToken),
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    return { status: res.status, text };
+  };
+
+  let first = await once(current);
+  if (first.status === 401 && current.refreshToken) {
+    try {
+      current = await refreshAndPersistGrokCredential(providerId, current);
+      first = await once(current);
+    } catch (err) {
+      logger.warn({ err, providerId }, 'Grok 401 refresh failed');
+    }
+  }
+  return first;
+}
+
 function parseUpstreamSse(text: string): string[] {
   return text.split(/\r?\n/);
+}
+
+function facadeErrorResponse(
+  streaming: boolean,
+  message: string,
+  status: 400 | 502 = 502,
+) {
+  if (streaming) {
+    return new Response(anthropicErrorSse(message), {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-cache',
+      },
+    });
+  }
+  return null;
 }
 
 export function createCodexFacadeApp(): Hono {
@@ -178,9 +313,15 @@ export function createCodexFacadeApp(): Hono {
     if (!providerId) {
       return c.json({ error: 'unauthorized' }, 401);
     }
-    const credential = readCodexCredential(providerId);
-    if (!credential) {
+    const provider = readProvider(providerId);
+    const isGrok = provider?.type === 'grok';
+    const codexCredential = isGrok ? null : readCodexCredential(providerId);
+    const grokCredential = isGrok ? readGrokCredential(providerId) : null;
+    if (!isGrok && !codexCredential) {
       return c.json(anthropicErrorJson('Codex account is not authorized'), 400);
+    }
+    if (isGrok && !grokCredential) {
+      return c.json(anthropicErrorJson('Grok account is not authorized'), 400);
     }
 
     const raw = (await c.req
@@ -195,40 +336,35 @@ export function createCodexFacadeApp(): Hono {
         content: stripThinkingBlocks(message.content),
       }));
     }
-    raw.model = raw.model?.trim() || CODEX_DEFAULT_MODEL;
+    raw.model =
+      raw.model?.trim() || (isGrok ? GROK_DEFAULT_MODEL : CODEX_DEFAULT_MODEL);
     const streaming = raw.stream === true;
-    const request = anthropicToCodexRequest(raw);
+    const request = isGrok
+      ? anthropicToGrokRequest(raw, resolveGrokEffort(raw, providerId))
+      : anthropicToCodexRequest(raw);
+    const label = isGrok ? 'grok' : 'codex';
 
     let upstream: { status: number; text: string };
     try {
-      upstream = await callCodexResponses(providerId, credential, request);
+      upstream = isGrok
+        ? await callGrokResponses(providerId, grokCredential!, request)
+        : await callCodexResponses(providerId, codexCredential!, request);
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'codex upstream failed';
-      logger.warn({ err, providerId }, 'Codex upstream call failed');
-      if (streaming) {
-        return new Response(anthropicErrorSse(message), {
-          status: 200,
-          headers: {
-            'Content-Type': 'text/event-stream; charset=utf-8',
-            'Cache-Control': 'no-cache',
-          },
-        });
-      }
+        err instanceof Error ? err.message : `${label} upstream failed`;
+      logger.warn(
+        { err, providerId },
+        `${isGrok ? 'Grok' : 'Codex'} upstream call failed`,
+      );
+      const sse = facadeErrorResponse(streaming, message);
+      if (sse) return sse;
       return c.json(anthropicErrorJson(message), 502);
     }
 
     if (upstream.status !== 200) {
-      const message = `codex ${upstream.status}: ${upstream.text.slice(0, 800)}`;
-      if (streaming) {
-        return new Response(anthropicErrorSse(message), {
-          status: 200,
-          headers: {
-            'Content-Type': 'text/event-stream; charset=utf-8',
-            'Cache-Control': 'no-cache',
-          },
-        });
-      }
+      const message = `${label} ${upstream.status}: ${upstream.text.slice(0, 800)}`;
+      const sse = facadeErrorResponse(streaming, message);
+      if (sse) return sse;
       return c.json(anthropicErrorJson(message), 502);
     }
 

--- a/src/codex-oauth.ts
+++ b/src/codex-oauth.ts
@@ -1,0 +1,292 @@
+/**
+ * ChatGPT Codex device-code OAuth and token refresh.
+ *
+ * Browser only sees a one-time user code. Access/refresh/id tokens stay on
+ * the server and are sealed before they are persisted.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { CodexCredential } from './codex-translator.js';
+
+export const CODEX_OAUTH_ISSUER = 'https://auth.openai.com';
+export const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+export const CODEX_OAUTH_TTL_MS = 15 * 60 * 1000;
+
+export interface CodexClaims {
+  email: string;
+  accountId: string;
+  userId: string;
+  planType: string;
+}
+
+export interface CodexDeviceCode {
+  deviceAuthId: string;
+  userCode: string;
+  interval: number;
+}
+
+export interface CodexDeviceGrant {
+  authorizationCode: string;
+  codeVerifier: string;
+}
+
+export function decodeCodexClaims(token: string): CodexClaims {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('invalid JWT');
+  }
+  const payload = Buffer.from(parts[1], 'base64url').toString('utf8');
+  const raw = JSON.parse(payload) as {
+    email?: string;
+    'https://api.openai.com/profile'?: { email?: string };
+    'https://api.openai.com/auth'?: {
+      chatgpt_account_id?: string;
+      chatgpt_user_id?: string;
+      user_id?: string;
+      chatgpt_plan_type?: string;
+    };
+  };
+  const auth = raw['https://api.openai.com/auth'] || {};
+  return {
+    email: raw.email || raw['https://api.openai.com/profile']?.email || '',
+    accountId: auth.chatgpt_account_id || '',
+    userId: auth.chatgpt_user_id || auth.user_id || '',
+    planType: auth.chatgpt_plan_type || '',
+  };
+}
+
+export function codexTokenExpiresSoon(
+  token: string,
+  bufferMs: number,
+  now = Date.now(),
+): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  try {
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf8');
+    const claims = JSON.parse(payload) as { exp?: number };
+    if (!claims.exp) return true;
+    return now + bufferMs >= claims.exp * 1000;
+  } catch {
+    return true;
+  }
+}
+
+export function decodeJwtExpMs(token: string): number | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf8');
+    const claims = JSON.parse(payload) as { exp?: number };
+    return typeof claims.exp === 'number' && claims.exp > 0
+      ? claims.exp * 1000
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function credentialSnapshot(credential: CodexCredential): string {
+  return JSON.stringify({
+    accessToken: credential.accessToken,
+    refreshToken: credential.refreshToken,
+    accountId: credential.accountId,
+    idToken: credential.idToken || '',
+    email: credential.email || '',
+    planType: credential.planType || '',
+  });
+}
+
+export async function requestCodexDeviceCode(
+  fetchImpl: typeof fetch = fetch,
+): Promise<CodexDeviceCode> {
+  const res = await fetchImpl(
+    `${CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/usercode`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: CODEX_OAUTH_CLIENT_ID }),
+    },
+  );
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(
+      `OpenAI device authorization unavailable (HTTP ${res.status})`,
+    );
+  }
+  const raw = (await res.json()) as {
+    device_auth_id?: string;
+    user_code?: string;
+    interval?: string | number;
+  };
+  const interval =
+    typeof raw.interval === 'number'
+      ? raw.interval
+      : Number.parseInt(String(raw.interval || ''), 10);
+  if (!raw.device_auth_id || !raw.user_code) {
+    throw new Error('OpenAI device authorization response is missing fields');
+  }
+  return {
+    deviceAuthId: raw.device_auth_id,
+    userCode: raw.user_code,
+    interval: Number.isFinite(interval) && interval >= 1 ? interval : 5,
+  };
+}
+
+export async function pollCodexDeviceGrant(
+  device: CodexDeviceCode,
+  options: {
+    fetchImpl?: typeof fetch;
+    signal?: AbortSignal;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<CodexDeviceGrant> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const endpoint = `${CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/token`;
+  for (;;) {
+    if (options.signal?.aborted) {
+      throw new Error('Codex authorization expired');
+    }
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        device_auth_id: device.deviceAuthId,
+        user_code: device.userCode,
+      }),
+      signal: options.signal,
+    });
+    if (res.status >= 200 && res.status < 300) {
+      const raw = (await res.json()) as {
+        authorization_code?: string;
+        code_verifier?: string;
+      };
+      if (!raw.authorization_code || !raw.code_verifier) {
+        throw new Error('OpenAI returned an invalid authorization result');
+      }
+      return {
+        authorizationCode: raw.authorization_code,
+        codeVerifier: raw.code_verifier,
+      };
+    }
+    if (res.status !== 403 && res.status !== 404) {
+      throw new Error(
+        `OpenAI device authorization poll failed (HTTP ${res.status})`,
+      );
+    }
+    await sleep(device.interval * 1000);
+  }
+}
+
+export async function exchangeCodexDeviceGrant(
+  grant: CodexDeviceGrant,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CodexCredential> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: grant.authorizationCode,
+    redirect_uri: `${CODEX_OAUTH_ISSUER}/deviceauth/callback`,
+    client_id: CODEX_OAUTH_CLIENT_ID,
+    code_verifier: grant.codeVerifier,
+  });
+  const res = await fetchImpl(`${CODEX_OAUTH_ISSUER}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`OpenAI token exchange failed (HTTP ${res.status})`);
+  }
+  return credentialFromTokenResponse(await res.json());
+}
+
+export async function refreshCodexCredential(
+  stale: CodexCredential,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CodexCredential> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: stale.refreshToken,
+    client_id: CODEX_OAUTH_CLIENT_ID,
+  });
+  const res = await fetchImpl(`${CODEX_OAUTH_ISSUER}/oauth/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Originator: 'codex_exec',
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    },
+    body: body.toString(),
+  });
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`codex token refresh HTTP ${res.status}`);
+  }
+  const raw = (await res.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    id_token?: string;
+  };
+  if (!raw.access_token) {
+    throw new Error('codex token refresh returned an invalid response');
+  }
+  const fresh: CodexCredential = {
+    ...stale,
+    accessToken: raw.access_token,
+  };
+  if (raw.refresh_token) fresh.refreshToken = raw.refresh_token;
+  if (raw.id_token) fresh.idToken = raw.id_token;
+  enrichCredentialFromTokens(fresh);
+  return fresh;
+}
+
+export function credentialFromTokenResponse(raw: unknown): CodexCredential {
+  const token = raw as {
+    access_token?: string;
+    refresh_token?: string;
+    id_token?: string;
+  };
+  if (!token.access_token || !token.refresh_token) {
+    throw new Error('OpenAI token response is missing fields');
+  }
+  const credential: CodexCredential = {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    accountId: '',
+    idToken: token.id_token,
+  };
+  enrichCredentialFromTokens(credential);
+  return credential;
+}
+
+export function enrichCredentialFromTokens(credential: CodexCredential): void {
+  const sources = [credential.idToken, credential.accessToken].filter(
+    (value): value is string => !!value,
+  );
+  for (const token of sources) {
+    try {
+      const claims = decodeCodexClaims(token);
+      if (!credential.accountId && claims.accountId) {
+        credential.accountId = claims.accountId;
+      }
+      if (!credential.email && claims.email) credential.email = claims.email;
+      if (!credential.planType && claims.planType) {
+        credential.planType = claims.planType;
+      }
+    } catch {
+      // ignore malformed JWT; account id may still come from the other token
+    }
+  }
+}
+
+export function verificationUrl(): string {
+  return `${CODEX_OAUTH_ISSUER}/codex/device`;
+}
+
+export function hashCredential(credential: CodexCredential): string {
+  return createHash('sha256')
+    .update(credentialSnapshot(credential))
+    .digest('hex');
+}

--- a/src/codex-runtime.ts
+++ b/src/codex-runtime.ts
@@ -1,0 +1,90 @@
+/**
+ * Runner-side Codex binding: local facade URL and per-provider bearer tokens.
+ * Official / third_party providers never use these values.
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { WEB_PORT } from './config.js';
+import { CODEX_DEFAULT_MODEL } from './codex-translator.js';
+
+export { CODEX_DEFAULT_MODEL };
+
+const runnerTokens = new Map<string, string>();
+
+export function getCodexFacadeBaseUrl(): string {
+  return `http://127.0.0.1:${WEB_PORT}/model`;
+}
+
+export function isCodexFacadeBaseUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.replace(/^\[/, '').replace(/\]$/, '');
+    return (
+      (host === '127.0.0.1' ||
+        host === 'localhost' ||
+        host === '::1' ||
+        host === 'host.docker.internal') &&
+      parsed.pathname.replace(/\/$/, '') === '/model'
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function rewriteCodexFacadeUrlForContainer(url: string): {
+  url: string;
+  addHostGateway: boolean;
+} {
+  if (!isCodexFacadeBaseUrl(url)) {
+    return { url, addHostGateway: false };
+  }
+  const parsed = new URL(url);
+  parsed.hostname = 'host.docker.internal';
+  return { url: parsed.toString().replace(/\/$/, ''), addHostGateway: true };
+}
+
+export function rewriteCodexFacadeEnvForContainer(lines: string[]): {
+  lines: string[];
+  addHostGateway: boolean;
+} {
+  let addHostGateway = false;
+  const next = lines.map((line) => {
+    if (!line.startsWith('ANTHROPIC_BASE_URL=')) return line;
+    const rewritten = rewriteCodexFacadeUrlForContainer(
+      line.slice('ANTHROPIC_BASE_URL='.length),
+    );
+    addHostGateway = addHostGateway || rewritten.addHostGateway;
+    return `ANTHROPIC_BASE_URL=${rewritten.url}`;
+  });
+  return { lines: next, addHostGateway };
+}
+
+export function issueCodexRunnerToken(providerId: string): string {
+  for (const [token, id] of runnerTokens) {
+    if (id === providerId) return token;
+  }
+  const token = randomBytes(24).toString('hex');
+  runnerTokens.set(token, providerId);
+  return token;
+}
+
+export function resetCodexRunnerTokensForTests(): void {
+  runnerTokens.clear();
+}
+
+export function resolveCodexRunnerProviderId(
+  authorization: string | undefined,
+): string | null {
+  if (!authorization?.startsWith('Bearer ')) return null;
+  const provided = authorization.slice(7).trim();
+  if (!provided) return null;
+  for (const [token, providerId] of runnerTokens) {
+    const left = Buffer.from(token);
+    const right = Buffer.from(provided);
+    if (left.length === right.length && timingSafeEqual(left, right)) {
+      return providerId;
+    }
+  }
+  return null;
+}

--- a/src/codex-translator.ts
+++ b/src/codex-translator.ts
@@ -1,0 +1,612 @@
+/**
+ * Anthropic Messages ↔ ChatGPT Codex Responses translation.
+ *
+ * The Claude Agent SDK only speaks Anthropic JSON/SSE. Codex is reached
+ * through Responses (`/responses`) with top-level function_call items.
+ * This module is the substrate for later Grok (and similar) facades.
+ */
+
+export const CODEX_DEFAULT_MODEL = 'gpt-5.6-sol';
+export const CODEX_RESPONSES_URL =
+  'https://chatgpt.com/backend-api/codex/responses';
+
+export interface AnthropicToolSpec {
+  name: string;
+  description?: string;
+  input_schema?: Record<string, unknown>;
+}
+
+export interface AnthropicMessage {
+  role: string;
+  content: unknown;
+}
+
+export interface AnthropicMessagesRequest {
+  model?: string;
+  max_tokens?: number;
+  stream?: boolean;
+  system?: unknown;
+  messages?: AnthropicMessage[];
+  tools?: AnthropicToolSpec[];
+}
+
+export interface CodexCredential {
+  accessToken: string;
+  refreshToken: string;
+  accountId: string;
+  idToken?: string;
+  email?: string;
+  planType?: string;
+}
+
+export interface CodexResponsesRequest {
+  model: string;
+  input: Array<Record<string, unknown>>;
+  stream: true;
+  store: false;
+  reasoning: { effort: 'medium'; summary: 'auto' };
+  instructions?: string;
+  tools?: Array<Record<string, unknown>>;
+  tool_choice?: 'auto';
+}
+
+export interface TranslatedUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+}
+
+export interface TranslatedToolUse {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface CodexTranslateResult {
+  text: string;
+  toolUses: TranslatedToolUse[];
+  usage: TranslatedUsage;
+  error: string | null;
+  sse: string;
+}
+
+export function parseCodexCredential(secret: string): CodexCredential {
+  try {
+    const parsed = JSON.parse(secret) as Partial<CodexCredential>;
+    if (parsed && typeof parsed === 'object' && parsed.accessToken) {
+      return {
+        accessToken: String(parsed.accessToken),
+        refreshToken: String(parsed.refreshToken || ''),
+        accountId: String(parsed.accountId || ''),
+        idToken: parsed.idToken ? String(parsed.idToken) : undefined,
+        email: parsed.email ? String(parsed.email) : undefined,
+        planType: parsed.planType ? String(parsed.planType) : undefined,
+      };
+    }
+  } catch {
+    // fall through: treat the whole string as a bare access token
+  }
+  const trimmed = secret.trim();
+  if (!trimmed) {
+    throw new Error('codex credential is missing access_token');
+  }
+  return { accessToken: trimmed, refreshToken: '', accountId: '' };
+}
+
+export function flattenAnthropicText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const raw of content) {
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      (raw as { type?: unknown }).type === 'text' &&
+      typeof (raw as { text?: unknown }).text === 'string'
+    ) {
+      parts.push((raw as { text: string }).text);
+    }
+  }
+  return parts.join('\n');
+}
+
+export function flattenSystemText(system: unknown): string {
+  if (typeof system === 'string') return system;
+  if (!Array.isArray(system)) return '';
+  const parts: string[] = [];
+  for (const raw of system) {
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      (raw as { type?: unknown }).type === 'text' &&
+      typeof (raw as { text?: unknown }).text === 'string' &&
+      (raw as { text: string }).text
+    ) {
+      parts.push((raw as { text: string }).text);
+    }
+  }
+  return parts.join('\n');
+}
+
+export function stripThinkingBlocks(content: unknown): unknown {
+  if (Array.isArray(content)) {
+    return content.filter((raw) => {
+      if (raw && typeof raw === 'object') {
+        return (raw as { type?: unknown }).type !== 'thinking';
+      }
+      return true;
+    });
+  }
+  return content;
+}
+
+export function codexToolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (
+        block &&
+        typeof block === 'object' &&
+        (block as { type?: unknown }).type === 'text' &&
+        typeof (block as { text?: unknown }).text === 'string'
+      ) {
+        parts.push((block as { text: string }).text);
+      }
+    }
+    if (parts.length > 0) return parts.join('\n');
+  }
+  try {
+    return JSON.stringify(content ?? '');
+  } catch {
+    return '';
+  }
+}
+
+function toolUseArguments(input: unknown): string {
+  if (input && typeof input === 'object' && !Array.isArray(input)) {
+    return JSON.stringify(input);
+  }
+  if (typeof input === 'string') return input;
+  return '';
+}
+
+export function dropOrphanFunctionCallOutputs(
+  items: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const callIds = new Set<string>();
+  for (const item of items) {
+    if (item.type === 'function_call' && typeof item.call_id === 'string') {
+      callIds.add(item.call_id);
+    }
+  }
+  return items.filter((item) => {
+    if (item.type !== 'function_call_output') return true;
+    return typeof item.call_id === 'string' && callIds.has(item.call_id);
+  });
+}
+
+function convertBlocks(
+  role: string,
+  textBlockType: string,
+  blocks: Array<Record<string, unknown>>,
+  items: Array<Record<string, unknown>>,
+): void {
+  let parts: Array<Record<string, unknown>> = [];
+  const flush = () => {
+    if (parts.length === 0) return;
+    items.push({ type: 'message', role, content: parts });
+    parts = [];
+  };
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'text': {
+        const text = typeof block.text === 'string' ? block.text : '';
+        if (text.trim()) {
+          parts.push({ type: textBlockType, text });
+        }
+        break;
+      }
+      case 'tool_result': {
+        flush();
+        const callId =
+          typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
+        if (callId) {
+          items.push({
+            type: 'function_call_output',
+            call_id: callId,
+            output: codexToolResultText(block.content),
+          });
+        }
+        break;
+      }
+      case 'tool_use': {
+        flush();
+        const callId = typeof block.id === 'string' ? block.id : '';
+        const name = typeof block.name === 'string' ? block.name : '';
+        if (callId) {
+          items.push({
+            type: 'function_call',
+            call_id: callId,
+            name,
+            arguments: toolUseArguments(block.input),
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  flush();
+}
+
+export function anthropicToCodexRequest(
+  req: AnthropicMessagesRequest,
+): CodexResponsesRequest {
+  let instructions = flattenSystemText(req.system);
+  const items: Array<Record<string, unknown>> = [];
+
+  for (const message of req.messages ?? []) {
+    const role = message.role;
+    if (role !== 'assistant' && role !== 'user') {
+      const extra = flattenAnthropicText(message.content);
+      if (extra.trim()) {
+        instructions = [instructions, extra].filter(Boolean).join('\n');
+      }
+      continue;
+    }
+    const textBlockType = role === 'assistant' ? 'output_text' : 'input_text';
+    if (typeof message.content === 'string') {
+      if (message.content.trim()) {
+        items.push({
+          type: 'message',
+          role,
+          content: [{ type: textBlockType, text: message.content }],
+        });
+      }
+      continue;
+    }
+    if (Array.isArray(message.content)) {
+      const blocks = message.content.filter(
+        (raw): raw is Record<string, unknown> =>
+          !!raw && typeof raw === 'object',
+      );
+      convertBlocks(role, textBlockType, blocks, items);
+    }
+  }
+
+  const filtered = dropOrphanFunctionCallOutputs(items);
+  if (filtered.length === 0) {
+    filtered.push({
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: '(continue)' }],
+    });
+  }
+
+  const body: CodexResponsesRequest = {
+    model: req.model?.trim() || CODEX_DEFAULT_MODEL,
+    input: filtered,
+    stream: true,
+    store: false,
+    reasoning: { effort: 'medium', summary: 'auto' },
+  };
+  if (instructions.trim()) body.instructions = instructions.trim();
+  if (req.tools && req.tools.length > 0) {
+    body.tools = req.tools.map((tool) => ({
+      type: 'function',
+      name: tool.name,
+      description: tool.description || '',
+      parameters: tool.input_schema ?? { type: 'object', properties: {} },
+      strict: false,
+    }));
+    body.tool_choice = 'auto';
+  }
+  return body;
+}
+
+function sseEvent(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export function estimateInputTokens(payload: unknown): number {
+  try {
+    const raw = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    return Math.max(1, Math.ceil(raw.length / 4));
+  } catch {
+    return 1;
+  }
+}
+
+/**
+ * Translate a Codex Responses SSE stream into Anthropic Messages SSE.
+ * Failed or truncated upstream streams set `error` and do not emit a
+ * successful message_stop / end_turn.
+ */
+export function translateCodexSse(
+  model: string,
+  lines: string[],
+): CodexTranslateResult {
+  const chunks: string[] = [
+    sseEvent('message_start', {
+      type: 'message_start',
+      message: {
+        model,
+        role: 'assistant',
+        content: [],
+        usage: { input_tokens: 0 },
+      },
+    }),
+  ];
+
+  const argStream = new Map<string, string>();
+  let nextBlockIndex = 0;
+  let textBlockIndex = -1;
+  let thinkingBlockIndex = -1;
+  let haveUsage = false;
+  let error: string | null = null;
+  const result: CodexTranslateResult = {
+    text: '',
+    toolUses: [],
+    usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0 },
+    error: null,
+    sse: '',
+  };
+
+  const closeThinking = () => {
+    if (thinkingBlockIndex < 0) return;
+    chunks.push(
+      sseEvent('content_block_stop', {
+        type: 'content_block_stop',
+        index: thinkingBlockIndex,
+      }),
+    );
+    thinkingBlockIndex = -1;
+  };
+  const closeText = () => {
+    if (textBlockIndex < 0) return;
+    chunks.push(
+      sseEvent('content_block_stop', {
+        type: 'content_block_stop',
+        index: textBlockIndex,
+      }),
+    );
+    textBlockIndex = -1;
+  };
+
+  for (const line of lines) {
+    if (!line.startsWith('data:')) continue;
+    const data = line.slice(5).trim();
+    if (!data || data === '[DONE]') continue;
+    let ev: {
+      type?: string;
+      delta?: string;
+      arguments?: string;
+      item_id?: string;
+      item?: {
+        type?: string;
+        name?: string;
+        call_id?: string;
+        arguments?: string;
+      };
+      response?: {
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          input_tokens_details?: { cached_tokens?: number };
+        };
+        error?: { message?: string };
+      };
+    };
+    try {
+      ev = JSON.parse(data) as typeof ev;
+    } catch {
+      continue;
+    }
+
+    if (ev.type === 'response.function_call_arguments.delta') {
+      const id = ev.item_id || '';
+      argStream.set(id, (argStream.get(id) || '') + (ev.delta || ''));
+      continue;
+    }
+    if (ev.type === 'response.function_call_arguments.done') {
+      if (ev.item_id) argStream.set(ev.item_id, ev.arguments || '');
+      continue;
+    }
+    if (ev.type === 'response.reasoning_summary_text.delta') {
+      if (thinkingBlockIndex < 0) {
+        thinkingBlockIndex = nextBlockIndex++;
+        chunks.push(
+          sseEvent('content_block_start', {
+            type: 'content_block_start',
+            index: thinkingBlockIndex,
+            content_block: { type: 'thinking', thinking: '' },
+          }),
+        );
+      }
+      chunks.push(
+        sseEvent('content_block_delta', {
+          type: 'content_block_delta',
+          index: thinkingBlockIndex,
+          delta: { type: 'thinking_delta', thinking: ev.delta || '' },
+        }),
+      );
+      continue;
+    }
+
+    switch (ev.type) {
+      case 'response.output_text.delta': {
+        result.text += ev.delta || '';
+        closeThinking();
+        if (textBlockIndex < 0) {
+          textBlockIndex = nextBlockIndex++;
+          chunks.push(
+            sseEvent('content_block_start', {
+              type: 'content_block_start',
+              index: textBlockIndex,
+              content_block: { type: 'text', text: '' },
+            }),
+          );
+        }
+        chunks.push(
+          sseEvent('content_block_delta', {
+            type: 'content_block_delta',
+            index: textBlockIndex,
+            delta: { type: 'text_delta', text: ev.delta || '' },
+          }),
+        );
+        break;
+      }
+      case 'response.output_item.done': {
+        if (ev.item?.type === 'function_call') {
+          const tool: TranslatedToolUse = {
+            id: ev.item.call_id || '',
+            name: ev.item.name || '',
+            input: {},
+          };
+          let args = ev.item.arguments || '';
+          if (!args && ev.item.call_id) {
+            args = argStream.get(ev.item.call_id) || '';
+          }
+          if (args) {
+            try {
+              const parsed = JSON.parse(args) as unknown;
+              if (
+                parsed &&
+                typeof parsed === 'object' &&
+                !Array.isArray(parsed)
+              ) {
+                tool.input = parsed as Record<string, unknown>;
+              }
+            } catch {
+              tool.input = {};
+            }
+          }
+          result.toolUses.push(tool);
+          closeThinking();
+          closeText();
+          const idx = nextBlockIndex++;
+          chunks.push(
+            sseEvent('content_block_start', {
+              type: 'content_block_start',
+              index: idx,
+              content_block: {
+                type: 'tool_use',
+                id: tool.id,
+                name: tool.name,
+                input: {},
+              },
+            }),
+          );
+          chunks.push(
+            sseEvent('content_block_delta', {
+              type: 'content_block_delta',
+              index: idx,
+              delta: {
+                type: 'input_json_delta',
+                partial_json: JSON.stringify(tool.input),
+              },
+            }),
+          );
+          chunks.push(
+            sseEvent('content_block_stop', {
+              type: 'content_block_stop',
+              index: idx,
+            }),
+          );
+        }
+        break;
+      }
+      case 'response.completed': {
+        if (ev.response?.usage && !haveUsage) {
+          haveUsage = true;
+          result.usage.inputTokens = ev.response.usage.input_tokens || 0;
+          result.usage.outputTokens = ev.response.usage.output_tokens || 0;
+          result.usage.cacheReadTokens =
+            ev.response.usage.input_tokens_details?.cached_tokens || 0;
+        }
+        if (ev.response?.error?.message) {
+          error = ev.response.error.message;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  result.error = error;
+  if (error) {
+    chunks.push(
+      sseEvent('error', {
+        type: 'error',
+        error: { type: 'api_error', message: error },
+      }),
+    );
+    result.sse = chunks.join('');
+    return result;
+  }
+
+  closeThinking();
+  closeText();
+  chunks.push(
+    sseEvent('message_delta', {
+      type: 'message_delta',
+      delta: {
+        stop_reason: result.toolUses.length > 0 ? 'tool_use' : 'end_turn',
+      },
+      usage: { output_tokens: result.usage.outputTokens },
+    }),
+  );
+  chunks.push(sseEvent('message_stop', { type: 'message_stop' }));
+  result.sse = chunks.join('');
+  return result;
+}
+
+export function anthropicErrorSse(message: string): string {
+  return sseEvent('error', {
+    type: 'error',
+    error: { type: 'api_error', message },
+  });
+}
+
+export function anthropicErrorJson(message: string): Record<string, unknown> {
+  return {
+    type: 'error',
+    error: { type: 'api_error', message },
+  };
+}
+
+export function anthropicMessageJson(
+  model: string,
+  translated: CodexTranslateResult,
+): Record<string, unknown> {
+  const content: Array<Record<string, unknown>> = [];
+  if (translated.text) {
+    content.push({ type: 'text', text: translated.text });
+  }
+  for (const tool of translated.toolUses) {
+    content.push({
+      type: 'tool_use',
+      id: tool.id,
+      name: tool.name,
+      input: tool.input,
+    });
+  }
+  return {
+    id: `msg_codex_${Date.now().toString(16)}`,
+    type: 'message',
+    role: 'assistant',
+    model,
+    content,
+    stop_reason: translated.toolUses.length > 0 ? 'tool_use' : 'end_turn',
+    usage: {
+      input_tokens: translated.usage.inputTokens,
+      output_tokens: translated.usage.outputTokens,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: translated.usage.cacheReadTokens,
+    },
+  };
+}

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -41,6 +41,7 @@ import {
   buildContainerEnvLines,
   clearInheritedClaudeProviderEnv,
   getClaudeProviderConfig,
+  getRunnerProviderConfig,
   getContainerEnvConfig,
   getDefaultProviderId,
   getEnabledProviders,
@@ -56,6 +57,7 @@ import {
   buildClaudeAiOauthPayload,
   updateProviderOAuthCredentialsIfCurrent,
 } from './runtime-config.js';
+import { rewriteCodexFacadeEnvForContainer } from './codex-runtime.js';
 import {
   removeClaudeKeychainOAuth,
   syncClaudeKeychainOAuth,
@@ -1731,16 +1733,18 @@ export function buildVolumeMounts(
       : null,
   );
   fs.mkdirSync(envDir, { recursive: true });
-  const globalConfig = resolvedProvider?.config ?? getClaudeProviderConfig();
+  const globalConfig = resolvedProvider?.config ?? getRunnerProviderConfig();
   const containerOverride = getContainerEnvConfig(group.folder);
   const effectiveContainerOverride = resolvedProvider
     ? { customEnv: containerOverride.customEnv }
     : containerOverride;
-  const envLines = buildContainerEnvLines(
+  const builtEnvLines = buildContainerEnvLines(
     globalConfig,
     effectiveContainerOverride,
     resolvedProvider?.customEnv,
   );
+  const facadeRewrite = rewriteCodexFacadeEnvForContainer(builtEnvLines);
+  const envLines = facadeRewrite.lines;
   const agentEffort = resolveAgentSdkEffort(agentProfile?.runtimePolicy);
   removeProviderEffortEnv(envLines, agentEffort);
   // Agent policy is authoritative; do not inherit global/custom runtime env.
@@ -2244,12 +2248,21 @@ export async function runContainerAgent(
       ? `-${sessionAgentId.replace(/[^a-zA-Z0-9-]/g, '-')}`
       : '';
     const containerName = `happyclaw-${safeName}${agentSuffix}-${Date.now()}`;
+    const runnerConfig = resolvedProvider?.config ?? getRunnerProviderConfig();
+    const facadeNetwork = rewriteCodexFacadeEnvForContainer(
+      runnerConfig.anthropicBaseUrl
+        ? [`ANTHROPIC_BASE_URL=${runnerConfig.anthropicBaseUrl}`]
+        : [],
+    );
     const containerArgs = buildContainerArgs(
       mounts,
       containerName,
       TIMEZONE,
       detectContainerHostIdentity(),
-      { addHostGateway: containerProxy.addHostGateway },
+      {
+        addHostGateway:
+          containerProxy.addHostGateway || facadeNetwork.addHostGateway,
+      },
     );
 
     logger.debug(
@@ -3026,7 +3039,7 @@ export async function runHostAgent(
     input.agentProfile?.modelConfigId,
   );
   const globalConfig =
-    hostPoolResult?.resolved.config ?? getClaudeProviderConfig();
+    hostPoolResult?.resolved.config ?? getRunnerProviderConfig();
   let hostProviderFailureReported = false;
   let hostProviderFailureTerminal: boolean | undefined;
   let hostProviderFailureMaintenance = false;

--- a/src/grok-oauth.ts
+++ b/src/grok-oauth.ts
@@ -1,0 +1,189 @@
+/**
+ * xAI Grok PKCE OIDC (auth.x.ai public Grok CLI client).
+ *
+ * Browser sees only the authorize URL / pasted callback. Access and refresh
+ * tokens stay on the server and are sealed before persist.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+
+import { WEB_PORT } from './config.js';
+import { codexTokenExpiresSoon } from './codex-oauth.js';
+import type { GrokCredential } from './grok-translator.js';
+
+export const GROK_OAUTH_ISSUER = 'https://auth.x.ai';
+export const GROK_OAUTH_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828';
+export const GROK_OAUTH_SCOPES =
+  'openid profile email offline_access grok-cli:access api:access';
+export const GROK_OAUTH_TTL_MS = 10 * 60 * 1000;
+
+export { codexTokenExpiresSoon as grokTokenExpiresSoon };
+
+export function grokCredentialExpiresSoon(
+  credential: GrokCredential,
+  bufferMs: number,
+  now = Date.now(),
+): boolean {
+  if (credential.expiresAt) {
+    const expires = Date.parse(credential.expiresAt);
+    if (Number.isFinite(expires)) return now + bufferMs >= expires;
+  }
+  return codexTokenExpiresSoon(credential.accessToken, bufferMs, now);
+}
+
+export function grokRedirectUri(port = WEB_PORT): string {
+  return `http://127.0.0.1:${port}/callback`;
+}
+
+export function generateGrokPkce(): {
+  state: string;
+  verifier: string;
+  challenge: string;
+} {
+  const state = randomBytes(16).toString('hex');
+  const verifier = randomBytes(32).toString('hex');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { state, verifier, challenge };
+}
+
+export function grokAuthorizeUrl(
+  state: string,
+  redirectUri: string,
+  challenge: string,
+): string {
+  const q = new URLSearchParams({
+    response_type: 'code',
+    client_id: GROK_OAUTH_CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: GROK_OAUTH_SCOPES,
+    state,
+    nonce: state,
+    plan: 'generic',
+    referrer: 'cli-proxy-api',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  return `${GROK_OAUTH_ISSUER}/oauth2/authorize?${q.toString().replace(/%20/g, '+')}`;
+}
+
+export function decodeGrokEmail(token: string): string {
+  const parts = token.split('.');
+  if (parts.length !== 3) return '';
+  try {
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf8');
+    const claims = JSON.parse(payload) as {
+      email?: string;
+      preferred_username?: string;
+    };
+    return claims.email || claims.preferred_username || '';
+  } catch {
+    return '';
+  }
+}
+
+export function grokCredentialSnapshot(credential: GrokCredential): string {
+  return JSON.stringify({
+    accessToken: credential.accessToken,
+    refreshToken: credential.refreshToken,
+    idToken: credential.idToken || '',
+    expiresAt: credential.expiresAt || '',
+    email: credential.email || '',
+  });
+}
+
+export function enrichGrokCredential(credential: GrokCredential): void {
+  if (credential.email) return;
+  const sources = [credential.idToken, credential.accessToken].filter(
+    (value): value is string => !!value,
+  );
+  for (const token of sources) {
+    const email = decodeGrokEmail(token);
+    if (email) {
+      credential.email = email;
+      return;
+    }
+  }
+}
+
+export function credentialFromGrokTokenResponse(
+  raw: unknown,
+  previous?: GrokCredential,
+): GrokCredential {
+  const token = raw as {
+    access_token?: string;
+    refresh_token?: string;
+    id_token?: string;
+    expires_in?: number;
+  };
+  if (!token.access_token) {
+    throw new Error('xAI token response is missing access_token');
+  }
+  const credential: GrokCredential = {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token || previous?.refreshToken || '',
+    idToken: token.id_token || previous?.idToken,
+    email: previous?.email,
+    expiresAt: previous?.expiresAt,
+  };
+  if (typeof token.expires_in === 'number' && token.expires_in > 0) {
+    credential.expiresAt = new Date(
+      Date.now() + token.expires_in * 1000,
+    ).toISOString();
+  }
+  enrichGrokCredential(credential);
+  return credential;
+}
+
+export async function exchangeGrokCode(
+  code: string,
+  redirectUri: string,
+  verifier: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<GrokCredential> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    client_id: GROK_OAUTH_CLIENT_ID,
+    code_verifier: verifier,
+  });
+  const res = await fetchImpl(`${GROK_OAUTH_ISSUER}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    },
+    body: body.toString(),
+  });
+  if (res.status < 200 || res.status >= 300) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `xAI token exchange failed (HTTP ${res.status})${text ? `: ${text.slice(0, 200)}` : ''}`,
+    );
+  }
+  return credentialFromGrokTokenResponse(await res.json());
+}
+
+export async function refreshGrokCredential(
+  stale: GrokCredential,
+  fetchImpl: typeof fetch = fetch,
+): Promise<GrokCredential> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: stale.refreshToken,
+    client_id: GROK_OAUTH_CLIENT_ID,
+  });
+  const res = await fetchImpl(`${GROK_OAUTH_ISSUER}/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    },
+    body: body.toString(),
+  });
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`grok token refresh HTTP ${res.status}`);
+  }
+  const raw = (await res.json()) as unknown;
+  return credentialFromGrokTokenResponse(raw, stale);
+}

--- a/src/grok-translator.ts
+++ b/src/grok-translator.ts
@@ -1,0 +1,158 @@
+/**
+ * Grok (xAI) Responses adapter on top of the Codex Anthropic translator.
+ *
+ * Same Messages → Responses mapping as Codex. Differences: default model
+ * grok-4.5, reasoning effort low|medium|high, and grok-shell client headers
+ * required by cli-chat-proxy.
+ */
+
+import {
+  anthropicToCodexRequest,
+  type AnthropicMessagesRequest,
+  type CodexResponsesRequest,
+} from './codex-translator.js';
+
+export const GROK_DEFAULT_MODEL = 'grok-4.5';
+export const GROK_RESPONSES_URL =
+  'https://cli-chat-proxy.grok.com/v1/responses';
+export const GROK_DEFAULT_BASE = 'https://cli-chat-proxy.grok.com/v1';
+
+export const GROK_TOKEN_AUTH = 'xai-grok-cli';
+export const GROK_CLIENT_VERSION = '0.2.93';
+export const GROK_CLIENT_IDENTIFIER = 'grok-shell';
+export const GROK_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36';
+
+export type GrokEffort = 'low' | 'medium' | 'high';
+
+export interface GrokCredential {
+  accessToken: string;
+  refreshToken: string;
+  idToken?: string;
+  expiresAt?: string;
+  email?: string;
+}
+
+export interface GrokResponsesRequest extends Omit<
+  CodexResponsesRequest,
+  'reasoning'
+> {
+  reasoning: { effort: GrokEffort; summary: 'auto' };
+}
+
+export function grokEffort(effort: string | undefined | null): GrokEffort {
+  switch (
+    String(effort || '')
+      .trim()
+      .toLowerCase()
+  ) {
+    case 'low':
+    case 'minimal':
+      return 'low';
+    case 'high':
+    case 'max':
+    case 'xhigh':
+    case 'ultracode':
+      return 'high';
+    default:
+      return 'medium';
+  }
+}
+
+export function parseGrokCredential(secret: string): GrokCredential {
+  try {
+    const parsed = JSON.parse(secret) as Partial<GrokCredential> & {
+      access_token?: string;
+      refresh_token?: string;
+      id_token?: string;
+      expires_at?: string;
+    };
+    if (parsed && typeof parsed === 'object') {
+      const accessToken = parsed.accessToken || parsed.access_token || '';
+      if (accessToken) {
+        return {
+          accessToken: String(accessToken),
+          refreshToken: String(
+            parsed.refreshToken || parsed.refresh_token || '',
+          ),
+          idToken:
+            parsed.idToken || parsed.id_token
+              ? String(parsed.idToken || parsed.id_token)
+              : undefined,
+          expiresAt:
+            parsed.expiresAt || parsed.expires_at
+              ? String(parsed.expiresAt || parsed.expires_at)
+              : undefined,
+          email: parsed.email ? String(parsed.email) : undefined,
+        };
+      }
+    }
+  } catch {
+    // fall through: treat the whole string as a bare access token
+  }
+  const trimmed = secret.trim();
+  if (!trimmed) {
+    throw new Error('grok credential is missing access_token');
+  }
+  return { accessToken: trimmed, refreshToken: '' };
+}
+
+export function grokUpstreamHeaders(
+  accessToken: string,
+): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+    'User-Agent': GROK_USER_AGENT,
+    'X-XAI-Token-Auth': GROK_TOKEN_AUTH,
+    'x-grok-client-version': GROK_CLIENT_VERSION,
+    'x-grok-client-identifier': GROK_CLIENT_IDENTIFIER,
+  };
+}
+
+export function anthropicToGrokRequest(
+  req: AnthropicMessagesRequest,
+  effort?: string | null,
+): GrokResponsesRequest {
+  const body = anthropicToCodexRequest({
+    ...req,
+    model: req.model?.trim() || GROK_DEFAULT_MODEL,
+  });
+  return {
+    ...body,
+    reasoning: { effort: grokEffort(effort), summary: 'auto' },
+  };
+}
+
+export function extractGrokAuthCode(input: string): {
+  code: string;
+  state?: string;
+} {
+  const trimmed = input.trim();
+  if (!trimmed) return { code: '' };
+
+  const fromSearch = (search: string): { code: string; state?: string } => {
+    const params = new URLSearchParams(
+      search.startsWith('?') ? search.slice(1) : search,
+    );
+    const code = params.get('code')?.trim() || '';
+    const state = params.get('state')?.trim() || undefined;
+    return { code, state };
+  };
+
+  try {
+    const url = new URL(trimmed);
+    const parsed = fromSearch(url.search);
+    if (parsed.code) return parsed;
+  } catch {
+    // not a full URL
+  }
+
+  if (trimmed.includes('code=')) {
+    const query = trimmed.includes('?') ? trimmed.split('?')[1] : trimmed;
+    const parsed = fromSearch(query);
+    if (parsed.code) return parsed;
+  }
+
+  return { code: trimmed.split('#')[0]?.split('&')[0] ?? trimmed };
+}

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -128,6 +128,15 @@ import {
   updateAllSessionCredentials,
   appendImConfigAudit,
 } from '../runtime-config.js';
+import type { CodexOAuthCredentials } from '../runtime-config.js';
+import {
+  CODEX_OAUTH_TTL_MS,
+  exchangeCodexDeviceGrant,
+  pollCodexDeviceGrant,
+  requestCodexDeviceCode,
+  verificationUrl,
+} from '../codex-oauth.js';
+import { CODEX_DEFAULT_MODEL } from '../codex-runtime.js';
 import type {
   ClaudeOAuthCredentials,
   CachedOAuthUsage,
@@ -755,11 +764,33 @@ interface OAuthFlow {
 }
 const oauthFlows = new Map<string, OAuthFlow>();
 
+interface CodexOAuthFlow {
+  id: string;
+  verificationUrl: string;
+  userCode: string;
+  status: 'pending' | 'completed' | 'failed' | 'expired';
+  accountName?: string;
+  providerId?: string;
+  error?: string;
+  expiresAt: number;
+  targetProviderId?: string;
+}
+const codexOAuthFlows = new Map<string, CodexOAuthFlow>();
+
 // Periodic cleanup of expired flows
 setInterval(() => {
   const now = Date.now();
   for (const [key, flow] of oauthFlows) {
     if (flow.expiresAt < now) oauthFlows.delete(key);
+  }
+  for (const [key, flow] of codexOAuthFlows) {
+    if (flow.expiresAt < now && flow.status === 'pending') {
+      flow.status = 'expired';
+      flow.error = 'Authorization expired';
+    }
+    if (flow.expiresAt + 60 * 60 * 1000 < now) {
+      codexOAuthFlows.delete(key);
+    }
   }
 }, 60_000);
 
@@ -1622,6 +1653,134 @@ configRoutes.post(
     }
   },
 );
+
+// ─── POST /codex/oauth/start — Codex device-code OAuth ─────
+configRoutes.post(
+  '/codex/oauth/start',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const targetProviderId =
+      typeof (body as Record<string, unknown>).targetProviderId === 'string'
+        ? ((body as Record<string, unknown>).targetProviderId as string)
+        : undefined;
+    try {
+      const device = await requestCodexDeviceCode();
+      const id = `oa_${randomBytes(12).toString('hex')}`;
+      const flow: CodexOAuthFlow = {
+        id,
+        verificationUrl: verificationUrl(),
+        userCode: device.userCode,
+        status: 'pending',
+        expiresAt: Date.now() + CODEX_OAUTH_TTL_MS,
+        targetProviderId,
+      };
+      codexOAuthFlows.set(id, flow);
+      void completeCodexOAuth(id, device).catch((err) => {
+        logger.warn({ err, id }, 'Codex OAuth background poll failed');
+      });
+      return c.json({
+        id: flow.id,
+        verificationUrl: flow.verificationUrl,
+        userCode: flow.userCode,
+        status: flow.status,
+        expiresAt: new Date(flow.expiresAt).toISOString(),
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to start Codex OAuth';
+      logger.warn({ err }, 'Codex OAuth start failed');
+      return c.json({ error: message }, 502);
+    }
+  },
+);
+
+configRoutes.get(
+  '/codex/oauth/:id',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const id = c.req.param('id');
+    const flow = codexOAuthFlows.get(id);
+    if (!flow) {
+      return c.json({ error: 'Authorization flow not found or expired' }, 404);
+    }
+    if (flow.status === 'pending' && Date.now() > flow.expiresAt) {
+      flow.status = 'expired';
+      flow.error = 'Authorization expired';
+    }
+    return c.json({
+      id: flow.id,
+      verificationUrl: flow.verificationUrl,
+      userCode: flow.userCode,
+      status: flow.status,
+      accountName: flow.accountName,
+      providerId: flow.providerId,
+      error: flow.error,
+      expiresAt: new Date(flow.expiresAt).toISOString(),
+    });
+  },
+);
+
+async function completeCodexOAuth(
+  flowId: string,
+  device: { deviceAuthId: string; userCode: string; interval: number },
+): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CODEX_OAUTH_TTL_MS);
+  try {
+    const grant = await pollCodexDeviceGrant(device, {
+      signal: controller.signal,
+    });
+    const credential = await exchangeCodexDeviceGrant(grant);
+    const actorFlow = codexOAuthFlows.get(flowId);
+    const provider = persistCodexOAuthProvider(
+      credential,
+      actorFlow?.targetProviderId,
+    );
+    const flow = codexOAuthFlows.get(flowId);
+    if (flow) {
+      flow.status = 'completed';
+      flow.providerId = provider.id;
+      flow.accountName = provider.name;
+    }
+  } catch (err) {
+    const flow = codexOAuthFlows.get(flowId);
+    if (flow) {
+      const expired =
+        err instanceof Error &&
+        (err.name === 'AbortError' || /expired/i.test(err.message));
+      flow.status = expired ? 'expired' : 'failed';
+      flow.error = expired
+        ? 'Authorization expired'
+        : err instanceof Error
+          ? err.message
+          : 'Codex authorization failed';
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function persistCodexOAuthProvider(
+  credential: CodexOAuthCredentials,
+  targetProviderId?: string,
+) {
+  if (targetProviderId) {
+    return updateProviderSecrets(targetProviderId, {
+      codexOAuthCredentials: credential,
+    });
+  }
+  const name = credential.email || 'ChatGPT Codex';
+  return createProvider({
+    name,
+    type: 'codex',
+    anthropicModel: CODEX_DEFAULT_MODEL,
+    codexOAuthCredentials: credential,
+    enabled: true,
+  });
+}
 
 // ─── PUT /claude/custom-env — 更新当前启用供应商的自定义环境变量 ─────
 configRoutes.put(

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -128,7 +128,10 @@ import {
   updateAllSessionCredentials,
   appendImConfigAudit,
 } from '../runtime-config.js';
-import type { CodexOAuthCredentials } from '../runtime-config.js';
+import type {
+  CodexOAuthCredentials,
+  GrokOAuthCredentials,
+} from '../runtime-config.js';
 import {
   CODEX_OAUTH_TTL_MS,
   exchangeCodexDeviceGrant,
@@ -137,6 +140,14 @@ import {
   verificationUrl,
 } from '../codex-oauth.js';
 import { CODEX_DEFAULT_MODEL } from '../codex-runtime.js';
+import {
+  GROK_OAUTH_TTL_MS,
+  exchangeGrokCode,
+  generateGrokPkce,
+  grokAuthorizeUrl,
+  grokRedirectUri,
+} from '../grok-oauth.js';
+import { GROK_DEFAULT_MODEL, extractGrokAuthCode } from '../grok-translator.js';
 import type {
   ClaudeOAuthCredentials,
   CachedOAuthUsage,
@@ -777,6 +788,21 @@ interface CodexOAuthFlow {
 }
 const codexOAuthFlows = new Map<string, CodexOAuthFlow>();
 
+interface GrokOAuthFlow {
+  id: string;
+  state: string;
+  codeVerifier: string;
+  redirectUri: string;
+  authorizeUrl: string;
+  status: 'pending' | 'completed' | 'failed' | 'expired';
+  accountName?: string;
+  providerId?: string;
+  error?: string;
+  expiresAt: number;
+  targetProviderId?: string;
+}
+const grokOAuthFlows = new Map<string, GrokOAuthFlow>();
+
 // Periodic cleanup of expired flows
 setInterval(() => {
   const now = Date.now();
@@ -790,6 +816,15 @@ setInterval(() => {
     }
     if (flow.expiresAt + 60 * 60 * 1000 < now) {
       codexOAuthFlows.delete(key);
+    }
+  }
+  for (const [key, flow] of grokOAuthFlows) {
+    if (flow.expiresAt < now && flow.status === 'pending') {
+      flow.status = 'expired';
+      flow.error = 'Authorization expired';
+    }
+    if (flow.expiresAt + 60 * 60 * 1000 < now) {
+      grokOAuthFlows.delete(key);
     }
   }
 }, 60_000);
@@ -1781,6 +1816,190 @@ function persistCodexOAuthProvider(
     enabled: true,
   });
 }
+
+function persistGrokOAuthProvider(
+  credential: GrokOAuthCredentials,
+  targetProviderId?: string,
+) {
+  if (targetProviderId) {
+    return updateProviderSecrets(targetProviderId, {
+      grokOAuthCredentials: credential,
+    });
+  }
+  const name = credential.email || 'xAI Grok';
+  return createProvider({
+    name,
+    type: 'grok',
+    anthropicModel: GROK_DEFAULT_MODEL,
+    grokOAuthCredentials: credential,
+    enabled: true,
+  });
+}
+
+async function completeGrokOAuthFlow(
+  flow: GrokOAuthFlow,
+  code: string,
+): Promise<void> {
+  if (flow.status === 'pending' && Date.now() > flow.expiresAt) {
+    flow.status = 'expired';
+    flow.error = 'Authorization expired';
+    throw new Error(flow.error);
+  }
+  if (flow.status !== 'pending') {
+    throw new Error(`Grok authorization already ${flow.status}`);
+  }
+  const credential = await exchangeGrokCode(
+    code,
+    flow.redirectUri,
+    flow.codeVerifier,
+  );
+  const provider = persistGrokOAuthProvider(credential, flow.targetProviderId);
+  flow.status = 'completed';
+  flow.providerId = provider.id;
+  flow.accountName = provider.name;
+}
+
+function findGrokFlowByState(state: string): GrokOAuthFlow | undefined {
+  for (const flow of grokOAuthFlows.values()) {
+    if (flow.state === state && flow.status === 'pending') return flow;
+  }
+  return undefined;
+}
+
+export async function handleGrokBrowserCallback(
+  code: string,
+  state: string,
+): Promise<{ ok: boolean; error?: string; accountName?: string }> {
+  if (!code || !state) {
+    return { ok: false, error: 'missing code/state' };
+  }
+  const flow = findGrokFlowByState(state);
+  if (!flow) {
+    return { ok: false, error: 'state invalid or expired' };
+  }
+  try {
+    await completeGrokOAuthFlow(flow, code);
+    return { ok: true, accountName: flow.accountName };
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Grok token exchange failed';
+    if (flow.status === 'pending') {
+      flow.status = 'failed';
+      flow.error = message;
+    }
+    return { ok: false, error: message };
+  }
+}
+
+// ─── POST /grok/oauth/start — xAI PKCE OAuth ─────
+configRoutes.post(
+  '/grok/oauth/start',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const targetProviderId =
+      typeof (body as Record<string, unknown>).targetProviderId === 'string'
+        ? ((body as Record<string, unknown>).targetProviderId as string)
+        : undefined;
+    const pkce = generateGrokPkce();
+    const redirectUri = grokRedirectUri();
+    const authorizeUrl = grokAuthorizeUrl(
+      pkce.state,
+      redirectUri,
+      pkce.challenge,
+    );
+    const id = `goa_${randomBytes(12).toString('hex')}`;
+    const flow: GrokOAuthFlow = {
+      id,
+      state: pkce.state,
+      codeVerifier: pkce.verifier,
+      redirectUri,
+      authorizeUrl,
+      status: 'pending',
+      expiresAt: Date.now() + GROK_OAUTH_TTL_MS,
+      targetProviderId,
+    };
+    grokOAuthFlows.set(id, flow);
+    return c.json({
+      id: flow.id,
+      authorizeUrl,
+      status: flow.status,
+      expiresAt: new Date(flow.expiresAt).toISOString(),
+      note: '授权后浏览器会跳到 127.0.0.1 页面（xAI 白名单限制），把地址栏整段 URL 粘贴回 HappyClaw 完成接入',
+    });
+  },
+);
+
+configRoutes.get(
+  '/grok/oauth/:id',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const id = c.req.param('id');
+    const flow = grokOAuthFlows.get(id);
+    if (!flow) {
+      return c.json({ error: 'Authorization flow not found or expired' }, 404);
+    }
+    if (flow.status === 'pending' && Date.now() > flow.expiresAt) {
+      flow.status = 'expired';
+      flow.error = 'Authorization expired';
+    }
+    return c.json({
+      id: flow.id,
+      authorizeUrl: flow.authorizeUrl,
+      status: flow.status,
+      accountName: flow.accountName,
+      providerId: flow.providerId,
+      error: flow.error,
+      expiresAt: new Date(flow.expiresAt).toISOString(),
+    });
+  },
+);
+
+configRoutes.post(
+  '/grok/oauth/:id/code',
+  authMiddleware,
+  systemConfigMiddleware,
+  async (c) => {
+    const id = c.req.param('id');
+    const flow = grokOAuthFlows.get(id);
+    if (!flow) {
+      return c.json({ error: 'Authorization flow not found or expired' }, 404);
+    }
+    const body = await c.req.json().catch(() => ({}));
+    const raw =
+      typeof (body as { code?: unknown }).code === 'string'
+        ? (body as { code: string }).code
+        : typeof (body as { url?: unknown }).url === 'string'
+          ? (body as { url: string }).url
+          : '';
+    const parsed = extractGrokAuthCode(raw);
+    if (!parsed.code) {
+      return c.json({ error: 'Missing authorization code' }, 400);
+    }
+    if (parsed.state && parsed.state !== flow.state) {
+      return c.json({ error: 'state mismatch' }, 400);
+    }
+    try {
+      await completeGrokOAuthFlow(flow, parsed.code);
+      return c.json({
+        status: flow.status,
+        accountName: flow.accountName,
+        providerId: flow.providerId,
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Grok token exchange failed';
+      if (flow.status === 'pending') {
+        flow.status = 'failed';
+        flow.error = message;
+      }
+      const status = flow.status === 'expired' ? 400 : 502;
+      return c.json({ error: message, status: flow.status }, status);
+    }
+  },
+);
 
 // ─── PUT /claude/custom-env — 更新当前启用供应商的自定义环境变量 ─────
 configRoutes.put(

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -11,6 +11,7 @@ import {
   getCodexFacadeBaseUrl,
   issueCodexRunnerToken,
 } from './codex-runtime.js';
+import { GROK_DEFAULT_MODEL, type GrokCredential } from './grok-translator.js';
 
 const MAX_FIELD_LENGTH = 2000;
 const CURRENT_CONFIG_VERSION = 3;
@@ -233,8 +234,9 @@ export interface ClaudeOAuthCredentials {
   subscriptionType?: string; // e.g. 'max', 'pro' — written to .credentials.json if present
 }
 
-export type ProviderType = 'official' | 'third_party' | 'codex';
+export type ProviderType = 'official' | 'third_party' | 'codex' | 'grok';
 export type CodexOAuthCredentials = CodexCredential;
+export type GrokOAuthCredentials = GrokCredential;
 
 export interface OAuthUsageBucket {
   utilization: number; // 0-100
@@ -342,6 +344,7 @@ interface SecretPayload {
   claudeCodeOauthToken: string;
   claudeOAuthCredentials?: ClaudeOAuthCredentials | null;
   codexOAuthCredentials?: CodexOAuthCredentials | null;
+  grokOAuthCredentials?: GrokOAuthCredentials | null;
 }
 
 interface EncryptedSecrets {
@@ -486,6 +489,7 @@ export interface UnifiedProvider {
   claudeCodeOauthToken: string;
   claudeOAuthCredentials: ClaudeOAuthCredentials | null;
   codexOAuthCredentials: CodexOAuthCredentials | null;
+  grokOAuthCredentials: GrokOAuthCredentials | null;
   customEnv: Record<string, string>;
   updatedAt: string;
 }
@@ -511,6 +515,8 @@ export interface UnifiedProviderPublic {
   hasCodexOAuthCredentials: boolean;
   codexOAuthEmailMasked: string | null;
   codexOAuthPlanType: string | null;
+  hasGrokOAuthCredentials: boolean;
+  grokOAuthEmailMasked: string | null;
   customEnv: Record<string, string>;
   updatedAt: string;
 }
@@ -800,6 +806,26 @@ function decryptSecrets(secrets: EncryptedSecrets): SecretPayload {
         ...(typeof creds.planType === 'string'
           ? { planType: creds.planType }
           : {}),
+      };
+    }
+  }
+  if (
+    parsed.grokOAuthCredentials &&
+    typeof parsed.grokOAuthCredentials === 'object'
+  ) {
+    const creds = parsed.grokOAuthCredentials as Record<string, unknown>;
+    if (typeof creds.accessToken === 'string' && creds.accessToken) {
+      result.grokOAuthCredentials = {
+        accessToken: creds.accessToken,
+        refreshToken:
+          typeof creds.refreshToken === 'string' ? creds.refreshToken : '',
+        ...(typeof creds.idToken === 'string'
+          ? { idToken: creds.idToken }
+          : {}),
+        ...(typeof creds.expiresAt === 'string'
+          ? { expiresAt: creds.expiresAt }
+          : {}),
+        ...(typeof creds.email === 'string' ? { email: creds.email } : {}),
       };
     }
   }
@@ -1168,6 +1194,7 @@ function toStoredProviderV4(provider: UnifiedProvider): StoredProviderV4 {
     claudeCodeOauthToken: provider.claudeCodeOauthToken || '',
     claudeOAuthCredentials: provider.claudeOAuthCredentials ?? null,
     codexOAuthCredentials: provider.codexOAuthCredentials ?? null,
+    grokOAuthCredentials: provider.grokOAuthCredentials ?? null,
   };
   const sanitizedEnv = sanitizeCustomEnvMap(provider.customEnv || {}, {
     skipReservedClaudeKeys: true,
@@ -1189,7 +1216,12 @@ function toStoredProviderV4(provider: UnifiedProvider): StoredProviderV4 {
 }
 
 function normalizeStoredProviderType(type: unknown): ProviderType {
-  if (type === 'codex' || type === 'third_party' || type === 'official') {
+  if (
+    type === 'codex' ||
+    type === 'grok' ||
+    type === 'third_party' ||
+    type === 'official'
+  ) {
     return type;
   }
   return 'official';
@@ -1210,6 +1242,7 @@ function fromStoredProviderV4(stored: StoredProviderV4): UnifiedProvider {
     claudeCodeOauthToken: secrets.claudeCodeOauthToken || '',
     claudeOAuthCredentials: secrets.claudeOAuthCredentials ?? null,
     codexOAuthCredentials: secrets.codexOAuthCredentials ?? null,
+    grokOAuthCredentials: secrets.grokOAuthCredentials ?? null,
     customEnv: sanitizeCustomEnvMap(stored.customEnv || {}, {
       skipReservedClaudeKeys: true,
     }),
@@ -1244,6 +1277,7 @@ function migrateV3toV4(v3: ClaudeStoredStateV3Resolved): {
       claudeCodeOauthToken: v3.officialSecrets.claudeCodeOauthToken,
       claudeOAuthCredentials: v3.officialSecrets.claudeOAuthCredentials ?? null,
       codexOAuthCredentials: null,
+      grokOAuthCredentials: null,
       customEnv: v3.officialCustomEnv || {},
       updatedAt: v3.officialUpdatedAt || now,
     });
@@ -1265,6 +1299,7 @@ function migrateV3toV4(v3: ClaudeStoredStateV3Resolved): {
       claudeCodeOauthToken: '',
       claudeOAuthCredentials: null,
       codexOAuthCredentials: null,
+      grokOAuthCredentials: null,
       customEnv: profile.customEnv || {},
       updatedAt: profile.updatedAt || now,
     });
@@ -1503,6 +1538,7 @@ export function createProvider(input: {
   claudeCodeOauthToken?: string;
   claudeOAuthCredentials?: ClaudeOAuthCredentials | null;
   codexOAuthCredentials?: CodexOAuthCredentials | null;
+  grokOAuthCredentials?: GrokOAuthCredentials | null;
   customEnv?: Record<string, string>;
   weight?: number;
   enabled?: boolean;
@@ -1541,19 +1577,28 @@ export function createProvider(input: {
       : '',
     claudeOAuthCredentials: input.claudeOAuthCredentials ?? null,
     codexOAuthCredentials: input.codexOAuthCredentials ?? null,
+    grokOAuthCredentials: input.grokOAuthCredentials ?? null,
     customEnv: sanitizeCustomEnvMap(input.customEnv || {}, {
       skipReservedClaudeKeys: true,
     }),
     updatedAt: now,
   };
-  if (provider.type === 'codex') {
+  if (provider.type === 'codex' || provider.type === 'grok') {
     provider.anthropicBaseUrl = '';
     provider.anthropicAuthToken = '';
     provider.anthropicApiKey = '';
     provider.claudeCodeOauthToken = '';
     provider.claudeOAuthCredentials = null;
-    if (!provider.anthropicModel) {
-      provider.anthropicModel = CODEX_DEFAULT_MODEL;
+    if (provider.type === 'codex') {
+      provider.grokOAuthCredentials = null;
+      if (!provider.anthropicModel) {
+        provider.anthropicModel = CODEX_DEFAULT_MODEL;
+      }
+    } else {
+      provider.codexOAuthCredentials = null;
+      if (!provider.anthropicModel) {
+        provider.anthropicModel = GROK_DEFAULT_MODEL;
+      }
     }
   }
 
@@ -1623,6 +1668,8 @@ export function updateProviderSecrets(
     clearClaudeOAuthCredentials?: boolean;
     codexOAuthCredentials?: CodexOAuthCredentials;
     clearCodexOAuthCredentials?: boolean;
+    grokOAuthCredentials?: GrokOAuthCredentials;
+    clearGrokOAuthCredentials?: boolean;
   },
 ): UnifiedProvider {
   const state = readStoredStateV4();
@@ -1673,6 +1720,12 @@ export function updateProviderSecrets(
     updated.codexOAuthCredentials = secrets.codexOAuthCredentials;
   } else if (secrets.clearCodexOAuthCredentials) {
     updated.codexOAuthCredentials = null;
+  }
+
+  if (secrets.grokOAuthCredentials) {
+    updated.grokOAuthCredentials = secrets.grokOAuthCredentials;
+  } else if (secrets.clearGrokOAuthCredentials) {
+    updated.grokOAuthCredentials = null;
   }
 
   state.providers[idx] = updated;
@@ -1808,18 +1861,20 @@ export function providerToConfig(
   };
 }
 
-/** Runner env for a provider. Codex is the only type that uses the local facade. */
+/** Runner env for a provider. Codex and Grok use the local Anthropic facade. */
 export function toRunnerProviderConfig(
   provider: UnifiedProvider,
 ): ClaudeProviderConfig {
-  if (provider.type === 'codex') {
+  if (provider.type === 'codex' || provider.type === 'grok') {
     return {
       anthropicBaseUrl: getCodexFacadeBaseUrl(),
       anthropicAuthToken: issueCodexRunnerToken(provider.id),
       anthropicApiKey: '',
       claudeCodeOauthToken: '',
       claudeOAuthCredentials: null,
-      anthropicModel: provider.anthropicModel || CODEX_DEFAULT_MODEL,
+      anthropicModel:
+        provider.anthropicModel ||
+        (provider.type === 'grok' ? GROK_DEFAULT_MODEL : CODEX_DEFAULT_MODEL),
       updatedAt: provider.updatedAt,
     };
   }
@@ -1836,6 +1891,33 @@ export function getRunnerProviderConfig(): ClaudeProviderConfig {
     if (selected) return toRunnerProviderConfig(selected);
   }
   return defaultsFromEnv();
+}
+
+export function updateProviderGrokCredentialsIfCurrent(
+  id: string,
+  expected: GrokOAuthCredentials,
+  refreshed: GrokOAuthCredentials,
+): boolean {
+  const state = readStoredStateV4();
+  if (!state) throw new Error('Claude 配置不存在');
+  const idx = state.providers.findIndex((provider) => provider.id === id);
+  if (idx < 0) throw new Error('未找到指定供应商');
+  const current = state.providers[idx];
+  const currentCred = current.grokOAuthCredentials;
+  if (
+    !currentCred ||
+    currentCred.accessToken !== expected.accessToken ||
+    currentCred.refreshToken !== expected.refreshToken
+  ) {
+    return false;
+  }
+  state.providers[idx] = {
+    ...current,
+    grokOAuthCredentials: { ...refreshed },
+    updatedAt: new Date().toISOString(),
+  };
+  writeStoredStateV4(state.providers, state.balancing, state.defaultProviderId);
+  return true;
 }
 
 export function updateProviderCodexCredentialsIfCurrent(
@@ -1894,6 +1976,10 @@ export function toPublicProvider(
       ? maskSecret(provider.codexOAuthCredentials.email)
       : null,
     codexOAuthPlanType: provider.codexOAuthCredentials?.planType ?? null,
+    hasGrokOAuthCredentials: !!provider.grokOAuthCredentials,
+    grokOAuthEmailMasked: provider.grokOAuthCredentials?.email
+      ? maskSecret(provider.grokOAuthCredentials.email)
+      : null,
     customEnv: provider.customEnv || {},
     updatedAt: provider.updatedAt,
   };

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -5,6 +5,12 @@ import os from 'os';
 
 import { ASSISTANT_NAME, DATA_DIR } from './config.js';
 import { logger } from './logger.js';
+import type { CodexCredential } from './codex-translator.js';
+import {
+  CODEX_DEFAULT_MODEL,
+  getCodexFacadeBaseUrl,
+  issueCodexRunnerToken,
+} from './codex-runtime.js';
 
 const MAX_FIELD_LENGTH = 2000;
 const CURRENT_CONFIG_VERSION = 3;
@@ -227,6 +233,9 @@ export interface ClaudeOAuthCredentials {
   subscriptionType?: string; // e.g. 'max', 'pro' — written to .credentials.json if present
 }
 
+export type ProviderType = 'official' | 'third_party' | 'codex';
+export type CodexOAuthCredentials = CodexCredential;
+
 export interface OAuthUsageBucket {
   utilization: number; // 0-100
   resets_at: string; // ISO 8601
@@ -332,6 +341,7 @@ interface SecretPayload {
   anthropicApiKey: string;
   claudeCodeOauthToken: string;
   claudeOAuthCredentials?: ClaudeOAuthCredentials | null;
+  codexOAuthCredentials?: CodexOAuthCredentials | null;
 }
 
 interface EncryptedSecrets {
@@ -435,7 +445,7 @@ const DEFAULT_BALANCING_CONFIG: BalancingConfig = {
 interface StoredProviderV4 {
   id: string;
   name: string;
-  type: 'official' | 'third_party';
+  type: ProviderType;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -466,7 +476,7 @@ interface StoredClaudeProviderConfigV5 {
 export interface UnifiedProvider {
   id: string;
   name: string;
-  type: 'official' | 'third_party';
+  type: ProviderType;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -475,6 +485,7 @@ export interface UnifiedProvider {
   anthropicApiKey: string;
   claudeCodeOauthToken: string;
   claudeOAuthCredentials: ClaudeOAuthCredentials | null;
+  codexOAuthCredentials: CodexOAuthCredentials | null;
   customEnv: Record<string, string>;
   updatedAt: string;
 }
@@ -483,7 +494,7 @@ export interface UnifiedProvider {
 export interface UnifiedProviderPublic {
   id: string;
   name: string;
-  type: 'official' | 'third_party';
+  type: ProviderType;
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -497,6 +508,9 @@ export interface UnifiedProviderPublic {
   hasClaudeOAuthCredentials: boolean;
   claudeOAuthCredentialsExpiresAt: number | null;
   claudeOAuthCredentialsAccessTokenMasked: string | null;
+  hasCodexOAuthCredentials: boolean;
+  codexOAuthEmailMasked: string | null;
+  codexOAuthPlanType: string | null;
   customEnv: Record<string, string>;
   updatedAt: string;
 }
@@ -764,6 +778,27 @@ function decryptSecrets(secrets: EncryptedSecrets): SecretPayload {
         scopes: Array.isArray(creds.scopes) ? (creds.scopes as string[]) : [],
         ...(typeof creds.subscriptionType === 'string'
           ? { subscriptionType: creds.subscriptionType }
+          : {}),
+      };
+    }
+  }
+  if (
+    parsed.codexOAuthCredentials &&
+    typeof parsed.codexOAuthCredentials === 'object'
+  ) {
+    const creds = parsed.codexOAuthCredentials as Record<string, unknown>;
+    if (typeof creds.accessToken === 'string' && creds.accessToken) {
+      result.codexOAuthCredentials = {
+        accessToken: creds.accessToken,
+        refreshToken:
+          typeof creds.refreshToken === 'string' ? creds.refreshToken : '',
+        accountId: typeof creds.accountId === 'string' ? creds.accountId : '',
+        ...(typeof creds.idToken === 'string'
+          ? { idToken: creds.idToken }
+          : {}),
+        ...(typeof creds.email === 'string' ? { email: creds.email } : {}),
+        ...(typeof creds.planType === 'string'
+          ? { planType: creds.planType }
           : {}),
       };
     }
@@ -1132,6 +1167,7 @@ function toStoredProviderV4(provider: UnifiedProvider): StoredProviderV4 {
     anthropicApiKey: provider.anthropicApiKey || '',
     claudeCodeOauthToken: provider.claudeCodeOauthToken || '',
     claudeOAuthCredentials: provider.claudeOAuthCredentials ?? null,
+    codexOAuthCredentials: provider.codexOAuthCredentials ?? null,
   };
   const sanitizedEnv = sanitizeCustomEnvMap(provider.customEnv || {}, {
     skipReservedClaudeKeys: true,
@@ -1152,12 +1188,19 @@ function toStoredProviderV4(provider: UnifiedProvider): StoredProviderV4 {
   };
 }
 
+function normalizeStoredProviderType(type: unknown): ProviderType {
+  if (type === 'codex' || type === 'third_party' || type === 'official') {
+    return type;
+  }
+  return 'official';
+}
+
 function fromStoredProviderV4(stored: StoredProviderV4): UnifiedProvider {
   const secrets = decryptSecrets(stored.secrets);
   return {
     id: stored.id,
     name: stored.name,
-    type: stored.type,
+    type: normalizeStoredProviderType(stored.type),
     enabled: stored.enabled,
     weight: Math.max(1, Math.min(100, stored.weight || 1)),
     anthropicBaseUrl: stored.anthropicBaseUrl || '',
@@ -1166,6 +1209,7 @@ function fromStoredProviderV4(stored: StoredProviderV4): UnifiedProvider {
     anthropicApiKey: secrets.anthropicApiKey || '',
     claudeCodeOauthToken: secrets.claudeCodeOauthToken || '',
     claudeOAuthCredentials: secrets.claudeOAuthCredentials ?? null,
+    codexOAuthCredentials: secrets.codexOAuthCredentials ?? null,
     customEnv: sanitizeCustomEnvMap(stored.customEnv || {}, {
       skipReservedClaudeKeys: true,
     }),
@@ -1199,6 +1243,7 @@ function migrateV3toV4(v3: ClaudeStoredStateV3Resolved): {
       anthropicApiKey: v3.officialSecrets.anthropicApiKey,
       claudeCodeOauthToken: v3.officialSecrets.claudeCodeOauthToken,
       claudeOAuthCredentials: v3.officialSecrets.claudeOAuthCredentials ?? null,
+      codexOAuthCredentials: null,
       customEnv: v3.officialCustomEnv || {},
       updatedAt: v3.officialUpdatedAt || now,
     });
@@ -1219,6 +1264,7 @@ function migrateV3toV4(v3: ClaudeStoredStateV3Resolved): {
       anthropicApiKey: '',
       claudeCodeOauthToken: '',
       claudeOAuthCredentials: null,
+      codexOAuthCredentials: null,
       customEnv: profile.customEnv || {},
       updatedAt: profile.updatedAt || now,
     });
@@ -1449,13 +1495,14 @@ export function saveBalancingConfig(
 
 export function createProvider(input: {
   name: string;
-  type: 'official' | 'third_party';
+  type: ProviderType;
   anthropicBaseUrl?: string;
   anthropicAuthToken?: string;
   anthropicModel?: string;
   anthropicApiKey?: string;
   claudeCodeOauthToken?: string;
   claudeOAuthCredentials?: ClaudeOAuthCredentials | null;
+  codexOAuthCredentials?: CodexOAuthCredentials | null;
   customEnv?: Record<string, string>;
   weight?: number;
   enabled?: boolean;
@@ -1493,11 +1540,22 @@ export function createProvider(input: {
       ? normalizeSecret(input.claudeCodeOauthToken, 'claudeCodeOauthToken')
       : '',
     claudeOAuthCredentials: input.claudeOAuthCredentials ?? null,
+    codexOAuthCredentials: input.codexOAuthCredentials ?? null,
     customEnv: sanitizeCustomEnvMap(input.customEnv || {}, {
       skipReservedClaudeKeys: true,
     }),
     updatedAt: now,
   };
+  if (provider.type === 'codex') {
+    provider.anthropicBaseUrl = '';
+    provider.anthropicAuthToken = '';
+    provider.anthropicApiKey = '';
+    provider.claudeCodeOauthToken = '';
+    provider.claudeOAuthCredentials = null;
+    if (!provider.anthropicModel) {
+      provider.anthropicModel = CODEX_DEFAULT_MODEL;
+    }
+  }
 
   state.providers.push(provider);
   const defaultProviderId =
@@ -1563,6 +1621,8 @@ export function updateProviderSecrets(
     clearClaudeCodeOauthToken?: boolean;
     claudeOAuthCredentials?: ClaudeOAuthCredentials;
     clearClaudeOAuthCredentials?: boolean;
+    codexOAuthCredentials?: CodexOAuthCredentials;
+    clearCodexOAuthCredentials?: boolean;
   },
 ): UnifiedProvider {
   const state = readStoredStateV4();
@@ -1607,6 +1667,12 @@ export function updateProviderSecrets(
     updated.claudeCodeOauthToken = '';
   } else if (secrets.clearClaudeOAuthCredentials) {
     updated.claudeOAuthCredentials = null;
+  }
+
+  if (secrets.codexOAuthCredentials) {
+    updated.codexOAuthCredentials = secrets.codexOAuthCredentials;
+  } else if (secrets.clearCodexOAuthCredentials) {
+    updated.codexOAuthCredentials = null;
   }
 
   state.providers[idx] = updated;
@@ -1742,6 +1808,63 @@ export function providerToConfig(
   };
 }
 
+/** Runner env for a provider. Codex is the only type that uses the local facade. */
+export function toRunnerProviderConfig(
+  provider: UnifiedProvider,
+): ClaudeProviderConfig {
+  if (provider.type === 'codex') {
+    return {
+      anthropicBaseUrl: getCodexFacadeBaseUrl(),
+      anthropicAuthToken: issueCodexRunnerToken(provider.id),
+      anthropicApiKey: '',
+      claudeCodeOauthToken: '',
+      claudeOAuthCredentials: null,
+      anthropicModel: provider.anthropicModel || CODEX_DEFAULT_MODEL,
+      updatedAt: provider.updatedAt,
+    };
+  }
+  return providerToConfig(provider);
+}
+
+export function getRunnerProviderConfig(): ClaudeProviderConfig {
+  const state = readStoredStateV4();
+  if (state) {
+    const selected =
+      state.providers.find((p) => p.id === state.defaultProviderId) ??
+      state.providers.find((p) => p.enabled) ??
+      state.providers[0];
+    if (selected) return toRunnerProviderConfig(selected);
+  }
+  return defaultsFromEnv();
+}
+
+export function updateProviderCodexCredentialsIfCurrent(
+  id: string,
+  expected: CodexOAuthCredentials,
+  refreshed: CodexOAuthCredentials,
+): boolean {
+  const state = readStoredStateV4();
+  if (!state) throw new Error('Claude 配置不存在');
+  const idx = state.providers.findIndex((provider) => provider.id === id);
+  if (idx < 0) throw new Error('未找到指定供应商');
+  const current = state.providers[idx];
+  const currentCred = current.codexOAuthCredentials;
+  if (
+    !currentCred ||
+    currentCred.accessToken !== expected.accessToken ||
+    currentCred.refreshToken !== expected.refreshToken
+  ) {
+    return false;
+  }
+  state.providers[idx] = {
+    ...current,
+    codexOAuthCredentials: { ...refreshed },
+    updatedAt: new Date().toISOString(),
+  };
+  writeStoredStateV4(state.providers, state.balancing, state.defaultProviderId);
+  return true;
+}
+
 /** Convert UnifiedProvider to public (masked) representation */
 export function toPublicProvider(
   provider: UnifiedProvider,
@@ -1766,6 +1889,11 @@ export function toPublicProvider(
     claudeOAuthCredentialsAccessTokenMasked: provider.claudeOAuthCredentials
       ? maskSecret(provider.claudeOAuthCredentials.accessToken)
       : null,
+    hasCodexOAuthCredentials: !!provider.codexOAuthCredentials,
+    codexOAuthEmailMasked: provider.codexOAuthCredentials?.email
+      ? maskSecret(provider.codexOAuthCredentials.email)
+      : null,
+    codexOAuthPlanType: provider.codexOAuthCredentials?.planType ?? null,
     customEnv: provider.customEnv || {},
     updatedAt: provider.updatedAt,
   };
@@ -1792,13 +1920,13 @@ export function resolveProviderById(providerId: string): {
       state.providers.find((p) => p.enabled) || state.providers[0];
     if (!fallback) return { config: defaultsFromEnv(), customEnv: {} };
     return {
-      config: providerToConfig(fallback),
+      config: toRunnerProviderConfig(fallback),
       customEnv: fallback.customEnv,
     };
   }
 
   return {
-    config: providerToConfig(provider),
+    config: toRunnerProviderConfig(provider),
     customEnv: provider.customEnv,
   };
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1169,16 +1169,26 @@ const ProviderBaseUrlSchema = z
     { message: 'Base URL must be an HTTP(S) URL' },
   );
 
+export const CodexOAuthCredentialsSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  accountId: z.string().min(1),
+  idToken: z.string().optional(),
+  email: z.string().optional(),
+  planType: z.string().optional(),
+});
+
 export const UnifiedProviderCreateSchema = z
   .object({
     name: z.string().min(1).max(64),
-    type: z.enum(['official', 'third_party']),
+    type: z.enum(['official', 'third_party', 'codex']),
     anthropicBaseUrl: ProviderBaseUrlSchema.optional(),
     anthropicAuthToken: z.string().max(2000).optional(),
     anthropicModel: z.string().max(128).optional(),
     anthropicApiKey: z.string().max(2000).optional(),
     claudeCodeOauthToken: z.string().max(2000).optional(),
     claudeOAuthCredentials: ClaudeOAuthCredentialsSchema.optional(),
+    codexOAuthCredentials: CodexOAuthCredentialsSchema.optional(),
     customEnv: z.record(z.string().max(256), z.string().max(4096)).optional(),
     weight: z.number().int().min(1).max(100).optional(),
     enabled: z.boolean().optional(),
@@ -1225,6 +1235,8 @@ export const UnifiedProviderSecretsSchema = z
     clearClaudeCodeOauthToken: z.boolean().optional(),
     claudeOAuthCredentials: ClaudeOAuthCredentialsSchema.optional(),
     clearClaudeOAuthCredentials: z.boolean().optional(),
+    codexOAuthCredentials: CodexOAuthCredentialsSchema.optional(),
+    clearCodexOAuthCredentials: z.boolean().optional(),
   })
   .refine(
     (data) => {
@@ -1236,7 +1248,9 @@ export const UnifiedProviderSecretsSchema = z
         typeof data.claudeCodeOauthToken === 'string' ||
         data.clearClaudeCodeOauthToken === true ||
         data.claudeOAuthCredentials !== undefined ||
-        data.clearClaudeOAuthCredentials === true
+        data.clearClaudeOAuthCredentials === true ||
+        data.codexOAuthCredentials !== undefined ||
+        data.clearCodexOAuthCredentials === true
       );
     },
     { message: 'At least one secret field must be provided' },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1178,10 +1178,18 @@ export const CodexOAuthCredentialsSchema = z.object({
   planType: z.string().optional(),
 });
 
+export const GrokOAuthCredentialsSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  idToken: z.string().optional(),
+  expiresAt: z.string().optional(),
+  email: z.string().optional(),
+});
+
 export const UnifiedProviderCreateSchema = z
   .object({
     name: z.string().min(1).max(64),
-    type: z.enum(['official', 'third_party', 'codex']),
+    type: z.enum(['official', 'third_party', 'codex', 'grok']),
     anthropicBaseUrl: ProviderBaseUrlSchema.optional(),
     anthropicAuthToken: z.string().max(2000).optional(),
     anthropicModel: z.string().max(128).optional(),
@@ -1189,6 +1197,7 @@ export const UnifiedProviderCreateSchema = z
     claudeCodeOauthToken: z.string().max(2000).optional(),
     claudeOAuthCredentials: ClaudeOAuthCredentialsSchema.optional(),
     codexOAuthCredentials: CodexOAuthCredentialsSchema.optional(),
+    grokOAuthCredentials: GrokOAuthCredentialsSchema.optional(),
     customEnv: z.record(z.string().max(256), z.string().max(4096)).optional(),
     weight: z.number().int().min(1).max(100).optional(),
     enabled: z.boolean().optional(),
@@ -1237,6 +1246,8 @@ export const UnifiedProviderSecretsSchema = z
     clearClaudeOAuthCredentials: z.boolean().optional(),
     codexOAuthCredentials: CodexOAuthCredentialsSchema.optional(),
     clearCodexOAuthCredentials: z.boolean().optional(),
+    grokOAuthCredentials: GrokOAuthCredentialsSchema.optional(),
+    clearGrokOAuthCredentials: z.boolean().optional(),
   })
   .refine(
     (data) => {
@@ -1250,7 +1261,9 @@ export const UnifiedProviderSecretsSchema = z
         data.claudeOAuthCredentials !== undefined ||
         data.clearClaudeOAuthCredentials === true ||
         data.codexOAuthCredentials !== undefined ||
-        data.clearCodexOAuthCredentials === true
+        data.clearCodexOAuthCredentials === true ||
+        data.grokOAuthCredentials !== undefined ||
+        data.clearGrokOAuthCredentials === true
       );
     },
     { message: 'At least one secret field must be provided' },

--- a/src/web.ts
+++ b/src/web.ts
@@ -49,7 +49,10 @@ import {
 import authRoutes from './routes/auth.js';
 import groupRoutes from './routes/groups.js';
 import memoryRoutes from './routes/memory.js';
-import configRoutes, { injectConfigDeps } from './routes/config.js';
+import configRoutes, {
+  handleGrokBrowserCallback,
+  injectConfigDeps,
+} from './routes/config.js';
 import { codexFacadeRoutes } from './codex-facade.js';
 import tasksRoutes from './routes/tasks.js';
 import adminRoutes from './routes/admin.js';
@@ -273,6 +276,20 @@ app.route('/api/groups', fileRoutes); // File routes also under /api/groups
 app.route('/api/memory', memoryRoutes);
 app.route('/api/config', configRoutes);
 app.route('/', codexFacadeRoutes);
+
+// xAI Grok PKCE redirect_uri whitelist is http://127.0.0.1:<port>/callback
+app.get('/callback', async (c) => {
+  const code = c.req.query('code') || '';
+  const state = c.req.query('state') || '';
+  const result = await handleGrokBrowserCallback(code, state);
+  const title = result.ok ? 'Grok 已接入' : 'Grok 接入失败';
+  const body = result.ok
+    ? `<h2>Grok 订阅已接入 HappyClaw</h2><p>账号「${escapeHtml(result.accountName || 'xAI Grok')}」与默认模型 grok-4.5 已创建，可以关闭本页。</p>`
+    : `<h2>未能完成 Grok 授权</h2><p>${escapeHtml(result.error || 'unknown error')}</p><p>把地址栏整段 URL 粘贴回 HappyClaw 设置页也可完成接入。</p>`;
+  return c.html(
+    `<!doctype html><meta charset="utf-8"><title>${title}</title><div style="font-family:sans-serif;max-width:480px;margin:80px auto;text-align:center">${body}</div>`,
+  );
+});
 app.route('/api/tasks', tasksRoutes);
 app.route('/api/skills', skillsRoutes);
 app.route('/api/admin', adminRoutes);
@@ -1257,6 +1274,15 @@ async function handleAgentConversationMessage(
   };
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
 // --- Static Files ---
 
 // @hono/node-server 的 serveStatic 不支持条件请求：带 If-None-Match /
@@ -1366,7 +1392,13 @@ app.use(
     root: './web/dist',
     rewriteRequestPath: (p) => {
       // SPA fallback
-      if (p.startsWith('/api') || p.startsWith('/ws')) return p;
+      if (
+        p.startsWith('/api') ||
+        p.startsWith('/ws') ||
+        p.startsWith('/model') ||
+        p === '/callback'
+      )
+        return p;
       if (p.match(/\.\w+$/)) return p; // Has file extension
       return '/index.html';
     },

--- a/src/web.ts
+++ b/src/web.ts
@@ -50,6 +50,7 @@ import authRoutes from './routes/auth.js';
 import groupRoutes from './routes/groups.js';
 import memoryRoutes from './routes/memory.js';
 import configRoutes, { injectConfigDeps } from './routes/config.js';
+import { codexFacadeRoutes } from './codex-facade.js';
 import tasksRoutes from './routes/tasks.js';
 import adminRoutes from './routes/admin.js';
 import fileRoutes from './routes/files.js';
@@ -271,6 +272,7 @@ app.route('/api/groups', groupRoutes);
 app.route('/api/groups', fileRoutes); // File routes also under /api/groups
 app.route('/api/memory', memoryRoutes);
 app.route('/api/config', configRoutes);
+app.route('/', codexFacadeRoutes);
 app.route('/api/tasks', tasksRoutes);
 app.route('/api/skills', skillsRoutes);
 app.route('/api/admin', adminRoutes);

--- a/tests/codex-oauth.test.ts
+++ b/tests/codex-oauth.test.ts
@@ -1,0 +1,272 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-oauth-'));
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: root,
+  STORE_DIR: path.join(root, 'db'),
+  GROUPS_DIR: path.join(root, 'groups'),
+  WEB_PORT: 3456,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const runtimeConfig = await import('../src/runtime-config.js');
+const db = await import('../src/db.js');
+const oauth = await import('../src/codex-oauth.js');
+const runtime = await import('../src/codex-runtime.js');
+const { createCodexFacadeApp } = await import('../src/codex-facade.js');
+const { buildContainerEnvLines } = runtimeConfig;
+
+function jwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' }),
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.sig`;
+}
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(root, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'groups'), { recursive: true });
+  db.initDatabase();
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('Codex JWT claims', () => {
+  test('reads account id, email, and plan from OpenAI claim namespaces', () => {
+    const token = jwt({
+      email: 'owner@example.com',
+      'https://api.openai.com/auth': {
+        chatgpt_account_id: 'acct_123',
+        chatgpt_user_id: 'user_9',
+        chatgpt_plan_type: 'plus',
+      },
+    });
+    expect(oauth.decodeCodexClaims(token)).toEqual({
+      email: 'owner@example.com',
+      accountId: 'acct_123',
+      userId: 'user_9',
+      planType: 'plus',
+    });
+  });
+
+  test('falls back to the profile email claim', () => {
+    const token = jwt({
+      'https://api.openai.com/profile': { email: 'profile@example.com' },
+      'https://api.openai.com/auth': { chatgpt_account_id: 'acct_2' },
+    });
+    expect(oauth.decodeCodexClaims(token).email).toBe('profile@example.com');
+  });
+
+  test('codexTokenExpiresSoon uses exp with a refresh buffer', () => {
+    const now = 1_700_000_000_000;
+    const fresh = jwt({ exp: Math.floor((now + 30 * 60 * 1000) / 1000) });
+    const soon = jwt({ exp: Math.floor((now + 2 * 60 * 1000) / 1000) });
+    expect(oauth.codexTokenExpiresSoon(fresh, 5 * 60 * 1000, now)).toBe(false);
+    expect(oauth.codexTokenExpiresSoon(soon, 5 * 60 * 1000, now)).toBe(true);
+    expect(oauth.codexTokenExpiresSoon('not-a-jwt', 5 * 60 * 1000, now)).toBe(
+      false,
+    );
+  });
+});
+
+describe('Codex OAuth persist and refresh rotation', () => {
+  test('seals credentials, CAS-refreshes them, and never exposes plaintext', () => {
+    const first = {
+      accessToken: 'access-1',
+      refreshToken: 'refresh-1',
+      accountId: 'acct_1',
+      email: 'owner@example.com',
+      planType: 'plus',
+    };
+    const provider = runtimeConfig.createProvider({
+      name: 'ChatGPT Codex',
+      type: 'codex',
+      codexOAuthCredentials: first,
+      enabled: true,
+    });
+
+    const publicView = runtimeConfig.toPublicProvider(provider);
+    expect(publicView.hasCodexOAuthCredentials).toBe(true);
+    expect(publicView.codexOAuthPlanType).toBe('plus');
+    expect(publicView.codexOAuthEmailMasked).toBeTruthy();
+    expect(JSON.stringify(publicView)).not.toContain('access-1');
+    expect(JSON.stringify(publicView)).not.toContain('refresh-1');
+    expect(publicView.anthropicBaseUrl).toBe('');
+
+    expect(runtimeConfig.getClaudeProviderConfig()).toMatchObject({
+      anthropicBaseUrl: '',
+      anthropicAuthToken: '',
+      anthropicApiKey: '',
+    });
+
+    const runner = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)!,
+    );
+    expect(runner.anthropicBaseUrl).toBe('http://127.0.0.1:3456/model');
+    expect(runner.anthropicAuthToken).toMatch(/^[0-9a-f]{48}$/);
+    expect(
+      runtime.resolveCodexRunnerProviderId(
+        `Bearer ${runner.anthropicAuthToken}`,
+      ),
+    ).toBe(provider.id);
+
+    const rotated = {
+      accessToken: 'access-2',
+      refreshToken: 'refresh-2',
+      accountId: 'acct_1',
+      email: 'owner@example.com',
+      planType: 'plus',
+    };
+    expect(
+      runtimeConfig.updateProviderCodexCredentialsIfCurrent(
+        provider.id,
+        first,
+        rotated,
+      ),
+    ).toBe(true);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.codexOAuthCredentials,
+    ).toMatchObject({ accessToken: 'access-2', refreshToken: 'refresh-2' });
+
+    expect(
+      runtimeConfig.updateProviderCodexCredentialsIfCurrent(
+        provider.id,
+        first,
+        { ...rotated, accessToken: 'access-stale' },
+      ),
+    ).toBe(false);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.codexOAuthCredentials?.accessToken,
+    ).toBe('access-2');
+  });
+
+  test('refreshCodexCredential persists a rotated refresh token from the token endpoint', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: jwt({
+              'https://api.openai.com/auth': {
+                chatgpt_account_id: 'acct_9',
+                chatgpt_plan_type: 'pro',
+              },
+            }),
+            refresh_token: 'refresh-rotated',
+          }),
+          { status: 200 },
+        ),
+    );
+    const next = await oauth.refreshCodexCredential(
+      {
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        accountId: 'acct_9',
+      },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(next.refreshToken).toBe('refresh-rotated');
+    expect(next.accountId).toBe('acct_9');
+    expect(next.planType).toBe('pro');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});
+
+describe('official and third_party stay direct', () => {
+  test('runner env only injects the local facade for Codex', () => {
+    const official = runtimeConfig.createProvider({
+      name: 'Official Claude',
+      type: 'official',
+      anthropicApiKey: 'sk-ant-official',
+      anthropicModel: 'sonnet',
+      enabled: true,
+    });
+    const third = runtimeConfig.createProvider({
+      name: 'Gateway',
+      type: 'third_party',
+      anthropicBaseUrl: 'https://gateway.example.test',
+      anthropicAuthToken: 'gateway-token',
+      anthropicModel: 'gateway-model',
+      enabled: true,
+    });
+    const officialCfg = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === official.id)!,
+    );
+    const thirdCfg = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === third.id)!,
+    );
+    expect(officialCfg).toMatchObject({
+      anthropicBaseUrl: '',
+      anthropicApiKey: 'sk-ant-official',
+      anthropicModel: 'sonnet',
+    });
+    expect(thirdCfg).toMatchObject({
+      anthropicBaseUrl: 'https://gateway.example.test',
+      anthropicAuthToken: 'gateway-token',
+    });
+
+    const officialLines = buildContainerEnvLines(officialCfg, {}, {});
+    const thirdLines = buildContainerEnvLines(thirdCfg, {}, {});
+    expect(officialLines).toContain('HAPPYCLAW_CLAUDE_ENDPOINT_KIND=official');
+    expect(officialLines.join('\n')).not.toContain('/model');
+    expect(thirdLines).toContain('HAPPYCLAW_CLAUDE_ENDPOINT_KIND=custom');
+    expect(thirdLines).toContain(
+      'ANTHROPIC_BASE_URL=https://gateway.example.test',
+    );
+    expect(thirdLines.join('\n')).not.toContain('127.0.0.1');
+  });
+});
+
+describe('local Anthropic facade auth', () => {
+  test('rejects missing or unknown bearer without calling upstream', async () => {
+    const fetchSpy = vi.fn();
+    const previous = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const app = createCodexFacadeApp();
+      const missing = await app.request('/model/v1/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'gpt-5.6-sol',
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      });
+      const unknown = await app.request('/model/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer deadbeef',
+        },
+        body: JSON.stringify({
+          model: 'gpt-5.6-sol',
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      });
+      const count = await app.request('/model/v1/messages/count_tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      expect(missing.status).toBe(401);
+      expect(unknown.status).toBe(401);
+      expect(count.status).toBe(401);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = previous;
+    }
+  });
+});

--- a/tests/codex-translator.test.ts
+++ b/tests/codex-translator.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  anthropicToCodexRequest,
+  dropOrphanFunctionCallOutputs,
+  flattenSystemText,
+  stripThinkingBlocks,
+  translateCodexSse,
+} from '../src/codex-translator.js';
+
+describe('anthropicToCodexRequest', () => {
+  test('maps system text, user text, and tools onto Responses input', () => {
+    const body = anthropicToCodexRequest({
+      model: 'gpt-5.6-sol',
+      system: [{ type: 'text', text: 'You are a coding agent.' }],
+      messages: [{ role: 'user', content: 'list the files' }],
+      tools: [
+        {
+          name: 'Bash',
+          description: 'run a command',
+          input_schema: {
+            type: 'object',
+            properties: { command: { type: 'string' } },
+          },
+        },
+      ],
+    });
+
+    expect(body.model).toBe('gpt-5.6-sol');
+    expect(body.stream).toBe(true);
+    expect(body.store).toBe(false);
+    expect(body.instructions).toBe('You are a coding agent.');
+    expect(body.input).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'list the files' }],
+      },
+    ]);
+    expect(body.tools).toEqual([
+      {
+        type: 'function',
+        name: 'Bash',
+        description: 'run a command',
+        parameters: {
+          type: 'object',
+          properties: { command: { type: 'string' } },
+        },
+        strict: false,
+      },
+    ]);
+    expect(body.tool_choice).toBe('auto');
+  });
+
+  test('pairs assistant function_call items with later tool results', () => {
+    const body = anthropicToCodexRequest({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'call_1',
+              name: 'Bash',
+              input: { command: 'pwd' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'call_1',
+              content: [{ type: 'text', text: '/tmp' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(body.input).toEqual([
+      {
+        type: 'function_call',
+        call_id: 'call_1',
+        name: 'Bash',
+        arguments: JSON.stringify({ command: 'pwd' }),
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: '/tmp',
+      },
+    ]);
+  });
+
+  test('drops orphan function_call_output items', () => {
+    expect(
+      dropOrphanFunctionCallOutputs([
+        {
+          type: 'function_call',
+          call_id: 'keep',
+          name: 'Bash',
+          arguments: '{}',
+        },
+        { type: 'function_call_output', call_id: 'keep', output: 'ok' },
+        { type: 'function_call_output', call_id: 'missing', output: 'stale' },
+      ]),
+    ).toEqual([
+      { type: 'function_call', call_id: 'keep', name: 'Bash', arguments: '{}' },
+      { type: 'function_call_output', call_id: 'keep', output: 'ok' },
+    ]);
+  });
+
+  test('does not forward thinking blocks or orphan tool results', () => {
+    const stripped = stripThinkingBlocks([
+      { type: 'thinking', thinking: 'secret scratch' },
+      { type: 'text', text: 'visible' },
+    ]);
+    expect(stripped).toEqual([{ type: 'text', text: 'visible' }]);
+    expect(flattenSystemText([{ type: 'text', text: 'sys' }])).toBe('sys');
+
+    const body = anthropicToCodexRequest({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'thinking', thinking: 'do not send' },
+            {
+              type: 'tool_result',
+              tool_use_id: 'orphan',
+              content: 'stale',
+            },
+            { type: 'text', text: 'hello' },
+          ],
+        },
+      ],
+    });
+    expect(body.input).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'hello' }],
+      },
+    ]);
+  });
+
+  test('inserts a continue placeholder when every block is dropped', () => {
+    const body = anthropicToCodexRequest({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'gone', content: 'x' }],
+        },
+      ],
+    });
+    expect(body.input).toEqual([
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: '(continue)' }],
+      },
+    ]);
+  });
+});
+
+describe('translateCodexSse', () => {
+  test('streams text and thinking without leaking a failed upstream as success', () => {
+    const ok = translateCodexSse('gpt-5.6-sol', [
+      'data: {"type":"response.reasoning_summary_text.delta","delta":"plan"}',
+      'data: {"type":"response.output_text.delta","delta":"Hello"}',
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":11,"output_tokens":2,"input_tokens_details":{"cached_tokens":3}}}}',
+    ]);
+    expect(ok.error).toBeNull();
+    expect(ok.text).toBe('Hello');
+    expect(ok.usage).toEqual({
+      inputTokens: 11,
+      outputTokens: 2,
+      cacheReadTokens: 3,
+    });
+    expect(ok.sse).toContain('"type":"thinking"');
+    expect(ok.sse).toContain('thinking_delta');
+    expect(ok.sse).toContain('"text":"Hello"');
+    expect(ok.sse).toContain('"stop_reason":"end_turn"');
+    expect(ok.sse).toContain('event: message_stop');
+
+    const failed = translateCodexSse('gpt-5.6-sol', [
+      'data: {"type":"response.output_text.delta","delta":"partial"}',
+      'data: {"type":"response.completed","response":{"error":{"message":"upstream exploded"}}}',
+    ]);
+    expect(failed.error).toBe('upstream exploded');
+    expect(failed.text).toBe('partial');
+    expect(failed.sse).toContain('event: error');
+    expect(failed.sse).toContain('upstream exploded');
+    expect(failed.sse).not.toContain('event: message_stop');
+    expect(failed.sse).not.toContain('"stop_reason":"end_turn"');
+  });
+
+  test('reconstructs tool arguments from the Responses arg stream', () => {
+    const translated = translateCodexSse('gpt-5.6-sol', [
+      'data: {"type":"response.function_call_arguments.delta","item_id":"call_9","delta":"{\\"command\\":"}',
+      'data: {"type":"response.function_call_arguments.delta","item_id":"call_9","delta":"\\"ls\\"}"}',
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_9","name":"Bash"}}',
+      'data: {"type":"response.completed","response":{"usage":{"output_tokens":4}}}',
+    ]);
+
+    expect(translated.error).toBeNull();
+    expect(translated.toolUses).toEqual([
+      { id: 'call_9', name: 'Bash', input: { command: 'ls' } },
+    ]);
+    expect(translated.sse).toContain('"type":"tool_use"');
+    expect(translated.sse).toContain('"stop_reason":"tool_use"');
+    expect(translated.sse).toContain('input_json_delta');
+    expect(translated.sse).toMatch(/partial_json.:.\{\\"command\\":\\"ls\\"\}/);
+  });
+});

--- a/tests/grok-oauth.test.ts
+++ b/tests/grok-oauth.test.ts
@@ -1,0 +1,403 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-oauth-'));
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: root,
+  STORE_DIR: path.join(root, 'db'),
+  GROUPS_DIR: path.join(root, 'groups'),
+  WEB_PORT: 3456,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const runtimeConfig = await import('../src/runtime-config.js');
+const db = await import('../src/db.js');
+const oauth = await import('../src/grok-oauth.js');
+const translator = await import('../src/grok-translator.js');
+const runtime = await import('../src/codex-runtime.js');
+const { createCodexFacadeApp } = await import('../src/codex-facade.js');
+const { buildContainerEnvLines } = runtimeConfig;
+
+function jwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' }),
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.sig`;
+}
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(root, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'groups'), { recursive: true });
+  db.initDatabase();
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('Grok translator headers and effort', () => {
+  test('maps effort onto the three cli-chat-proxy grades', () => {
+    expect(translator.grokEffort('low')).toBe('low');
+    expect(translator.grokEffort('minimal')).toBe('low');
+    expect(translator.grokEffort('HIGH')).toBe('high');
+    expect(translator.grokEffort('xhigh')).toBe('high');
+    expect(translator.grokEffort('max')).toBe('high');
+    expect(translator.grokEffort('ultracode')).toBe('high');
+    expect(translator.grokEffort('')).toBe('medium');
+    expect(translator.grokEffort('balanced')).toBe('medium');
+  });
+
+  test('sets grok-shell identity headers required by cli-chat-proxy', () => {
+    expect(translator.grokUpstreamHeaders('tok-1')).toMatchObject({
+      Authorization: 'Bearer tok-1',
+      'X-XAI-Token-Auth': 'xai-grok-cli',
+      'x-grok-client-version': '0.2.93',
+      'x-grok-client-identifier': 'grok-shell',
+    });
+  });
+
+  test('anthropicToGrokRequest defaults to grok-4.5 and maps effort', () => {
+    const body = translator.anthropicToGrokRequest(
+      {
+        messages: [{ role: 'user', content: 'hi' }],
+      },
+      'xhigh',
+    );
+    expect(body.model).toBe('grok-4.5');
+    expect(body.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+    expect(body.stream).toBe(true);
+    expect(body.store).toBe(false);
+  });
+
+  test('extractGrokAuthCode accepts raw code or a callback URL', () => {
+    expect(translator.extractGrokAuthCode('abc123')).toEqual({
+      code: 'abc123',
+    });
+    expect(
+      translator.extractGrokAuthCode(
+        'http://127.0.0.1:3456/callback?code=from-url&state=st1',
+      ),
+    ).toEqual({ code: 'from-url', state: 'st1' });
+  });
+});
+
+describe('Grok PKCE authorize URL', () => {
+  test('uses auth.x.ai public client, PKCE, and grok-cli scopes', () => {
+    const url = oauth.grokAuthorizeUrl(
+      'st123',
+      'http://127.0.0.1:3456/callback',
+      'AQIDBA',
+    );
+    expect(url).toContain('https://auth.x.ai/oauth2/authorize');
+    expect(url).toContain('client_id=b1a00492-073a-47ea-816f-4c329264a828');
+    expect(url).toContain('response_type=code');
+    expect(url).toContain('code_challenge_method=S256');
+    expect(url).toContain('state=st123');
+    expect(url).toContain('nonce=st123');
+    expect(url).toContain('plan=generic');
+    expect(url).toContain('referrer=cli-proxy-api');
+    expect(url).toContain('grok-cli%3Aaccess');
+    expect(url).toContain(
+      'redirect_uri=http%3A%2F%2F127.0.0.1%3A3456%2Fcallback',
+    );
+    expect(url).not.toContain('prompt');
+    expect(oauth.grokRedirectUri()).toBe('http://127.0.0.1:3456/callback');
+  });
+});
+
+describe('Grok OAuth persist and refresh rotation', () => {
+  test('seals credentials, CAS-refreshes them, and never exposes plaintext', () => {
+    const first = {
+      accessToken: 'grok-access-1',
+      refreshToken: 'grok-refresh-1',
+      email: 'owner@x.ai',
+    };
+    const provider = runtimeConfig.createProvider({
+      name: 'xAI Grok',
+      type: 'grok',
+      grokOAuthCredentials: first,
+      enabled: true,
+    });
+
+    const publicView = runtimeConfig.toPublicProvider(provider);
+    expect(publicView.type).toBe('grok');
+    expect(publicView.hasGrokOAuthCredentials).toBe(true);
+    expect(publicView.grokOAuthEmailMasked).toBeTruthy();
+    expect(JSON.stringify(publicView)).not.toContain('grok-access-1');
+    expect(JSON.stringify(publicView)).not.toContain('grok-refresh-1');
+    expect(publicView.anthropicBaseUrl).toBe('');
+    expect(publicView.anthropicModel).toBe('grok-4.5');
+
+    const runner = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)!,
+    );
+    expect(runner.anthropicBaseUrl).toBe('http://127.0.0.1:3456/model');
+    expect(runner.anthropicAuthToken).toMatch(/^[0-9a-f]{48}$/);
+    expect(runner.anthropicModel).toBe('grok-4.5');
+    expect(
+      runtime.resolveCodexRunnerProviderId(
+        `Bearer ${runner.anthropicAuthToken}`,
+      ),
+    ).toBe(provider.id);
+
+    const rotated = {
+      accessToken: 'grok-access-2',
+      refreshToken: 'grok-refresh-2',
+      email: 'owner@x.ai',
+    };
+    expect(
+      runtimeConfig.updateProviderGrokCredentialsIfCurrent(
+        provider.id,
+        first,
+        rotated,
+      ),
+    ).toBe(true);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.grokOAuthCredentials,
+    ).toMatchObject({
+      accessToken: 'grok-access-2',
+      refreshToken: 'grok-refresh-2',
+    });
+    expect(
+      runtimeConfig.updateProviderGrokCredentialsIfCurrent(provider.id, first, {
+        ...rotated,
+        accessToken: 'stale',
+      }),
+    ).toBe(false);
+  });
+
+  test('refreshGrokCredential persists a rotated refresh token', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: jwt({ email: 'fresh@x.ai' }),
+            refresh_token: 'refresh-rotated',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+    );
+    const next = await oauth.refreshGrokCredential(
+      {
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+      },
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(next.refreshToken).toBe('refresh-rotated');
+    expect(next.email).toBe('fresh@x.ai');
+    expect(next.expiresAt).toBeTruthy();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});
+
+describe('official and third_party stay direct after Grok', () => {
+  test('runner env only injects the local facade for Codex and Grok', () => {
+    const official = runtimeConfig.createProvider({
+      name: 'Official Claude',
+      type: 'official',
+      anthropicApiKey: 'sk-ant-official',
+      anthropicModel: 'sonnet',
+      enabled: true,
+    });
+    const third = runtimeConfig.createProvider({
+      name: 'Gateway',
+      type: 'third_party',
+      anthropicBaseUrl: 'https://gateway.example.test',
+      anthropicAuthToken: 'gateway-token',
+      anthropicModel: 'gateway-model',
+      enabled: true,
+    });
+    const officialCfg = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === official.id)!,
+    );
+    const thirdCfg = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === third.id)!,
+    );
+    expect(officialCfg).toMatchObject({
+      anthropicBaseUrl: '',
+      anthropicApiKey: 'sk-ant-official',
+      anthropicModel: 'sonnet',
+    });
+    expect(thirdCfg).toMatchObject({
+      anthropicBaseUrl: 'https://gateway.example.test',
+      anthropicAuthToken: 'gateway-token',
+    });
+
+    const officialLines = buildContainerEnvLines(officialCfg, {}, {});
+    const thirdLines = buildContainerEnvLines(thirdCfg, {}, {});
+    expect(officialLines).toContain('HAPPYCLAW_CLAUDE_ENDPOINT_KIND=official');
+    expect(officialLines.join('\n')).not.toContain('/model');
+    expect(thirdLines).toContain('HAPPYCLAW_CLAUDE_ENDPOINT_KIND=custom');
+    expect(thirdLines).toContain(
+      'ANTHROPIC_BASE_URL=https://gateway.example.test',
+    );
+    expect(thirdLines.join('\n')).not.toContain('127.0.0.1');
+  });
+});
+
+describe('Grok facade routing and 401 refresh', () => {
+  test('sends grok-shell headers and retries once after 401 refresh', async () => {
+    const access = jwt({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email: 'owner@x.ai',
+    });
+    const provider = runtimeConfig.createProvider({
+      name: 'Grok Facade',
+      type: 'grok',
+      grokOAuthCredentials: {
+        accessToken: access,
+        refreshToken: 'refresh-live',
+        email: 'owner@x.ai',
+      },
+      enabled: true,
+    });
+    const runner = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)!,
+    );
+
+    const calls: Array<{ url: string; headers: Headers; body: unknown }> = [];
+    const previous = globalThis.fetch;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+      const rawBody = init?.body == null ? null : String(init.body);
+      let body: unknown = rawBody;
+      if (rawBody) {
+        try {
+          body = JSON.parse(rawBody);
+        } catch {
+          body = rawBody;
+        }
+      }
+      calls.push({ url, headers, body });
+      if (url.includes('auth.x.ai')) {
+        return new Response(
+          JSON.stringify({
+            access_token: jwt({
+              exp: Math.floor(Date.now() / 1000) + 3600,
+              email: 'owner@x.ai',
+            }),
+            refresh_token: 'refresh-after-401',
+          }),
+          { status: 200 },
+        );
+      }
+      if (
+        calls.filter((item) => item.url.includes('cli-chat-proxy')).length === 1
+      ) {
+        return new Response('unauthorized', { status: 401 });
+      }
+      return new Response(
+        [
+          'data: {"type":"response.output_text.delta","delta":"ok"}',
+          'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}',
+        ].join('\n'),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    try {
+      const app = createCodexFacadeApp();
+      const res = await app.request('/model/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${runner.anthropicAuthToken}`,
+        },
+        body: JSON.stringify({
+          model: 'grok-4.5',
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { content?: Array<{ text?: string }> };
+      expect(json.content?.[0]?.text).toBe('ok');
+
+      const upstream = calls.filter((item) =>
+        item.url.includes('cli-chat-proxy.grok.com/v1/responses'),
+      );
+      expect(upstream).toHaveLength(2);
+      expect(upstream[0].headers.get('X-XAI-Token-Auth')).toBe('xai-grok-cli');
+      expect(upstream[0].headers.get('x-grok-client-identifier')).toBe(
+        'grok-shell',
+      );
+      expect(upstream[0].headers.get('chatgpt-account-id')).toBeNull();
+      expect(upstream[0].body).toMatchObject({
+        model: 'grok-4.5',
+        reasoning: { effort: 'medium', summary: 'auto' },
+      });
+      expect(
+        calls.some((item) => item.url.includes('auth.x.ai/oauth2/token')),
+      ).toBe(true);
+      expect(
+        runtimeConfig.getProviders().find((item) => item.id === provider.id)
+          ?.grokOAuthCredentials?.refreshToken,
+      ).toBe('refresh-after-401');
+    } finally {
+      globalThis.fetch = previous;
+    }
+  });
+
+  test('Codex facade token still does not hit cli-chat-proxy', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Codex Control',
+      type: 'codex',
+      codexOAuthCredentials: {
+        accessToken: 'codex-access',
+        refreshToken: 'codex-refresh',
+        accountId: 'acct_1',
+      },
+      enabled: true,
+    });
+    const runner = runtimeConfig.toRunnerProviderConfig(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)!,
+    );
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('chatgpt.com')) {
+        return new Response(
+          'data: {"type":"response.output_text.delta","delta":"codex"}\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}',
+          { status: 200 },
+        );
+      }
+      return new Response('unexpected', { status: 500 });
+    });
+    const previous = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const app = createCodexFacadeApp();
+      const res = await app.request('/model/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${runner.anthropicAuthToken}`,
+        },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(fetchSpy).toHaveBeenCalled();
+      const urls = fetchSpy.mock.calls.map((call) => String(call[0]));
+      expect(urls.some((url) => url.includes('chatgpt.com'))).toBe(true);
+      expect(urls.some((url) => url.includes('cli-chat-proxy'))).toBe(false);
+    } finally {
+      globalThis.fetch = previous;
+    }
+  });
+});

--- a/web/src/components/settings/ProviderEditor.tsx
+++ b/web/src/components/settings/ProviderEditor.tsx
@@ -30,7 +30,7 @@ import {
 import type { ProviderWithHealth, EnvRow } from './types';
 import { getErrorMessage } from './types';
 
-type ProviderType = 'official' | 'third_party' | 'codex';
+type ProviderType = 'official' | 'third_party' | 'codex' | 'grok';
 type OfficialAuthTab = 'oauth' | 'setup_token' | 'api_key';
 
 const RESERVED_ENV_KEYS = new Set([
@@ -134,6 +134,11 @@ export function ProviderEditor({
   const [codexUserCode, setCodexUserCode] = useState('');
   const [codexVerifyUrl, setCodexVerifyUrl] = useState('');
   const [codexStatus, setCodexStatus] = useState<string | null>(null);
+  const [grokFlowId, setGrokFlowId] = useState<string | null>(null);
+  const [grokAuthorizeUrl, setGrokAuthorizeUrl] = useState('');
+  const [grokStatus, setGrokStatus] = useState<string | null>(null);
+  const [grokPaste, setGrokPaste] = useState('');
+  const [grokExchanging, setGrokExchanging] = useState(false);
 
   // 第三方认证
   const [authToken, setAuthToken] = useState('');
@@ -174,6 +179,10 @@ export function ProviderEditor({
       setCodexUserCode('');
       setCodexVerifyUrl('');
       setCodexStatus(null);
+      setGrokFlowId(null);
+      setGrokAuthorizeUrl('');
+      setGrokStatus(null);
+      setGrokPaste('');
       setAuthToken('');
       setAuthTokenDirty(false);
       setClearTokenOnSave(false);
@@ -363,6 +372,91 @@ export function ProviderEditor({
     };
   }, [codexFlowId, codexStatus, onSave, setError, setNotice]);
 
+  const handleGrokOAuthStart = useCallback(async () => {
+    setOauthLoading(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = {};
+      if (!isCreate && provider) {
+        body.targetProviderId = provider.id;
+      }
+      const data = await api.post<{
+        id: string;
+        authorizeUrl: string;
+        status: string;
+      }>('/api/config/grok/oauth/start', body);
+      setGrokFlowId(data.id);
+      setGrokAuthorizeUrl(data.authorizeUrl);
+      setGrokStatus(data.status);
+      setGrokPaste('');
+      window.open(data.authorizeUrl, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Grok 授权启动失败'));
+    } finally {
+      setOauthLoading(false);
+    }
+  }, [isCreate, provider, setError]);
+
+  const handleGrokOAuthPaste = useCallback(async () => {
+    if (!grokFlowId || !grokPaste.trim()) {
+      setError('请粘贴授权回调 URL 或 code');
+      return;
+    }
+    setGrokExchanging(true);
+    setError(null);
+    try {
+      const data = await api.post<{
+        status: string;
+        accountName?: string;
+      }>(`/api/config/grok/oauth/${grokFlowId}/code`, {
+        code: grokPaste.trim(),
+      });
+      setGrokStatus(data.status);
+      setNotice(
+        data.accountName
+          ? `Grok 已登录：${data.accountName}`
+          : 'Grok 登录成功，凭据已加密保存。',
+      );
+      onSave();
+    } catch (err) {
+      setError(getErrorMessage(err, 'Grok 授权码换取失败'));
+    } finally {
+      setGrokExchanging(false);
+    }
+  }, [grokFlowId, grokPaste, onSave, setError, setNotice]);
+
+  useEffect(() => {
+    if (!grokFlowId || (grokStatus && grokStatus !== 'pending')) return;
+    let cancelled = false;
+    const timer = window.setInterval(async () => {
+      try {
+        const data = await api.get<{
+          status: string;
+          accountName?: string;
+          error?: string;
+        }>(`/api/config/grok/oauth/${grokFlowId}`);
+        if (cancelled) return;
+        setGrokStatus(data.status);
+        if (data.status === 'completed') {
+          setNotice(
+            data.accountName
+              ? `Grok 已登录：${data.accountName}`
+              : 'Grok 登录成功，凭据已加密保存。',
+          );
+          onSave();
+        } else if (data.status === 'failed' || data.status === 'expired') {
+          setError(data.error || 'Grok 授权失败，请重新发起');
+        }
+      } catch {
+        // keep polling until expiry
+      }
+    }, 2500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [grokFlowId, grokStatus, onSave, setError, setNotice]);
+
   // ─── 保存 ──────────────────────────────────────────────────
   const handleSave = async () => {
     const normalizedModel =
@@ -370,7 +464,9 @@ export function ProviderEditor({
         ? buildProviderModel(model, oneMillionContext)
         : providerType === 'codex'
           ? model.trim() || 'gpt-5.6-sol'
-          : model.trim();
+          : providerType === 'grok'
+            ? model.trim() || 'grok-4.5'
+            : model.trim();
     if (providerType === 'third_party' && !normalizedModel) {
       setError('请填写第三方 API 支持的模型名称');
       return;
@@ -381,7 +477,9 @@ export function ProviderEditor({
         ? parseProviderModel(normalizedModel).model
         : providerType === 'codex'
           ? 'ChatGPT Codex'
-          : '');
+          : providerType === 'grok'
+            ? 'xAI Grok'
+            : '');
     if (!trimmedName) {
       setError('请填写模型配置名称');
       return;
@@ -427,7 +525,7 @@ export function ProviderEditor({
           }
           createBody.anthropicBaseUrl = trimmedBaseUrl;
           createBody.anthropicAuthToken = trimmedToken;
-        } else if (providerType === 'codex') {
+        } else if (providerType === 'codex' || providerType === 'grok') {
           createBody.anthropicModel = normalizedModel;
         } else {
           // 官方模式 — 根据认证方式设置凭据
@@ -577,7 +675,7 @@ export function ProviderEditor({
   };
 
   const handleClose = () => {
-    if (!saving && !oauthExchanging) {
+    if (!saving && !oauthExchanging && !grokExchanging) {
       setOauthState(null);
       onCancel();
     }
@@ -595,7 +693,9 @@ export function ProviderEditor({
               ? '填写端点、密钥和模型即可；Claude Code 运行参数会自动预填，也可在高级设置中调整。'
               : providerType === 'codex'
                 ? '通过 ChatGPT 设备码登录 Codex。Runner 仍走 Anthropic Messages，由本机 facade 翻译。'
-                : '配置 Claude 官方认证方式与默认模型。'}
+                : providerType === 'grok'
+                  ? '通过 xAI Grok CLI OAuth 登录。Runner 仍走 Anthropic Messages，由本机 facade 翻译到 cli-chat-proxy。'
+                  : '配置 Claude 官方认证方式与默认模型。'}
           </DialogDescription>
         </DialogHeader>
 
@@ -642,6 +742,18 @@ export function ProviderEditor({
                   }`}
                 >
                   Codex
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={providerType === 'grok'}
+                  onClick={() => setProviderType('grok')}
+                  className={`min-h-9 rounded-md px-3 py-1.5 text-sm transition-colors cursor-pointer ${
+                    providerType === 'grok'
+                      ? 'bg-background text-primary shadow-sm'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  Grok
                 </button>
               </div>
             </div>
@@ -1074,6 +1186,99 @@ export function ProviderEditor({
             </div>
           )}
 
+          {providerType === 'grok' && (
+            <div className="space-y-4">
+              <div className="rounded-lg border border-sky-200 bg-sky-50/50 p-4 space-y-3 dark:border-sky-800 dark:bg-sky-950/20">
+                <div className="text-sm font-medium text-foreground">
+                  xAI Grok（CLI 订阅 OAuth）
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  打开 auth.x.ai 授权后，浏览器会跳到 127.0.0.1
+                  /callback。本机部署会自动完成；远端部署请把地址栏整段 URL
+                  粘贴回来。Access / refresh token 仅在服务端交换并加密入库。
+                </div>
+                {!isCreate && provider?.hasGrokOAuthCredentials && (
+                  <div className="rounded-md border border-sky-200 bg-sky-50/50 p-3 text-xs dark:border-sky-800 dark:bg-sky-950/30">
+                    <div className="text-sky-700 dark:text-sky-300">
+                      已绑定 {provider.grokOAuthEmailMasked || 'Grok 订阅'}
+                    </div>
+                  </div>
+                )}
+                {!grokFlowId ? (
+                  <Button
+                    onClick={handleGrokOAuthStart}
+                    disabled={saving || oauthLoading}
+                  >
+                    {oauthLoading ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <ExternalLink className="size-4" />
+                    )}
+                    {!isCreate && provider?.hasGrokOAuthCredentials
+                      ? '重新登录 Grok'
+                      : '登录 xAI Grok'}
+                  </Button>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="text-xs text-amber-700 dark:text-amber-300">
+                      授权窗口已打开。完成后把地址栏 URL 或 code 粘贴到下方。
+                    </div>
+                    {grokAuthorizeUrl && (
+                      <a
+                        href={grokAuthorizeUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-teal-600 underline break-all"
+                      >
+                        {grokAuthorizeUrl}
+                      </a>
+                    )}
+                    <div className="flex gap-2">
+                      <Input
+                        type="text"
+                        value={grokPaste}
+                        onChange={(e) => setGrokPaste(e.target.value)}
+                        disabled={grokExchanging}
+                        placeholder="粘贴 http://127.0.0.1:.../callback?code=... 或授权码"
+                        className="flex-1"
+                      />
+                      <Button
+                        onClick={handleGrokOAuthPaste}
+                        disabled={grokExchanging || !grokPaste.trim()}
+                      >
+                        {grokExchanging && (
+                          <Loader2 className="size-4 animate-spin" />
+                        )}
+                        确认
+                      </Button>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      状态：{grokStatus || 'pending'}
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1">
+                  模型
+                </label>
+                <Input
+                  type="text"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  disabled={saving}
+                  placeholder="grok-4.5"
+                  className="font-mono"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  默认 grok-4.5。推理力度 low / medium /
+                  high（其余档位会映射到这三档）。Claude Agent SDK 经本机
+                  Anthropic facade 访问 cli-chat-proxy。
+                </p>
+              </div>
+            </div>
+          )}
+
           {/* ─── 官方模型选择 ─── */}
           {providerType === 'official' && (
             <div>
@@ -1311,12 +1516,15 @@ export function ProviderEditor({
             <Button
               variant="outline"
               onClick={handleClose}
-              disabled={saving || oauthExchanging}
+              disabled={saving || oauthExchanging || grokExchanging}
             >
               取消
             </Button>
             {/* OAuth 模式下创建时不需要保存按钮（OAuth 回调会自动触发 onSave） */}
-            <Button onClick={handleSave} disabled={saving || oauthExchanging}>
+            <Button
+              onClick={handleSave}
+              disabled={saving || oauthExchanging || grokExchanging}
+            >
               {saving && <Loader2 className="size-4 animate-spin" />}
               {isCreate ? '创建' : '保存'}
             </Button>

--- a/web/src/components/settings/ProviderEditor.tsx
+++ b/web/src/components/settings/ProviderEditor.tsx
@@ -30,7 +30,7 @@ import {
 import type { ProviderWithHealth, EnvRow } from './types';
 import { getErrorMessage } from './types';
 
-type ProviderType = 'official' | 'third_party';
+type ProviderType = 'official' | 'third_party' | 'codex';
 type OfficialAuthTab = 'oauth' | 'setup_token' | 'api_key';
 
 const RESERVED_ENV_KEYS = new Set([
@@ -130,6 +130,10 @@ export function ProviderEditor({
   const [oauthState, setOauthState] = useState<string | null>(null);
   const [oauthCode, setOauthCode] = useState('');
   const [oauthExchanging, setOauthExchanging] = useState(false);
+  const [codexFlowId, setCodexFlowId] = useState<string | null>(null);
+  const [codexUserCode, setCodexUserCode] = useState('');
+  const [codexVerifyUrl, setCodexVerifyUrl] = useState('');
+  const [codexStatus, setCodexStatus] = useState<string | null>(null);
 
   // 第三方认证
   const [authToken, setAuthToken] = useState('');
@@ -166,6 +170,10 @@ export function ProviderEditor({
       setApiKey('');
       setOauthState(null);
       setOauthCode('');
+      setCodexFlowId(null);
+      setCodexUserCode('');
+      setCodexVerifyUrl('');
+      setCodexStatus(null);
       setAuthToken('');
       setAuthTokenDirty(false);
       setClearTokenOnSave(false);
@@ -297,12 +305,72 @@ export function ProviderEditor({
     }
   }, [oauthState, oauthCode, setError, setNotice, onSave]);
 
+  const handleCodexOAuthStart = useCallback(async () => {
+    setOauthLoading(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = {};
+      if (!isCreate && provider) {
+        body.targetProviderId = provider.id;
+      }
+      const data = await api.post<{
+        id: string;
+        verificationUrl: string;
+        userCode: string;
+        status: string;
+      }>('/api/config/codex/oauth/start', body);
+      setCodexFlowId(data.id);
+      setCodexUserCode(data.userCode);
+      setCodexVerifyUrl(data.verificationUrl);
+      setCodexStatus(data.status);
+      window.open(data.verificationUrl, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Codex 授权启动失败'));
+    } finally {
+      setOauthLoading(false);
+    }
+  }, [isCreate, provider, setError]);
+
+  useEffect(() => {
+    if (!codexFlowId || (codexStatus && codexStatus !== 'pending')) return;
+    let cancelled = false;
+    const timer = window.setInterval(async () => {
+      try {
+        const data = await api.get<{
+          status: string;
+          accountName?: string;
+          error?: string;
+        }>(`/api/config/codex/oauth/${codexFlowId}`);
+        if (cancelled) return;
+        setCodexStatus(data.status);
+        if (data.status === 'completed') {
+          setNotice(
+            data.accountName
+              ? `Codex 已登录：${data.accountName}`
+              : 'Codex 登录成功，凭据已加密保存。',
+          );
+          onSave();
+        } else if (data.status === 'failed' || data.status === 'expired') {
+          setError(data.error || 'Codex 授权失败，请重新发起');
+        }
+      } catch {
+        // keep polling until expiry
+      }
+    }, 2500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [codexFlowId, codexStatus, onSave, setError, setNotice]);
+
   // ─── 保存 ──────────────────────────────────────────────────
   const handleSave = async () => {
     const normalizedModel =
       providerType === 'third_party'
         ? buildProviderModel(model, oneMillionContext)
-        : model.trim();
+        : providerType === 'codex'
+          ? model.trim() || 'gpt-5.6-sol'
+          : model.trim();
     if (providerType === 'third_party' && !normalizedModel) {
       setError('请填写第三方 API 支持的模型名称');
       return;
@@ -311,7 +379,9 @@ export function ProviderEditor({
       name.trim() ||
       (providerType === 'third_party'
         ? parseProviderModel(normalizedModel).model
-        : '');
+        : providerType === 'codex'
+          ? 'ChatGPT Codex'
+          : '');
     if (!trimmedName) {
       setError('请填写模型配置名称');
       return;
@@ -357,6 +427,8 @@ export function ProviderEditor({
           }
           createBody.anthropicBaseUrl = trimmedBaseUrl;
           createBody.anthropicAuthToken = trimmedToken;
+        } else if (providerType === 'codex') {
+          createBody.anthropicModel = normalizedModel;
         } else {
           // 官方模式 — 根据认证方式设置凭据
           if (authTab === 'setup_token') {
@@ -521,7 +593,9 @@ export function ProviderEditor({
           <DialogDescription className="text-left text-xs leading-5">
             {providerType === 'third_party'
               ? '填写端点、密钥和模型即可；Claude Code 运行参数会自动预填，也可在高级设置中调整。'
-              : '配置 Claude 官方认证方式与默认模型。'}
+              : providerType === 'codex'
+                ? '通过 ChatGPT 设备码登录 Codex。Runner 仍走 Anthropic Messages，由本机 facade 翻译。'
+                : '配置 Claude 官方认证方式与默认模型。'}
           </DialogDescription>
         </DialogHeader>
 
@@ -556,6 +630,18 @@ export function ProviderEditor({
                   }`}
                 >
                   第三方
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={providerType === 'codex'}
+                  onClick={() => setProviderType('codex')}
+                  className={`min-h-9 rounded-md px-3 py-1.5 text-sm transition-colors cursor-pointer ${
+                    providerType === 'codex'
+                      ? 'bg-background text-primary shadow-sm'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  Codex
                 </button>
               </div>
             </div>
@@ -906,6 +992,84 @@ export function ProviderEditor({
                     </p>
                   </div>
                 </div>
+              </div>
+            </div>
+          )}
+
+          {providerType === 'codex' && (
+            <div className="space-y-4">
+              <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 space-y-3 dark:border-emerald-800 dark:bg-emerald-950/20">
+                <div className="text-sm font-medium text-foreground">
+                  ChatGPT Codex（设备码登录）
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  浏览器只接触一次性验证码。Access / refresh token
+                  仅在服务端交换并加密入库，API 不返回明文。
+                </div>
+                {!isCreate && provider?.hasCodexOAuthCredentials && (
+                  <div className="rounded-md border border-emerald-200 bg-emerald-50/50 p-3 text-xs dark:border-emerald-800 dark:bg-emerald-950/30">
+                    <div className="text-emerald-700 dark:text-emerald-300">
+                      已绑定 {provider.codexOAuthEmailMasked || 'ChatGPT 订阅'}
+                      {provider.codexOAuthPlanType
+                        ? ` · ${provider.codexOAuthPlanType}`
+                        : ''}
+                    </div>
+                  </div>
+                )}
+                {!codexFlowId ? (
+                  <Button
+                    onClick={handleCodexOAuthStart}
+                    disabled={saving || oauthLoading}
+                  >
+                    {oauthLoading ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <ExternalLink className="size-4" />
+                    )}
+                    {!isCreate && provider?.hasCodexOAuthCredentials
+                      ? '重新登录 ChatGPT'
+                      : '登录 ChatGPT Codex'}
+                  </Button>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="text-xs text-amber-700 dark:text-amber-300">
+                      在 ChatGPT 打开验证页，输入代码{' '}
+                      <code className="rounded bg-muted px-1 font-mono">
+                        {codexUserCode}
+                      </code>
+                    </div>
+                    {codexVerifyUrl && (
+                      <a
+                        href={codexVerifyUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-teal-600 underline"
+                      >
+                        {codexVerifyUrl}
+                      </a>
+                    )}
+                    <div className="text-xs text-muted-foreground">
+                      状态：{codexStatus || 'pending'}
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1">
+                  模型
+                </label>
+                <Input
+                  type="text"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  disabled={saving}
+                  placeholder="gpt-5.6-sol"
+                  className="font-mono"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  默认 gpt-5.6-sol。Claude Agent SDK 经本机 Anthropic facade
+                  访问 Codex Responses。
+                </p>
               </div>
             </div>
           )}

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -113,6 +113,16 @@ function CredentialBadges({ provider }: { provider: ProviderWithHealth }) {
         'bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800',
     });
   }
+  if (provider.hasCodexOAuthCredentials) {
+    badges.push({
+      label: provider.codexOAuthPlanType
+        ? `Codex · ${provider.codexOAuthPlanType}`
+        : 'Codex',
+      color:
+        'bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800',
+      detail: provider.codexOAuthEmailMasked ?? undefined,
+    });
+  }
 
   if (badges.length === 0) {
     return (
@@ -199,10 +209,16 @@ export function ProviderList({
                         className={`text-[11px] px-1.5 py-0.5 rounded shrink-0 ${
                           provider.type === 'official'
                             ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
-                            : 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+                            : provider.type === 'codex'
+                              ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+                              : 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
                         }`}
                       >
-                        {provider.type === 'official' ? '官方' : '第三方'}
+                        {provider.type === 'official'
+                          ? '官方'
+                          : provider.type === 'codex'
+                            ? 'Codex'
+                            : '第三方'}
                       </span>
                       {isDefault && (
                         <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[11px] text-primary">

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -123,6 +123,14 @@ function CredentialBadges({ provider }: { provider: ProviderWithHealth }) {
       detail: provider.codexOAuthEmailMasked ?? undefined,
     });
   }
+  if (provider.hasGrokOAuthCredentials) {
+    badges.push({
+      label: 'Grok',
+      color:
+        'bg-sky-50 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300 border-sky-200 dark:border-sky-800',
+      detail: provider.grokOAuthEmailMasked ?? undefined,
+    });
+  }
 
   if (badges.length === 0) {
     return (
@@ -211,14 +219,18 @@ export function ProviderList({
                             ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
                             : provider.type === 'codex'
                               ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
-                              : 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+                              : provider.type === 'grok'
+                                ? 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300'
+                                : 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
                         }`}
                       >
                         {provider.type === 'official'
                           ? '官方'
                           : provider.type === 'codex'
                             ? 'Codex'
-                            : '第三方'}
+                            : provider.type === 'grok'
+                              ? 'Grok'
+                              : '第三方'}
                       </span>
                       {isDefault && (
                         <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[11px] text-primary">

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -3,7 +3,7 @@
 export interface UnifiedProviderPublic {
   id: string;
   name: string;
-  type: 'official' | 'third_party' | 'codex';
+  type: 'official' | 'third_party' | 'codex' | 'grok';
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -20,6 +20,8 @@ export interface UnifiedProviderPublic {
   hasCodexOAuthCredentials: boolean;
   codexOAuthEmailMasked: string | null;
   codexOAuthPlanType: string | null;
+  hasGrokOAuthCredentials: boolean;
+  grokOAuthEmailMasked: string | null;
   customEnv: Record<string, string>;
   updatedAt: string;
 }

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -3,7 +3,7 @@
 export interface UnifiedProviderPublic {
   id: string;
   name: string;
-  type: 'official' | 'third_party';
+  type: 'official' | 'third_party' | 'codex';
   enabled: boolean;
   weight: number;
   anthropicBaseUrl: string;
@@ -17,6 +17,9 @@ export interface UnifiedProviderPublic {
   hasClaudeOAuthCredentials: boolean;
   claudeOAuthCredentialsExpiresAt: number | null;
   claudeOAuthCredentialsAccessTokenMasked: string | null;
+  hasCodexOAuthCredentials: boolean;
+  codexOAuthEmailMasked: string | null;
+  codexOAuthPlanType: string | null;
   customEnv: Record<string, string>;
   updatedAt: string;
 }

--- a/web/src/pages/SetupProvidersPage.tsx
+++ b/web/src/pages/SetupProvidersPage.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useState } from 'react';
-import { ArrowRight, ExternalLink, KeyRound, Loader2, Link2, Plus, Server, ShieldCheck, X } from 'lucide-react';
+import {
+  ArrowRight,
+  ExternalLink,
+  KeyRound,
+  Loader2,
+  Link2,
+  Plus,
+  Server,
+  ShieldCheck,
+  X,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { Input } from '@/components/ui/input';
@@ -12,7 +22,7 @@ import type {
 import { getErrorMessage } from '../components/settings/types';
 import { useAuthStore } from '../stores/auth';
 
-type ProviderMode = 'official' | 'third_party' | 'codex';
+type ProviderMode = 'official' | 'third_party' | 'codex' | 'grok';
 
 const RESERVED_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
@@ -22,20 +32,32 @@ const RESERVED_ENV_KEYS = new Set([
   'ANTHROPIC_MODEL',
 ]);
 
-function buildCustomEnv(rows: EnvRow[]): { customEnv: Record<string, string>; error: string | null } {
+function buildCustomEnv(rows: EnvRow[]): {
+  customEnv: Record<string, string>;
+  error: string | null;
+} {
   const customEnv: Record<string, string> = {};
   for (const [idx, row] of rows.entries()) {
     const key = row.key.trim();
     const value = row.value.trim();
     if (!key && !value) continue;
     if (!key || !value) {
-      return { customEnv: {}, error: `第 ${idx + 1} 行环境变量的 Key 和 Value 都要填写` };
+      return {
+        customEnv: {},
+        error: `第 ${idx + 1} 行环境变量的 Key 和 Value 都要填写`,
+      };
     }
     if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
-      return { customEnv: {}, error: `环境变量 Key "${key}" 格式无效（仅允许大写字母/数字/下划线，且不能数字开头）` };
+      return {
+        customEnv: {},
+        error: `环境变量 Key "${key}" 格式无效（仅允许大写字母/数字/下划线，且不能数字开头）`,
+      };
     }
     if (RESERVED_ENV_KEYS.has(key)) {
-      return { customEnv: {}, error: `${key} 属于系统保留字段，请在必填区域填写` };
+      return {
+        customEnv: {},
+        error: `${key} 属于系统保留字段，请在必填区域填写`,
+      };
     }
     if (customEnv[key] !== undefined) {
       return { customEnv: {}, error: `环境变量 Key "${key}" 重复` };
@@ -75,6 +97,12 @@ export function SetupProvidersPage() {
   const [codexVerifyUrl, setCodexVerifyUrl] = useState('');
   const [codexStatus, setCodexStatus] = useState<string | null>(null);
   const [codexDone, setCodexDone] = useState(false);
+  const [grokFlowId, setGrokFlowId] = useState<string | null>(null);
+  const [grokAuthorizeUrl, setGrokAuthorizeUrl] = useState('');
+  const [grokStatus, setGrokStatus] = useState<string | null>(null);
+  const [grokPaste, setGrokPaste] = useState('');
+  const [grokExchanging, setGrokExchanging] = useState(false);
+  const [grokDone, setGrokDone] = useState(false);
 
   // Third-party mode
   const [baseUrl, setBaseUrl] = useState('');
@@ -96,20 +124,26 @@ export function SetupProvidersPage() {
     }
   }, [setupStatus, navigate]);
 
-  const addCustomEnvRow = () => setCustomEnvRows((rows) => [...rows, { key: '', value: '' }]);
+  const addCustomEnvRow = () =>
+    setCustomEnvRows((rows) => [...rows, { key: '', value: '' }]);
   const removeCustomEnvRow = (idx: number) =>
     setCustomEnvRows((rows) => rows.filter((_, i) => i !== idx));
-  const updateCustomEnvRow = (idx: number, field: keyof EnvRow, value: string) =>
+  const updateCustomEnvRow = (
+    idx: number,
+    field: keyof EnvRow,
+    value: string,
+  ) =>
     setCustomEnvRows((rows) =>
       rows.map((row, i) => (i === idx ? { ...row, [field]: value } : row)),
     );
-
 
   const handleOAuthStart = async () => {
     setOauthLoading(true);
     setError(null);
     try {
-      const data = await api.post<{ authorizeUrl: string; state: string }>('/api/config/claude/oauth/start');
+      const data = await api.post<{ authorizeUrl: string; state: string }>(
+        '/api/config/claude/oauth/start',
+      );
       setOauthState(data.state);
       setOauthCode('');
       window.open(data.authorizeUrl, '_blank', 'noopener,noreferrer');
@@ -173,8 +207,15 @@ export function SetupProvidersPage() {
         setError('请先完成 ChatGPT Codex 设备码登录');
         return;
       }
+    } else if (providerMode === 'grok') {
+      if (!grokDone) {
+        setError('请先完成 xAI Grok OAuth 登录');
+        return;
+      }
     } else if (!officialToken.trim() && !apiKey.trim() && !oauthDone) {
-      setError('官方渠道请通过一键登录、填写 API Key 或手动填写 setup-token / .credentials.json');
+      setError(
+        '官方渠道请通过一键登录、填写 API Key 或手动填写 setup-token / .credentials.json',
+      );
       return;
     }
 
@@ -205,7 +246,9 @@ export function SetupProvidersPage() {
           if (trimmed.startsWith('{')) {
             try {
               const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-              const oauth = parsed.claudeAiOauth as Record<string, unknown> | undefined;
+              const oauth = parsed.claudeAiOauth as
+                | Record<string, unknown>
+                | undefined;
               if (oauth?.accessToken && oauth?.refreshToken) {
                 created = true;
                 await api.post('/api/config/claude/providers', {
@@ -237,18 +280,15 @@ export function SetupProvidersPage() {
           }
         }
       } else if (providerMode === 'third_party') {
-        await api.post<UnifiedProviderPublic>(
-          '/api/config/claude/providers',
-          {
-            name: '默认第三方',
-            type: 'third_party',
-            anthropicBaseUrl: baseUrl.trim(),
-            anthropicAuthToken: authToken.trim(),
-            anthropicModel: model.trim(),
-            customEnv,
-            enabled: true,
-          },
-        );
+        await api.post<UnifiedProviderPublic>('/api/config/claude/providers', {
+          name: '默认第三方',
+          type: 'third_party',
+          anthropicBaseUrl: baseUrl.trim(),
+          anthropicAuthToken: authToken.trim(),
+          anthropicModel: model.trim(),
+          customEnv,
+          enabled: true,
+        });
       }
 
       await checkAuth();
@@ -270,27 +310,43 @@ export function SetupProvidersPage() {
     <div className="h-screen bg-background overflow-y-auto p-4">
       <div className="w-full max-w-4xl mx-auto space-y-5">
         <div className="text-center">
-          <p className="text-xs font-semibold text-primary tracking-wider mb-2">STEP 2 / 2</p>
-          <h1 className="text-2xl font-bold text-foreground mb-2">系统接入初始化</h1>
-          <p className="text-sm text-muted-foreground">此页面保存的是系统全局默认配置。完成后才进入正式后台。</p>
+          <p className="text-xs font-semibold text-primary tracking-wider mb-2">
+            STEP 2 / 2
+          </p>
+          <h1 className="text-2xl font-bold text-foreground mb-2">
+            系统接入初始化
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            此页面保存的是系统全局默认配置。完成后才进入正式后台。
+          </p>
         </div>
 
         {error && (
-          <div className="p-3 rounded-lg bg-error-bg border border-error/30 text-error text-sm">{error}</div>
+          <div className="p-3 rounded-lg bg-error-bg border border-error/30 text-error text-sm">
+            {error}
+          </div>
         )}
         {notice && (
-          <div className="p-3 rounded-lg bg-success-bg border border-success/30 text-success text-sm">{notice}</div>
+          <div className="p-3 rounded-lg bg-success-bg border border-success/30 text-success text-sm">
+            {notice}
+          </div>
         )}
 
         <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <div className="flex items-center gap-2 mb-3">
             <Link2 className="w-4 h-4 text-primary" />
-            <h2 className="text-base font-semibold text-foreground">飞书配置（可选）</h2>
+            <h2 className="text-base font-semibold text-foreground">
+              飞书配置（可选）
+            </h2>
           </div>
-          <p className="text-xs text-muted-foreground mb-3">首装不预填任何默认值，全部由你手动输入。</p>
+          <p className="text-xs text-muted-foreground mb-3">
+            首装不预填任何默认值，全部由你手动输入。
+          </p>
           <div className="grid md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium text-foreground mb-1">App ID</label>
+              <label className="block text-sm font-medium text-foreground mb-1">
+                App ID
+              </label>
               <Input
                 type="text"
                 value={feishuAppId}
@@ -299,7 +355,9 @@ export function SetupProvidersPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-foreground mb-1">App Secret</label>
+              <label className="block text-sm font-medium text-foreground mb-1">
+                App Secret
+              </label>
               <Input
                 type="password"
                 value={feishuAppSecret}
@@ -313,7 +371,9 @@ export function SetupProvidersPage() {
         <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <div className="flex items-center gap-2 mb-3">
             <KeyRound className="w-4 h-4 text-primary" />
-            <h2 className="text-base font-semibold text-foreground">模型配置（官方 / 第三方 / Codex）</h2>
+            <h2 className="text-base font-semibold text-foreground">
+              模型配置（官方 / 第三方 / Codex / Grok）
+            </h2>
           </div>
 
           <div className="inline-flex rounded-lg border border-border p-1 bg-muted mb-4">
@@ -321,7 +381,9 @@ export function SetupProvidersPage() {
               type="button"
               onClick={() => setProviderMode('official')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'official' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                providerMode === 'official'
+                  ? 'bg-background text-primary shadow-sm'
+                  : 'text-muted-foreground'
               }`}
             >
               官方渠道
@@ -330,7 +392,9 @@ export function SetupProvidersPage() {
               type="button"
               onClick={() => setProviderMode('third_party')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'third_party' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                providerMode === 'third_party'
+                  ? 'bg-background text-primary shadow-sm'
+                  : 'text-muted-foreground'
               }`}
             >
               第三方渠道
@@ -339,18 +403,161 @@ export function SetupProvidersPage() {
               type="button"
               onClick={() => setProviderMode('codex')}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                providerMode === 'codex' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                providerMode === 'codex'
+                  ? 'bg-background text-primary shadow-sm'
+                  : 'text-muted-foreground'
               }`}
             >
               Codex
             </button>
+            <button
+              type="button"
+              onClick={() => setProviderMode('grok')}
+              className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
+                providerMode === 'grok'
+                  ? 'bg-background text-primary shadow-sm'
+                  : 'text-muted-foreground'
+              }`}
+            >
+              Grok
+            </button>
           </div>
 
-          {providerMode === 'codex' ? (
+          {providerMode === 'grok' ? (
+            <div className="space-y-3 rounded-lg border border-sky-200 bg-sky-50/40 p-4">
+              <p className="text-sm text-foreground">
+                通过 xAI Grok CLI OAuth 登录。授权后把 127.0.0.1 回调 URL
+                粘贴回来。凭据加密保存。
+              </p>
+              {grokDone ? (
+                <p className="text-sm text-sky-700">Grok 已登录，可以继续。</p>
+              ) : !grokFlowId ? (
+                <Button
+                  onClick={async () => {
+                    setOauthLoading(true);
+                    setError(null);
+                    try {
+                      const data = await api.post<{
+                        id: string;
+                        authorizeUrl: string;
+                        status: string;
+                      }>('/api/config/grok/oauth/start');
+                      setGrokFlowId(data.id);
+                      setGrokAuthorizeUrl(data.authorizeUrl);
+                      setGrokStatus(data.status);
+                      setGrokPaste('');
+                      window.open(
+                        data.authorizeUrl,
+                        '_blank',
+                        'noopener,noreferrer',
+                      );
+                    } catch (err) {
+                      setError(getErrorMessage(err, 'Grok 授权启动失败'));
+                    } finally {
+                      setOauthLoading(false);
+                    }
+                  }}
+                  disabled={oauthLoading || saving}
+                >
+                  {oauthLoading ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <ExternalLink className="size-4" />
+                  )}
+                  登录 xAI Grok
+                </Button>
+              ) : (
+                <div className="space-y-2 text-sm">
+                  <p className="text-xs text-muted-foreground">
+                    授权后把地址栏 URL 或 code 粘贴到下方。
+                  </p>
+                  {grokAuthorizeUrl && (
+                    <a
+                      href={grokAuthorizeUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-teal-600 underline break-all"
+                    >
+                      {grokAuthorizeUrl}
+                    </a>
+                  )}
+                  <div className="flex gap-2">
+                    <Input
+                      type="text"
+                      value={grokPaste}
+                      onChange={(e) => setGrokPaste(e.target.value)}
+                      disabled={grokExchanging}
+                      placeholder="粘贴回调 URL 或授权码"
+                      className="flex-1"
+                    />
+                    <Button
+                      onClick={async () => {
+                        if (!grokFlowId || !grokPaste.trim()) return;
+                        setGrokExchanging(true);
+                        setError(null);
+                        try {
+                          const data = await api.post<{ status: string }>(
+                            `/api/config/grok/oauth/${grokFlowId}/code`,
+                            { code: grokPaste.trim() },
+                          );
+                          setGrokStatus(data.status);
+                          if (data.status === 'completed') setGrokDone(true);
+                        } catch (err) {
+                          setError(getErrorMessage(err, 'Grok 授权码换取失败'));
+                        } finally {
+                          setGrokExchanging(false);
+                        }
+                      }}
+                      disabled={grokExchanging || !grokPaste.trim()}
+                    >
+                      {grokExchanging && (
+                        <Loader2 className="size-4 animate-spin" />
+                      )}
+                      确认
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    状态：{grokStatus || 'pending'}
+                  </p>
+                  <Button
+                    variant="outline"
+                    onClick={async () => {
+                      if (!grokFlowId) return;
+                      try {
+                        const data = await api.get<{
+                          status: string;
+                          error?: string;
+                        }>(`/api/config/grok/oauth/${grokFlowId}`);
+                        setGrokStatus(data.status);
+                        if (data.status === 'completed') setGrokDone(true);
+                        if (
+                          data.status === 'failed' ||
+                          data.status === 'expired'
+                        ) {
+                          setError(data.error || 'Grok 授权失败');
+                        }
+                      } catch (err) {
+                        setError(
+                          getErrorMessage(err, '查询 Grok 授权状态失败'),
+                        );
+                      }
+                    }}
+                  >
+                    刷新状态
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : providerMode === 'codex' ? (
             <div className="space-y-3 rounded-lg border border-emerald-200 bg-emerald-50/40 p-4">
-              <p className="text-sm text-foreground">通过 ChatGPT 设备码登录 Codex。凭据加密保存，不会出现在 API 响应里。</p>
+              <p className="text-sm text-foreground">
+                通过 ChatGPT 设备码登录 Codex。凭据加密保存，不会出现在 API
+                响应里。
+              </p>
               {codexDone ? (
-                <p className="text-sm text-emerald-700">Codex 已登录，可以继续。</p>
+                <p className="text-sm text-emerald-700">
+                  Codex 已登录，可以继续。
+                </p>
               ) : !codexFlowId ? (
                 <Button
                   onClick={async () => {
@@ -367,7 +574,11 @@ export function SetupProvidersPage() {
                       setCodexUserCode(data.userCode);
                       setCodexVerifyUrl(data.verificationUrl);
                       setCodexStatus(data.status);
-                      window.open(data.verificationUrl, '_blank', 'noopener,noreferrer');
+                      window.open(
+                        data.verificationUrl,
+                        '_blank',
+                        'noopener,noreferrer',
+                      );
                     } catch (err) {
                       setError(getErrorMessage(err, 'Codex 授权启动失败'));
                     } finally {
@@ -376,33 +587,53 @@ export function SetupProvidersPage() {
                   }}
                   disabled={oauthLoading || saving}
                 >
-                  {oauthLoading ? <Loader2 className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
+                  {oauthLoading ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <ExternalLink className="size-4" />
+                  )}
                   登录 ChatGPT Codex
                 </Button>
               ) : (
                 <div className="space-y-2 text-sm">
                   <p>
-                    验证码 <code className="rounded bg-muted px-1 font-mono">{codexUserCode}</code>
+                    验证码{' '}
+                    <code className="rounded bg-muted px-1 font-mono">
+                      {codexUserCode}
+                    </code>
                   </p>
-                  <a href={codexVerifyUrl} target="_blank" rel="noopener noreferrer" className="text-teal-600 underline">
+                  <a
+                    href={codexVerifyUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-teal-600 underline"
+                  >
                     {codexVerifyUrl}
                   </a>
-                  <p className="text-xs text-muted-foreground">状态：{codexStatus || 'pending'}</p>
+                  <p className="text-xs text-muted-foreground">
+                    状态：{codexStatus || 'pending'}
+                  </p>
                   <Button
                     variant="outline"
                     onClick={async () => {
                       if (!codexFlowId) return;
                       try {
-                        const data = await api.get<{ status: string; error?: string }>(
-                          `/api/config/codex/oauth/${codexFlowId}`,
-                        );
+                        const data = await api.get<{
+                          status: string;
+                          error?: string;
+                        }>(`/api/config/codex/oauth/${codexFlowId}`);
                         setCodexStatus(data.status);
                         if (data.status === 'completed') setCodexDone(true);
-                        if (data.status === 'failed' || data.status === 'expired') {
+                        if (
+                          data.status === 'failed' ||
+                          data.status === 'expired'
+                        ) {
                           setError(data.error || 'Codex 授权失败');
                         }
                       } catch (err) {
-                        setError(getErrorMessage(err, '查询 Codex 授权状态失败'));
+                        setError(
+                          getErrorMessage(err, '查询 Codex 授权状态失败'),
+                        );
                       }
                     }}
                   >
@@ -419,7 +650,9 @@ export function SetupProvidersPage() {
                   type="button"
                   onClick={() => setOfficialTab('oauth')}
                   className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                    officialTab === 'oauth' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                    officialTab === 'oauth'
+                      ? 'bg-background text-primary shadow-sm'
+                      : 'text-muted-foreground'
                   }`}
                 >
                   OAuth 登录
@@ -428,7 +661,9 @@ export function SetupProvidersPage() {
                   type="button"
                   onClick={() => setOfficialTab('setup-token')}
                   className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                    officialTab === 'setup-token' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                    officialTab === 'setup-token'
+                      ? 'bg-background text-primary shadow-sm'
+                      : 'text-muted-foreground'
                   }`}
                 >
                   Setup Token
@@ -437,7 +672,9 @@ export function SetupProvidersPage() {
                   type="button"
                   onClick={() => setOfficialTab('api-key')}
                   className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
-                    officialTab === 'api-key' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+                    officialTab === 'api-key'
+                      ? 'bg-background text-primary shadow-sm'
+                      : 'text-muted-foreground'
                   }`}
                 >
                   API Key
@@ -448,9 +685,12 @@ export function SetupProvidersPage() {
                 <>
                   {/* OAuth one-click login */}
                   <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3">
-                    <div className="text-sm font-medium text-foreground">一键登录 Claude（推荐）</div>
+                    <div className="text-sm font-medium text-foreground">
+                      一键登录 Claude（推荐）
+                    </div>
                     <div className="text-xs text-muted-foreground">
-                      点击按钮后会打开 claude.ai 授权页面，完成授权后将页面上显示的授权码粘贴回来。
+                      点击按钮后会打开 claude.ai
+                      授权页面，完成授权后将页面上显示的授权码粘贴回来。
                     </div>
 
                     {oauthDone ? (
@@ -458,14 +698,22 @@ export function SetupProvidersPage() {
                         OAuth 登录成功，点击下方按钮完成配置。
                       </div>
                     ) : !oauthState ? (
-                      <Button onClick={handleOAuthStart} disabled={oauthLoading || saving}>
-                        {oauthLoading ? <Loader2 className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
+                      <Button
+                        onClick={handleOAuthStart}
+                        disabled={oauthLoading || saving}
+                      >
+                        {oauthLoading ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <ExternalLink className="size-4" />
+                        )}
                         一键登录 Claude
                       </Button>
                     ) : (
                       <div className="space-y-2">
                         <div className="text-xs bg-warning-bg border border-warning/30 text-warning rounded-md px-3 py-2">
-                          授权窗口已打开，请在 claude.ai 完成授权后，将页面上显示的授权码粘贴到下方。
+                          授权窗口已打开，请在 claude.ai
+                          完成授权后，将页面上显示的授权码粘贴到下方。
                         </div>
                         <div className="flex gap-2">
                           <Input
@@ -476,11 +724,22 @@ export function SetupProvidersPage() {
                             placeholder="粘贴授权码"
                             className="flex-1"
                           />
-                          <Button onClick={handleOAuthCallback} disabled={oauthExchanging || !oauthCode.trim()}>
-                            {oauthExchanging && <Loader2 className="size-4 animate-spin" />}
+                          <Button
+                            onClick={handleOAuthCallback}
+                            disabled={oauthExchanging || !oauthCode.trim()}
+                          >
+                            {oauthExchanging && (
+                              <Loader2 className="size-4 animate-spin" />
+                            )}
                             确认
                           </Button>
-                          <Button variant="outline" onClick={() => { setOauthState(null); setOauthCode(''); }}>
+                          <Button
+                            variant="outline"
+                            onClick={() => {
+                              setOauthState(null);
+                              setOauthCode('');
+                            }}
+                          >
                             取消
                           </Button>
                         </div>
@@ -496,12 +755,17 @@ export function SetupProvidersPage() {
                     <div className="font-medium mb-2">获取凭据</div>
                     <ol className="list-decimal ml-5 space-y-1 text-xs text-muted-foreground">
                       <li>在目标机器安装 Claude Code CLI（若未安装）。</li>
-                      <li>在终端执行 <code>claude login</code> 完成账号登录。</li>
                       <li>
-                        方式 A：执行 <code>cat ~/.claude/.credentials.json</code>，复制完整 JSON 内容到下方（推荐）。
+                        在终端执行 <code>claude login</code> 完成账号登录。
                       </li>
                       <li>
-                        方式 B：执行 <code>claude setup-token</code>，复制输出 token 到下方。
+                        方式 A：执行{' '}
+                        <code>cat ~/.claude/.credentials.json</code>，复制完整
+                        JSON 内容到下方（推荐）。
+                      </li>
+                      <li>
+                        方式 B：执行 <code>claude setup-token</code>，复制输出
+                        token 到下方。
                       </li>
                     </ol>
                   </div>
@@ -517,7 +781,11 @@ export function SetupProvidersPage() {
                       placeholder="粘贴 setup-token 或 cat ~/.claude/.credentials.json 输出"
                     />
                     <p className="text-xs text-muted-foreground mt-1">
-                      支持粘贴 <code className="bg-muted px-1 rounded">cat ~/.claude/.credentials.json</code> 的 JSON 内容
+                      支持粘贴{' '}
+                      <code className="bg-muted px-1 rounded">
+                        cat ~/.claude/.credentials.json
+                      </code>{' '}
+                      的 JSON 内容
                     </p>
                   </div>
                 </>
@@ -540,7 +808,9 @@ export function SetupProvidersPage() {
                         </a>{' '}
                         创建 API Key。
                       </li>
-                      <li>将以 <code>sk-ant-api03-</code> 开头的 Key 粘贴到下方。</li>
+                      <li>
+                        将以 <code>sk-ant-api03-</code> 开头的 Key 粘贴到下方。
+                      </li>
                     </ol>
                   </div>
 
@@ -566,12 +836,15 @@ export function SetupProvidersPage() {
             <div className="space-y-4">
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Server className="w-4 h-4 text-primary" />
-                第三方渠道会写入系统全局默认环境变量。必填项为 ANTHROPIC_BASE_URL 和 ANTHROPIC_AUTH_TOKEN。
+                第三方渠道会写入系统全局默认环境变量。必填项为
+                ANTHROPIC_BASE_URL 和 ANTHROPIC_AUTH_TOKEN。
               </div>
 
               <div className="grid grid-cols-1 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_BASE_URL（必填）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    ANTHROPIC_BASE_URL（必填）
+                  </label>
                   <Input
                     type="text"
                     value={baseUrl}
@@ -581,7 +854,9 @@ export function SetupProvidersPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_MODEL（可选）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    ANTHROPIC_MODEL（可选）
+                  </label>
                   <Input
                     type="text"
                     value={model}
@@ -592,7 +867,9 @@ export function SetupProvidersPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-1">ANTHROPIC_AUTH_TOKEN（必填）</label>
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    ANTHROPIC_AUTH_TOKEN（必填）
+                  </label>
                   <Input
                     type="password"
                     value={authToken}
@@ -604,7 +881,9 @@ export function SetupProvidersPage() {
 
               <div className="border-t border-border pt-4">
                 <div className="flex items-center justify-between mb-2">
-                  <label className="text-xs text-muted-foreground">其他自定义环境变量（可选）</label>
+                  <label className="text-xs text-muted-foreground">
+                    其他自定义环境变量（可选）
+                  </label>
                   <button
                     type="button"
                     onClick={addCustomEnvRow}
@@ -623,18 +902,25 @@ export function SetupProvidersPage() {
                 ) : (
                   <div className="space-y-2">
                     {customEnvRows.map((row, idx) => (
-                      <div key={idx} className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+                      <div
+                        key={idx}
+                        className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2"
+                      >
                         <Input
                           type="text"
                           value={row.key}
-                          onChange={(e) => updateCustomEnvRow(idx, 'key', e.target.value)}
+                          onChange={(e) =>
+                            updateCustomEnvRow(idx, 'key', e.target.value)
+                          }
                           placeholder="KEY"
                           className="w-full sm:w-[38%] px-2.5 py-1.5 text-xs font-mono h-auto"
                         />
                         <Input
                           type="text"
                           value={row.value}
-                          onChange={(e) => updateCustomEnvRow(idx, 'value', e.target.value)}
+                          onChange={(e) =>
+                            updateCustomEnvRow(idx, 'value', e.target.value)
+                          }
                           placeholder="value"
                           className="flex-1 px-2.5 py-1.5 text-xs font-mono h-auto"
                         />

--- a/web/src/pages/SetupProvidersPage.tsx
+++ b/web/src/pages/SetupProvidersPage.tsx
@@ -12,7 +12,7 @@ import type {
 import { getErrorMessage } from '../components/settings/types';
 import { useAuthStore } from '../stores/auth';
 
-type ProviderMode = 'official' | 'third_party';
+type ProviderMode = 'official' | 'third_party' | 'codex';
 
 const RESERVED_ENV_KEYS = new Set([
   'ANTHROPIC_BASE_URL',
@@ -70,6 +70,11 @@ export function SetupProvidersPage() {
   const [oauthCode, setOauthCode] = useState('');
   const [oauthExchanging, setOauthExchanging] = useState(false);
   const [oauthDone, setOauthDone] = useState(false);
+  const [codexFlowId, setCodexFlowId] = useState<string | null>(null);
+  const [codexUserCode, setCodexUserCode] = useState('');
+  const [codexVerifyUrl, setCodexVerifyUrl] = useState('');
+  const [codexStatus, setCodexStatus] = useState<string | null>(null);
+  const [codexDone, setCodexDone] = useState(false);
 
   // Third-party mode
   const [baseUrl, setBaseUrl] = useState('');
@@ -163,6 +168,11 @@ export function SetupProvidersPage() {
         return;
       }
       customEnv = envResult.customEnv;
+    } else if (providerMode === 'codex') {
+      if (!codexDone) {
+        setError('请先完成 ChatGPT Codex 设备码登录');
+        return;
+      }
     } else if (!officialToken.trim() && !apiKey.trim() && !oauthDone) {
       setError('官方渠道请通过一键登录、填写 API Key 或手动填写 setup-token / .credentials.json');
       return;
@@ -226,7 +236,7 @@ export function SetupProvidersPage() {
             });
           }
         }
-      } else {
+      } else if (providerMode === 'third_party') {
         await api.post<UnifiedProviderPublic>(
           '/api/config/claude/providers',
           {
@@ -303,7 +313,7 @@ export function SetupProvidersPage() {
         <section className="bg-card rounded-xl border border-border shadow-sm p-5">
           <div className="flex items-center gap-2 mb-3">
             <KeyRound className="w-4 h-4 text-primary" />
-            <h2 className="text-base font-semibold text-foreground">Claude Code 配置（二选一）</h2>
+            <h2 className="text-base font-semibold text-foreground">模型配置（官方 / 第三方 / Codex）</h2>
           </div>
 
           <div className="inline-flex rounded-lg border border-border p-1 bg-muted mb-4">
@@ -325,9 +335,83 @@ export function SetupProvidersPage() {
             >
               第三方渠道
             </button>
+            <button
+              type="button"
+              onClick={() => setProviderMode('codex')}
+              className={`px-3 py-1.5 text-sm rounded-md transition-colors cursor-pointer ${
+                providerMode === 'codex' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground'
+              }`}
+            >
+              Codex
+            </button>
           </div>
 
-          {providerMode === 'official' ? (
+          {providerMode === 'codex' ? (
+            <div className="space-y-3 rounded-lg border border-emerald-200 bg-emerald-50/40 p-4">
+              <p className="text-sm text-foreground">通过 ChatGPT 设备码登录 Codex。凭据加密保存，不会出现在 API 响应里。</p>
+              {codexDone ? (
+                <p className="text-sm text-emerald-700">Codex 已登录，可以继续。</p>
+              ) : !codexFlowId ? (
+                <Button
+                  onClick={async () => {
+                    setOauthLoading(true);
+                    setError(null);
+                    try {
+                      const data = await api.post<{
+                        id: string;
+                        verificationUrl: string;
+                        userCode: string;
+                        status: string;
+                      }>('/api/config/codex/oauth/start');
+                      setCodexFlowId(data.id);
+                      setCodexUserCode(data.userCode);
+                      setCodexVerifyUrl(data.verificationUrl);
+                      setCodexStatus(data.status);
+                      window.open(data.verificationUrl, '_blank', 'noopener,noreferrer');
+                    } catch (err) {
+                      setError(getErrorMessage(err, 'Codex 授权启动失败'));
+                    } finally {
+                      setOauthLoading(false);
+                    }
+                  }}
+                  disabled={oauthLoading || saving}
+                >
+                  {oauthLoading ? <Loader2 className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
+                  登录 ChatGPT Codex
+                </Button>
+              ) : (
+                <div className="space-y-2 text-sm">
+                  <p>
+                    验证码 <code className="rounded bg-muted px-1 font-mono">{codexUserCode}</code>
+                  </p>
+                  <a href={codexVerifyUrl} target="_blank" rel="noopener noreferrer" className="text-teal-600 underline">
+                    {codexVerifyUrl}
+                  </a>
+                  <p className="text-xs text-muted-foreground">状态：{codexStatus || 'pending'}</p>
+                  <Button
+                    variant="outline"
+                    onClick={async () => {
+                      if (!codexFlowId) return;
+                      try {
+                        const data = await api.get<{ status: string; error?: string }>(
+                          `/api/config/codex/oauth/${codexFlowId}`,
+                        );
+                        setCodexStatus(data.status);
+                        if (data.status === 'completed') setCodexDone(true);
+                        if (data.status === 'failed' || data.status === 'expired') {
+                          setError(data.error || 'Codex 授权失败');
+                        }
+                      } catch (err) {
+                        setError(getErrorMessage(err, '查询 Codex 授权状态失败'));
+                      }
+                    }}
+                  >
+                    刷新状态
+                  </Button>
+                </div>
+              )}
+            </div>
+          ) : providerMode === 'official' ? (
             <div className="space-y-4">
               {/* Official auth tabs */}
               <div className="inline-flex rounded-lg border border-border p-1 bg-muted">


### PR DESCRIPTION
## Why
Follow-up to #656 (Codex + local Anthropic facade). Same facade, Grok subscription as the upstream.

This branch is stacked on `feat/codex-anthropic-facade`. It includes those commits until #656 merges; the new work is the `grok` provider.

## What
- Provider type `grok` (default `grok-4.5`; effort `low|medium|high`)
- PKCE OIDC at `auth.x.ai` (scopes include `grok-cli:access`)
- `POST /api/config/grok/oauth/start`, `GET /api/config/grok/oauth/:id`, paste-code `POST /api/config/grok/oauth/:id/code`
- Public callback `GET /callback`
- Upstream `https://cli-chat-proxy.grok.com/v1/responses` with `X-XAI-Token-Auth: xai-grok-cli`
- Official / third_party stay direct; Codex path unchanged

## Test plan
- [x] `tests/grok-oauth.test.ts` + existing Codex/provider tests
- [ ] Browser PKCE login; streamed turn via facade
- [ ] Paste-code path if redirect cannot hit the host