### PR TITLE
fix(im): remount leftover LID DMs after v73 with current classifier

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -104,7 +104,7 @@ let db: InstanceType<typeof Database>;
  * restating the number. Hardcoding it meant every schema bump edited a dozen
  * unrelated test files, which is churn that hides real assertion changes.
  */
-export const CURRENT_SCHEMA_VERSION = 73;
+export const CURRENT_SCHEMA_VERSION = 74;
 
 export function isDatabaseInitialized(): boolean {
   return Boolean(db?.open);
@@ -2545,6 +2545,22 @@ export function initDatabase(): void {
     migrateClassifiableDirectWorkspaceMountsToSessions();
   }
 
+  // v73 -> v74: v73 used resolveChannelConversationKind as it existed then.
+  // #659 later classified WhatsApp @lid / @hosted / @hosted.lid as direct.
+  // Databases already stamped schema 73 in that window still have those
+  // JIDs on target_main_jid (they were unknown and skipped) and can share
+  // channel_session_owner:{folder}:main with a group. Re-run the same
+  // remount with the current classifier. Groups, manual target_agent_id,
+  // missing workspaces, and unknown JIDs stay skipped. Already-migrated
+  // WeCom / QQ / Discord / PN-WhatsApp rows are idempotent. Do not rewrite
+  // the v72 or v73 blocks.
+  const leftoverClassifiableDirectMountSchemaVersion = Number(
+    getRouterStateInternal('schema_version') ?? '0',
+  );
+  if (leftoverClassifiableDirectMountSchemaVersion < 74) {
+    migrateClassifiableDirectWorkspaceMountsToSessions();
+  }
+
   db.prepare(
     'INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)',
   ).run('schema_version', String(CURRENT_SCHEMA_VERSION));
@@ -2649,11 +2665,13 @@ export function migrateWecomDirectWorkspaceMountsToSessions(): number {
 
 /**
  * Move leftover JID-classifiable DMs off a shared workspace main mount.
+ * Uses the current conversation classifier (including WhatsApp LID/hosted).
  * Same skip rules as v72: already-bound sessions (manual or v72 WeCom),
  * groups, unknown/unclassifiable JIDs (including Feishu without metadata),
  * and missing workspaces stay untouched. If the workspace main owner still
  * points at the DM, clear it so a later group message cannot keep
- * delivering into that private chat.
+ * delivering into that private chat. Idempotent for already-migrated rows;
+ * v74 re-runs this for databases stamped 73 before the LID classifier.
  */
 export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
   return db
@@ -2715,6 +2733,14 @@ export function migrateClassifiableDirectWorkspaceMountsToSessions(): number {
           target_main_jid: undefined,
           binding_mode: 'single_context',
         });
+        // Isolation only clears main owner on first marker insert. A leftover
+        // DM remounted onto an already-isolated workspace (v73 ran for a
+        // sibling, then this JID later became classifiable) must still drop a
+        // stolen main owner without wiping an unrelated group owner.
+        const ownerJid = getSessionChannelOwner(workspace.folder, null);
+        if (ownerJid && channelConversationJid(ownerJid) === conversationJid) {
+          clearSessionChannelOwner(workspace.folder, null);
+        }
 
         affectedWorkspaces.set(workspaceJid, workspace);
 

--- a/tests/db-upgrade-safety.test.ts
+++ b/tests/db-upgrade-safety.test.ts
@@ -171,10 +171,10 @@ describe('schema version head', () => {
     // one assertion that fails when the head moves, forcing whoever bumps it
     // to confirm the matching migration block — and a test covering it —
     // actually landed. Update the literal in the same commit as the migration.
-    // v73: generalizes the v72 WeCom DM remount to other JID-classifiable
-    // DMs (QQ / DingTalk / Discord / WhatsApp / Telegram / WeChat leftover
-    // target_main_jid collisions). See
-    // tests/schema-v73-classifiable-direct-mount.test.ts. Do not rewrite v72.
-    expect(db.CURRENT_SCHEMA_VERSION).toBe(73);
+    // v74: re-runs leftover JID-classifiable DM remount with the current
+    // classifier so WhatsApp @lid / @hosted / @hosted.lid rows skipped by
+    // v73 (stamped before #659) leave shared workspace main. See
+    // tests/schema-v74-leftover-direct-mount.test.ts. Do not rewrite v72/v73.
+    expect(db.CURRENT_SCHEMA_VERSION).toBe(74);
   });
 });

