### PR TITLE
fix(feishu): keep usage note on split or oversized final cards

### DIFF
--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -2099,6 +2099,18 @@ export class StreamingCardController {
     titlePrefix: string;
     title?: string;
   } | null = null;
+  /** Usage that arrived before finalize settled, parked for redelivery.
+   *
+   * The runner emits usage right after the final result, while complete() is
+   * still mid-flight (state flips to 'completed' at its top, the card writes
+   * settle much later). Rendering the note immediately would either race the
+   * finalize rebuild on the same serialized backend queue — last writer wins,
+   * and the finalize card carries no note — or, on the split path, read
+   * lastSplitCard before splitOnFinalize has recorded it. Park the usage and
+   * let complete() flush it after the terminal card is actually in place. */
+  private pendingUsage: FeishuUsageNoteInput | null = null;
+  /** True once complete() has finished writing the terminal card(s). */
+  private finalizeSettled = false;
   /** Serializes legacy im.v1.message.patch calls — that API has no sequence
    * number, so an in-flight「生成中」patch landing AFTER the terminal patch
    * would permanently revert the card to streaming state. */
@@ -2516,6 +2528,17 @@ export class StreamingCardController {
       this.emitLifecycle('failed', err);
       throw err;
     }
+
+    // Terminal card is in place — deliver any usage that arrived while the
+    // finalize writes were still in flight. Ordering via the same serialized
+    // backend queue guarantees the note lands after the terminal card instead
+    // of being overwritten by it.
+    this.finalizeSettled = true;
+    if (this.pendingUsage) {
+      const parked = this.pendingUsage;
+      this.pendingUsage = null;
+      await this.patchUsageNote(parked).catch(() => {});
+    }
   }
 
   /**
@@ -2533,7 +2556,15 @@ export class StreamingCardController {
     reasoningTokens?: number;
     modelUsage?: Record<string, { outputTokens?: number }>;
   }): Promise<void> {
-    if (this.state !== 'completed') return;
+    if (this.state === 'aborted' || this.state === 'error') return;
+    if (this.state !== 'completed' || !this.finalizeSettled) {
+      // Finalize still in flight (or usage arrived before the final result):
+      // rendering now would be overwritten by the terminal card rebuild or,
+      // on the split path, miss lastSplitCard. complete() flushes this after
+      // the terminal card settles.
+      this.pendingUsage = usage;
+      return;
+    }
 
     try {
       if (this.backendMode === 'streaming' && this.streamingBackend) {

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -25,6 +25,7 @@ import {
 } from './feishu-cards/builder.js';
 import type { CardStatus, ToolCallStat } from './feishu-cards/types.js';
 import { formatFeishuUsageNote } from './feishu-usage-display.js';
+import type { FeishuUsageNoteInput } from './feishu-usage-display.js';
 import {
   CARD_ELEMENT_IDS,
   statusHeadline,
@@ -2079,6 +2080,25 @@ export class StreamingCardController {
   /** True when finalize split content across multiple cards — patchUsageNote
    * must not rebuild a single card or it would overwrite the first card. */
   private finalizedAsSplit = false;
+  /** Handle to the LAST card produced by splitOnFinalize. Without it a split
+   * reply silently loses its usage note (model / tokens / elapsed): the single
+   * card rebuild is forbidden, so patchUsageNote used to just return. Keeping
+   * the tail card's renderer + text lets us re-render only that card with the
+   * note appended, which is where a reader looks for it anyway.
+   *
+   * `render` rather than a backend handle because the tail is not always a
+   * continuation card: the split branch is entered on the FINAL card's JSON
+   * size too, and a tool-heavy turn blows past that limit while its reply text
+   * still fits one group. The tail is then the reused streaming card, which is
+   * a StreamingModeBackend (updateCardFull) rather than a CardKitBackend
+   * (updateCard). */
+  private lastSplitCard: {
+    render: (cardJson: object) => Promise<void>;
+    text: string;
+    state: Schema2State;
+    titlePrefix: string;
+    title?: string;
+  } | null = null;
   /** Serializes legacy im.v1.message.patch calls — that API has no sequence
    * number, so an in-flight「生成中」patch landing AFTER the terminal patch
    * would permanently revert the card to streaming state. */
