### PR TITLE
fix: isolate direct sessions and preserve failover context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,11 @@ backup: ## 备份运行时数据到 happyclaw-backup-{date}.tar.gz
 	  "$$TMP_ROOT/data/db/messages.db"; \
 	for DIR in config groups sessions skills mcp-servers plugins memory avatars extra builtin-skills; do \
 	  if [ -d "$(RUNTIME_DATA_DIR)/$$DIR" ]; then \
+	    SOURCE_HARDLINK=$$(find "$(RUNTIME_DATA_DIR)/$$DIR" -type f -links +1 -print -quit); \
+	    if [ -n "$$SOURCE_HARDLINK" ]; then \
+	      echo "❌ 运行时数据包含硬链接文件，复制工具在不同平台可能拆散链接并绕过归档校验，拒绝创建：$$SOURCE_HARDLINK"; \
+	      exit 1; \
+	    fi; \
 	    mkdir -p "$$TMP_ROOT/data/$$DIR"; \
 	    cp -a "$(RUNTIME_DATA_DIR)/$$DIR/." "$$TMP_ROOT/data/$$DIR/"; \
 	  fi; \

--- a/src/channel-conversation-kind.ts
+++ b/src/channel-conversation-kind.ts
@@ -60,7 +60,17 @@ export function resolveChannelConversationKind(
   }
 
   if (baseJid.startsWith('whatsapp:')) {
-    if (baseJid.endsWith('@s.whatsapp.net')) return 'direct';
+    // Live JIDs are `whatsapp:${remoteJid}` from Baileys. User chats are PN
+    // (`@s.whatsapp.net`, including device-suffixed `user:device@…`), LID
+    // (`@lid`), and hosted PN/LID (`@hosted`, `@hosted.lid`). Groups stay
+    // `@g.us`. Do not guess other suffixes as groups.
+    if (
+      baseJid.endsWith('@s.whatsapp.net') ||
+      baseJid.endsWith('@lid') ||
+      baseJid.endsWith('@hosted')
+    ) {
+      return 'direct';
+    }
     if (baseJid.endsWith('@g.us')) return 'group';
     return 'unknown';
   }

