### PR TITLE
fix: create home workspace directory on disk to prevent upload 500

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { STORE_DIR, GROUPS_DIR } from './config.js';
 import { normalizeAgentEffort } from './agent-effort.js';
 import { logger } from './logger.js';
+import { isValidWorkspaceFolderName } from './workspace-folder.js';
 import {
   AgentProfile,
   AgentBuilderDefinition,
@@ -11660,6 +11661,26 @@ export function getUserHomeGroup(
 }
 
 /**
+ * Ensure the on-disk workspace directory for a group folder exists, mirroring
+ * what registerGroup() does for non-home workspaces. Home groups created via
+ * ensureUserHomeGroup() historically only wrote the DB row, which left
+ * ENOENT traps for any filesystem access (e.g. file uploads) before the
+ * first Agent run lazily created the directory. Failure here must not block
+ * the login/registration path that calls this, so it only warns.
+ */
+function ensureGroupDirExists(folder: string): void {
+  if (!isValidWorkspaceFolderName(folder)) {
+    logger.warn({ folder }, 'Skipping group dir creation: invalid folder name');
+    return;
+  }
+  try {
+    fs.mkdirSync(path.join(GROUPS_DIR, folder, 'logs'), { recursive: true });
+  } catch (err) {
+    logger.warn({ err, folder }, 'Failed to ensure group directory exists');
+  }
+}
+
+/**
  * Ensure a user has a home group. If not, create one.
  * The first admin keeps the legacy web:main home. Every other account gets an
  * owner-specific home workspace. Admin homes use host execution; member homes
@@ -11673,6 +11694,7 @@ export function ensureUserHomeGroup(
 ): string {
   const existing = getUserHomeGroup(userId);
   if (existing) {
+    ensureGroupDirExists(existing.folder);
     assignWorkspaceAgentProfile(
       existing.folder,
       getOrCreateDefaultAgentProfile(userId).id,
@@ -11699,6 +11721,7 @@ export function ensureUserHomeGroup(
   };
 
   setRegisteredGroup(jid, group);
+  ensureGroupDirExists(folder);
   assignWorkspaceAgentProfile(
     folder,
     getOrCreateDefaultAgentProfile(userId).id,

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -349,6 +349,20 @@ fileRoutes.post('/:jid/files', authMiddleware, async (c) => {
     const fileList = Array.isArray(files) ? files : [files];
     const workspaceRoot = path.resolve(getFileRoot(group.folder, rootOverride));
 
+    if (!fs.existsSync(workspaceRoot)) {
+      logger.error(
+        { jid, folder: group.folder, workspaceRoot },
+        'Workspace directory missing on disk during upload',
+      );
+      return c.json(
+        {
+          error:
+            'Workspace directory not initialized yet. Please try again in a moment, or re-login and retry.',
+        },
+        409,
+      );
+    }
+
     return await withUploadMutationLock(workspaceRoot, async () => {
       const uploads: Array<{ file: File; relativePath: string }> = [];
       const quotaTargets = new Map<

--- a/tests/user-home-isolation.test.ts
+++ b/tests/user-home-isolation.test.ts
@@ -72,4 +72,40 @@ describe('per-user home workspace isolation', () => {
     expect(db.getUserHomeGroup('admin-two')?.jid).toBe(secondAdminJid);
     expect(db.ensureUserHomeGroup('admin-two', 'admin')).toBe(secondAdminJid);
   });
+
+  test('creates the on-disk workspace directory for a new member home', () => {
+    db.initDatabase();
+
+    const jid = db.ensureUserHomeGroup('member-two', 'member', 'member-two');
+    const group = db.getRegisteredGroup(jid);
+    expect(group).toBeDefined();
+
+    const logsDir = path.join(groupsDir, group!.folder, 'logs');
+    expect(fs.existsSync(logsDir)).toBe(true);
+  });
+
+  test('self-heals a missing workspace directory on repeat calls', () => {
+    db.initDatabase();
+
+    const jid = db.ensureUserHomeGroup(
+      'member-three',
+      'member',
+      'member-three',
+    );
+    const group = db.getRegisteredGroup(jid);
+    expect(group).toBeDefined();
+
+    const groupDir = path.join(groupsDir, group!.folder);
+    fs.rmSync(groupDir, { recursive: true, force: true });
+    expect(fs.existsSync(groupDir)).toBe(false);
+
+    // existing-group branch (early return) must also repair the directory
+    const jidAgain = db.ensureUserHomeGroup(
+      'member-three',
+      'member',
+      'member-three',
+    );
+    expect(jidAgain).toBe(jid);
+    expect(fs.existsSync(path.join(groupDir, 'logs'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## 问题

非首个 admin 用户（member 账号）在 Web 端上传文件时持续返回 HTTP 500。

## 根因

`ensureUserHomeGroup()` 创建 Home 工作区时只写数据库（`registered_groups`），
不像 `registerGroup()` 那样创建磁盘目录。上传接口 (`files.ts`) 在写文件前对
工作区根目录调用 `realpathSync()`，目录不存在时抛出 `ENOENT`，被上层兜底成
裸 500。目录原本靠首次 Agent 运行时懒创建，因此账号在从未与 Agent 对话之前，
上传功能必然失败；首个 admin 复用早已存在的 legacy `main` 目录，不受影响，
也无法复现。

## 修复

- `src/db.ts`：新增 `ensureGroupDirExists()`，在 `ensureUserHomeGroup()` 的
  **早返回（自愈）分支**和**新建分支**都调用它，对齐 `registerGroup()` 的行为
  （`mkdirSync(<folder>/logs, {recursive:true})`）。校验 folder 名合法，
  失败只记 warn，不阻断登录/注册主流程。四个调用方
  （`auth.ts:195/323/494`、`index.ts:5028`）都自动受益，无需改动调用点。
- `src/routes/files.ts`：上传前判断工作区根目录是否存在，缺失时返回明确的
  409 + 可读错误信息，不再落入裸 500，便于运维和用户定位问题。
- `tests/user-home-isolation.test.ts`：补两个用例——新建 Home 工作区后
  `logs` 目录存在；目录被删除后再次调用 `ensureUserHomeGroup()`（走
  early-return 分支）能自愈重建。

## 用户影响

- 修复后，非首个 admin 账号下次登录即可自动补建缺失的工作区目录
  （无需额外的启动期扫描逻辑），上传功能随即恢复正常。
- 已存在但目录健全的工作区无行为变化（`mkdirSync` 幂等）。

## 验证方式

- `make typecheck`、`make build`、`npm run format:check`、
  `npm run docs:check`、`git diff --check` 全部通过。
- `make test` 全量通过，仅有的两个失败用例
  （`container-session-permissions.test.ts`、
  `agent-runner-sdk-subagent-contract.integration.test.ts`）经
  `git stash` 交叉验证为改动前既有失败，与本次修改无关。
- 新增单测覆盖自愈路径和新建路径。

## 兼容性

- 不涉及数据库 schema 变更，未升级 `CURRENT_SCHEMA_VERSION`，无 migration。
- 不改变 `getFileRoot()` / `safeWriteWorkspaceFile()` 的安全边界语义。

## 与 #652 的关系

本 PR 和 #652（上传失败自动重试，暴露真实错误原因）的原始动机是同一个问题：
**新用户在首次与 Agent 对话之前上传文件会失败**。#652 从前端角度改善了这个问题
的可见性——对瞬时性错误（408、网络错误、502/503/504）自动重试，并把真实错误
原因透出给用户；但 #652 把本 issue 触发的裸 500 归类为"服务端逻辑错误"，明确
不重试、立即失败，所以只让报错更清晰，并未修复根因。本 PR 才是修复同一问题的
服务端根因：`ensureUserHomeGroup()` 未创建磁盘目录。两个 PR 合起来才是这个问题
的完整闭环——#652 兜底体验，本 PR 消除触发条件。

## 临时规避方案（合并前）

在本 PR 合并前，受影响用户可以先与 Agent 完成一次对话（触发
`container-runner.ts` 中的懒加载目录创建逻辑），此后上传即可恢复正常，作为过渡
期的临时规避方式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)