### PR TITLE
fix(runner): keep unfinished async_launched lines across compact trim

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -63,6 +63,7 @@ import {
   extractSessionHistory as extractSessionHistoryImpl,
   parseTranscript,
 } from './session-history.js';
+import { trimSessionJsonl } from './session-trim.js';
 import { StreamEventProcessor } from './stream-processor.js';
 import {
   acknowledgeHappyClawOwnerProfileFirstWake,
@@ -940,100 +941,6 @@ function getSessionSummary(
 }
 
 /**
- * Trim session JSONL file by removing all entries before the last compact_boundary.
- * After compaction, entries before the boundary are already summarized and no longer
- * needed for session reconstruction. This prevents unbounded file growth.
- *
- * Safety: uses atomic write (tmp + rename) to avoid data loss on crash.
- */
-function trimSessionJsonl(jsonlPath: string): void {
-  try {
-    const content = fs.readFileSync(jsonlPath, 'utf-8');
-    const lines = content.split('\n');
-    const nonEmptyLines: { index: number; line: string }[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (lines[i].trim()) nonEmptyLines.push({ index: i, line: lines[i] });
-    }
-
-    // Find the last compact_boundary entry (and any preserved segment it references)
-    let lastBoundaryPos = -1;
-    let preservedHeadUuid: string | undefined;
-    let parseSkipped = 0;
-    for (let i = nonEmptyLines.length - 1; i >= 0; i--) {
-      try {
-        const entry = JSON.parse(nonEmptyLines[i].line);
-        if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
-          lastBoundaryPos = i;
-          preservedHeadUuid =
-            entry.compact_metadata?.preserved_segment?.head_uuid;
-          break;
-        }
-      } catch {
-        parseSkipped++;
-      }
-    }
-    if (parseSkipped > 0) {
-      log(`Session trim: skipped ${parseSkipped} unparseable JSONL lines`);
-    }
-
-    if (lastBoundaryPos <= 0) {
-      // No boundary found or it's already the first entry — nothing to trim
-      log('Session trim: no compact_boundary found or already minimal');
-      return;
-    }
-
-    // partial compaction 时 boundary 带 preserved_segment{head_uuid, anchor_uuid, tail_uuid}：
-    // 保留段内容是 head_uuid..tail_uuid，SDK 的 resume loader 会在 anchor_uuid 处把它拼回。
-    // 若裁切越过 head_uuid，会连同这些消息及其 uuid 一起删掉，导致 loader 找不到锚点、resume
-    // 丢上下文。因此把裁切起点回退到 head_uuid 所在行，保住整段保留消息。
-    let trimStartPos = lastBoundaryPos;
-    if (preservedHeadUuid) {
-      const preservedPos = nonEmptyLines.findIndex((e) => {
-        try {
-          return JSON.parse(e.line).uuid === preservedHeadUuid;
-        } catch {
-          return false;
-        }
-      });
-      if (preservedPos >= 0 && preservedPos < trimStartPos) {
-        trimStartPos = preservedPos;
-        log(
-          `Session trim: preserving segment from head_uuid=${preservedHeadUuid.slice(0, 8)} (pos ${preservedPos} < boundary ${lastBoundaryPos})`,
-        );
-      }
-    }
-
-    // Keep entries from trimStartPos onwards
-    const trimmedLines = nonEmptyLines.slice(trimStartPos).map((e) => e.line);
-    const removedCount = trimStartPos;
-
-    const TRIM_MIN_ENTRIES = 50; // Skip trimming if fewer entries before boundary (not worth the I/O)
-    if (removedCount < TRIM_MIN_ENTRIES) {
-      log(
-        `Session trim: only ${removedCount} entries before boundary, skipping`,
-      );
-      return;
-    }
-
-    // Atomic write: temp file + rename
-    const tmpPath = jsonlPath + '.trim-tmp';
-    fs.writeFileSync(tmpPath, trimmedLines.join('\n') + '\n');
-    fs.renameSync(tmpPath, jsonlPath);
-
-    const sizeBefore = Buffer.byteLength(content, 'utf-8');
-    const sizeAfter = fs.statSync(jsonlPath).size;
-    log(
-      `Session trim: ${nonEmptyLines.length} → ${trimmedLines.length} entries (removed ${removedCount}), ` +
-        `${(sizeBefore / 1024 / 1024).toFixed(1)}MB → ${(sizeAfter / 1024 / 1024).toFixed(1)}MB`,
-    );
-  } catch (err) {
-    log(
-      `Session trim failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-/**
  * Archive the full transcript to conversations/ before compaction.
  * Also flush any accumulated streaming text as a compact_partial message
  * so users don't lose the response that was being generated.
@@ -1118,7 +1025,7 @@ function createPreCompactHook(deps: {
     // ── Trim session JSONL to prevent unbounded growth ──
     // Remove entries before the last compact_boundary (already summarized).
     // Must run AFTER archiving (archive needs full transcript).
-    trimSessionJsonl(transcriptPath);
+    trimSessionJsonl(transcriptPath, log);
 
     // Flag compaction so the query loop auto-continues instead of
     // waiting for user input (non-blocking compaction #229).

--- a/container/agent-runner/src/session-trim.ts
+++ b/container/agent-runner/src/session-trim.ts
@@ -1,0 +1,206 @@
+import fs from 'fs';
+
+export type SessionTrimLogger = (message: string) => void;
+
+const PENDING_LAUNCH_STATUSES = new Set(['async_launched', 'remote_launched']);
+
+type TranscriptEntry = Record<string, unknown>;
+
+function defaultLog(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function collectText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return '';
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      if (item && typeof item === 'object' && 'text' in item) {
+        return typeof item.text === 'string' ? item.text : '';
+      }
+      if (item && typeof item === 'object' && 'content' in item) {
+        return collectText(item.content);
+      }
+      return '';
+    })
+    .join('');
+}
+
+function transcriptText(parsed: TranscriptEntry): string {
+  const message = parsed.message;
+  if (message && typeof message === 'object' && 'content' in message) {
+    const fromMessage = collectText((message as { content?: unknown }).content);
+    if (fromMessage) return fromMessage;
+  }
+  return collectText(parsed.content);
+}
+
+function launchAgentId(parsed: TranscriptEntry): string | undefined {
+  const result = parsed.toolUseResult;
+  if (!result || typeof result !== 'object') return undefined;
+  const status = (result as { status?: unknown }).status;
+  if (typeof status !== 'string' || !PENDING_LAUNCH_STATUSES.has(status)) {
+    return undefined;
+  }
+  const agentId = (result as { agentId?: unknown }).agentId;
+  const taskId = (result as { taskId?: unknown }).taskId;
+  if (typeof agentId === 'string' && agentId) return agentId;
+  if (typeof taskId === 'string' && taskId) return taskId;
+  return undefined;
+}
+
+/**
+ * SDK resume treats `async_launched` / `remote_launched` without a matching
+ * `<task-notification><task-id>…</task-id>` as an orphan. Keep those launch
+ * records when they would otherwise be deleted before compact_boundary.
+ */
+function unfinishedLaunchLines(
+  removedRegion: { line: string }[],
+  allLines: { line: string }[],
+): string[] {
+  const pending: { agentId: string; line: string }[] = [];
+  for (const entry of removedRegion) {
+    try {
+      const parsed = JSON.parse(entry.line) as TranscriptEntry;
+      const agentId = launchAgentId(parsed);
+      if (agentId) pending.push({ agentId, line: entry.line });
+    } catch {
+      /* skip unparseable */
+    }
+  }
+  if (pending.length === 0) return [];
+
+  const completed = new Set<string>();
+  for (const entry of allLines) {
+    try {
+      const parsed = JSON.parse(entry.line) as TranscriptEntry;
+      const content = transcriptText(parsed);
+      if (!content.includes('<task-notification>')) continue;
+      for (const launch of pending) {
+        if (content.includes(`<task-id>${launch.agentId}</task-id>`)) {
+          completed.add(launch.agentId);
+        }
+      }
+    } catch {
+      /* skip unparseable */
+    }
+  }
+
+  return pending
+    .filter((launch) => !completed.has(launch.agentId))
+    .map((launch) => launch.line);
+}
+
+/**
+ * Trim session JSONL file by removing all entries before the last compact_boundary.
+ * After compaction, entries before the boundary are already summarized and no longer
+ * needed for session reconstruction. This prevents unbounded file growth.
+ *
+ * Safety: uses atomic write (tmp + rename) to avoid data loss on crash.
+ */
+export function trimSessionJsonl(
+  jsonlPath: string,
+  log: SessionTrimLogger = defaultLog,
+): void {
+  try {
+    const content = fs.readFileSync(jsonlPath, 'utf-8');
+    const lines = content.split('\n');
+    const nonEmptyLines: { index: number; line: string }[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim()) nonEmptyLines.push({ index: i, line: lines[i] });
+    }
+
+    // Find the last compact_boundary entry (and any preserved segment it references)
+    let lastBoundaryPos = -1;
+    let preservedHeadUuid: string | undefined;
+    let parseSkipped = 0;
+    for (let i = nonEmptyLines.length - 1; i >= 0; i--) {
+      try {
+        const entry = JSON.parse(nonEmptyLines[i].line);
+        if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+          lastBoundaryPos = i;
+          preservedHeadUuid =
+            entry.compact_metadata?.preserved_segment?.head_uuid;
+          break;
+        }
+      } catch {
+        parseSkipped++;
+      }
+    }
+    if (parseSkipped > 0) {
+      log(`Session trim: skipped ${parseSkipped} unparseable JSONL lines`);
+    }
+
+    if (lastBoundaryPos <= 0) {
+      // No boundary found or it's already the first entry — nothing to trim
+      log('Session trim: no compact_boundary found or already minimal');
+      return;
+    }
+
+    // partial compaction 时 boundary 带 preserved_segment{head_uuid, anchor_uuid, tail_uuid}：
+    // 保留段内容是 head_uuid..tail_uuid，SDK 的 resume loader 会在 anchor_uuid 处把它拼回。
+    // 若裁切越过 head_uuid，会连同这些消息及其 uuid 一起删掉，导致 loader 找不到锚点、resume
+    // 丢上下文。因此把裁切起点回退到 head_uuid 所在行，保住整段保留消息。
+    let trimStartPos = lastBoundaryPos;
+    if (preservedHeadUuid) {
+      const preservedPos = nonEmptyLines.findIndex((e) => {
+        try {
+          return JSON.parse(e.line).uuid === preservedHeadUuid;
+        } catch {
+          return false;
+        }
+      });
+      if (preservedPos >= 0 && preservedPos < trimStartPos) {
+        trimStartPos = preservedPos;
+        log(
+          `Session trim: preserving segment from head_uuid=${preservedHeadUuid.slice(0, 8)} (pos ${preservedPos} < boundary ${lastBoundaryPos})`,
+        );
+      }
+    }
+
+    const removedRegion = nonEmptyLines.slice(0, trimStartPos);
+    const keptRegion = nonEmptyLines.slice(trimStartPos);
+    const preservedLaunchLines = unfinishedLaunchLines(
+      removedRegion,
+      nonEmptyLines,
+    );
+    if (preservedLaunchLines.length > 0) {
+      log(
+        `Session trim: preserving ${preservedLaunchLines.length} pending async_launched entries to prevent orphan detection`,
+      );
+    }
+
+    // Keep unfinished Task launch records + entries from trimStartPos onwards
+    const trimmedLines = [
+      ...preservedLaunchLines,
+      ...keptRegion.map((e) => e.line),
+    ];
+    const historyBeforeBoundary = trimStartPos;
+    const removedCount = historyBeforeBoundary - preservedLaunchLines.length;
+
+    const TRIM_MIN_ENTRIES = 50; // Skip trimming if fewer entries before boundary (not worth the I/O)
+    if (historyBeforeBoundary < TRIM_MIN_ENTRIES) {
+      log(
+        `Session trim: only ${historyBeforeBoundary} entries before boundary, skipping`,
+      );
+      return;
+    }
+
+    // Atomic write: temp file + rename
+    const tmpPath = jsonlPath + '.trim-tmp';
+    fs.writeFileSync(tmpPath, trimmedLines.join('\n') + '\n');
+    fs.renameSync(tmpPath, jsonlPath);
+
+    const sizeBefore = Buffer.byteLength(content, 'utf-8');
+    const sizeAfter = fs.statSync(jsonlPath).size;
+    log(
+      `Session trim: ${nonEmptyLines.length} → ${trimmedLines.length} entries (removed ${removedCount}), ` +
+        `${(sizeBefore / 1024 / 1024).toFixed(1)}MB → ${(sizeAfter / 1024 / 1024).toFixed(1)}MB`,
+    );
+  } catch (err) {
+    log(
+      `Session trim failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/tests/session-trim.test.ts
+++ b/tests/session-trim.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { trimSessionJsonl } from '../container/agent-runner/src/session-trim.js';
+
+const TASK_ID = 'agent-bg-research-1';
+const LAUNCH_UUID = 'async-launch-uuid';
+
+function launchEntry(taskId = TASK_ID) {
+  return {
+    type: 'user',
+    uuid: LAUNCH_UUID,
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu-task-1',
+          content: `Background agent launched: ${taskId}`,
+        },
+      ],
+    },
+    toolUseResult: {
+      status: 'async_launched',
+      agentId: taskId,
+      taskId,
+    },
+  };
+}
+
+function dummyEntry(i: number) {
+  return {
+    type: 'user',
+    uuid: `dummy-${i}`,
+    message: { role: 'user', content: `dummy ${i}` },
+  };
+}
+
+function compactBoundary() {
+  return {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: 'compact-boundary-1',
+    compact_metadata: { trigger: 'auto' },
+  };
+}
+
+function taskNotification(taskId: string) {
+  return {
+    type: 'user',
+    uuid: `task-notification-${taskId}`,
+    message: {
+      role: 'user',
+      content: `<task-notification><task-id>${taskId}</task-id><status>completed</status></task-notification>`,
+    },
+  };
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-trim-test-'));
+});
+
+afterEach(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function writeJsonl(name: string, entries: object[]): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(
+    filePath,
+    entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+  );
+  return filePath;
+}
+
+function readJsonl(filePath: string): unknown[] {
+  return fs
+    .readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line));
+}
+
+describe('trimSessionJsonl', () => {
+  test('keeps an unfinished async_launched Task line across compact_boundary', () => {
+    const dummyCount = 50;
+    const transcriptPath = writeJsonl('session.jsonl', [
+      launchEntry(),
+      ...Array.from({ length: dummyCount }, (_, i) => dummyEntry(i)),
+      compactBoundary(),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    const launchLines = kept.filter((entry) => {
+      const result = (entry as { toolUseResult?: { status?: string } })
+        .toolUseResult;
+      return result?.status === 'async_launched';
+    });
+
+    expect(launchLines).toHaveLength(1);
+    expect(
+      (launchLines[0] as { toolUseResult: { agentId: string } }).toolUseResult
+        .agentId,
+    ).toBe(TASK_ID);
+    expect(
+      kept.some((entry) => (entry as { uuid?: string }).uuid === LAUNCH_UUID),
+    ).toBe(true);
+    expect(
+      kept.some(
+        (entry) =>
+          (entry as { type?: string; subtype?: string }).type === 'system' &&
+          (entry as { subtype?: string }).subtype === 'compact_boundary',
+      ),
+    ).toBe(true);
+    expect(
+      kept.some((entry) =>
+        String((entry as { uuid?: string }).uuid ?? '').startsWith('dummy-'),
+      ),
+    ).toBe(false);
+  });
+
+  test('does not keep an async_launched line that already has a task-notification', () => {
+    const transcriptPath = writeJsonl('completed.jsonl', [
+      launchEntry(),
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      taskNotification(TASK_ID),
+      compactBoundary(),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(
+      kept.some(
+        (entry) =>
+          (entry as { toolUseResult?: { status?: string } }).toolUseResult
+            ?.status === 'async_launched',
+      ),
+    ).toBe(false);
+    expect(
+      kept.some(
+        (entry) =>
+          (entry as { type?: string; subtype?: string }).subtype ===
+          'compact_boundary',
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`trimSessionJsonl` deleted every session JSONL entry before the last `compact_boundary`. An in-flight Task's `async_launched` launch record sat in that prefix and was removed, so SDK resume reported the background agent as an orphan (`No completion record was found for background agent ... from the previous session`).

This is the compact-path root cause from #594 / unmerged #597. This PR is the trim-only fix — not the stale heartbeat / orphan-recovery extras from #597.

Before writing the trimmed JSONL:
1. Scan the region about to be deleted for `toolUseResult.status` of `async_launched` or `remote_launched`.
2. Look through the full transcript for a matching `<task-notification><task-id>…</task-id>`.
3. If no completion exists, keep the launch line so it survives compact.

Completed launches are still trimmed. Dummy history before the boundary is still removed.

## Test plan

- [x] `tests/session-trim.test.ts`: `async_launched` + 50 dummy lines + `compact_boundary` → launch line survives, dummies gone
- [x] Same fixture plus a matching `<task-notification>` → completed launch is not kept
- [x] Verified fail-then-pass on current vs fixed `trimSessionJsonl`

Signed-off-by: Tony Coder <407243179@qq.com>