--- a/src/channel-conversation-kind.ts
+++ b/src/channel-conversation-kind.ts
@@ -66,6 +66,7 @@ export function resolveChannelConversationKind(
     // `@g.us`. Do not guess other suffixes as groups.
     if (
       baseJid.endsWith('@s.whatsapp.net') ||
+      baseJid.endsWith('@hosted.lid') ||
       baseJid.endsWith('@lid') ||
       baseJid.endsWith('@hosted')
     ) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -429,6 +429,8 @@ export interface ContainerInput {
   /** @deprecated Use isHome + isAdminHome instead */
   isMain: boolean;
   turnId?: string;
+  /** Persisted message IDs already represented by this cold-run prompt. */
+  readonly currentBatchMessageIds?: readonly string[];
   isHome?: boolean;
   isAdminHome?: boolean;
   isScheduledTask?: boolean;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -68,8 +68,8 @@ import {
   type WorkspaceMemoryCapabilityScope,
 } from './workspace-memory-capability.js';
 import { releaseHappyClawOwnerIntroductionLease } from './owner-profile-store.js';
+import { applyProviderSwitchToInput } from './provider-switch-context.js';
 import {
-  deleteSession,
   getUserById,
   getSessionProviderId,
   setSessionProviderId,
@@ -2184,26 +2184,7 @@ export async function runContainerAgent(
   let providerFailureTerminal: boolean | undefined;
   let providerFailureMaintenance = false;
   let healthyInputTurnCompleted = false;
-  if (poolResult?.resetSession && input.sessionId) {
-    logger.info(
-      {
-        groupFolder: group.folder,
-        agentId: sessionAgentId || null,
-        previousProviderId: poolResult.previousProviderId,
-        providerId: selectedProfileId,
-      },
-      'Clearing Claude session after switching providers',
-    );
-    // deleteSession removes the whole sessions row, including the provider_id
-    // binding trySelectPoolProvider just wrote. Re-bind the freshly-selected
-    // provider so the next turn stays sticky to it instead of degrading to a
-    // fresh pool pick.
-    deleteSession(group.folder, sessionAgentId);
-    if (selectedProfileId) {
-      setSessionProviderId(group.folder, sessionAgentId, selectedProfileId);
-    }
-    input = { ...input, sessionId: undefined };
-  }
+  input = applyProviderSwitchToInput(input, poolResult, sessionAgentId);
 
   const workspaceMemoryCapabilityScope: WorkspaceMemoryCapabilityScope = {
     groupFolder: group.folder,
@@ -3031,25 +3012,7 @@ export async function runHostAgent(
   let hostProviderFailureTerminal: boolean | undefined;
   let hostProviderFailureMaintenance = false;
   let hostHealthyInputTurnCompleted = false;
-  if (hostPoolResult?.resetSession && input.sessionId) {
-    logger.info(
-      {
-        groupFolder: group.folder,
-        agentId: sessionAgentId || null,
-        previousProviderId: hostPoolResult.previousProviderId,
-        providerId: hostSelectedProfileId,
-      },
-      'Clearing Claude session after switching providers',
-    );
-    // deleteSession removes the whole sessions row, including the provider_id
-    // binding trySelectPoolProvider just wrote. Re-bind so the next turn stays
-    // sticky to the freshly-selected provider (mirrors the container path).
-    deleteSession(group.folder, sessionAgentId);
-    if (hostSelectedProfileId) {
-      setSessionProviderId(group.folder, sessionAgentId, hostSelectedProfileId);
-    }
-    input = { ...input, sessionId: undefined };
-  }
+  input = applyProviderSwitchToInput(input, hostPoolResult, sessionAgentId);
 
   const workspaceMemoryCapabilityScope: WorkspaceMemoryCapabilityScope = {
     groupFolder: group.folder,

--- a/src/conversation-history.ts
+++ b/src/conversation-history.ts
@@ -1,4 +1,4 @@
-import { getConversationHistoryCutoff, getMessagesPage } from './db.js';
+import { getConversationHistoryMessagesPage } from './db.js';
 import { escapeXml } from './message-prompt.js';
 
 /**
@@ -23,11 +23,15 @@ export function buildRecentConversationHistoryContext(
     intro: string;
   },
 ): { context: string; count: number; messageIds: string[] } | null {
-  const recentHistory = getMessagesPage(chatJid, undefined, opts.limit ?? 30);
-  const historyCutoff = getConversationHistoryCutoff(chatJid);
+  const recentHistory = getConversationHistoryMessagesPage(
+    chatJid,
+    pendingMessageIds,
+    opts.limit ?? 30,
+  );
   const historyMsgs = recentHistory
     .reverse()
-    .filter((m) => !historyCutoff || m.timestamp > historyCutoff)
+    // Defense in depth for mocked/custom DB adapters: production already
+    // excludes these IDs in SQL so a large batch cannot consume the window.
     .filter((m) => !pendingMessageIds.has(m.id))
     .filter((m) => m.content.trim().length > 0);
 

--- a/src/conversation-history.ts
+++ b/src/conversation-history.ts
@@ -1,4 +1,4 @@
-import { getMessagesPage } from './db.js';
+import { getConversationHistoryCutoff, getMessagesPage } from './db.js';
 import { escapeXml } from './message-prompt.js';
 
 /**
@@ -24,8 +24,10 @@ export function buildRecentConversationHistoryContext(
   },
 ): { context: string; count: number; messageIds: string[] } | null {
   const recentHistory = getMessagesPage(chatJid, undefined, opts.limit ?? 30);
+  const historyCutoff = getConversationHistoryCutoff(chatJid);
   const historyMsgs = recentHistory
     .reverse()
+    .filter((m) => !historyCutoff || m.timestamp > historyCutoff)
     .filter((m) => !pendingMessageIds.has(m.id))
     .filter((m) => m.content.trim().length > 0);
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -2545,6 +2545,8 @@ export function migrateWecomDirectWorkspaceMountsToSessions(): number {
     .transaction(() => {
       const groups = getAllRegisteredGroups();
       let migrated = 0;
+      const affectedWorkspaces = new Map<string, RegisteredGroup>();
+      const cutoff = new Date().toISOString();
 
       for (const [jid, group] of Object.entries(groups)) {
         if (!jid.startsWith('wecom:c2c:')) continue;
@@ -2599,17 +2601,27 @@ export function migrateWecomDirectWorkspaceMountsToSessions(): number {
           binding_mode: 'single_context',
         });
 
-        const ownerJid = getSessionChannelOwner(workspace.folder, null);
-        if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
-          clearSessionChannelOwner(workspace.folder, null);
-        }
+        affectedWorkspaces.set(workspaceJid, workspace);
 
         migrated += 1;
       }
 
+      let isolated = 0;
+      for (const [workspaceJid, workspace] of affectedWorkspaces) {
+        if (
+          isolateLegacyDirectWorkspaceMain(
+            workspaceJid,
+            workspace.folder,
+            cutoff,
+          )
+        ) {
+          isolated += 1;
+        }
+      }
+
       if (migrated > 0) {
         logger.info(
-          { migrated },
+          { migrated, isolatedWorkspaces: isolated },
           'Migrated WeCom direct chats off shared workspace main mounts',
         );
       }
@@ -2631,6 +2643,8 @@ export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
     .transaction(() => {
       const groups = getAllRegisteredGroups();
       let migrated = 0;
+      const affectedWorkspaces = new Map<string, RegisteredGroup>();
+      const cutoff = new Date().toISOString();
 
       for (const [jid, group] of Object.entries(groups)) {
         if (resolveChannelConversationKind(jid) !== 'direct') continue;
@@ -2685,17 +2699,56 @@ export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
           binding_mode: 'single_context',
         });
 
-        const ownerJid = getSessionChannelOwner(workspace.folder, null);
-        if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
-          clearSessionChannelOwner(workspace.folder, null);
-        }
+        affectedWorkspaces.set(workspaceJid, workspace);
 
         migrated += 1;
       }
 
-      if (migrated > 0) {
+      // A database already stamped v72 may have had its WeCom mount moved by
+      // the old migration without invalidating the contaminated main SDK
+      // session. Do not infer contamination merely from a dedicated session:
+      // require a persisted inbound row whose workspace chat_jid and direct
+      // source_jid prove that this DM previously entered main history.
+      for (const [jid, group] of Object.entries(groups)) {
+        if (resolveChannelConversationKind(jid) !== 'direct') continue;
+        if (!group.target_agent_id || group.target_main_jid) continue;
+        const agent = getAgent(group.target_agent_id);
+        if (!agent || agent.source_kind !== 'channel_direct') continue;
+        const workspaceJid = agent.chat_jid;
+        const workspace = getRegisteredGroup(workspaceJid);
+        if (!workspace) continue;
+        const conversationJid = channelConversationJid(jid);
+        const persistedSources = db
+          .prepare(
+            `SELECT DISTINCT source_jid FROM messages
+             WHERE chat_jid = ? AND is_from_me = 0 AND source_jid IS NOT NULL`,
+          )
+          .all(workspaceJid) as Array<{ source_jid: string }>;
+        if (
+          persistedSources.some(
+            (row) => channelConversationJid(row.source_jid) === conversationJid,
+          )
+        ) {
+          affectedWorkspaces.set(workspaceJid, workspace);
+        }
+      }
+
+      let isolated = 0;
+      for (const [workspaceJid, workspace] of affectedWorkspaces) {
+        if (
+          isolateLegacyDirectWorkspaceMain(
+            workspaceJid,
+            workspace.folder,
+            cutoff,
+          )
+        ) {
+          isolated += 1;
+        }
+      }
+
+      if (migrated > 0 || isolated > 0) {
         logger.info(
-          { migrated },
+          { migrated, isolatedWorkspaces: isolated },
           'Migrated classifiable direct chats off shared workspace main mounts',
         );
       }
@@ -8304,6 +8357,48 @@ function sessionChannelOwnerKey(
   agentId?: string | null,
 ): string {
   return `channel_session_owner:${groupFolder}:${agentId || 'main'}`;
+}
+
+const CONVERSATION_HISTORY_CUTOFF_PREFIX = 'conversation_history_cutoff:';
+
+/**
+ * Earliest persisted message timestamp that may be replayed into a fresh SDK
+ * session for this logical chat. A cutoff is written when a legacy direct
+ * mount proves the workspace main history may contain private conversation
+ * content. The Web transcript remains intact; only model-context recovery is
+ * fenced.
+ */
+export function getConversationHistoryCutoff(
+  chatJid: string,
+): string | undefined {
+  return getRouterState(`${CONVERSATION_HISTORY_CUTOFF_PREFIX}${chatJid}`);
+}
+
+/**
+ * Atomically invalidate a workspace main resume lifecycle once. The cutoff is
+ * the durable idempotency marker: a later retry must not delete a clean session
+ * that the workspace created after this migration completed.
+ */
+function isolateLegacyDirectWorkspaceMain(
+  workspaceJid: string,
+  groupFolder: string,
+  cutoff: string,
+): boolean {
+  const inserted = db
+    .prepare('INSERT OR IGNORE INTO router_state (key, value) VALUES (?, ?)')
+    .run(`${CONVERSATION_HISTORY_CUTOFF_PREFIX}${workspaceJid}`, cutoff);
+  if (inserted.changes === 0) return false;
+
+  db.prepare(
+    "DELETE FROM sessions WHERE group_folder = ? AND agent_id = ''",
+  ).run(groupFolder);
+  db.prepare(
+    "DELETE FROM workspace_runtime_sessions WHERE group_folder = ? AND runtime_agent_id = ''",
+  ).run(groupFolder);
+  db.prepare('DELETE FROM router_state WHERE key = ?').run(
+    sessionChannelOwnerKey(groupFolder, null),
+  );
+  return true;
 }
 
 /** The first native transport that owns a logical warm Session. */

--- a/src/db.ts
+++ b/src/db.ts
@@ -140,8 +140,14 @@ function stmts() {
         `INSERT OR REPLACE INTO messages (
           id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me,
           attachments, token_usage, channel_context, turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason, task_id,
-          delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at,
+          history_recovery_allowed
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          COALESCE((
+            SELECT history_recovery_allowed FROM messages
+            WHERE id = ? AND chat_jid = ?
+          ), 1)
+        )`,
       ),
       insertUsageInsert: db.prepare(
         `INSERT INTO usage_records (id, event_id, user_id, group_folder, agent_id, message_id, model,
@@ -566,6 +572,7 @@ export function initDatabase(): void {
       delivery_run_id TEXT,
       delivery_priority INTEGER NOT NULL DEFAULT 0,
       delivery_updated_at TEXT,
+      history_recovery_allowed INTEGER NOT NULL DEFAULT 1,
       PRIMARY KEY (id, chat_jid),
       FOREIGN KEY (chat_jid) REFERENCES chats(jid)
     );
@@ -1442,9 +1449,19 @@ export function initDatabase(): void {
   ensureColumn('messages', 'delivery_run_id', 'TEXT');
   ensureColumn('messages', 'delivery_priority', 'INTEGER NOT NULL DEFAULT 0');
   ensureColumn('messages', 'delivery_updated_at', 'TEXT');
+  // v72 -> v73: fence legacy workspace transcript rows that mixed private and
+  // group messages without trusting provider-controlled timestamps. Existing
+  // rows can be disabled for model recovery while future rows default to safe.
+  ensureColumn(
+    'messages',
+    'history_recovery_allowed',
+    'INTEGER NOT NULL DEFAULT 1',
+  );
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_messages_follow_up_queue
       ON messages(chat_jid, delivery_status, delivery_priority, timestamp, id);
+    CREATE INDEX IF NOT EXISTS idx_messages_history_recovery
+      ON messages(chat_jid, history_recovery_allowed, timestamp);
   `);
   // A process may have crashed after reserving a queued message for a card
   // action but before injecting it. Reservations are process-local, so make
@@ -2709,6 +2726,7 @@ export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
       // session. Do not infer contamination merely from a dedicated session:
       // require a persisted inbound row whose workspace chat_jid and direct
       // source_jid prove that this DM previously entered main history.
+      const persistedSourcesByWorkspace = new Map<string, Set<string>>();
       for (const [jid, group] of Object.entries(groups)) {
         if (resolveChannelConversationKind(jid) !== 'direct') continue;
         if (!group.target_agent_id || group.target_main_jid) continue;
@@ -2718,17 +2736,20 @@ export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
         const workspace = getRegisteredGroup(workspaceJid);
         if (!workspace) continue;
         const conversationJid = channelConversationJid(jid);
-        const persistedSources = db
-          .prepare(
-            `SELECT DISTINCT source_jid FROM messages
-             WHERE chat_jid = ? AND is_from_me = 0 AND source_jid IS NOT NULL`,
-          )
-          .all(workspaceJid) as Array<{ source_jid: string }>;
-        if (
-          persistedSources.some(
-            (row) => channelConversationJid(row.source_jid) === conversationJid,
-          )
-        ) {
+        let persistedSources = persistedSourcesByWorkspace.get(workspaceJid);
+        if (!persistedSources) {
+          const rows = db
+            .prepare(
+              `SELECT DISTINCT source_jid FROM messages
+               WHERE chat_jid = ? AND is_from_me = 0 AND source_jid IS NOT NULL`,
+            )
+            .all(workspaceJid) as Array<{ source_jid: string }>;
+          persistedSources = new Set(
+            rows.map((row) => channelConversationJid(row.source_jid)),
+          );
+          persistedSourcesByWorkspace.set(workspaceJid, persistedSources);
+        }
+        if (persistedSources.has(conversationJid)) {
           affectedWorkspaces.set(workspaceJid, workspace);
         }
       }
@@ -2999,6 +3020,8 @@ export function storeMessageDirect(
     meta?.deliveryRunId ?? null,
     meta?.deliveryPriority ?? 0,
     meta?.deliveryUpdatedAt ?? null,
+    effectiveMsgId,
+    chatJid,
   );
   return effectiveMsgId;
 }
@@ -8359,36 +8382,40 @@ function sessionChannelOwnerKey(
   return `channel_session_owner:${groupFolder}:${agentId || 'main'}`;
 }
 
-const CONVERSATION_HISTORY_CUTOFF_PREFIX = 'conversation_history_cutoff:';
+const CONVERSATION_HISTORY_ISOLATION_PREFIX = 'conversation_history_isolation:';
 
 /**
- * Earliest persisted message timestamp that may be replayed into a fresh SDK
- * session for this logical chat. A cutoff is written when a legacy direct
- * mount proves the workspace main history may contain private conversation
- * content. The Web transcript remains intact; only model-context recovery is
- * fenced.
+ * Durable marker written after a legacy direct mount proves the workspace main
+ * history may contain private conversation content. The Web transcript remains
+ * intact; affected rows are unavailable only to model-context recovery.
  */
-export function getConversationHistoryCutoff(
+export function getConversationHistoryIsolationMarker(
   chatJid: string,
 ): string | undefined {
-  return getRouterState(`${CONVERSATION_HISTORY_CUTOFF_PREFIX}${chatJid}`);
+  return getRouterState(`${CONVERSATION_HISTORY_ISOLATION_PREFIX}${chatJid}`);
 }
 
 /**
- * Atomically invalidate a workspace main resume lifecycle once. The cutoff is
- * the durable idempotency marker: a later retry must not delete a clean session
- * that the workspace created after this migration completed.
+ * Atomically invalidate a workspace main resume lifecycle once. The marker
+ * makes this idempotent: a later retry must not delete a clean session that the
+ * workspace created after this migration completed.
  */
 function isolateLegacyDirectWorkspaceMain(
   workspaceJid: string,
   groupFolder: string,
-  cutoff: string,
+  isolationStartedAt: string,
 ): boolean {
   const inserted = db
     .prepare('INSERT OR IGNORE INTO router_state (key, value) VALUES (?, ?)')
-    .run(`${CONVERSATION_HISTORY_CUTOFF_PREFIX}${workspaceJid}`, cutoff);
+    .run(
+      `${CONVERSATION_HISTORY_ISOLATION_PREFIX}${workspaceJid}`,
+      isolationStartedAt,
+    );
   if (inserted.changes === 0) return false;
 
+  db.prepare(
+    'UPDATE messages SET history_recovery_allowed = 0 WHERE chat_jid = ?',
+  ).run(workspaceJid);
   db.prepare(
     "DELETE FROM sessions WHERE group_folder = ? AND agent_id = ''",
   ).run(groupFolder);
@@ -12451,6 +12478,36 @@ export function getMessagesPage(
     NewMessage & { is_from_me: number }
   >;
 
+  return rows.map((row) => normalizeMessageRow(row));
+}
+
+/**
+ * Recent persisted messages that are safe to replay into a fresh model
+ * session. Privacy migrations leave the Web transcript untouched and fence
+ * only legacy mixed-history rows. Current cold-run messages are excluded in
+ * SQL so a large pending batch cannot consume the entire recovery window.
+ */
+export function getConversationHistoryMessagesPage(
+  chatJid: string,
+  excludedMessageIds: ReadonlySet<string>,
+  limit = 50,
+): Array<NewMessage & { is_from_me: boolean }> {
+  const excluded = [...excludedMessageIds].filter(Boolean);
+  const safeLimit = Math.min(200, Math.max(1, Math.floor(limit)));
+  const rows = db
+    .prepare(
+      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
+              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
+              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
+       FROM messages
+       WHERE chat_jid = ? AND history_recovery_allowed = 1
+         AND id NOT IN (SELECT value FROM json_each(?))
+       ORDER BY timestamp DESC, id DESC
+       LIMIT ?`,
+    )
+    .all(chatJid, JSON.stringify(excluded), safeLimit) as Array<
+    NewMessage & { is_from_me: number }
+  >;
   return rows.map((row) => normalizeMessageRow(row));
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -70,6 +70,7 @@ import {
 } from './types.js';
 import { getDefaultPermissions, normalizePermissions } from './permissions.js';
 import { channelConversationJid } from './channel-address.js';
+import { resolveChannelConversationKind } from './channel-conversation-kind.js';
 import { getChannelFromJid } from './channel-prefixes.js';
 import { parseAudienceMode } from './im-audience-policy.js';
 import { parseContainerConfig } from './mount-security.js';
@@ -103,7 +104,7 @@ let db: InstanceType<typeof Database>;
  * restating the number. Hardcoding it meant every schema bump edited a dozen
  * unrelated test files, which is churn that hides real assertion changes.
  */
-export const CURRENT_SCHEMA_VERSION = 72;
+export const CURRENT_SCHEMA_VERSION = 73;
 
 export function isDatabaseInitialized(): boolean {
   return Boolean(db?.open);
@@ -2513,6 +2514,20 @@ export function initDatabase(): void {
     migrateWecomDirectWorkspaceMountsToSessions();
   }
 
+  // v72 -> v73: #654 already made new registration kind-aware and migrated
+  // leftover WeCom DMs. Pre-#654 chats on other JID-classifiable channels
+  // (QQ / DingTalk / Discord / WhatsApp / Telegram / WeChat) can still sit
+  // on target_main_jid and share channel_session_owner:{folder}:main with a
+  // group in the same workspace — including a WeChat DM stealing owner from
+  // a group on another channel. Classify from the JID only; Feishu stays
+  // unknown here and is not migrated. Do not rewrite the v72 WeCom block.
+  const classifiableDirectMountSchemaVersion = Number(
+    getRouterStateInternal('schema_version') ?? '0',
+  );
+  if (classifiableDirectMountSchemaVersion < 73) {
+    migrateClassifiableDirectWorkspaceMountsToSessions();
+  }
+
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', String(CURRENT_SCHEMA_VERSION));
@@ -2596,6 +2611,92 @@ export function migrateWecomDirectWorkspaceMountsToSessions(): number {
         logger.info(
           { migrated },
           'Migrated WeCom direct chats off shared workspace main mounts',
+        );
+      }
+      return migrated;
+    })
+    .immediate();
+}
+
+/**
+ * Move leftover JID-classifiable DMs off a shared workspace main mount.
+ * Same skip rules as v72: already-bound sessions (manual or v72 WeCom),
+ * groups, unknown/unclassifiable JIDs (including Feishu without metadata),
+ * and missing workspaces stay untouched. If the workspace main owner still
+ * points at the DM, clear it so a later group message cannot keep
+ * delivering into that private chat.
+ */
+export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
+  return db
+    .transaction(() => {
+      const groups = getAllRegisteredGroups();
+      let migrated = 0;
+
+      for (const [jid, group] of Object.entries(groups)) {
+        if (resolveChannelConversationKind(jid) !== 'direct') continue;
+        if (!group.target_main_jid || group.target_agent_id) continue;
+
+        const workspaceJid = resolveWorkspaceJidForMount(group.target_main_jid);
+        if (!workspaceJid) continue;
+        const workspace = getRegisteredGroup(workspaceJid);
+        if (!workspace) continue;
+
+        const conversationJid = channelConversationJid(jid);
+        const reusable = listAgentsByJid(workspaceJid).find(
+          (agent) =>
+            agent.source_kind === 'channel_direct' &&
+            agent.last_im_jid &&
+            (agent.last_im_jid === conversationJid ||
+              channelConversationJid(agent.last_im_jid) === conversationJid),
+        );
+
+        const now = new Date().toISOString();
+        const agent =
+          reusable ??
+          (() => {
+            const created: SubAgent = {
+              id: crypto.randomUUID(),
+              group_folder: workspace.folder,
+              chat_jid: workspaceJid,
+              name: group.name || conversationJid,
+              prompt: '',
+              status: 'idle',
+              kind: 'conversation',
+              created_by: group.created_by ?? workspace.created_by ?? null,
+              created_at: now,
+              completed_at: null,
+              result_summary: null,
+              last_im_jid: conversationJid,
+              spawned_from_jid: null,
+              source_kind: 'channel_direct',
+              last_active_at: now,
+            };
+            createAgent(created);
+            const virtualChatJid = `${workspaceJid}#agent:${created.id}`;
+            ensureChatExists(virtualChatJid);
+            updateChatName(virtualChatJid, created.name);
+            return created;
+          })();
+
+        setRegisteredGroup(jid, {
+          ...group,
+          target_agent_id: agent.id,
+          target_main_jid: undefined,
+          binding_mode: 'single_context',
+        });
+
+        const ownerJid = getSessionChannelOwner(workspace.folder, null);
+        if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
+          clearSessionChannelOwner(workspace.folder, null);
+        }
+
+        migrated += 1;
+      }
+
+      if (migrated > 0) {
+        logger.info(
+          { migrated },
+          'Migrated classifiable direct chats off shared workspace main mounts',
         );
       }
       return migrated;

--- a/src/im-command-utils.ts
+++ b/src/im-command-utils.ts
@@ -328,7 +328,7 @@ export function checkImOwnerCommand(
  *   - qq:        `qq:c2c:{openid}`            (group → `qq:group:...`)
  *   - dingtalk:  `dingtalk:c2c:{staffId}`     (group → `dingtalk:{cid...}`)
  *   - discord:   `discord:dm:{userId}`        (guild → `discord:{channelId}`)
- *   - whatsapp:  `...@s.whatsapp.net`         (group → `...@g.us`)
+ *   - whatsapp:  `...@s.whatsapp.net` / `...@lid` (group → `...@g.us`)
  *   - wechat:    `wechat:{userId}`            (1:1 only — no group support)
  *   - telegram:  `telegram:{chatId}`          (private chat id is positive;
  *                groups/supergroups are negative — a stable Bot API guarantee)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8816,6 +8816,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       currentSourceJid,
       currentChannelContext,
       agentProfile,
+      missedMessages.map((message) => message.id),
     );
   } finally {
     runEnded = true;
@@ -9727,6 +9728,7 @@ async function runAgent(
   currentSourceJid?: string,
   channelContext?: ChannelTurnContext,
   agentProfile?: AgentProfile,
+  currentBatchMessageIds?: readonly string[],
 ): Promise<{ status: 'success' | 'error' | 'closed'; error?: string }> {
   const isHome = !!group.is_home;
   const owner = group.created_by ? getUserById(group.created_by) : undefined;
@@ -9920,6 +9922,7 @@ async function runAgent(
           prompt,
           sessionId,
           turnId,
+          currentBatchMessageIds,
           queryRunId: queue.getActiveQueryId(chatJid) ?? undefined,
           groupFolder: group.folder,
           chatJid,
@@ -9949,6 +9952,7 @@ async function runAgent(
           prompt,
           sessionId,
           turnId,
+          currentBatchMessageIds,
           queryRunId: queue.getActiveQueryId(chatJid) ?? undefined,
           groupFolder: group.folder,
           chatJid,
@@ -16826,6 +16830,7 @@ async function processAgentConversation(
       prompt,
       sessionId,
       turnId: lastProcessed.id,
+      currentBatchMessageIds: missedMessages.map((message) => message.id),
       queryRunId: queue.getActiveQueryId(virtualJid) ?? undefined,
       groupFolder: effectiveGroup.folder,
       chatJid,

--- a/src/provider-switch-context.ts
+++ b/src/provider-switch-context.ts
@@ -7,6 +7,8 @@ export interface ProviderSwitchInput {
   groupFolder: string;
   chatJid: string;
   turnId?: string;
+  /** Persisted message IDs already represented by this cold-run prompt. */
+  readonly currentBatchMessageIds?: readonly string[];
   isScheduledTask?: boolean;
   agentId?: string;
 }
@@ -36,7 +38,7 @@ function seedPromptWithPersistedHistory<T extends ProviderSwitchInput>(
   // Orchestration may already have prepended recovery/provider-switch history.
   if (input.prompt.includes('<system_context>')) return input;
 
-  const pendingMessageIds = new Set<string>();
+  const pendingMessageIds = new Set(input.currentBatchMessageIds);
   if (input.turnId) pendingMessageIds.add(input.turnId);
 
   const chatJid = conversationHistoryChatJid(input);

--- a/src/provider-switch-context.ts
+++ b/src/provider-switch-context.ts
@@ -1,0 +1,106 @@
+import { logger } from './logger.js';
+import { deleteSession, setSessionProviderId } from './db.js';
+import { buildRecentConversationHistoryContext } from './conversation-history.js';
+export interface ProviderSwitchInput {
+  prompt: string;
+  sessionId?: string;
+  groupFolder: string;
+  chatJid: string;
+  turnId?: string;
+  isScheduledTask?: boolean;
+  agentId?: string;
+}
+
+const PROVIDER_SWITCH_HISTORY_INTRO =
+  '检测到本次因切换 provider 需要使用新的底层模型 session。以下是 HappyClaw 保存的最近对话记录，供你延续上下文。';
+
+export interface ProviderSwitchSelection {
+  profileId: string;
+  previousProviderId?: string;
+  resetSession?: boolean;
+}
+
+function conversationHistoryChatJid(input: ProviderSwitchInput): string {
+  if (!input.agentId) return input.chatJid;
+  if (input.chatJid.includes('#agent:')) return input.chatJid;
+  return `${input.chatJid}#agent:${input.agentId}`;
+}
+
+function seedPromptWithPersistedHistory<T extends ProviderSwitchInput>(
+  input: T,
+): T {
+  // Isolated scheduled tasks use their own session namespace and must not
+  // inherit the workspace chat. Conversation turns (including group-mode
+  // scheduled prompts that arrive via processGroupMessages) do.
+  if (input.isScheduledTask) return input;
+  // Orchestration may already have prepended recovery/provider-switch history.
+  if (input.prompt.includes('<system_context>')) return input;
+
+  const pendingMessageIds = new Set<string>();
+  if (input.turnId) pendingMessageIds.add(input.turnId);
+
+  const chatJid = conversationHistoryChatJid(input);
+  const history = buildRecentConversationHistoryContext(
+    chatJid,
+    pendingMessageIds,
+    {
+      limit: 30,
+      maxMessageLength: 700,
+      intro: PROVIDER_SWITCH_HISTORY_INTRO,
+    },
+  );
+  if (!history) return input;
+
+  logger.info(
+    {
+      groupFolder: input.groupFolder,
+      chatJid,
+      historyCount: history.count,
+    },
+    'Provider switch: injected recent conversation history into prompt',
+  );
+  return { ...input, prompt: history.context + input.prompt };
+}
+
+/**
+ * Claude SDK sessions are bound to one OAuth account / provider. When the
+ * pool fails over, drop the resume token and seed the replacement session
+ * with HappyClaw's persisted transcript so prior user/assistant turns survive.
+ *
+ * Isolated scheduled tasks only drop the resume token.
+ */
+export function applyProviderSwitchToInput<T extends ProviderSwitchInput>(
+  input: T,
+  poolResult: ProviderSwitchSelection | null,
+  sessionAgentId?: string | null,
+): T {
+  if (!poolResult?.resetSession) return input;
+
+  logger.info(
+    {
+      groupFolder: input.groupFolder,
+      agentId: sessionAgentId || null,
+      previousProviderId: poolResult.previousProviderId,
+      providerId: poolResult.profileId,
+    },
+    'Clearing Claude session after switching providers',
+  );
+
+  // deleteSession removes the whole sessions row, including the provider_id
+  // binding trySelectPoolProvider just wrote. Re-bind the freshly-selected
+  // provider so the next turn stays sticky to it instead of degrading to a
+  // fresh pool pick.
+  if (input.sessionId) {
+    deleteSession(input.groupFolder, sessionAgentId);
+    setSessionProviderId(
+      input.groupFolder,
+      sessionAgentId,
+      poolResult.profileId,
+    );
+  }
+
+  return {
+    ...seedPromptWithPersistedHistory(input),
+    sessionId: undefined,
+  };
+}

--- a/tests/channel-conversation-kind.test.ts
+++ b/tests/channel-conversation-kind.test.ts
@@ -13,6 +13,11 @@ describe('resolveChannelConversationKind', () => {
     ['discord:dm:123', 'direct'],
     ['discord:456', 'group'],
     ['whatsapp:123@s.whatsapp.net', 'direct'],
+    ['whatsapp:1555:42@s.whatsapp.net', 'direct'],
+    ['whatsapp:123456789012345@lid', 'direct'],
+    ['whatsapp:123456789012345@lid#account:bot-a', 'direct'],
+    ['whatsapp:hosted-user@hosted', 'direct'],
+    ['whatsapp:hosted-user@hosted.lid', 'direct'],
     ['whatsapp:123@g.us', 'group'],
     ['wechat:wxid_user', 'direct'],
     ['wecom:c2c:user#account:bot-a', 'direct'],
@@ -40,6 +45,12 @@ describe('resolveChannelConversationKind', () => {
       'unknown',
     );
     expect(resolveChannelConversationKind('web:main')).toBe('unknown');
+    expect(resolveChannelConversationKind('whatsapp:status@broadcast')).toBe(
+      'unknown',
+    );
+    expect(resolveChannelConversationKind('whatsapp:123@newsletter')).toBe(
+      'unknown',
+    );
   });
 });
 

--- a/tests/conversation-history.test.ts
+++ b/tests/conversation-history.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getMessagesPage: vi.fn(),
+  getConversationHistoryCutoff: vi.fn(),
 }));
 
 vi.mock('../src/db.js', () => ({
   getMessagesPage: mocks.getMessagesPage,
+  getConversationHistoryCutoff: mocks.getConversationHistoryCutoff,
 }));
 
 const { buildRecentConversationHistoryContext } =
@@ -14,6 +16,7 @@ const { buildRecentConversationHistoryContext } =
 describe('conversation history recovery context', () => {
   beforeEach(() => {
     mocks.getMessagesPage.mockReset();
+    mocks.getConversationHistoryCutoff.mockReset();
   });
 
   test('returns stable message IDs and tags every recovered turn', () => {
@@ -71,5 +74,44 @@ describe('conversation history recovery context', () => {
 
     expect(result?.messageIds).toEqual(['history-1']);
     expect(result?.context).not.toContain('id="pending-1"');
+  });
+
+  test('does not replay messages at or before a persisted isolation cutoff', () => {
+    mocks.getConversationHistoryCutoff.mockReturnValue(
+      '2026-08-19T01:00:00.000Z',
+    );
+    mocks.getMessagesPage.mockReturnValue([
+      {
+        id: 'safe-after-cutoff',
+        content: '新的群聊消息',
+        sender_name: 'Bob',
+        is_from_me: false,
+        timestamp: '2026-08-19T01:00:00.001Z',
+      },
+      {
+        id: 'private-at-cutoff',
+        content: '旧私聊秘密',
+        sender_name: 'Alice',
+        is_from_me: false,
+        timestamp: '2026-08-19T01:00:00.000Z',
+      },
+      {
+        id: 'private-before-cutoff',
+        content: '更早的私聊秘密',
+        sender_name: 'Alice',
+        is_from_me: false,
+        timestamp: '2026-08-19T00:59:59.999Z',
+      },
+    ]);
+
+    const result = buildRecentConversationHistoryContext(
+      'web:main',
+      new Set(),
+      { intro: '恢复上下文' },
+    );
+
+    expect(result?.messageIds).toEqual(['safe-after-cutoff']);
+    expect(result?.context).toContain('新的群聊消息');
+    expect(result?.context).not.toContain('旧私聊秘密');
   });
 });

--- a/tests/conversation-history.test.ts
+++ b/tests/conversation-history.test.ts
@@ -1,13 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  getMessagesPage: vi.fn(),
-  getConversationHistoryCutoff: vi.fn(),
+  getConversationHistoryMessagesPage: vi.fn(),
 }));
 
 vi.mock('../src/db.js', () => ({
-  getMessagesPage: mocks.getMessagesPage,
-  getConversationHistoryCutoff: mocks.getConversationHistoryCutoff,
+  getConversationHistoryMessagesPage: mocks.getConversationHistoryMessagesPage,
 }));
 
 const { buildRecentConversationHistoryContext } =
@@ -15,12 +13,11 @@ const { buildRecentConversationHistoryContext } =
 
 describe('conversation history recovery context', () => {
   beforeEach(() => {
-    mocks.getMessagesPage.mockReset();
-    mocks.getConversationHistoryCutoff.mockReset();
+    mocks.getConversationHistoryMessagesPage.mockReset();
   });
 
   test('returns stable message IDs and tags every recovered turn', () => {
-    mocks.getMessagesPage.mockReturnValue([
+    mocks.getConversationHistoryMessagesPage.mockReturnValue([
       {
         id: 'assistant-1',
         content: '收到',
@@ -51,7 +48,7 @@ describe('conversation history recovery context', () => {
   });
 
   test('excludes the pending turn from both context and known IDs', () => {
-    mocks.getMessagesPage.mockReturnValue([
+    mocks.getConversationHistoryMessagesPage.mockReturnValue([
       {
         id: 'pending-1',
         content: '当前消息',
@@ -76,42 +73,29 @@ describe('conversation history recovery context', () => {
     expect(result?.context).not.toContain('id="pending-1"');
   });
 
-  test('does not replay messages at or before a persisted isolation cutoff', () => {
-    mocks.getConversationHistoryCutoff.mockReturnValue(
-      '2026-08-19T01:00:00.000Z',
-    );
-    mocks.getMessagesPage.mockReturnValue([
+  test('uses the recovery-safe DB page and forwards the full pending-ID exclusion', () => {
+    mocks.getConversationHistoryMessagesPage.mockReturnValue([
       {
-        id: 'safe-after-cutoff',
+        id: 'safe-history',
         content: '新的群聊消息',
         sender_name: 'Bob',
         is_from_me: false,
-        timestamp: '2026-08-19T01:00:00.001Z',
-      },
-      {
-        id: 'private-at-cutoff',
-        content: '旧私聊秘密',
-        sender_name: 'Alice',
-        is_from_me: false,
-        timestamp: '2026-08-19T01:00:00.000Z',
-      },
-      {
-        id: 'private-before-cutoff',
-        content: '更早的私聊秘密',
-        sender_name: 'Alice',
-        is_from_me: false,
-        timestamp: '2026-08-19T00:59:59.999Z',
       },
     ]);
 
-    const result = buildRecentConversationHistoryContext(
-      'web:main',
-      new Set(),
-      { intro: '恢复上下文' },
+    const pending = new Set(
+      Array.from({ length: 30 }, (_, index) => `pending-${index}`),
     );
+    const result = buildRecentConversationHistoryContext('web:main', pending, {
+      intro: '恢复上下文',
+    });
 
-    expect(result?.messageIds).toEqual(['safe-after-cutoff']);
+    expect(mocks.getConversationHistoryMessagesPage).toHaveBeenCalledWith(
+      'web:main',
+      pending,
+      30,
+    );
+    expect(result?.messageIds).toEqual(['safe-history']);
     expect(result?.context).toContain('新的群聊消息');
-    expect(result?.context).not.toContain('旧私聊秘密');
   });
 });

--- a/tests/db-upgrade-safety.test.ts
+++ b/tests/db-upgrade-safety.test.ts
@@ -171,8 +171,10 @@ describe('schema version head', () => {
     // one assertion that fails when the head moves, forcing whoever bumps it
     // to confirm the matching migration block — and a test covering it —
     // actually landed. Update the literal in the same commit as the migration.
-    // v72: moves WeCom DMs off a shared workspace main owner slot; see
-    // tests/schema-v72-wecom-direct-mount.test.ts for migration coverage.
-    expect(db.CURRENT_SCHEMA_VERSION).toBe(72);
+    // v73: generalizes the v72 WeCom DM remount to other JID-classifiable
+    // DMs (QQ / DingTalk / Discord / WhatsApp / Telegram / WeChat leftover
+    // target_main_jid collisions). See
+    // tests/schema-v73-classifiable-direct-mount.test.ts. Do not rewrite v72.
+    expect(db.CURRENT_SCHEMA_VERSION).toBe(73);
   });
 });

--- a/tests/im-owner-gate.test.ts
+++ b/tests/im-owner-gate.test.ts
@@ -112,6 +112,10 @@ describe('isDirectMessageJid', () => {
     expect(isDirectMessageJid('whatsapp:15551234567@s.whatsapp.net')).toBe(
       true,
     );
+    expect(isDirectMessageJid('whatsapp:123456789012345@lid')).toBe(true);
+    expect(
+      isDirectMessageJid('whatsapp:123456789012345@lid#account:bot-a'),
+    ).toBe(true);
     expect(isDirectMessageJid('wechat:wxid_abc123')).toBe(true);
     // Telegram private chats have positive ids
     expect(isDirectMessageJid('telegram:123456789')).toBe(true);

--- a/tests/provider-failover-batch-wiring.test.ts
+++ b/tests/provider-failover-batch-wiring.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+
+import { describe, expect, test } from 'vitest';
+
+const main = fs.readFileSync('src/index.ts', 'utf8');
+
+describe('provider failover cold-run batch wiring', () => {
+  test('main conversations pass every pending message ID through both execution modes', () => {
+    const mainConversation = main.slice(
+      main.indexOf('async function processGroupMessages('),
+      main.indexOf('async function runTerminalWarmup('),
+    );
+    expect(mainConversation).toMatch(
+      /runAgent\([\s\S]*?missedMessages\.map\(\(message\) => message\.id\),\s*\);/,
+    );
+
+    const runAgent = main.slice(
+      main.indexOf('async function runAgent('),
+      main.indexOf('interface SendMessageOutcome'),
+    );
+    expect(runAgent.match(/currentBatchMessageIds,/g)).toHaveLength(2);
+  });
+
+  test('conversation agents put every pending message ID on their cold-run input', () => {
+    const agentConversation = main.slice(
+      main.indexOf('async function processAgentConversation('),
+      main.indexOf('async function startMessageLoop()'),
+    );
+    expect(agentConversation).toContain(
+      'currentBatchMessageIds: missedMessages.map((message) => message.id)',
+    );
+  });
+});

--- a/tests/provider-failover-keep-context.test.ts
+++ b/tests/provider-failover-keep-context.test.ts
@@ -90,6 +90,7 @@ function conversationInput(opts?: {
   sessionId?: string;
   chatJid?: string;
   turnId?: string;
+  currentBatchMessageIds?: readonly string[];
   isScheduledTask?: boolean;
   agentId?: string;
   groupFolder?: string;
@@ -100,6 +101,7 @@ function conversationInput(opts?: {
     groupFolder: opts?.groupFolder ?? 'failover-keep-context',
     chatJid: opts?.chatJid ?? 'web:failover-keep-context',
     turnId: opts?.turnId ?? 'pending-now',
+    currentBatchMessageIds: opts?.currentBatchMessageIds,
     isScheduledTask: opts?.isScheduledTask,
     agentId: opts?.agentId,
     isMain: true,
@@ -190,6 +192,58 @@ describe('provider failover keeps conversation context', () => {
     expect(prepared.sessionId).toBe('sess-keep');
     expect(prepared.prompt).toBe('只问这一句');
     expect(prepared.prompt).not.toContain('<system_context>');
+  });
+
+  test('excludes every pending message in a cold-run batch while preserving the original prompt', () => {
+    const groupFolder = 'failover-pending-batch';
+    const chatJid = 'web:failover-pending-batch';
+    const currentPrompt = 'Dennis: 第一条当前消息\nDennis: 第二条当前消息';
+    persistTurn(
+      chatJid,
+      'hist-user',
+      '需要保留的历史消息',
+      false,
+      '2026-08-18T10:30:00.000Z',
+    );
+    persistTurn(
+      chatJid,
+      'pending-first',
+      '第一条当前消息',
+      false,
+      '2026-08-18T10:30:01.000Z',
+    );
+    persistTurn(
+      chatJid,
+      'pending-last',
+      '第二条当前消息',
+      false,
+      '2026-08-18T10:30:02.000Z',
+    );
+
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({
+        groupFolder,
+        chatJid,
+        turnId: 'pending-last',
+        currentBatchMessageIds: ['pending-first', 'pending-last'],
+        prompt: currentPrompt,
+      }),
+      {
+        profileId: created[1],
+        previousProviderId: created[0],
+        resetSession: true,
+      },
+      null,
+    );
+
+    const historyBlock = prepared.prompt.slice(
+      0,
+      prepared.prompt.indexOf('</system_context>'),
+    );
+    expect(historyBlock).toContain('需要保留的历史消息');
+    expect(historyBlock).not.toContain('第一条当前消息');
+    expect(historyBlock).not.toContain('第二条当前消息');
+    expect(prepared.prompt.endsWith(currentPrompt)).toBe(true);
   });
 
   test('does not double-inject when orchestration already seeded history', () => {

--- a/tests/provider-failover-keep-context.test.ts
+++ b/tests/provider-failover-keep-context.test.ts
@@ -1,0 +1,237 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'provider-failover-context-'),
+);
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: root,
+  STORE_DIR: path.join(root, 'db'),
+  GROUPS_DIR: path.join(root, 'groups'),
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const runtimeConfig = await import('../src/runtime-config.js');
+const db = await import('../src/db.js');
+const { trySelectPoolProvider } = await import('../src/container-runner.js');
+const { applyProviderSwitchToInput } =
+  await import('../src/provider-switch-context.js');
+const { providerPool } = await import('../src/provider-pool.js');
+
+const created: string[] = [];
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(root, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'groups'), { recursive: true });
+  db.initDatabase();
+  for (const name of ['Account A', 'Account B']) {
+    created.push(
+      runtimeConfig.createProvider({
+        name,
+        type: 'official',
+        anthropicApiKey: `${name.replace(/\s+/g, '-').toLowerCase()}-key`,
+        anthropicModel: 'claude-fable-5',
+        enabled: true,
+      }).id,
+    );
+  }
+  runtimeConfig.saveBalancingConfig({
+    strategy: 'failover',
+    unhealthyThreshold: 1,
+    recoveryIntervalMs: 300_000,
+  });
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const id of created) providerPool.resetHealth(id);
+});
+
+function persistTurn(
+  chatJid: string,
+  id: string,
+  content: string,
+  isFromMe: boolean,
+  timestamp: string,
+) {
+  db.ensureChatExists(chatJid);
+  db.storeMessageDirect(
+    id,
+    chatJid,
+    isFromMe ? 'happyclaw' : 'user-1',
+    isFromMe ? 'HappyClaw' : 'Dennis',
+    content,
+    timestamp,
+    isFromMe,
+  );
+}
+
+function conversationInput(opts?: {
+  prompt?: string;
+  sessionId?: string;
+  chatJid?: string;
+  turnId?: string;
+  isScheduledTask?: boolean;
+  agentId?: string;
+  groupFolder?: string;
+}) {
+  return {
+    prompt: opts?.prompt ?? '当前用户消息',
+    sessionId: opts?.sessionId ?? 'sess-account-a',
+    groupFolder: opts?.groupFolder ?? 'failover-keep-context',
+    chatJid: opts?.chatJid ?? 'web:failover-keep-context',
+    turnId: opts?.turnId ?? 'pending-now',
+    isScheduledTask: opts?.isScheduledTask,
+    agentId: opts?.agentId,
+    isMain: true,
+  };
+}
+
+/**
+ * Session stickiness binds a Claude SDK session to one OAuth account.
+ * Failover must start a new session on the next provider, but the new
+ * prompt has to carry HappyClaw's persisted user/assistant turns — otherwise
+ * the replacement account sees an empty conversation.
+ */
+describe('provider failover keeps conversation context', () => {
+  test('sticky provider fails → next provider is selected with prior turns seeded', () => {
+    const groupFolder = 'failover-keep-context';
+    const chatJid = 'web:failover-keep-context';
+    db.setSession(groupFolder, 'sess-account-a', null);
+    db.setSessionProviderId(groupFolder, null, created[0]);
+    persistTurn(
+      chatJid,
+      'user-1',
+      '请记住项目代号 Phoenix',
+      false,
+      '2026-08-18T10:00:00.000Z',
+    );
+    persistTurn(
+      chatJid,
+      'asst-1',
+      '已记住，项目代号是 Phoenix。',
+      true,
+      '2026-08-18T10:00:01.000Z',
+    );
+    persistTurn(
+      chatJid,
+      'pending-now',
+      '继续刚才的计划',
+      false,
+      '2026-08-18T10:00:02.000Z',
+    );
+
+    providerPool.reportFailure(created[0], true);
+    expect(providerPool.getHealthStatus(created[0]).healthy).toBe(false);
+
+    const selected = trySelectPoolProvider(groupFolder, null, null);
+    expect(selected).not.toBeNull();
+    expect(selected!.profileId).toBe(created[1]);
+    expect(selected!.resetSession).toBe(true);
+    expect(selected!.previousProviderId).toBe(created[0]);
+
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({ groupFolder, chatJid }),
+      selected,
+      null,
+    );
+
+    expect(prepared.sessionId).toBeUndefined();
+    expect(prepared.prompt).toContain('请记住项目代号 Phoenix');
+    expect(prepared.prompt).toContain('已记住，项目代号是 Phoenix。');
+    expect(prepared.prompt).toContain('当前用户消息');
+    expect(prepared.prompt).not.toContain('继续刚才的计划');
+    expect(db.getSessionProviderId(groupFolder, null)).toBe(created[1]);
+  });
+
+  test('healthy sticky path keeps the resume token and does not rewrite the prompt', () => {
+    const groupFolder = 'failover-sticky-healthy';
+    const chatJid = 'web:failover-sticky-healthy';
+    db.setSession(groupFolder, 'sess-keep', null);
+    db.setSessionProviderId(groupFolder, null, created[0]);
+    persistTurn(
+      chatJid,
+      'hist-user',
+      '历史不该被注入',
+      false,
+      '2026-08-18T11:00:00.000Z',
+    );
+
+    const selected = trySelectPoolProvider(groupFolder, null, null);
+    expect(selected?.profileId).toBe(created[0]);
+    expect(selected?.resetSession ?? false).toBe(false);
+
+    const input = conversationInput({
+      groupFolder,
+      chatJid,
+      sessionId: 'sess-keep',
+      prompt: '只问这一句',
+    });
+    const prepared = applyProviderSwitchToInput(input, selected, null);
+    expect(prepared.sessionId).toBe('sess-keep');
+    expect(prepared.prompt).toBe('只问这一句');
+    expect(prepared.prompt).not.toContain('<system_context>');
+  });
+
+  test('does not double-inject when orchestration already seeded history', () => {
+    const already =
+      '<system_context>\n已注入的历史\n</system_context>\n\n当前用户消息';
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({ prompt: already }),
+      {
+        profileId: created[1],
+        previousProviderId: created[0],
+        resetSession: true,
+      },
+      null,
+    );
+    expect(prepared.prompt).toBe(already);
+    expect(prepared.sessionId).toBeUndefined();
+  });
+
+  test('isolated scheduled tasks drop resume without inheriting workspace chat', () => {
+    const chatJid = 'web:failover-scheduled';
+    persistTurn(
+      chatJid,
+      'ws-user',
+      '工作区闲聊不该进隔离任务',
+      false,
+      '2026-08-18T12:00:00.000Z',
+    );
+    const prepared = applyProviderSwitchToInput(
+      conversationInput({
+        chatJid,
+        prompt: '跑每日巡检',
+        isScheduledTask: true,
+      }),
+      {
+        profileId: created[1],
+        previousProviderId: created[0],
+        resetSession: true,
+      },
+      null,
+    );
+    expect(prepared.sessionId).toBeUndefined();
+    expect(prepared.prompt).toBe('跑每日巡检');
+    expect(prepared.prompt).not.toContain('工作区闲聊');
+  });
+});

--- a/tests/schema-v72-wecom-direct-mount.test.ts
+++ b/tests/schema-v72-wecom-direct-mount.test.ts
@@ -99,6 +99,7 @@ describe('schema v72 WeCom direct workspace-mount migration', () => {
     expect(db.setSessionChannelOwnerOnce('wecom-legacy-ws', null, dmJid)).toBe(
       dmJid,
     );
+    db.setSession('wecom-legacy-ws', 'contaminated-wecom-main');
 
     const failureInjector = new Database(databasePath);
     failureInjector.exec(`
@@ -123,6 +124,8 @@ describe('schema v72 WeCom direct workspace-mount migration', () => {
         .filter((agent) => agent.source_kind === 'channel_direct'),
     ).toHaveLength(0);
     expect(db.getSessionChannelOwner('wecom-legacy-ws')).toBe(dmJid);
+    expect(db.getSession('wecom-legacy-ws')).toBe('contaminated-wecom-main');
+    expect(db.getConversationHistoryCutoff(workspaceJid)).toBeUndefined();
 
     const triggerCleanup = new Database(databasePath);
     triggerCleanup.exec('DROP TRIGGER fail_wecom_direct_mount_update');
@@ -141,7 +144,10 @@ describe('schema v72 WeCom direct workspace-mount migration', () => {
       workspace_jid: workspaceJid,
       session_id: migratedDm.target_agent_id,
     });
+    expect(db.getSession('wecom-legacy-ws')).toBeUndefined();
+    expect(db.getWorkspaceRuntimeSession('wecom-legacy-ws')).toBeUndefined();
     expect(db.getSessionChannelOwner('wecom-legacy-ws')).toBeUndefined();
+    expect(db.getConversationHistoryCutoff(workspaceJid)).toBeTruthy();
 
     expect(db.getRegisteredGroup(groupJid)).toMatchObject({
       target_main_jid: workspaceJid,

--- a/tests/schema-v72-wecom-direct-mount.test.ts
+++ b/tests/schema-v72-wecom-direct-mount.test.ts
@@ -125,7 +125,9 @@ describe('schema v72 WeCom direct workspace-mount migration', () => {
     ).toHaveLength(0);
     expect(db.getSessionChannelOwner('wecom-legacy-ws')).toBe(dmJid);
     expect(db.getSession('wecom-legacy-ws')).toBe('contaminated-wecom-main');
-    expect(db.getConversationHistoryCutoff(workspaceJid)).toBeUndefined();
+    expect(
+      db.getConversationHistoryIsolationMarker(workspaceJid),
+    ).toBeUndefined();
 
     const triggerCleanup = new Database(databasePath);
     triggerCleanup.exec('DROP TRIGGER fail_wecom_direct_mount_update');
@@ -147,7 +149,7 @@ describe('schema v72 WeCom direct workspace-mount migration', () => {
     expect(db.getSession('wecom-legacy-ws')).toBeUndefined();
     expect(db.getWorkspaceRuntimeSession('wecom-legacy-ws')).toBeUndefined();
     expect(db.getSessionChannelOwner('wecom-legacy-ws')).toBeUndefined();
-    expect(db.getConversationHistoryCutoff(workspaceJid)).toBeTruthy();
+    expect(db.getConversationHistoryIsolationMarker(workspaceJid)).toBeTruthy();
 
     expect(db.getRegisteredGroup(groupJid)).toMatchObject({
       target_main_jid: workspaceJid,

--- a/tests/schema-v73-classifiable-direct-mount.test.ts
+++ b/tests/schema-v73-classifiable-direct-mount.test.ts
@@ -27,6 +27,8 @@ vi.mock('../src/logger.js', () => ({
 }));
 
 const db = await import('../src/db.js');
+const { buildRecentConversationHistoryContext } =
+  await import('../src/conversation-history.js');
 
 const now = '2026-08-18T00:00:00.000Z';
 const workspaceJid = 'web:legacy-shared-ws';
@@ -183,12 +185,14 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     expect(
       db.setSessionChannelOwnerOnce('legacy-shared-ws', null, qqDmJid),
     ).toBe(qqDmJid);
+    db.setSession('legacy-shared-ws', 'contaminated-main-session');
+    db.setSession('legacy-shared-ws', 'manual-session-sdk', 'manual-session');
 
     const failureInjector = new Database(databasePath);
     failureInjector.exec(`
-      CREATE TRIGGER fail_classifiable_direct_mount_update
-      BEFORE UPDATE OF target_agent_id ON registered_groups
-      WHEN OLD.jid = '${qqDmJid}'
+      CREATE TRIGGER fail_classifiable_direct_session_delete
+      BEFORE DELETE ON sessions
+      WHEN OLD.group_folder = 'legacy-shared-ws' AND OLD.agent_id = ''
       BEGIN
         SELECT RAISE(ABORT, 'injected migration failure');
       END;
@@ -211,13 +215,36 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
         ),
     ).toHaveLength(0);
     expect(db.getSessionChannelOwner('legacy-shared-ws')).toBe(qqDmJid);
+    expect(db.getSession('legacy-shared-ws')).toBe('contaminated-main-session');
+    expect(db.getWorkspaceRuntimeSession('legacy-shared-ws')).toMatchObject({
+      sdk_session_id: 'contaminated-main-session',
+    });
+    expect(db.getConversationHistoryCutoff(workspaceJid)).toBeUndefined();
 
     const triggerCleanup = new Database(databasePath);
-    triggerCleanup.exec('DROP TRIGGER fail_classifiable_direct_mount_update');
+    triggerCleanup.exec('DROP TRIGGER fail_classifiable_direct_session_delete');
     triggerCleanup.close();
 
     expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(4);
+    expect(db.getSession('legacy-shared-ws')).toBeUndefined();
+    expect(db.getWorkspaceRuntimeSession('legacy-shared-ws')).toBeUndefined();
+    expect(db.getSession('legacy-shared-ws', 'manual-session')).toBe(
+      'manual-session-sdk',
+    );
+    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBeUndefined();
+    const isolationCutoff = db.getConversationHistoryCutoff(workspaceJid);
+    expect(isolationCutoff).toBeTruthy();
+
+    // Re-running the migration must not erase a clean main session/owner that
+    // was established after the one-shot isolation completed.
+    db.setSession('legacy-shared-ws', 'clean-main-session');
+    expect(
+      db.setSessionChannelOwnerOnce('legacy-shared-ws', null, qqGroupJid),
+    ).toBe(qqGroupJid);
     expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(0);
+    expect(db.getSession('legacy-shared-ws')).toBe('clean-main-session');
+    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBe(qqGroupJid);
+    expect(db.getConversationHistoryCutoff(workspaceJid)).toBe(isolationCutoff);
 
     const migratedQq = db.getRegisteredGroup(qqDmJid)!;
     expect(migratedQq.target_main_jid).toBeUndefined();
@@ -250,8 +277,6 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     const migratedWecomLeftover = db.getRegisteredGroup(wecomLeftoverJid)!;
     expect(migratedWecomLeftover.target_main_jid).toBeUndefined();
     expect(migratedWecomLeftover.target_agent_id).toBeTruthy();
-
-    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBeUndefined();
 
     expect(db.getRegisteredGroup(qqGroupJid)).toMatchObject({
       target_main_jid: workspaceJid,
@@ -310,5 +335,210 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     expect(db.getRegisteredGroup(feishuUnknownJid)?.target_main_jid).toBe(
       workspaceJid,
     );
+  });
+
+  test('first v72-to-v73 startup migrates real WhatsApp LID forms per account and fences contaminated history', () => {
+    const waWorkspaceJid = 'web:wa-lid-upgrade';
+    const waFolder = 'wa-lid-upgrade';
+    const waGroupJid = 'whatsapp:120363000000000000@g.us#account:bot-a';
+    const waDirectJids = [
+      'whatsapp:123456789012345@lid#account:bot-a',
+      'whatsapp:123456789012345@lid#account:bot-b',
+      'whatsapp:15551230000@hosted#account:bot-a',
+      'whatsapp:15551230001@hosted.lid#account:bot-a',
+    ];
+    db.setRegisteredGroup(waWorkspaceJid, {
+      name: 'WhatsApp upgrade workspace',
+      folder: waFolder,
+      added_at: now,
+      created_by: 'owner-wa',
+    });
+    db.setRegisteredGroup(waGroupJid, {
+      name: 'WhatsApp group',
+      folder: 'wa-group',
+      added_at: now,
+      created_by: 'owner-wa',
+      channel_account_id: 'bot-a',
+      target_main_jid: waWorkspaceJid,
+    });
+    for (const [index, jid] of waDirectJids.entries()) {
+      db.setRegisteredGroup(jid, {
+        name: `WhatsApp direct ${index}`,
+        folder: `wa-direct-${index}`,
+        added_at: now,
+        created_by: 'owner-wa',
+        channel_account_id: index === 1 ? 'bot-b' : 'bot-a',
+        target_main_jid: waWorkspaceJid,
+      });
+    }
+    db.setSession(waFolder, 'contaminated-wa-main');
+    db.setSessionChannelOwnerOnce(waFolder, null, waGroupJid);
+    db.ensureChatExists(waWorkspaceJid);
+    db.storeMessageDirect(
+      'wa-private-before-v73',
+      waWorkspaceJid,
+      waDirectJids[0],
+      'Private Alice',
+      'private value that must never be replayed',
+      now,
+      false,
+      { sourceJid: waDirectJids[0] },
+    );
+    db.storeMessageDirect(
+      'wa-group-before-v73',
+      waWorkspaceJid,
+      waGroupJid,
+      'Group Bob',
+      'old group context before the privacy boundary',
+      '2026-08-18T00:00:00.001Z',
+      false,
+      { sourceJid: waGroupJid },
+    );
+
+    // Reproduce the old v72 WeCom migration shape: the mount is already a
+    // channel_direct session, but the workspace main transcript still proves
+    // that private input was persisted there. A sibling with no such row must
+    // not be invalidated merely because it has a channel_direct mount.
+    const repairedWorkspaceJid = 'web:v72-wecom-contaminated';
+    const repairedFolder = 'v72-wecom-contaminated';
+    const repairedDirectJid = 'wecom:c2c:v72-alice#account:wecom-a';
+    const cleanWorkspaceJid = 'web:v72-wecom-no-evidence';
+    const cleanFolder = 'v72-wecom-no-evidence';
+    const cleanDirectJid = 'wecom:c2c:v72-bob#account:wecom-a';
+    for (const [workspace, folder] of [
+      [repairedWorkspaceJid, repairedFolder],
+      [cleanWorkspaceJid, cleanFolder],
+    ] as const) {
+      db.setRegisteredGroup(workspace, {
+        name: workspace,
+        folder,
+        added_at: now,
+        created_by: 'owner-wecom',
+      });
+      db.ensureChatExists(workspace);
+    }
+    for (const [id, jid, workspace, folder] of [
+      [
+        'v72-repaired-direct-session',
+        repairedDirectJid,
+        repairedWorkspaceJid,
+        repairedFolder,
+      ],
+      [
+        'v72-clean-direct-session',
+        cleanDirectJid,
+        cleanWorkspaceJid,
+        cleanFolder,
+      ],
+    ] as const) {
+      db.createAgent({
+        id,
+        group_folder: folder,
+        chat_jid: workspace,
+        name: jid,
+        prompt: '',
+        status: 'idle',
+        kind: 'conversation',
+        created_by: 'owner-wecom',
+        created_at: now,
+        completed_at: null,
+        result_summary: null,
+        last_im_jid: jid,
+        spawned_from_jid: null,
+        source_kind: 'channel_direct',
+      });
+      db.setRegisteredGroup(jid, {
+        name: jid,
+        folder: `${folder}-direct`,
+        added_at: now,
+        created_by: 'owner-wecom',
+        channel_account_id: 'wecom-a',
+        target_agent_id: id,
+      });
+      db.setSession(folder, `${folder}-main-session`);
+    }
+    db.storeMessageDirect(
+      'v72-wecom-private-evidence',
+      repairedWorkspaceJid,
+      repairedDirectJid,
+      'Private Alice',
+      'old v72 private evidence',
+      now,
+      false,
+      { sourceJid: repairedDirectJid },
+    );
+
+    // Reproduce a database whose v73 migration has genuinely never run.
+    db.closeDatabase();
+    const stamped = new Database(databasePath);
+    stamped
+      .prepare(
+        "UPDATE router_state SET value = '72' WHERE key = 'schema_version'",
+      )
+      .run();
+    stamped.close();
+    db.initDatabase();
+
+    const migratedAgentIds = waDirectJids.map((jid) => {
+      const group = db.getRegisteredGroup(jid)!;
+      expect(group.target_main_jid).toBeUndefined();
+      expect(group.target_agent_id).toBeTruthy();
+      expect(db.getAgent(group.target_agent_id!)?.source_kind).toBe(
+        'channel_direct',
+      );
+      return group.target_agent_id!;
+    });
+    expect(new Set(migratedAgentIds).size).toBe(waDirectJids.length);
+    expect(db.getRegisteredGroup(waGroupJid)).toMatchObject({
+      target_main_jid: waWorkspaceJid,
+    });
+    expect(db.getSession(waFolder)).toBeUndefined();
+    expect(db.getWorkspaceRuntimeSession(waFolder)).toBeUndefined();
+    expect(db.getSessionChannelOwner(waFolder)).toBeUndefined();
+    expect(db.getSession(repairedFolder)).toBeUndefined();
+    expect(db.getConversationHistoryCutoff(repairedWorkspaceJid)).toBeTruthy();
+    expect(db.getSession(cleanFolder)).toBe(`${cleanFolder}-main-session`);
+    expect(db.getConversationHistoryCutoff(cleanWorkspaceJid)).toBeUndefined();
+
+    const cutoff = db.getConversationHistoryCutoff(waWorkspaceJid);
+    expect(cutoff).toBeTruthy();
+    const afterCutoff = new Date(Date.parse(cutoff!) + 1).toISOString();
+    db.storeMessageDirect(
+      'wa-safe-after-v73',
+      waWorkspaceJid,
+      waGroupJid,
+      'Group Bob',
+      'safe group context after migration',
+      afterCutoff,
+      false,
+      { sourceJid: waGroupJid },
+    );
+    const history = buildRecentConversationHistoryContext(
+      waWorkspaceJid,
+      new Set(),
+      { intro: 'recovery' },
+    );
+    expect(history?.messageIds).toEqual(['wa-safe-after-v73']);
+    expect(history?.context).toContain('safe group context after migration');
+    expect(history?.context).not.toContain(
+      'private value that must never be replayed',
+    );
+
+    // A schema retry observes the cutoff marker and preserves the clean main
+    // lifecycle instead of invalidating the workspace a second time.
+    db.setSession(waFolder, 'clean-wa-main');
+    db.setSessionChannelOwnerOnce(waFolder, null, waGroupJid);
+    db.closeDatabase();
+    const retryStamp = new Database(databasePath);
+    retryStamp
+      .prepare(
+        "UPDATE router_state SET value = '72' WHERE key = 'schema_version'",
+      )
+      .run();
+    retryStamp.close();
+    db.initDatabase();
+    expect(db.getSession(waFolder)).toBe('clean-wa-main');
+    expect(db.getSessionChannelOwner(waFolder)).toBe(waGroupJid);
+    expect(db.getConversationHistoryCutoff(waWorkspaceJid)).toBe(cutoff);
   });
 });

--- a/tests/schema-v73-classifiable-direct-mount.test.ts
+++ b/tests/schema-v73-classifiable-direct-mount.test.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'schema-v73-classifiable-mount-'),
+);
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const dataDir = path.join(root, 'data');
+const databasePath = path.join(storeDir, 'messages.db');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+fs.mkdirSync(dataDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  ASSISTANT_NAME: 'HappyClaw Test',
+  DATA_DIR: dataDir,
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+
+const now = '2026-08-18T00:00:00.000Z';
+const workspaceJid = 'web:legacy-shared-ws';
+const legacyFolderJid = 'web:legacy-shared-ws';
+
+const qqDmJid = 'qq:c2c:alice#account:bot-a';
+const qqGroupJid = 'qq:group:sales#account:bot-a';
+const telegramDmJid = 'telegram:123456#account:bot-a';
+const telegramGroupJid = 'telegram:-100123#account:bot-a';
+const wechatDmJid = 'wechat:wxid_alice#account:bot-a';
+const wecomMigratedJid = 'wecom:c2c:already#account:bot-a';
+const wecomLeftoverJid = 'wecom:c2c:leftover#account:bot-a';
+const manualDmJid = 'qq:c2c:bob#account:bot-a';
+const missingWsDmJid = 'dingtalk:c2c:carol#account:bot-a';
+const feishuUnknownJid = 'feishu:oc_opaque#account:bot-a';
+const malformedTelegramJid = 'telegram:not-a-number#account:bot-a';
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('schema v73 classifiable direct workspace-mount migration', () => {
+  test('moves leftover classifiable DMs off a shared workspace owner and skips groups/manual/unknown', () => {
+    db.initDatabase();
+    db.setRegisteredGroup(workspaceJid, {
+      name: 'Legacy shared workspace',
+      folder: 'legacy-shared-ws',
+      added_at: now,
+      created_by: 'owner-a',
+    });
+    db.createAgent({
+      id: 'manual-session',
+      group_folder: 'legacy-shared-ws',
+      chat_jid: workspaceJid,
+      name: 'Manual QQ DM session',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: 'owner-a',
+      created_at: now,
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: manualDmJid,
+      spawned_from_jid: null,
+      source_kind: 'manual',
+    });
+    db.createAgent({
+      id: 'wecom-v72-session',
+      group_folder: 'legacy-shared-ws',
+      chat_jid: workspaceJid,
+      name: 'Already migrated WeCom DM',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: 'owner-a',
+      created_at: now,
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: wecomMigratedJid,
+      spawned_from_jid: null,
+      source_kind: 'channel_direct',
+    });
+
+    db.setRegisteredGroup(qqDmJid, {
+      name: 'Alice QQ DM',
+      folder: 'qq-alice',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: legacyFolderJid,
+    });
+    db.setRegisteredGroup(qqGroupJid, {
+      name: 'QQ sales group',
+      folder: 'qq-sales',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(telegramDmJid, {
+      name: 'Telegram DM',
+      folder: 'tg-dm',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(telegramGroupJid, {
+      name: 'Telegram group',
+      folder: 'tg-group',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(wechatDmJid, {
+      name: 'WeChat DM',
+      folder: 'wechat-alice',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(wecomMigratedJid, {
+      name: 'WeCom already migrated',
+      folder: 'wecom-already',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_agent_id: 'wecom-v72-session',
+    });
+    db.setRegisteredGroup(wecomLeftoverJid, {
+      name: 'WeCom leftover',
+      folder: 'wecom-leftover',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(manualDmJid, {
+      name: 'Bob QQ DM',
+      folder: 'qq-bob',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_agent_id: 'manual-session',
+    });
+    db.setRegisteredGroup(missingWsDmJid, {
+      name: 'Carol DingTalk DM',
+      folder: 'dt-carol',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: 'web:deleted-workspace',
+    });
+    db.setRegisteredGroup(feishuUnknownJid, {
+      name: 'Feishu opaque chat',
+      folder: 'feishu-opaque',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+    db.setRegisteredGroup(malformedTelegramJid, {
+      name: 'Malformed Telegram',
+      folder: 'tg-bad',
+      added_at: now,
+      created_by: 'owner-a',
+      channel_account_id: 'bot-a',
+      target_main_jid: workspaceJid,
+    });
+
+    expect(
+      db.setSessionChannelOwnerOnce('legacy-shared-ws', null, qqDmJid),
+    ).toBe(qqDmJid);
+
+    const failureInjector = new Database(databasePath);
+    failureInjector.exec(`
+      CREATE TRIGGER fail_classifiable_direct_mount_update
+      BEFORE UPDATE OF target_agent_id ON registered_groups
+      WHEN OLD.jid = '${qqDmJid}'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected migration failure');
+      END;
+    `);
+    failureInjector.close();
+
+    expect(() =>
+      db.migrateClassifiableDirectWorkspaceMountsToSessions(),
+    ).toThrow('injected migration failure');
+    expect(db.getRegisteredGroup(qqDmJid)).toMatchObject({
+      target_main_jid: legacyFolderJid,
+    });
+    expect(
+      db
+        .listAgentsByJid(workspaceJid)
+        .filter(
+          (agent) =>
+            agent.source_kind === 'channel_direct' &&
+            agent.id !== 'wecom-v72-session',
+        ),
+    ).toHaveLength(0);
+    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBe(qqDmJid);
+
+    const triggerCleanup = new Database(databasePath);
+    triggerCleanup.exec('DROP TRIGGER fail_classifiable_direct_mount_update');
+    triggerCleanup.close();
+
+    expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(4);
+    expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(0);
+
+    const migratedQq = db.getRegisteredGroup(qqDmJid)!;
+    expect(migratedQq.target_main_jid).toBeUndefined();
+    expect(migratedQq.target_agent_id).toBeTruthy();
+    expect(db.getAgent(migratedQq.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
+    expect(db.getChannelMount(qqDmJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: migratedQq.target_agent_id,
+    });
+
+    const migratedTelegram = db.getRegisteredGroup(telegramDmJid)!;
+    expect(migratedTelegram.target_main_jid).toBeUndefined();
+    expect(migratedTelegram.target_agent_id).toBeTruthy();
+    expect(migratedTelegram.target_agent_id).not.toBe(
+      migratedQq.target_agent_id,
+    );
+    expect(db.getAgent(migratedTelegram.target_agent_id!)?.source_kind).toBe(
+      'channel_direct',
+    );
+
+    const migratedWechat = db.getRegisteredGroup(wechatDmJid)!;
+    expect(migratedWechat.target_main_jid).toBeUndefined();
+    expect(migratedWechat.target_agent_id).toBeTruthy();
+    expect(db.getAgent(migratedWechat.target_agent_id!)?.last_im_jid).toBe(
+      wechatDmJid,
+    );
+
+    const migratedWecomLeftover = db.getRegisteredGroup(wecomLeftoverJid)!;
+    expect(migratedWecomLeftover.target_main_jid).toBeUndefined();
+    expect(migratedWecomLeftover.target_agent_id).toBeTruthy();
+
+    expect(db.getSessionChannelOwner('legacy-shared-ws')).toBeUndefined();
+
+    expect(db.getRegisteredGroup(qqGroupJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+    expect(db.getRegisteredGroup(qqGroupJid)?.target_agent_id).toBeUndefined();
+    expect(db.getChannelMount(qqGroupJid)).toMatchObject({
+      workspace_jid: workspaceJid,
+      session_id: null,
+    });
+    expect(db.getRegisteredGroup(telegramGroupJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+
+    expect(db.getRegisteredGroup(wecomMigratedJid)).toMatchObject({
+      target_agent_id: 'wecom-v72-session',
+    });
+    expect(db.getRegisteredGroup(wecomMigratedJid)?.target_main_jid).toBe(
+      undefined,
+    );
+
+    expect(db.getRegisteredGroup(manualDmJid)).toMatchObject({
+      target_agent_id: 'manual-session',
+    });
+    expect(db.getRegisteredGroup(missingWsDmJid)).toMatchObject({
+      target_main_jid: 'web:deleted-workspace',
+    });
+    expect(db.getRegisteredGroup(feishuUnknownJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+    expect(db.getRegisteredGroup(malformedTelegramJid)).toMatchObject({
+      target_main_jid: workspaceJid,
+    });
+
+    db.closeDatabase();
+    const stamped = new Database(databasePath);
+    stamped
+      .prepare(
+        "UPDATE router_state SET value = '72' WHERE key = 'schema_version'",
+      )
+      .run();
+    stamped.close();
+
+    db.initDatabase();
+    expect(db.getRouterState('schema_version')).toBe(
+      String(db.CURRENT_SCHEMA_VERSION),
+    );
+    expect(db.getRegisteredGroup(qqDmJid)?.target_agent_id).toBe(
+      migratedQq.target_agent_id,
+    );
+    expect(db.getRegisteredGroup(wecomMigratedJid)?.target_agent_id).toBe(
+      'wecom-v72-session',
+    );
+    expect(db.getRegisteredGroup(qqGroupJid)?.target_main_jid).toBe(
+      workspaceJid,
+    );
+    expect(db.getRegisteredGroup(feishuUnknownJid)?.target_main_jid).toBe(
+      workspaceJid,
+    );
+  });
+});

--- a/tests/schema-v73-classifiable-direct-mount.test.ts
+++ b/tests/schema-v73-classifiable-direct-mount.test.ts
@@ -219,7 +219,9 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     expect(db.getWorkspaceRuntimeSession('legacy-shared-ws')).toMatchObject({
       sdk_session_id: 'contaminated-main-session',
     });
-    expect(db.getConversationHistoryCutoff(workspaceJid)).toBeUndefined();
+    expect(
+      db.getConversationHistoryIsolationMarker(workspaceJid),
+    ).toBeUndefined();
 
     const triggerCleanup = new Database(databasePath);
     triggerCleanup.exec('DROP TRIGGER fail_classifiable_direct_session_delete');
@@ -232,8 +234,9 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
       'manual-session-sdk',
     );
     expect(db.getSessionChannelOwner('legacy-shared-ws')).toBeUndefined();
-    const isolationCutoff = db.getConversationHistoryCutoff(workspaceJid);
-    expect(isolationCutoff).toBeTruthy();
+    const isolationMarker =
+      db.getConversationHistoryIsolationMarker(workspaceJid);
+    expect(isolationMarker).toBeTruthy();
 
     // Re-running the migration must not erase a clean main session/owner that
     // was established after the one-shot isolation completed.
@@ -244,7 +247,9 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(0);
     expect(db.getSession('legacy-shared-ws')).toBe('clean-main-session');
     expect(db.getSessionChannelOwner('legacy-shared-ws')).toBe(qqGroupJid);
-    expect(db.getConversationHistoryCutoff(workspaceJid)).toBe(isolationCutoff);
+    expect(db.getConversationHistoryIsolationMarker(workspaceJid)).toBe(
+      isolationMarker,
+    );
 
     const migratedQq = db.getRegisteredGroup(qqDmJid)!;
     expect(migratedQq.target_main_jid).toBeUndefined();
@@ -394,6 +399,16 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
       false,
       { sourceJid: waGroupJid },
     );
+    db.storeMessageDirect(
+      'wa-private-future-clock-before-v73',
+      waWorkspaceJid,
+      waDirectJids[0],
+      'Private Alice',
+      'future-clock private value that must never be replayed',
+      '2099-01-01T00:00:00.000Z',
+      false,
+      { sourceJid: waDirectJids[0] },
+    );
 
     // Reproduce the old v72 WeCom migration shape: the mount is already a
     // channel_direct session, but the workspace main transcript still proves
@@ -496,20 +511,24 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     expect(db.getWorkspaceRuntimeSession(waFolder)).toBeUndefined();
     expect(db.getSessionChannelOwner(waFolder)).toBeUndefined();
     expect(db.getSession(repairedFolder)).toBeUndefined();
-    expect(db.getConversationHistoryCutoff(repairedWorkspaceJid)).toBeTruthy();
+    expect(
+      db.getConversationHistoryIsolationMarker(repairedWorkspaceJid),
+    ).toBeTruthy();
     expect(db.getSession(cleanFolder)).toBe(`${cleanFolder}-main-session`);
-    expect(db.getConversationHistoryCutoff(cleanWorkspaceJid)).toBeUndefined();
+    expect(
+      db.getConversationHistoryIsolationMarker(cleanWorkspaceJid),
+    ).toBeUndefined();
 
-    const cutoff = db.getConversationHistoryCutoff(waWorkspaceJid);
-    expect(cutoff).toBeTruthy();
-    const afterCutoff = new Date(Date.parse(cutoff!) + 1).toISOString();
+    const isolationMarker =
+      db.getConversationHistoryIsolationMarker(waWorkspaceJid);
+    expect(isolationMarker).toBeTruthy();
     db.storeMessageDirect(
       'wa-safe-after-v73',
       waWorkspaceJid,
       waGroupJid,
       'Group Bob',
       'safe group context after migration',
-      afterCutoff,
+      '2026-08-18T00:00:00.002Z',
       false,
       { sourceJid: waGroupJid },
     );
@@ -523,8 +542,43 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     expect(history?.context).not.toContain(
       'private value that must never be replayed',
     );
+    expect(history?.context).not.toContain(
+      'future-clock private value that must never be replayed',
+    );
+    const oversizedPendingSet = new Set(
+      Array.from({ length: 40_000 }, (_, index) => `pending-${index}`),
+    );
+    expect(
+      db
+        .getConversationHistoryMessagesPage(
+          waWorkspaceJid,
+          oversizedPendingSet,
+          30,
+        )
+        .map((message) => message.id),
+    ).toEqual(['wa-safe-after-v73']);
 
-    // A schema retry observes the cutoff marker and preserves the clean main
+    // Replacing an old row must preserve its recovery fence.
+    db.storeMessageDirect(
+      'wa-private-before-v73',
+      waWorkspaceJid,
+      waDirectJids[0],
+      'Private Alice',
+      'replaced private value that must still stay fenced',
+      '2099-01-02T00:00:00.000Z',
+      false,
+      { sourceJid: waDirectJids[0] },
+    );
+    const historyAfterReplace = buildRecentConversationHistoryContext(
+      waWorkspaceJid,
+      new Set(),
+      { intro: 'recovery' },
+    );
+    expect(historyAfterReplace?.context).not.toContain(
+      'replaced private value that must still stay fenced',
+    );
+
+    // A schema retry observes the isolation marker and preserves the clean main
     // lifecycle instead of invalidating the workspace a second time.
     db.setSession(waFolder, 'clean-wa-main');
     db.setSessionChannelOwnerOnce(waFolder, null, waGroupJid);
@@ -539,6 +593,8 @@ describe('schema v73 classifiable direct workspace-mount migration', () => {
     db.initDatabase();
     expect(db.getSession(waFolder)).toBe('clean-wa-main');
     expect(db.getSessionChannelOwner(waFolder)).toBe(waGroupJid);
-    expect(db.getConversationHistoryCutoff(waWorkspaceJid)).toBe(cutoff);
+    expect(db.getConversationHistoryIsolationMarker(waWorkspaceJid)).toBe(
+      isolationMarker,
+    );
   });
 });


### PR DESCRIPTION
## Summary\n\nIntegrates the approved bug-fix direction from #655, #658, and #659 while closing the reviewed gaps before production rollout.\n\n- classify WhatsApp LID/hosted direct chats before schema v73 migration\n- migrate legacy direct mounts into account-scoped channel_direct sessions\n- atomically invalidate contaminated main SDK sessions and owner state\n- fence legacy mixed transcript rows from model recovery without deleting Web history\n- preserve recovery fences across message replacement and provider timestamp skew\n- exclude the complete cold-run batch before provider-failover history recovery\n- cover main/conversation-agent and host/container wiring\n- avoid repeated history scans per workspace during migration\n\n## Validation\n\n- formatting and docs consistency\n- production dependency audits: 0 vulnerabilities\n- shared generated types in sync\n- typecheck passed\n- 3155 tests passed, 23 skipped\n- backend/web/agent-runner production builds passed\n- 9 Playwright mobile tests passed\n- agent-runner self-test passed\n\nProduction deployment and Mac mini verification will be completed against this exact branch SHA before advancing main.\n\nIntegrates #655\nIntegrates #658\nIntegrates #659