@@ -2521,10 +2541,23 @@ export class StreamingCardController {
         // would overwrite the first card with full text while continuation
         // cards remain. The explicit flag matters: for ASCII long replies the
         // truncated JSON is small, so a byte-size check alone never trips.
-        if (this.finalizedAsSplit) return;
+        if (this.finalizedAsSplit) {
+          // Rebuilding one card would clobber the continuations, but the note
+          // itself must not be lost — re-render just the tail card with it.
+          await this.patchUsageNoteOnSplitTail(usage);
+          return;
+        }
         const cardJson = this.buildStructuredFinalCard('completed', usage);
         const cardSize = Buffer.byteLength(JSON.stringify(cardJson), 'utf-8');
-        if (cardSize > CARD_SIZE_LIMIT) return;
+        if (cardSize > CARD_SIZE_LIMIT) {
+          // Silent drop here is what made long replies lose model/token info;
+          // keep the card intact but leave a trace instead of vanishing.
+          logger.debug(
+            { chatId: this.chatId, cardSize, limit: CARD_SIZE_LIMIT },
+            'Streaming card: usage note skipped, rebuilt card exceeds size limit',
+          );
+          return;
+        }
         await this.streamingBackend.updateCardFull(cardJson);
       } else if (this.messageId || this.multiCard) {
         // For CardKit v1 / legacy: skip if multiCard has split content
@@ -2539,6 +2572,38 @@ export class StreamingCardController {
         'Streaming card: patchUsageNote failed (non-fatal)',
       );
     }
