### PR TITLE
fix(im): throw on send after Telegram/QQ/DingTalk/Discord disconnect

### DIFF
--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -609,11 +609,9 @@ export function createTelegramChannel(
       localImagePaths?: string[],
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Telegram channel not connected, skip sending message',
+        throw new Error(
+          `Telegram channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text, localImagePaths);
     },
@@ -626,11 +624,9 @@ export function createTelegramChannel(
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Telegram channel not connected, skip sending image',
+        throw new Error(
+          `Telegram channel is not connected; image to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -641,11 +637,9 @@ export function createTelegramChannel(
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Telegram channel not connected, skip sending file',
+        throw new Error(
+          `Telegram channel is not connected; file to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -742,11 +736,9 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       localImagePaths?: string[],
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'QQ channel not connected, skip sending message',
+        throw new Error(
+          `QQ channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text, localImagePaths);
     },
@@ -759,8 +751,9 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn({ chatId }, 'QQ channel not connected, skip sending image');
-        return;
+        throw new Error(
+          `QQ channel is not connected; image to ${chatId} was not sent`,
+        );
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -771,8 +764,9 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn({ chatId }, 'QQ channel not connected, skip sending file');
-        return;
+        throw new Error(
+          `QQ channel is not connected; file to ${chatId} was not sent`,
+        );
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -1072,11 +1066,9 @@ export function createDingTalkChannel(
 
     async sendMessage(chatId: string, text: string): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'DingTalk channel not connected, skip sending message',
+        throw new Error(
+          `DingTalk channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text);
     },
@@ -1093,11 +1085,9 @@ export function createDingTalkChannel(
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'DingTalk channel not connected, skip sending image',
+        throw new Error(
+          `DingTalk channel is not connected; image to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -1108,11 +1098,9 @@ export function createDingTalkChannel(
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'DingTalk channel not connected, skip sending file',
+        throw new Error(
+          `DingTalk channel is not connected; file to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -1233,17 +1221,23 @@ export function createDiscordChannel(
     },
 
     async sendMessage(chatId, text, localImagePaths?) {
-      if (!inner) return;
+      if (!inner) {
+        throw new Error('Discord channel not connected');
+      }
       await inner.sendMessage(chatId, text, localImagePaths);
     },
 
     async sendFile(chatId, filePath, fileName) {
-      if (!inner) return;
+      if (!inner) {
+        throw new Error('Discord channel not connected');
+      }
       await inner.sendFile(chatId, filePath, fileName);
     },
 
     async sendImage(chatId, imageBuffer, mimeType, caption?, fileName?) {
-      if (!inner) return;
+      if (!inner) {
+        throw new Error('Discord channel not connected');
+      }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
 

--- a/tests/im-channel-disconnect-send.test.ts
+++ b/tests/im-channel-disconnect-send.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { syntheticChannelProviderAck } from '../src/channel-outbox-runtime-scope.js';
+import type { IMChannel, IMChannelConnectOpts } from '../src/im-channel.js';
+
+const innerCalls = vi.hoisted(() => ({
+  sendMessage: 0,
+  sendImage: 0,
+  sendFile: 0,
+}));
+
+function createMockConnection() {
+  return {
+    async connect() {
+      return true;
+    },
+    async disconnect() {},
+    async sendMessage() {
+      innerCalls.sendMessage += 1;
+    },
+    async sendImage() {
+      innerCalls.sendImage += 1;
+    },
+    async sendFile() {
+      innerCalls.sendFile += 1;
+    },
+    async sendChatAction() {},
+    async sendReaction() {},
+    async setTyping() {},
+    async clearAckReaction() {},
+    isConnected() {
+      return true;
+    },
+  };
+}
+
+vi.mock('../src/telegram.js', () => ({
+  createTelegramConnection: () => createMockConnection(),
+}));
+vi.mock('../src/qq.js', () => ({
+  createQQConnection: () => createMockConnection(),
+}));
+vi.mock('../src/dingtalk.js', () => ({
+  createDingTalkConnection: () => createMockConnection(),
+}));
+vi.mock('../src/discord.js', () => ({
+  createDiscordConnection: () => createMockConnection(),
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const {
+  createTelegramChannel,
+  createQQChannel,
+  createDingTalkChannel,
+  createDiscordChannel,
+} = await import('../src/im-channel.js');
+
+const connectOpts: IMChannelConnectOpts = {
+  onReady: vi.fn(),
+  onNewChat: vi.fn(),
+};
+
+const cases: Array<{
+  name: string;
+  create: () => IMChannel;
+}> = [
+  {
+    name: 'Telegram',
+    create: () => createTelegramChannel({ botToken: 'token' }),
+  },
+  {
+    name: 'QQ',
+    create: () => createQQChannel({ appId: 'app', appSecret: 'secret' }),
+  },
+  {
+    name: 'DingTalk',
+    create: () =>
+      createDingTalkChannel({ clientId: 'client', clientSecret: 'secret' }),
+  },
+  {
+    name: 'Discord',
+    create: () => createDiscordChannel({ botToken: 'token' }),
+  },
+];
+
+/**
+ * Mirrors deliverScopedChannelOutput / sendImWithRetry: a void send that
+ * does not throw is treated as success and a synthetic delivered ACK is
+ * minted. After disconnect that must not happen.
+ */
+async function sendAndMintDeliveredAck(
+  send: () => Promise<void>,
+): Promise<string> {
+  await send();
+  return syntheticChannelProviderAck({
+    turnRunId: 'disconnect-send-test',
+    ordinal: 1,
+    payloadHash: 'payload',
+  });
+}
+
+describe('disconnect must not mint a delivered ACK', () => {
+  test.each(cases)(
+    '$name send after disconnect throws and does not mint a synthetic ACK',
+    async ({ create }) => {
+      innerCalls.sendMessage = 0;
+      innerCalls.sendImage = 0;
+      innerCalls.sendFile = 0;
+
+      const channel = create();
+      await expect(channel.connect(connectOpts)).resolves.toBe(true);
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+
+      let mintedAck: string | undefined;
+      await expect(
+        sendAndMintDeliveredAck(async () => {
+          await channel.sendMessage('chat-1', 'hello after disconnect');
+          mintedAck = 'must-not-assign';
+        }),
+      ).rejects.toThrow('not connected');
+
+      expect(mintedAck).toBeUndefined();
+      expect(innerCalls.sendMessage).toBe(0);
+
+      await expect(
+        sendAndMintDeliveredAck(async () => {
+          await channel.sendImage?.(
+            'chat-1',
+            Buffer.from('image'),
+            'image/png',
+          );
+        }),
+      ).rejects.toThrow('not connected');
+      expect(innerCalls.sendImage).toBe(0);
+
+      await expect(
+        sendAndMintDeliveredAck(async () => {
+          await channel.sendFile?.('chat-1', '/tmp/file', 'file.txt');
+        }),
+      ).rejects.toThrow('not connected');
+      expect(innerCalls.sendFile).toBe(0);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

After `disconnect()`, Telegram / QQ / DingTalk / Discord `sendMessage` (and image/file) returned without throwing. `sendImWithRetry` / `deliverScopedChannelOutput` treat a void send as success and mint a `happyclaw-synthetic:…` delivered ACK even though nothing was sent.

Those adapters now throw when there is no live connector, matching WeChat / WeCom / WhatsApp. No synthetic ACK after disconnect.

Scope is `src/im-channel.ts` only. Feishu has the same silent-return pattern and is left out of this PR.

## Test plan

- [x] `tests/im-channel-disconnect-send.test.ts`: connect, disconnect, send text/image/file — must throw (`not connected`), must not mint an ACK, must not call the inner send
- [x] Fail-then-pass on current `main` (`2c16fb1bff`): disconnect then send minted `happyclaw-synthetic:fa8e9f4c…` before the fix
- [x] Related channel tests green; `tsc --noEmit` green

Signed-off-by: Tony Coder <407243179@qq.com>