--- a/tests/schema-v74-leftover-direct-mount.test.ts
+++ b/tests/schema-v74-leftover-direct-mount.test.ts
@@ -1,0 +1,594 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'schema-v74-leftover-mount-'),
+);
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const dataDir = path.join(root, 'data');
+const databasePath = path.join(storeDir, 'messages.db');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+fs.mkdirSync(dataDir, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  ASSISTANT_NAME: 'HappyClaw Test',
+  DATA_DIR: dataDir,
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+const { buildRecentConversationHistoryContext } =
+  await import('../src/conversation-history.js');
+
+const now = '2026-08-19T00:00:00.000Z';
+const workspaceJid = 'web:v73-stamped-ws';
+const folder = 'v73-stamped-ws';
+
+const leftoverWaLidA = 'whatsapp:123456789012345@lid#account:bot-a';
+const leftoverWaLidB = 'whatsapp:123456789012345@lid#account:bot-b';
+const leftoverWaHosted = 'whatsapp:15551230000@hosted#account:bot-a';
+const leftoverWaHostedLid = 'whatsapp:15551230001@hosted.lid#account:bot-a';
+const leftoverQqDm = 'qq:c2c:leftover-alice#account:bot-a';
+const leftoverDiscordDm = 'discord:dm:leftover-alice#account:bot-a';
+
+const qqGroupJid = 'qq:group:sales#account:bot-a';
+const discordGroupJid = 'discord:guild-channel-1#account:bot-a';
+const waGroupJid = 'whatsapp:120363000000000000@g.us#account:bot-a';
+
+const wecomMigratedJid = 'wecom:c2c:already#account:bot-a';
+const qqMigratedJid = 'qq:c2c:already#account:bot-a';
+const discordMigratedJid = 'discord:dm:already#account:bot-a';
+const waPnMigratedJid = 'whatsapp:15550001111@s.whatsapp.net#account:bot-a';
+
+const manualDmJid = 'qq:c2c:bob#account:bot-a';
+const missingWsDmJid = 'dingtalk:c2c:carol#account:bot-a';
+const feishuUnknownJid = 'feishu:oc_opaque#account:bot-a';
+const malformedTelegramJid = 'telegram:not-a-number#account:bot-a';
+const waBroadcastJid = 'whatsapp:status@broadcast#account:bot-a';
+
+const leftoverDirectJids = [
+  leftoverWaLidA,
+  leftoverWaLidB,
+  leftoverWaHosted,
+  leftoverWaHostedLid,
+  leftoverQqDm,
+  leftoverDiscordDm,
+];
+
+function stampSchema(version: string): void {
+  db.closeDatabase();
+  const stamped = new Database(databasePath);
+  stamped
+    .prepare("UPDATE router_state SET value = ? WHERE key = 'schema_version'")
+    .run(version);
+  stamped.close();
+  db.initDatabase();
+}
+
+function expectDirectSessionMount(jid: string): string {
+  const group = db.getRegisteredGroup(jid)!;
+  expect(group.target_main_jid).toBeUndefined();
+  expect(group.target_agent_id).toBeTruthy();
+  expect(db.getAgent(group.target_agent_id!)?.source_kind).toBe(
+    'channel_direct',
+  );
+  expect(db.getChannelMount(jid)).toMatchObject({
+    workspace_jid: workspaceJid,
+    session_id: group.target_agent_id,
+  });
+  return group.target_agent_id!;
+}
+
+function expectGroupStaysOnMain(jid: string): void {
+  expect(db.getRegisteredGroup(jid)).toMatchObject({
+    target_main_jid: workspaceJid,
+  });
+  expect(db.getRegisteredGroup(jid)?.target_agent_id).toBeUndefined();
+  expect(db.getChannelMount(jid)).toMatchObject({
+    workspace_jid: workspaceJid,
+    session_id: null,
+  });
+}
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe.sequential(
+  'schema v74 leftover classifiable direct workspace-mount migration',
+  () => {
+    test('remounts leftover LID/QQ/Discord DMs on a v73-stamped database and skips groups/manual/unknown', () => {
+      db.initDatabase();
+      db.setRegisteredGroup(workspaceJid, {
+        name: 'v73 stamped workspace',
+        folder,
+        added_at: now,
+        created_by: 'owner-a',
+      });
+      db.createAgent({
+        id: 'manual-session',
+        group_folder: folder,
+        chat_jid: workspaceJid,
+        name: 'Manual QQ DM session',
+        prompt: '',
+        status: 'idle',
+        kind: 'conversation',
+        created_by: 'owner-a',
+        created_at: now,
+        completed_at: null,
+        result_summary: null,
+        last_im_jid: manualDmJid,
+        spawned_from_jid: null,
+        source_kind: 'manual',
+      });
+      for (const [id, jid] of [
+        ['wecom-v72-session', wecomMigratedJid],
+        ['qq-v73-session', qqMigratedJid],
+        ['discord-v73-session', discordMigratedJid],
+        ['wa-pn-v73-session', waPnMigratedJid],
+      ] as const) {
+        db.createAgent({
+          id,
+          group_folder: folder,
+          chat_jid: workspaceJid,
+          name: jid,
+          prompt: '',
+          status: 'idle',
+          kind: 'conversation',
+          created_by: 'owner-a',
+          created_at: now,
+          completed_at: null,
+          result_summary: null,
+          last_im_jid: jid,
+          spawned_from_jid: null,
+          source_kind: 'channel_direct',
+        });
+        db.setRegisteredGroup(jid, {
+          name: jid,
+          folder: `${id}-folder`,
+          added_at: now,
+          created_by: 'owner-a',
+          channel_account_id: 'bot-a',
+          target_agent_id: id,
+        });
+      }
+
+      for (const [index, jid] of leftoverDirectJids.entries()) {
+        db.setRegisteredGroup(jid, {
+          name: `Leftover direct ${index}`,
+          folder: `leftover-${index}`,
+          added_at: now,
+          created_by: 'owner-a',
+          channel_account_id: jid.includes('bot-b') ? 'bot-b' : 'bot-a',
+          target_main_jid: workspaceJid,
+        });
+      }
+      db.setRegisteredGroup(qqGroupJid, {
+        name: 'QQ sales group',
+        folder: 'qq-sales',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      });
+      db.setRegisteredGroup(discordGroupJid, {
+        name: 'Discord guild channel',
+        folder: 'discord-guild',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      });
+      db.setRegisteredGroup(waGroupJid, {
+        name: 'WhatsApp group',
+        folder: 'wa-group',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      });
+      db.setRegisteredGroup(manualDmJid, {
+        name: 'Bob QQ DM',
+        folder: 'qq-bob',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_agent_id: 'manual-session',
+      });
+      db.setRegisteredGroup(missingWsDmJid, {
+        name: 'Carol DingTalk DM',
+        folder: 'dt-carol',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: 'web:deleted-workspace',
+      });
+      db.setRegisteredGroup(feishuUnknownJid, {
+        name: 'Feishu opaque chat',
+        folder: 'feishu-opaque',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      });
+      db.setRegisteredGroup(malformedTelegramJid, {
+        name: 'Malformed Telegram',
+        folder: 'tg-bad',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      });
+      db.setRegisteredGroup(waBroadcastJid, {
+        name: 'WhatsApp broadcast',
+        folder: 'wa-broadcast',
+        added_at: now,
+        created_by: 'owner-a',
+        channel_account_id: 'bot-a',
+        target_main_jid: workspaceJid,
+      });
+
+      expect(db.setSessionChannelOwnerOnce(folder, null, leftoverWaLidA)).toBe(
+        leftoverWaLidA,
+      );
+      db.setSession(folder, 'contaminated-main-session');
+      db.setSession(folder, 'manual-session-sdk', 'manual-session');
+
+      const failureInjector = new Database(databasePath);
+      failureInjector.exec(`
+      CREATE TRIGGER fail_leftover_direct_session_delete
+      BEFORE DELETE ON sessions
+      WHEN OLD.group_folder = '${folder}' AND OLD.agent_id = ''
+      BEGIN
+        SELECT RAISE(ABORT, 'injected migration failure');
+      END;
+    `);
+      failureInjector.close();
+
+      expect(() =>
+        db.migrateClassifiableDirectWorkspaceMountsToSessions(),
+      ).toThrow('injected migration failure');
+      expect(db.getRegisteredGroup(leftoverWaLidA)).toMatchObject({
+        target_main_jid: workspaceJid,
+      });
+      expect(db.getSessionChannelOwner(folder)).toBe(leftoverWaLidA);
+      expect(db.getSession(folder)).toBe('contaminated-main-session');
+      expect(db.getConversationHistoryIsolationMarker(workspaceJid)).toBe(
+        undefined,
+      );
+
+      const triggerCleanup = new Database(databasePath);
+      triggerCleanup.exec('DROP TRIGGER fail_leftover_direct_session_delete');
+      triggerCleanup.close();
+
+      expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(
+        leftoverDirectJids.length,
+      );
+      expect(db.getSession(folder)).toBeUndefined();
+      expect(db.getWorkspaceRuntimeSession(folder)).toBeUndefined();
+      expect(db.getSession(folder, 'manual-session')).toBe(
+        'manual-session-sdk',
+      );
+      expect(db.getSessionChannelOwner(folder)).toBeUndefined();
+      const isolationMarker =
+        db.getConversationHistoryIsolationMarker(workspaceJid);
+      expect(isolationMarker).toBeTruthy();
+
+      const migratedIds = leftoverDirectJids.map((jid) =>
+        expectDirectSessionMount(jid),
+      );
+      expect(new Set(migratedIds).size).toBe(leftoverDirectJids.length);
+
+      expectGroupStaysOnMain(qqGroupJid);
+      expectGroupStaysOnMain(discordGroupJid);
+      expectGroupStaysOnMain(waGroupJid);
+
+      expect(db.getRegisteredGroup(wecomMigratedJid)?.target_agent_id).toBe(
+        'wecom-v72-session',
+      );
+      expect(db.getRegisteredGroup(qqMigratedJid)?.target_agent_id).toBe(
+        'qq-v73-session',
+      );
+      expect(db.getRegisteredGroup(discordMigratedJid)?.target_agent_id).toBe(
+        'discord-v73-session',
+      );
+      expect(db.getRegisteredGroup(waPnMigratedJid)?.target_agent_id).toBe(
+        'wa-pn-v73-session',
+      );
+      expect(db.getRegisteredGroup(manualDmJid)).toMatchObject({
+        target_agent_id: 'manual-session',
+      });
+      expect(db.getRegisteredGroup(missingWsDmJid)).toMatchObject({
+        target_main_jid: 'web:deleted-workspace',
+      });
+      expect(db.getRegisteredGroup(feishuUnknownJid)).toMatchObject({
+        target_main_jid: workspaceJid,
+      });
+      expect(db.getRegisteredGroup(malformedTelegramJid)).toMatchObject({
+        target_main_jid: workspaceJid,
+      });
+      expect(db.getRegisteredGroup(waBroadcastJid)).toMatchObject({
+        target_main_jid: workspaceJid,
+      });
+
+      db.setSession(folder, 'clean-main-session');
+      expect(db.setSessionChannelOwnerOnce(folder, null, waGroupJid)).toBe(
+        waGroupJid,
+      );
+      expect(db.migrateClassifiableDirectWorkspaceMountsToSessions()).toBe(0);
+      expect(db.getSession(folder)).toBe('clean-main-session');
+      expect(db.getSessionChannelOwner(folder)).toBe(waGroupJid);
+      expect(db.getConversationHistoryIsolationMarker(workspaceJid)).toBe(
+        isolationMarker,
+      );
+
+      // A database already stamped 73 must still run v74 on upgrade.
+      stampSchema('73');
+      expect(db.getRouterState('schema_version')).toBe(
+        String(db.CURRENT_SCHEMA_VERSION),
+      );
+      expect(db.getRegisteredGroup(leftoverWaLidA)?.target_agent_id).toBe(
+        migratedIds[0],
+      );
+      expect(db.getRegisteredGroup(leftoverQqDm)?.target_agent_id).toBe(
+        migratedIds[4],
+      );
+      expect(db.getRegisteredGroup(leftoverDiscordDm)?.target_agent_id).toBe(
+        migratedIds[5],
+      );
+      expect(db.getRegisteredGroup(waPnMigratedJid)?.target_agent_id).toBe(
+        'wa-pn-v73-session',
+      );
+      expect(db.getSession(folder)).toBe('clean-main-session');
+      expect(db.getSessionChannelOwner(folder)).toBe(waGroupJid);
+    });
+
+    test('v73 leftover QQ/Discord/WhatsApp DMs do not share main owner and fence recovery without timestamps', () => {
+      const cases = [
+        {
+          folder: 'qq-v74-recovery',
+          workspaceJid: 'web:qq-v74-recovery',
+          dmJid: 'qq:c2c:recovery-alice#account:bot-a',
+          groupJid: 'qq:group:recovery-sales#account:bot-a',
+          privateText: 'qq private value that must never be replayed',
+          futurePrivateText:
+            'qq future-clock private value that must never be replayed',
+          groupBeforeText: 'qq old group context before the privacy boundary',
+          groupAfterText: 'qq safe group context after migration',
+        },
+        {
+          folder: 'discord-v74-recovery',
+          workspaceJid: 'web:discord-v74-recovery',
+          dmJid: 'discord:dm:recovery-alice#account:bot-a',
+          groupJid: 'discord:recovery-guild#account:bot-a',
+          privateText: 'discord private value that must never be replayed',
+          futurePrivateText:
+            'discord future-clock private value that must never be replayed',
+          groupBeforeText:
+            'discord old group context before the privacy boundary',
+          groupAfterText: 'discord safe group context after migration',
+        },
+        {
+          folder: 'wa-v74-recovery',
+          workspaceJid: 'web:wa-v74-recovery',
+          dmJid: 'whatsapp:123456789099999@lid#account:bot-a',
+          extraDmJid: 'whatsapp:15559990000@s.whatsapp.net#account:bot-a',
+          groupJid: 'whatsapp:120363000000000111@g.us#account:bot-a',
+          privateText: 'wa private value that must never be replayed',
+          futurePrivateText:
+            'wa future-clock private value that must never be replayed',
+          groupBeforeText: 'wa old group context before the privacy boundary',
+          groupAfterText: 'wa safe group context after migration',
+        },
+      ] as const;
+
+      for (const fixture of cases) {
+        db.setRegisteredGroup(fixture.workspaceJid, {
+          name: fixture.workspaceJid,
+          folder: fixture.folder,
+          added_at: now,
+          created_by: 'owner-recovery',
+        });
+        db.setRegisteredGroup(fixture.dmJid, {
+          name: fixture.dmJid,
+          folder: `${fixture.folder}-dm`,
+          added_at: now,
+          created_by: 'owner-recovery',
+          channel_account_id: 'bot-a',
+          target_main_jid: fixture.workspaceJid,
+        });
+        if ('extraDmJid' in fixture && fixture.extraDmJid) {
+          db.setRegisteredGroup(fixture.extraDmJid, {
+            name: fixture.extraDmJid,
+            folder: `${fixture.folder}-pn`,
+            added_at: now,
+            created_by: 'owner-recovery',
+            channel_account_id: 'bot-a',
+            target_main_jid: fixture.workspaceJid,
+          });
+        }
+        db.setRegisteredGroup(fixture.groupJid, {
+          name: fixture.groupJid,
+          folder: `${fixture.folder}-group`,
+          added_at: now,
+          created_by: 'owner-recovery',
+          channel_account_id: 'bot-a',
+          target_main_jid: fixture.workspaceJid,
+        });
+        db.setSession(fixture.folder, `${fixture.folder}-contaminated`);
+        db.setSessionChannelOwnerOnce(fixture.folder, null, fixture.dmJid);
+        db.ensureChatExists(fixture.workspaceJid);
+        db.storeMessageDirect(
+          `${fixture.folder}-private-before`,
+          fixture.workspaceJid,
+          fixture.dmJid,
+          'Private Alice',
+          fixture.privateText,
+          now,
+          false,
+          { sourceJid: fixture.dmJid },
+        );
+        db.storeMessageDirect(
+          `${fixture.folder}-group-before`,
+          fixture.workspaceJid,
+          fixture.groupJid,
+          'Group Bob',
+          fixture.groupBeforeText,
+          '2026-08-19T00:00:00.001Z',
+          false,
+          { sourceJid: fixture.groupJid },
+        );
+        db.storeMessageDirect(
+          `${fixture.folder}-private-future`,
+          fixture.workspaceJid,
+          fixture.dmJid,
+          'Private Alice',
+          fixture.futurePrivateText,
+          '2099-01-01T00:00:00.000Z',
+          false,
+          { sourceJid: fixture.dmJid },
+        );
+      }
+
+      const isolatedFolder = 'already-isolated-ws';
+      const isolatedWorkspaceJid = 'web:already-isolated-ws';
+      const isolatedLid = 'whatsapp:15551239999@lid#account:bot-a';
+      const isolatedGroup = 'whatsapp:120363000000000222@g.us#account:bot-a';
+      db.setRegisteredGroup(isolatedWorkspaceJid, {
+        name: isolatedWorkspaceJid,
+        folder: isolatedFolder,
+        added_at: now,
+        created_by: 'owner-recovery',
+      });
+      db.setRegisteredGroup(isolatedLid, {
+        name: isolatedLid,
+        folder: `${isolatedFolder}-lid`,
+        added_at: now,
+        created_by: 'owner-recovery',
+        channel_account_id: 'bot-a',
+        target_main_jid: isolatedWorkspaceJid,
+      });
+      db.setRegisteredGroup(isolatedGroup, {
+        name: isolatedGroup,
+        folder: `${isolatedFolder}-group`,
+        added_at: now,
+        created_by: 'owner-recovery',
+        channel_account_id: 'bot-a',
+        target_main_jid: isolatedWorkspaceJid,
+      });
+      db.setRouterState(
+        `conversation_history_isolation:${isolatedWorkspaceJid}`,
+        now,
+      );
+      db.setSession(isolatedFolder, 'clean-after-v73-main');
+      expect(
+        db.setSessionChannelOwnerOnce(isolatedFolder, null, isolatedLid),
+      ).toBe(isolatedLid);
+
+      stampSchema('73');
+
+      for (const fixture of cases) {
+        const migrated = db.getRegisteredGroup(fixture.dmJid)!;
+        expect(migrated.target_main_jid).toBeUndefined();
+        expect(migrated.target_agent_id).toBeTruthy();
+        expect(db.getAgent(migrated.target_agent_id!)?.source_kind).toBe(
+          'channel_direct',
+        );
+        if ('extraDmJid' in fixture && fixture.extraDmJid) {
+          const extra = db.getRegisteredGroup(fixture.extraDmJid)!;
+          expect(extra.target_main_jid).toBeUndefined();
+          expect(extra.target_agent_id).toBeTruthy();
+          expect(extra.target_agent_id).not.toBe(migrated.target_agent_id);
+        }
+        expect(db.getRegisteredGroup(fixture.groupJid)).toMatchObject({
+          target_main_jid: fixture.workspaceJid,
+        });
+        expect(db.getSession(fixture.folder)).toBeUndefined();
+        expect(db.getSessionChannelOwner(fixture.folder)).toBeUndefined();
+        expect(
+          db.setSessionChannelOwnerOnce(fixture.folder, null, fixture.groupJid),
+        ).toBe(fixture.groupJid);
+        expect(
+          db.setSessionChannelOwnerOnce(fixture.folder, null, fixture.dmJid),
+        ).toBe(fixture.groupJid);
+        expect(
+          db.setSessionChannelOwnerOnce(
+            fixture.folder,
+            migrated.target_agent_id,
+            fixture.dmJid,
+          ),
+        ).toBe(fixture.dmJid);
+
+        const isolationMarker = db.getConversationHistoryIsolationMarker(
+          fixture.workspaceJid,
+        );
+        expect(isolationMarker).toBeTruthy();
+        db.storeMessageDirect(
+          `${fixture.folder}-group-after`,
+          fixture.workspaceJid,
+          fixture.groupJid,
+          'Group Bob',
+          fixture.groupAfterText,
+          '2026-08-19T00:00:00.002Z',
+          false,
+          { sourceJid: fixture.groupJid },
+        );
+        const history = buildRecentConversationHistoryContext(
+          fixture.workspaceJid,
+          new Set(),
+          { intro: 'recovery' },
+        );
+        expect(history?.messageIds).toEqual([`${fixture.folder}-group-after`]);
+        expect(history?.context).toContain(fixture.groupAfterText);
+        expect(history?.context).not.toContain(fixture.privateText);
+        expect(history?.context).not.toContain(fixture.futurePrivateText);
+        expect(history?.context).not.toContain(fixture.groupBeforeText);
+
+        db.storeMessageDirect(
+          `${fixture.folder}-private-before`,
+          fixture.workspaceJid,
+          fixture.dmJid,
+          'Private Alice',
+          `replaced ${fixture.privateText}`,
+          '2099-01-02T00:00:00.000Z',
+          false,
+          { sourceJid: fixture.dmJid },
+        );
+        const historyAfterReplace = buildRecentConversationHistoryContext(
+          fixture.workspaceJid,
+          new Set(),
+          { intro: 'recovery' },
+        );
+        expect(historyAfterReplace?.context).not.toContain(
+          `replaced ${fixture.privateText}`,
+        );
+      }
+
+      const remountedLid = db.getRegisteredGroup(isolatedLid)!;
+      expect(remountedLid.target_main_jid).toBeUndefined();
+      expect(remountedLid.target_agent_id).toBeTruthy();
+      expect(db.getSession(isolatedFolder)).toBe('clean-after-v73-main');
+      expect(db.getSessionChannelOwner(isolatedFolder)).toBeUndefined();
+      expect(
+        db.getConversationHistoryIsolationMarker(isolatedWorkspaceJid),
+      ).toBe(now);
+      expect(
+        db.setSessionChannelOwnerOnce(isolatedFolder, null, isolatedGroup),
+      ).toBe(isolatedGroup);
+      expect(
+        db.setSessionChannelOwnerOnce(isolatedFolder, null, isolatedLid),
+      ).toBe(isolatedGroup);
+    });
+  },
+);

--- a/tests/wecom-direct-mount.test.ts
+++ b/tests/wecom-direct-mount.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 
+import type { ChannelProvider } from '../src/types.js';
+
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wecom-direct-mount-'));
 const store = path.join(tmp, 'db');
 const groups = path.join(tmp, 'groups');
@@ -33,6 +35,42 @@ const now = '2026-08-17T00:00:00.000Z';
 const workspaceJid = 'web:wecom-ws';
 const dmJid = 'wecom:c2c:user-1#account:bot-a';
 const groupJid = 'wecom:group:chat-1#account:bot-a';
+
+const CLASSIFIABLE_ISOLATION_CASES = [
+  {
+    name: 'QQ',
+    provider: 'qq' as ChannelProvider,
+    accountId: 'qq-bot-a',
+    workspaceJid: 'web:qq-iso-ws',
+    folder: 'qq-iso-ws',
+    dms: ['qq:c2c:alice#account:qq-bot-a'],
+    groupJid: 'qq:group:sales#account:qq-bot-a',
+    restoreJid: 'qq:c2c:restore-user#account:qq-bot-a',
+  },
+  {
+    name: 'Discord',
+    provider: 'discord' as ChannelProvider,
+    accountId: 'discord-bot-a',
+    workspaceJid: 'web:discord-iso-ws',
+    folder: 'discord-iso-ws',
+    dms: ['discord:dm:alice#account:discord-bot-a'],
+    groupJid: 'discord:guild-channel-1#account:discord-bot-a',
+    restoreJid: 'discord:dm:restore-user#account:discord-bot-a',
+  },
+  {
+    name: 'WhatsApp',
+    provider: 'whatsapp' as ChannelProvider,
+    accountId: 'wa-bot-a',
+    workspaceJid: 'web:wa-iso-ws',
+    folder: 'wa-iso-ws',
+    dms: [
+      'whatsapp:15551230000@s.whatsapp.net#account:wa-bot-a',
+      'whatsapp:123456789012345@lid#account:wa-bot-a',
+    ],
+    groupJid: 'whatsapp:120363000000000000@g.us#account:wa-bot-a',
+    restoreJid: 'whatsapp:15551239999@hosted.lid#account:wa-bot-a',
+  },
+] as const;
 
 function workspaceGroup() {
   return {
@@ -64,6 +102,22 @@ beforeAll(() => {
     secret_ref: 'channel-account:bot-a',
     default_workspace_jid: workspaceJid,
   });
+  for (const fixture of CLASSIFIABLE_ISOLATION_CASES) {
+    db.setRegisteredGroup(fixture.workspaceJid, {
+      name: `${fixture.name} workspace`,
+      folder: fixture.folder,
+      added_at: now,
+      created_by: 'owner-a',
+    });
+    db.createChannelAccount({
+      id: fixture.accountId,
+      owner_user_id: 'owner-a',
+      provider: fixture.provider,
+      name: `${fixture.name} bot`,
+      secret_ref: `channel-account:${fixture.accountId}`,
+      default_workspace_jid: fixture.workspaceJid,
+    });
+  }
 });
 
 afterAll(() => {
@@ -254,3 +308,142 @@ describe.sequential('WeCom DM / group channel-account mounts', () => {
     expect(db.getSessionChannelOwner('wecom-ws')).toBeUndefined();
   });
 });
+
+describe.sequential(
+  'QQ/Discord/WhatsApp DM / group channel-account mounts',
+  () => {
+    test.each(CLASSIFIABLE_ISOLATION_CASES)(
+      '$name: new attach isolates DM from group main owner',
+      (fixture) => {
+        const mountedDms = fixture.dms.map((sourceJid) => {
+          const dm = attachDefaultChannelAccountMount({
+            sourceJid,
+            group: chatGroup(`${fixture.name} private DM`),
+            accountId: fixture.accountId,
+            fallbackWorkspaceJid: fixture.workspaceJid,
+            userId: 'owner-a',
+          });
+          expect(dm.channel_account_id).toBe(fixture.accountId);
+          expect(dm.target_main_jid).toBeUndefined();
+          expect(dm.target_agent_id).toBeTruthy();
+          db.setRegisteredGroup(sourceJid, dm);
+          expect(db.getChannelMount(sourceJid)).toMatchObject({
+            workspace_jid: fixture.workspaceJid,
+            session_id: dm.target_agent_id,
+            routing_mode: 'single_session',
+          });
+          const dmTarget = resolveChannelMountTarget(
+            db.getChannelMount(sourceJid)!,
+            {
+              getAgent: db.getAgent,
+              getRegisteredGroup: db.getRegisteredGroup,
+            },
+          );
+          expect(dmTarget).toMatchObject({
+            status: 'resolved',
+            effectiveJid: `${fixture.workspaceJid}#agent:${dm.target_agent_id}`,
+            agentId: dm.target_agent_id,
+          });
+          return dm;
+        });
+        expect(new Set(mountedDms.map((dm) => dm.target_agent_id)).size).toBe(
+          fixture.dms.length,
+        );
+
+        const group = attachDefaultChannelAccountMount({
+          sourceJid: fixture.groupJid,
+          group: chatGroup(`${fixture.name} group`),
+          accountId: fixture.accountId,
+          fallbackWorkspaceJid: fixture.workspaceJid,
+          userId: 'owner-a',
+        });
+        expect(group).toMatchObject({
+          channel_account_id: fixture.accountId,
+          target_main_jid: fixture.workspaceJid,
+        });
+        expect(group.target_agent_id).toBeUndefined();
+        db.setRegisteredGroup(fixture.groupJid, group);
+        expect(db.getChannelMount(fixture.groupJid)).toMatchObject({
+          workspace_jid: fixture.workspaceJid,
+          session_id: null,
+        });
+
+        expect(
+          db.setSessionChannelOwnerOnce(fixture.folder, null, fixture.groupJid),
+        ).toBe(fixture.groupJid);
+        for (const [index, sourceJid] of fixture.dms.entries()) {
+          const agentId = mountedDms[index]!.target_agent_id!;
+          expect(
+            db.setSessionChannelOwnerOnce(fixture.folder, null, sourceJid),
+          ).toBe(fixture.groupJid);
+          expect(
+            db.setSessionChannelOwnerOnce(fixture.folder, agentId, sourceJid),
+          ).toBe(sourceJid);
+          expect(
+            db.setSessionChannelOwnerOnce(
+              fixture.folder,
+              agentId,
+              fixture.groupJid,
+            ),
+          ).toBe(sourceJid);
+        }
+      },
+    );
+
+    test.each(CLASSIFIABLE_ISOLATION_CASES)(
+      '$name: /unbind restore remounts leftover DM off workspace main',
+      (fixture) => {
+        db.setRegisteredGroup(
+          fixture.restoreJid,
+          chatGroup(`${fixture.name} leftover DM`, {
+            channel_account_id: fixture.accountId,
+            target_main_jid: fixture.workspaceJid,
+          }),
+        );
+        db.clearSessionChannelOwner(fixture.folder, null);
+        expect(
+          db.setSessionChannelOwnerOnce(
+            fixture.folder,
+            null,
+            fixture.restoreJid,
+          ),
+        ).toBe(fixture.restoreJid);
+        const restored = restoreDefaultChannelMount(
+          fixture.restoreJid,
+          db.getRegisteredGroup(fixture.restoreJid)!,
+          'owner-a',
+        );
+        expect(restored.status).toBe('resolved');
+        if (restored.status !== 'resolved') return;
+        expect(restored.workspaceJid).toBe(fixture.workspaceJid);
+        expect(restored.updated.target_main_jid).toBeUndefined();
+        expect(restored.updated.target_agent_id).toBeTruthy();
+        expect(db.getChannelMount(fixture.restoreJid)).toMatchObject({
+          workspace_jid: fixture.workspaceJid,
+          session_id: restored.updated.target_agent_id,
+        });
+        expect(
+          db.getAgent(restored.updated.target_agent_id!)?.source_kind,
+        ).toBe('channel_direct');
+        expect(db.getSessionChannelOwner(fixture.folder)).toBeUndefined();
+        expect(
+          db.setSessionChannelOwnerOnce(fixture.folder, null, fixture.groupJid),
+        ).toBe(fixture.groupJid);
+        expect(
+          db.setSessionChannelOwnerOnce(
+            fixture.folder,
+            null,
+            fixture.restoreJid,
+          ),
+        ).toBe(fixture.groupJid);
+        expect(
+          db.setSessionChannelOwnerOnce(
+            fixture.folder,
+            restored.updated.target_agent_id,
+            fixture.restoreJid,
+          ),
+        ).toBe(fixture.restoreJid);
+      },
+    );
+  },
+);


### PR DESCRIPTION
Follow-up to #654/#655/#659. v73 only runs when schema_version < 73 and used the old classifier, so a DB stamped 73 before #659 can still have whatsapp @lid/@hosted/@hosted.lid on target_main_jid. Schema v74 remounts leftover JID-classifiable DMs with the current classifier. v72/v73 untouched. Already-migrated rows are idempotent. Regression tests cover QQ c2c+group, Discord dm+guild, WhatsApp LID/PN + @g.us for attach, remount, unbind, and recovery. Tests: 3163 passed, 23 skipped.