+  }
+
+  /**
+   * Re-render the tail card of a split finalize so the usage note (model /
+   * tokens / elapsed) still reaches the reader. Only the last card is touched;
+   * earlier cards keep their frozen content.
+   */
+  private async patchUsageNoteOnSplitTail(
+    usage: FeishuUsageNoteInput,
+  ): Promise<void> {
+    const tail = this.lastSplitCard;
+    if (!tail) return;
+    const note = formatFeishuUsageNote(usage);
+    if (!note) return;
+    const cardJson = buildSchema2Card(
+      tail.text,
+      tail.state,
+      tail.titlePrefix,
+      tail.title,
+      undefined,
+      note,
+    );
+    if (
+      Buffer.byteLength(JSON.stringify(cardJson), 'utf-8') > CARD_SIZE_LIMIT
+    ) {
+      logger.debug(
+        { chatId: this.chatId },
+        'Streaming card: split-tail usage note skipped, card exceeds size limit',
+      );
+      return;
+    }
+    await tail.render(cardJson);
   }
 
   /**
@@ -3399,6 +3464,18 @@ export class StreamingCardController {
         // override title so their first line stays in the body.
         const firstCard = buildSchema2Card(text, state, '');
         await backend.updateCardFull(firstCard);
+        // Single group: the reused streaming card IS the tail. Recording it
+        // only in the continuation branch below would leave lastSplitCard null
+        // for every oversized-JSON-but-short-text reply, and the usage note
+        // would be dropped exactly as before the fix.
+        if (isLast) {
+          this.lastSplitCard = {
+            render: (cardJson) => backend.updateCardFull(cardJson),
+            text,
+            state,
+            titlePrefix: '',
+          };
+        }
       } else {
         const contCard = new CardKitBackend(this.client);
         const contCardJson = buildSchema2Card(text, state, '(续) ', title);
@@ -3409,6 +3486,17 @@ export class StreamingCardController {
           this.replyInThread,
         );
         this.onCardCreated?.(newMsgId);
+        // Remember the tail card so patchUsageNote can still deliver the usage
+        // note on split replies (see lastSplitCard).
+        if (isLast) {
+          this.lastSplitCard = {
+            render: (cardJson) => contCard.updateCard(cardJson),
+            text,
+            state,
+            titlePrefix: '(续) ',
+            title,
+          };
+        }
       }
     }
   }

--- a/tests/feishu-cardkit-controller.test.ts
+++ b/tests/feishu-cardkit-controller.test.ts
@@ -453,4 +453,48 @@ describe('Feishu CardKit streaming controller', () => {
     expect(rendered).toContain('输出 340');
     controller.dispose();
   });
+
+  // Regression: the runner emits usage right after the final result, while
+  // complete() is still writing the terminal card. state flips to 'completed'
+  // at the top of complete(), so the note used to render immediately and race
+  // the finalize rebuild on the same serialized queue — last writer wins, and
+  // the finalize card carries no note. The usage must be parked and delivered
+  // after the terminal card settles.
+  test('usage arriving while complete() is mid-flight still lands on the final card', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_usage_race',
+    });
+    controller.append('短回复正文');
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    // Fire usage while complete() is in flight — do not await complete first.
+    const completing = controller.complete('短回复正文');
+    const patching = controller.patchUsageNote({
+      inputTokens: 800,
+      outputTokens: 120,
+      costUSD: 0.1,
+      durationMs: 5000,
+      numTurns: 2,
+    });
+    await Promise.all([completing, patching]);
+    await backend.drain();
+
+    // The LAST terminal card write must carry the usage — earlier writes may
+    // legitimately lack it, but if the final one does, the usage was lost.
+    // The single-card path renders usage as the structured meta_row (⏱/💡),
+    // not the 💰 footer note (that form is for split-tail cards).
+    const lastCard = String(
+      mock.cardUpdate.mock.calls.at(-1)![0].data.card.data,
+    );
+    expect(lastCard).toContain('meta_row');
+    expect(lastCard).toContain('输出 120');
+    expect(lastCard).toContain('输入 800');
+    controller.dispose();
+  });
 });

--- a/tests/feishu-cardkit-controller.test.ts
+++ b/tests/feishu-cardkit-controller.test.ts
@@ -399,4 +399,58 @@ describe('Feishu CardKit streaming controller', () => {
       controller.dispose();
     },
   );
+
+  // Regression: finalize enters the split branch on raw text length as well as
+  // on card JSON size, and splitOnFinalize can still emit a SINGLE group. The
+  // tail is then the reused streaming card rather than a continuation card, so
+  // recording the tail only in the continuation branch silently dropped the
+  // usage note on exactly the long, tool-heavy replies that carry one.
+  test('a split finalize that yields one group still lands the usage note on the tail card', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_split_tail',
+    });
+
+    // Over MAX_FINAL_SINGLE_CARD_CHARS (15000) so finalize splits, but ASCII
+    // and under FREEZE_SLICE_BYTES (16KB) so the split produces one group.
+    const body = Array.from(
+      { length: 40 },
+      (_, i) => `paragraph ${i} ${'a'.repeat(370)}`,
+    ).join('\n\n');
+    expect(body.length).toBeGreaterThan(15000);
+    expect(Buffer.byteLength(body, 'utf-8')).toBeLessThan(16 * 1024);
+
+    controller.append(body);
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    await controller.complete(body);
+    expect(controller.currentState).toBe('completed');
+    // Guard the premise: if this ever stops splitting, the test below would
+    // pass for the wrong reason.
+    expect((controller as any).finalizedAsSplit).toBe(true);
+    expect((controller as any).lastSplitCard).not.toBeNull();
+
+    mock.cardUpdate.mockClear();
+    await controller.patchUsageNote({
+      inputTokens: 1200,
+      outputTokens: 340,
+      costUSD: 0.42,
+      durationMs: 12000,
+      numTurns: 3,
+    });
+    await backend.drain();
+
+    const rendered = mock.cardUpdate.mock.calls
+      .map((call) => String(call[0].data.card.data))
+      .join('\n');
+    expect(rendered).toContain('💰');
+    expect(rendered).toContain('输入 1.2K');
+    expect(rendered).toContain('输出 340');
+    controller.dispose();
+  });
 });


### PR DESCRIPTION
## 问题

`patchUsageNote()` 有两个不打日志的 early return，会把卡片底部的 usage 行（模型 / token / 耗时）静默丢掉，而且恰好丢在最可能需要它的回复上：

1. **拆卡路径**（`finalizedAsSplit`）：定稿拆成多张卡后，重建单卡会覆盖首卡，所以直接 `return` —— note 整个丢弃。
2. **超限路径**：重建卡 JSON 超过 `CARD_SIZE_LIMIT`（25KB）时无痕 `return`。

关键在于拆卡分支的进入条件是**最终卡 JSON 体积**（含工具时间轴 / 思考 / 待办面板），不只是正文长度——工具调用多的回合，正文不长也会顶破 25KB。所以这是长回合的**主流场景**，不是边角。

## 修复

- 拆卡定稿时记录**尾卡**为 render 闭包，`patchUsageNote` 只重渲尾卡并追加 usage 行，前面的卡保持冻结。用闭包而不是 backend 句柄，是因为拆卡结果只有一组时，尾卡是复用的流式卡（`StreamingModeBackend.updateCardFull`），多组时才是续卡（`CardKitBackend.updateCard`），两者接口不同。
- 超限路径改为 `logger.debug` 留痕后返回，不再静默消失。

## 验证

- 新增回归测试覆盖「拆卡但只产出一组」路径（正文 >15000 字触发拆卡、ASCII <16KB 单组），断言 usage 行落到尾卡。
- 做过变异验证：撤掉修复后该测试如期失败在 `lastSplitCard` 断言上。
- 全量测试通过；补丁已在自有部署上运行验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
