### PR TITLE
fix(whatsapp): classify LID DMs so they do not share workspace owner

### DIFF
--- a/src/channel-conversation-kind.ts
+++ b/src/channel-conversation-kind.ts
@@ -60,7 +60,17 @@ export function resolveChannelConversationKind(
   }
 
   if (baseJid.startsWith('whatsapp:')) {
-    if (baseJid.endsWith('@s.whatsapp.net')) return 'direct';
+    // Live JIDs are `whatsapp:${remoteJid}` from Baileys. User chats are PN
+    // (`@s.whatsapp.net`, including device-suffixed `user:device@…`), LID
+    // (`@lid`), and hosted PN/LID (`@hosted`, `@hosted.lid`). Groups stay
+    // `@g.us`. Do not guess other suffixes as groups.
+    if (
+      baseJid.endsWith('@s.whatsapp.net') ||
+      baseJid.endsWith('@lid') ||
+      baseJid.endsWith('@hosted')
+    ) {
+      return 'direct';
+    }
     if (baseJid.endsWith('@g.us')) return 'group';
     return 'unknown';
   }

--- a/src/channel-conversation-kind.ts
+++ b/src/channel-conversation-kind.ts
@@ -66,6 +66,7 @@ export function resolveChannelConversationKind(
     // `@g.us`. Do not guess other suffixes as groups.
     if (
       baseJid.endsWith('@s.whatsapp.net') ||
+      baseJid.endsWith('@hosted.lid') ||
       baseJid.endsWith('@lid') ||
       baseJid.endsWith('@hosted')
     ) {

--- a/src/im-command-utils.ts
+++ b/src/im-command-utils.ts
@@ -328,7 +328,7 @@ export function checkImOwnerCommand(
  *   - qq:        `qq:c2c:{openid}`            (group → `qq:group:...`)
  *   - dingtalk:  `dingtalk:c2c:{staffId}`     (group → `dingtalk:{cid...}`)
  *   - discord:   `discord:dm:{userId}`        (guild → `discord:{channelId}`)
- *   - whatsapp:  `...@s.whatsapp.net`         (group → `...@g.us`)
+ *   - whatsapp:  `...@s.whatsapp.net` / `...@lid` (group → `...@g.us`)
  *   - wechat:    `wechat:{userId}`            (1:1 only — no group support)
  *   - telegram:  `telegram:{chatId}`          (private chat id is positive;
  *                groups/supergroups are negative — a stable Bot API guarantee)

--- a/tests/channel-conversation-kind.test.ts
+++ b/tests/channel-conversation-kind.test.ts
@@ -13,6 +13,11 @@ describe('resolveChannelConversationKind', () => {
     ['discord:dm:123', 'direct'],
     ['discord:456', 'group'],
     ['whatsapp:123@s.whatsapp.net', 'direct'],
+    ['whatsapp:1555:42@s.whatsapp.net', 'direct'],
+    ['whatsapp:123456789012345@lid', 'direct'],
+    ['whatsapp:123456789012345@lid#account:bot-a', 'direct'],
+    ['whatsapp:hosted-user@hosted', 'direct'],
+    ['whatsapp:hosted-user@hosted.lid', 'direct'],
     ['whatsapp:123@g.us', 'group'],
     ['wechat:wxid_user', 'direct'],
     ['wecom:c2c:user#account:bot-a', 'direct'],
@@ -40,6 +45,12 @@ describe('resolveChannelConversationKind', () => {
       'unknown',
     );
     expect(resolveChannelConversationKind('web:main')).toBe('unknown');
+    expect(resolveChannelConversationKind('whatsapp:status@broadcast')).toBe(
+      'unknown',
+    );
+    expect(resolveChannelConversationKind('whatsapp:123@newsletter')).toBe(
+      'unknown',
+    );
   });
 });
 

--- a/tests/im-owner-gate.test.ts
+++ b/tests/im-owner-gate.test.ts
@@ -112,6 +112,10 @@ describe('isDirectMessageJid', () => {
     expect(isDirectMessageJid('whatsapp:15551234567@s.whatsapp.net')).toBe(
       true,
     );
+    expect(isDirectMessageJid('whatsapp:123456789012345@lid')).toBe(true);
+    expect(
+      isDirectMessageJid('whatsapp:123456789012345@lid#account:bot-a'),
+    ).toBe(true);
     expect(isDirectMessageJid('wechat:wxid_abc123')).toBe(true);
     // Telegram private chats have positive ids
     expect(isDirectMessageJid('telegram:123456789')).toBe(true);


### PR DESCRIPTION
Follow-up to #654/#655. Live WhatsApp LID DMs (whatsapp:...@lid / @hosted / @hosted.lid) were unknown and still got target_main_jid, so they shared channel_session_owner:{folder}:main with a group. Device-suffixed @s.whatsapp.net already matched. Groups stay @g.us. No v72/v73 rewrite. Tests: 3145 passed, 23 skipped.