### PR TITLE
fix(providers): keep conversation context when failing over to a new provider

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -68,8 +68,8 @@ import {
   type WorkspaceMemoryCapabilityScope,
 } from './workspace-memory-capability.js';
 import { releaseHappyClawOwnerIntroductionLease } from './owner-profile-store.js';
+import { applyProviderSwitchToInput } from './provider-switch-context.js';
 import {
-  deleteSession,
   getUserById,
   getSessionProviderId,
   setSessionProviderId,
@@ -2184,26 +2184,7 @@ export async function runContainerAgent(
   let providerFailureTerminal: boolean | undefined;
   let providerFailureMaintenance = false;
   let healthyInputTurnCompleted = false;
-  if (poolResult?.resetSession && input.sessionId) {
-    logger.info(
-      {
-        groupFolder: group.folder,
-        agentId: sessionAgentId || null,
-        previousProviderId: poolResult.previousProviderId,
-        providerId: selectedProfileId,
-      },
-      'Clearing Claude session after switching providers',
-    );
-    // deleteSession removes the whole sessions row, including the provider_id
-    // binding trySelectPoolProvider just wrote. Re-bind the freshly-selected
-    // provider so the next turn stays sticky to it instead of degrading to a
-    // fresh pool pick.
-    deleteSession(group.folder, sessionAgentId);
-    if (selectedProfileId) {
-      setSessionProviderId(group.folder, sessionAgentId, selectedProfileId);
-    }
-    input = { ...input, sessionId: undefined };
-  }
+  input = applyProviderSwitchToInput(input, poolResult, sessionAgentId);
 
   const workspaceMemoryCapabilityScope: WorkspaceMemoryCapabilityScope = {
     groupFolder: group.folder,
@@ -3031,25 +3012,7 @@ export async function runHostAgent(
   let hostProviderFailureTerminal: boolean | undefined;
   let hostProviderFailureMaintenance = false;
   let hostHealthyInputTurnCompleted = false;
-  if (hostPoolResult?.resetSession && input.sessionId) {
-    logger.info(
-      {
-        groupFolder: group.folder,
-        agentId: sessionAgentId || null,
-        previousProviderId: hostPoolResult.previousProviderId,
-        providerId: hostSelectedProfileId,
-      },
-      'Clearing Claude session after switching providers',
-    );
-    // deleteSession removes the whole sessions row, including the provider_id
-    // binding trySelectPoolProvider just wrote. Re-bind so the next turn stays
-    // sticky to the freshly-selected provider (mirrors the container path).
-    deleteSession(group.folder, sessionAgentId);
-    if (hostSelectedProfileId) {
-      setSessionProviderId(group.folder, sessionAgentId, hostSelectedProfileId);
-    }
-    input = { ...input, sessionId: undefined };
-  }
+  input = applyProviderSwitchToInput(input, hostPoolResult, sessionAgentId);
 
   const workspaceMemoryCapabilityScope: WorkspaceMemoryCapabilityScope = {
     groupFolder: group.folder,

--- a/src/provider-switch-context.ts
+++ b/src/provider-switch-context.ts
@@ -1,0 +1,106 @@
+import { logger } from './logger.js';
+import { deleteSession, setSessionProviderId } from './db.js';
+import { buildRecentConversationHistoryContext } from './conversation-history.js';
+export interface ProviderSwitchInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  turnId?: string;
+  isScheduledTask?: boolean;
+  agentId?: string;
+}
+
+const PROVIDER_SWITCH_HISTORY_INTRO =
+  '检测到本次因切换 provider 需要使用新的底层模型 session。以下是 HappyClaw 保存的最近对话记录，供你延续上下文。';
+
+export interface ProviderSwitchSelection {
+  profileId: string;
+  previousProviderId?: string;
+  resetSession?: boolean;
+}
+
+function conversationHistoryChatJid(input: ProviderSwitchInput): string {
+  if (!input.agentId) return input.chatJid;
+  if (input.chatJid.includes('#agent:')) return input.chatJid;
+  return `${input.chatJid}#agent:${input.agentId}`;
+}
+
+function seedPromptWithPersistedHistory<T extends ProviderSwitchInput>(
+  input: T,
+): T {
+  // Isolated scheduled tasks use their own session namespace and must not
+  // inherit the workspace chat. Conversation turns (including group-mode
+  // scheduled prompts that arrive via processGroupMessages) do.
+  if (input.isScheduledTask) return input;
+  // Orchestration may already have prepended recovery/provider-switch history.
+  if (input.prompt.includes('<system_context>')) return input;
+
+  const pendingMessageIds = new Set<string>();
+  if (input.turnId) pendingMessageIds.add(input.turnId);
+
+  const chatJid = conversationHistoryChatJid(input);
+  const history = buildRecentConversationHistoryContext(
+    chatJid,
+    pendingMessageIds,
+    {
+      limit: 30,
+      maxMessageLength: 700,
+      intro: PROVIDER_SWITCH_HISTORY_INTRO,
+    },
+  );
+  if (!history) return input;
+
+  logger.info(
+    {
+      groupFolder: input.groupFolder,
+      chatJid,
+      historyCount: history.count,
+    },
+    'Provider switch: injected recent conversation history into prompt',
+  );
+  return { ...input, prompt: history.context + input.prompt };
+}
+
+/**
+ * Claude SDK sessions are bound to one OAuth account / provider. When the
+ * pool fails over, drop the resume token and seed the replacement session
+ * with HappyClaw's persisted transcript so prior user/assistant turns survive.
+ *
+ * Isolated scheduled tasks only drop the resume token.
+ */
+export function applyProviderSwitchToInput<T extends ProviderSwitchInput>(
+  input: T,
+  poolResult: ProviderSwitchSelection | null,
+  sessionAgentId?: string | null,
+): T {
+  if (!poolResult?.resetSession) return input;
+
+  logger.info(
+    {
+      groupFolder: input.groupFolder,
+      agentId: sessionAgentId || null,
+      previousProviderId: poolResult.previousProviderId,
+      providerId: poolResult.profileId,
+    },
+    'Clearing Claude session after switching providers',
+  );
+
+  // deleteSession removes the whole sessions row, including the provider_id
+  // binding trySelectPoolProvider just wrote. Re-bind the freshly-selected
+  // provider so the next turn stays sticky to it instead of degrading to a
+  // fresh pool pick.
+  if (input.sessionId) {
+    deleteSession(input.groupFolder, sessionAgentId);
+    setSessionProviderId(
+      input.groupFolder,
+      sessionAgentId,
+      poolResult.profileId,
+    );
+  }
+
+  return {
+    ...seedPromptWithPersistedHistory(input),
+    sessionId: undefined,
+  };
+}

--- a/tests/provider-failover-keep-context.test.ts
+++ b/tests/provider-failover-keep-context.test.ts
@@ -1,0 +1,237 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'provider-failover-context-'),
+);
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: root,
+  STORE_DIR: path.join(root, 'db'),
+  GROUPS_DIR: path.join(root, 'groups'),
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const runtimeConfig = await import('../src/runtime-config.js');
+const db = await import('../src/db.js');
+const { trySelectPoolProvider } = await import('../src/container-runner.js');
+const { applyProviderSwitchToInput } =
+  await import('../src/provider-switch-context.js');
+const { providerPool } = await import('../src/provider-pool.js');
+
+const created: string[] = [];
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(root, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'groups'), { recursive: true });
+  db.initDatabase();
+  for (const name of ['Account A', 'Account B']) {
+    created.push(
+      runtimeConfig.createProvider({
+        name,
+        type: 'official',
+        anthropicApiKey: `${name.replace(/\s+/g, '-').toLowerCase()}-key`,
+        anthropicModel: 'claude-fable-5',
+        enabled: true,
+      }).id,
+    );
+  }
+  runtimeConfig.saveBalancingConfig({
+    strategy: 'failover',
+    unhealthyThreshold: 1,
+    recoveryIntervalMs: 300_000,
+  });
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const id of created) providerPool.resetHealth(id);
+});
+
+function persistTurn(
+  chatJid: string,
+  id: string,
+  content: string,
+  isFromMe: boolean,
+  timestamp: string,
+) {
+  db.ensureChatExists(chatJid);
+  db.storeMessageDirect(
+    id,
+    chatJid,
+    isFromMe ? 'happyclaw' : 'user-1',
+    isFromMe ? 'HappyClaw' : 'Dennis',
+    content,
+    timestamp,
+    isFromMe,
+  );
+}
+
+function conversationInput(opts?: {
+  prompt?: string;
+  sessionId?: string;
+  chatJid?: string;
+  turnId?: string;
+  isScheduledTask?: boolean;
+  agentId?: string;
+  groupFolder?: string;
+}) {
+  return {
+    prompt: opts?.prompt ?? '当前用户消息',
+    sessionId: opts?.sessionId ?? 'sess-account-a',
+    groupFolder: opts?.groupFolder ?? 'failover-keep-context',
+    chatJid: opts?.chatJid ?? 'web:failover-keep-context',
+    turnId: opts?.turnId ?? 'pending-now',
+    isScheduledTask: opts?.isScheduledTask,
+    agentId: opts?.agentId,
+    isMain: true,
+  };
+}
+
+/**
+ * Session stickiness binds a Claude SDK session to one OAuth account.
+ * Failover must start a new session on the next provider, but the new
+ * prompt has to carry HappyClaw's persisted user/assistant turns — otherwise
+ * the replacement account sees an empty conversation.
+ */
+describe('provider failover keeps conversation context', () => {
+  test('sticky provider fails → next provider is selected with prior turns seeded', () => {
+    const groupFolder = 'failover-keep-context';
+    const chatJid = 'web:failover-keep-context';
+    db.setSession(groupFolder, 'sess-account-a', null);
+    db.setSessionProviderId(groupFolder, null, created[0]);
+    persistTurn(
+      chatJid,
+      'user-1',
+      '请记住项目代号 Phoenix',
+      false,
+      '2026-08-18T10:00:00.000Z',
+    );
+    persistTurn(
+      chatJid,
+      'asst-1',
+      '已记住，项目代号是 Phoenix。',
+      true,
+      '2026-08-18T10:00:01.000Z',
+    );
+    persistTurn(
+      chatJid,
+      'pending-now',
+      '继续刚才的计划',
+      false,
+      '2026-08-18T10:00:02.000Z',
+    );
+
+    providerPool.reportFailure(created[0], true);
+    expect(providerPool.getHealthStatus(created[0]).healthy).toBe(false);
+
+    const selected = trySelectPoolProvider(groupFolder, null, null);
+    expect(selected).not.toBeNull();
+    expect(selected!.profileId).toBe(created[1]);
+    expect(selected!.resetSession).toBe(true);
+    expect(selected!.previousProviderId).toBe(created[0]);
+
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({ groupFolder, chatJid }),
+      selected,
+      null,
+    );
+
+    expect(prepared.sessionId).toBeUndefined();
+    expect(prepared.prompt).toContain('请记住项目代号 Phoenix');
+    expect(prepared.prompt).toContain('已记住，项目代号是 Phoenix。');
+    expect(prepared.prompt).toContain('当前用户消息');
+    expect(prepared.prompt).not.toContain('继续刚才的计划');
+    expect(db.getSessionProviderId(groupFolder, null)).toBe(created[1]);
+  });
+
+  test('healthy sticky path keeps the resume token and does not rewrite the prompt', () => {
+    const groupFolder = 'failover-sticky-healthy';
+    const chatJid = 'web:failover-sticky-healthy';
+    db.setSession(groupFolder, 'sess-keep', null);
+    db.setSessionProviderId(groupFolder, null, created[0]);
+    persistTurn(
+      chatJid,
+      'hist-user',
+      '历史不该被注入',
+      false,
+      '2026-08-18T11:00:00.000Z',
+    );
+
+    const selected = trySelectPoolProvider(groupFolder, null, null);
+    expect(selected?.profileId).toBe(created[0]);
+    expect(selected?.resetSession ?? false).toBe(false);
+
+    const input = conversationInput({
+      groupFolder,
+      chatJid,
+      sessionId: 'sess-keep',
+      prompt: '只问这一句',
+    });
+    const prepared = applyProviderSwitchToInput(input, selected, null);
+    expect(prepared.sessionId).toBe('sess-keep');
+    expect(prepared.prompt).toBe('只问这一句');
+    expect(prepared.prompt).not.toContain('<system_context>');
+  });
+
+  test('does not double-inject when orchestration already seeded history', () => {
+    const already =
+      '<system_context>\n已注入的历史\n</system_context>\n\n当前用户消息';
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({ prompt: already }),
+      {
+        profileId: created[1],
+        previousProviderId: created[0],
+        resetSession: true,
+      },
+      null,
+    );
+    expect(prepared.prompt).toBe(already);
+    expect(prepared.sessionId).toBeUndefined();
+  });
+
+  test('isolated scheduled tasks drop resume without inheriting workspace chat', () => {
+    const chatJid = 'web:failover-scheduled';
+    persistTurn(
+      chatJid,
+      'ws-user',
+      '工作区闲聊不该进隔离任务',
+      false,
+      '2026-08-18T12:00:00.000Z',
+    );
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({
+        chatJid,
+        prompt: '跑每日巡检',
+        isScheduledTask: true,
+      }),
+      {
+        profileId: created[1],
+        previousProviderId: created[0],
+        resetSession: true,
+      },
+      null,
+    );
+    expect(prepared.sessionId).toBeUndefined();
+    expect(prepared.prompt).toBe('跑每日巡检');
+    expect(prepared.prompt).not.toContain('工作区闲聊');
+  });
+});


### PR DESCRIPTION
## Problem
When the sticky provider dies and the pool fails over, the new provider starts with no conversation context.

Claude SDK session IDs are bound to one OAuth account. On failover `trySelectPoolProvider` set `resetSession` and the runner only dropped `--resume`. HappyClaw already stored the transcript, but seeding lived only as an `index.ts` prediction (`willClearSessionOnProviderSwitch`) and was missed on retry / already-cleared / non-orchestration paths.

## Fix
- `applyProviderSwitchToInput`: on `resetSession`, clear the resume token, re-bind the new provider, prepend `buildRecentConversationHistoryContext` from HappyClaw’s message store.
- Wired into both `runContainerAgent` and `runHostAgent`.
- Skip isolated scheduled tasks. Skip if the prompt already has `<system_context>`.
- Healthy sticky path unchanged.

Independent of #656 / #657.

## Test plan
- [x] `tests/provider-failover-keep-context.test.ts`
- [x] existing provider-switch / pool / history tests
- [x] `tsc --noEmit`