### PR TITLE
fix: IM false-ACK, duplicate send, compact orphan, and Feishu usage drops

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -63,6 +63,7 @@ import {
   extractSessionHistory as extractSessionHistoryImpl,
   parseTranscript,
 } from './session-history.js';
+import { trimSessionJsonl } from './session-trim.js';
 import { StreamEventProcessor } from './stream-processor.js';
 import {
   acknowledgeHappyClawOwnerProfileFirstWake,
@@ -941,100 +942,6 @@ function getSessionSummary(
 }
 
 /**
- * Trim session JSONL file by removing all entries before the last compact_boundary.
- * After compaction, entries before the boundary are already summarized and no longer
- * needed for session reconstruction. This prevents unbounded file growth.
- *
- * Safety: uses atomic write (tmp + rename) to avoid data loss on crash.
- */
-function trimSessionJsonl(jsonlPath: string): void {
-  try {
-    const content = fs.readFileSync(jsonlPath, 'utf-8');
-    const lines = content.split('\n');
-    const nonEmptyLines: { index: number; line: string }[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (lines[i].trim()) nonEmptyLines.push({ index: i, line: lines[i] });
-    }
-
-    // Find the last compact_boundary entry (and any preserved segment it references)
-    let lastBoundaryPos = -1;
-    let preservedHeadUuid: string | undefined;
-    let parseSkipped = 0;
-    for (let i = nonEmptyLines.length - 1; i >= 0; i--) {
-      try {
-        const entry = JSON.parse(nonEmptyLines[i].line);
-        if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
-          lastBoundaryPos = i;
-          preservedHeadUuid =
-            entry.compact_metadata?.preserved_segment?.head_uuid;
-          break;
-        }
-      } catch {
-        parseSkipped++;
-      }
-    }
-    if (parseSkipped > 0) {
-      log(`Session trim: skipped ${parseSkipped} unparseable JSONL lines`);
-    }
-
-    if (lastBoundaryPos <= 0) {
-      // No boundary found or it's already the first entry — nothing to trim
-      log('Session trim: no compact_boundary found or already minimal');
-      return;
-    }
-
-    // partial compaction 时 boundary 带 preserved_segment{head_uuid, anchor_uuid, tail_uuid}：
-    // 保留段内容是 head_uuid..tail_uuid，SDK 的 resume loader 会在 anchor_uuid 处把它拼回。
-    // 若裁切越过 head_uuid，会连同这些消息及其 uuid 一起删掉，导致 loader 找不到锚点、resume
-    // 丢上下文。因此把裁切起点回退到 head_uuid 所在行，保住整段保留消息。
-    let trimStartPos = lastBoundaryPos;
-    if (preservedHeadUuid) {
-      const preservedPos = nonEmptyLines.findIndex((e) => {
-        try {
-          return JSON.parse(e.line).uuid === preservedHeadUuid;
-        } catch {
-          return false;
-        }
-      });
-      if (preservedPos >= 0 && preservedPos < trimStartPos) {
-        trimStartPos = preservedPos;
-        log(
-          `Session trim: preserving segment from head_uuid=${preservedHeadUuid.slice(0, 8)} (pos ${preservedPos} < boundary ${lastBoundaryPos})`,
-        );
-      }
-    }
-
-    // Keep entries from trimStartPos onwards
-    const trimmedLines = nonEmptyLines.slice(trimStartPos).map((e) => e.line);
-    const removedCount = trimStartPos;
-
-    const TRIM_MIN_ENTRIES = 50; // Skip trimming if fewer entries before boundary (not worth the I/O)
-    if (removedCount < TRIM_MIN_ENTRIES) {
-      log(
-        `Session trim: only ${removedCount} entries before boundary, skipping`,
-      );
-      return;
-    }
-
-    // Atomic write: temp file + rename
-    const tmpPath = jsonlPath + '.trim-tmp';
-    fs.writeFileSync(tmpPath, trimmedLines.join('\n') + '\n');
-    fs.renameSync(tmpPath, jsonlPath);
-
-    const sizeBefore = Buffer.byteLength(content, 'utf-8');
-    const sizeAfter = fs.statSync(jsonlPath).size;
-    log(
-      `Session trim: ${nonEmptyLines.length} → ${trimmedLines.length} entries (removed ${removedCount}), ` +
-        `${(sizeBefore / 1024 / 1024).toFixed(1)}MB → ${(sizeAfter / 1024 / 1024).toFixed(1)}MB`,
-    );
-  } catch (err) {
-    log(
-      `Session trim failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-/**
  * Archive the full transcript to conversations/ before compaction.
  * Also flush any accumulated streaming text as a compact_partial message
  * so users don't lose the response that was being generated.
@@ -1119,7 +1026,7 @@ function createPreCompactHook(deps: {
     // ── Trim session JSONL to prevent unbounded growth ──
     // Remove entries before the last compact_boundary (already summarized).
     // Must run AFTER archiving (archive needs full transcript).
-    trimSessionJsonl(transcriptPath);
+    trimSessionJsonl(transcriptPath, log);
 
     // Flag compaction so the query loop auto-continues instead of
     // waiting for user input (non-blocking compaction #229).

--- a/container/agent-runner/src/session-trim.ts
+++ b/container/agent-runner/src/session-trim.ts
@@ -1,0 +1,347 @@
+import fs from 'fs';
+
+export type SessionTrimLogger = (message: string) => void;
+
+const PENDING_LAUNCH_STATUSES = new Set(['async_launched', 'remote_launched']);
+const TRIM_MIN_ENTRIES = 50;
+
+type TranscriptEntry = Record<string, unknown>;
+
+type ParsedLine = {
+  index: number;
+  line: string;
+  parsed: TranscriptEntry | null;
+};
+
+function defaultLog(message: string): void {
+  console.error(`[agent-runner] ${message}`);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function collectText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return '';
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      const rec = asRecord(item);
+      if (!rec) return '';
+      if (typeof rec.text === 'string') return rec.text;
+      if ('content' in rec) return collectText(rec.content);
+      return '';
+    })
+    .join('');
+}
+
+function transcriptText(parsed: TranscriptEntry): string {
+  const message = asRecord(parsed.message);
+  if (message && 'content' in message) {
+    const fromMessage = collectText(message.content);
+    if (fromMessage) return fromMessage;
+  }
+  return collectText(parsed.content);
+}
+
+function entryUuid(parsed: TranscriptEntry): string | undefined {
+  return typeof parsed.uuid === 'string' && parsed.uuid
+    ? parsed.uuid
+    : undefined;
+}
+
+function entryParentUuid(parsed: TranscriptEntry): string | undefined {
+  return typeof parsed.parentUuid === 'string' && parsed.parentUuid
+    ? parsed.parentUuid
+    : undefined;
+}
+
+function launchAgentId(parsed: TranscriptEntry): string | undefined {
+  const result = asRecord(parsed.toolUseResult);
+  if (!result) return undefined;
+  const status = result.status;
+  if (typeof status !== 'string' || !PENDING_LAUNCH_STATUSES.has(status)) {
+    return undefined;
+  }
+  const agentId = result.agentId;
+  const taskId = result.taskId;
+  if (typeof agentId === 'string' && agentId) return agentId;
+  if (typeof taskId === 'string' && taskId) return taskId;
+  return undefined;
+}
+
+function toolUseIdFromLaunch(parsed: TranscriptEntry): string | undefined {
+  const message = asRecord(parsed.message);
+  const content = message?.content;
+  if (!Array.isArray(content)) return undefined;
+  for (const item of content) {
+    const rec = asRecord(item);
+    if (
+      rec &&
+      rec.type === 'tool_result' &&
+      typeof rec.tool_use_id === 'string' &&
+      rec.tool_use_id
+    ) {
+      return rec.tool_use_id;
+    }
+  }
+  return undefined;
+}
+
+function assistantHasToolUse(
+  parsed: TranscriptEntry,
+  toolUseId: string,
+): boolean {
+  if (parsed.type !== 'assistant') return false;
+  const message = asRecord(parsed.message);
+  const content = message?.content;
+  if (!Array.isArray(content)) return false;
+  return content.some((item) => {
+    const rec = asRecord(item);
+    return rec?.type === 'tool_use' && rec.id === toolUseId;
+  });
+}
+
+function originKind(parsed: TranscriptEntry): string | undefined {
+  const origin = asRecord(parsed.origin);
+  if (typeof origin?.kind === 'string') return origin.kind;
+  const message = asRecord(parsed.message);
+  const messageOrigin = asRecord(message?.origin);
+  if (typeof messageOrigin?.kind === 'string') return messageOrigin.kind;
+  return undefined;
+}
+
+function structuredTaskId(parsed: TranscriptEntry): string | undefined {
+  const candidates = [
+    parsed.task_id,
+    parsed.taskId,
+    parsed.agentId,
+    asRecord(parsed.toolUseResult)?.task_id,
+    asRecord(parsed.toolUseResult)?.taskId,
+    asRecord(parsed.toolUseResult)?.agentId,
+  ];
+  for (const value of candidates) {
+    if (typeof value === 'string' && value) return value;
+  }
+  return undefined;
+}
+
+function xmlTaskId(text: string): string | undefined {
+  const match = text.match(/<task-id>\s*([^<]+?)\s*<\/task-id>/i);
+  const id = match?.[1]?.trim();
+  return id || undefined;
+}
+
+/**
+ * Completions are structured SDK records. XML is only accepted inside those
+ * records so an assistant summary or pasted transcript cannot mark an
+ * in-flight Task complete.
+ */
+function completedTaskId(parsed: TranscriptEntry): string | undefined {
+  const kind = originKind(parsed);
+  const isStructured =
+    (parsed.type === 'system' && parsed.subtype === 'task_notification') ||
+    (parsed.type === 'user' && kind === 'task-notification') ||
+    parsed.type === 'queue-operation' ||
+    kind === 'task-notification';
+  if (!isStructured) return undefined;
+  return structuredTaskId(parsed) ?? xmlTaskId(transcriptText(parsed));
+}
+
+function withParentUuid(
+  parsed: TranscriptEntry,
+  parentUuid: string | undefined,
+): string {
+  const next = { ...parsed };
+  if (parentUuid) next.parentUuid = parentUuid;
+  else delete next.parentUuid;
+  return JSON.stringify(next);
+}
+
+/**
+ * Keep unfinished Task launch records that would otherwise be deleted before
+ * compact_boundary, together with their assistant tool_use partner so resume
+ * does not see a dangling parentUuid / tool_use_id.
+ */
+function unfinishedLaunchLines(
+  removedRegion: ParsedLine[],
+  allLines: ParsedLine[],
+  attachParentUuid: string | undefined,
+): string[] {
+  const pending: {
+    agentId: string;
+    line: ParsedLine;
+  }[] = [];
+  for (const entry of removedRegion) {
+    if (!entry.parsed) continue;
+    const agentId = launchAgentId(entry.parsed);
+    if (agentId) pending.push({ agentId, line: entry });
+  }
+  if (pending.length === 0) return [];
+
+  const completed = new Set<string>();
+  for (const entry of allLines) {
+    if (!entry.parsed) continue;
+    const taskId = completedTaskId(entry.parsed);
+    if (taskId) completed.add(taskId);
+  }
+
+  const keptUuids = new Set<string>();
+  const preserved: string[] = [];
+
+  for (const launch of pending) {
+    if (completed.has(launch.agentId)) continue;
+    const parsed = launch.line.parsed!;
+    const toolUseId = toolUseIdFromLaunch(parsed);
+    const parentUuid = entryParentUuid(parsed);
+
+    const assistant = removedRegion.find((entry) => {
+      if (!entry.parsed) return false;
+      const uuid = entryUuid(entry.parsed);
+      if (uuid && keptUuids.has(uuid)) return false;
+      if (toolUseId && assistantHasToolUse(entry.parsed, toolUseId)) {
+        return true;
+      }
+      return Boolean(parentUuid && uuid === parentUuid);
+    });
+
+    if (assistant?.parsed) {
+      const assistantUuid = entryUuid(assistant.parsed);
+      if (assistantUuid) keptUuids.add(assistantUuid);
+      preserved.push(withParentUuid(assistant.parsed, attachParentUuid));
+      preserved.push(withParentUuid(parsed, assistantUuid ?? attachParentUuid));
+    } else {
+      preserved.push(withParentUuid(parsed, attachParentUuid));
+    }
+    const launchUuid = entryUuid(parsed);
+    if (launchUuid) keptUuids.add(launchUuid);
+  }
+
+  return preserved;
+}
+
+/**
+ * Trim session JSONL file by removing all entries before the last compact_boundary.
+ * After compaction, entries before the boundary are already summarized and no longer
+ * needed for session reconstruction. This prevents unbounded file growth.
+ *
+ * Safety: uses atomic write (tmp + rename) to avoid data loss on crash.
+ */
+export function trimSessionJsonl(
+  jsonlPath: string,
+  log: SessionTrimLogger = defaultLog,
+): void {
+  try {
+    const content = fs.readFileSync(jsonlPath, 'utf-8');
+    const lines = content.split('\n');
+    const nonEmptyLines: ParsedLine[] = [];
+    let parseSkipped = 0;
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i].trim()) continue;
+      try {
+        nonEmptyLines.push({
+          index: i,
+          line: lines[i],
+          parsed: JSON.parse(lines[i]) as TranscriptEntry,
+        });
+      } catch {
+        parseSkipped++;
+        nonEmptyLines.push({ index: i, line: lines[i], parsed: null });
+      }
+    }
+
+    let lastBoundaryPos = -1;
+    let preservedHeadUuid: string | undefined;
+    for (let i = nonEmptyLines.length - 1; i >= 0; i--) {
+      const entry = nonEmptyLines[i].parsed;
+      if (!entry) continue;
+      if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+        lastBoundaryPos = i;
+        const metadata = asRecord(entry.compact_metadata);
+        const preserved = asRecord(metadata?.preserved_segment);
+        preservedHeadUuid =
+          typeof preserved?.head_uuid === 'string'
+            ? preserved.head_uuid
+            : undefined;
+        break;
+      }
+    }
+    if (parseSkipped > 0) {
+      log(`Session trim: skipped ${parseSkipped} unparseable JSONL lines`);
+    }
+
+    if (lastBoundaryPos <= 0) {
+      log('Session trim: no compact_boundary found or already minimal');
+      return;
+    }
+
+    // partial compaction 时 boundary 带 preserved_segment{head_uuid, anchor_uuid, tail_uuid}：
+    // 保留段内容是 head_uuid..tail_uuid，SDK 的 resume loader 会在 anchor_uuid 处把它拼回。
+    // 若裁切越过 head_uuid，会连同这些消息及其 uuid 一起删掉，导致 loader 找不到锚点、resume
+    // 丢上下文。因此把裁切起点回退到 head_uuid 所在行，保住整段保留消息。
+    let trimStartPos = lastBoundaryPos;
+    if (preservedHeadUuid) {
+      const preservedPos = nonEmptyLines.findIndex(
+        (e) => e.parsed && entryUuid(e.parsed) === preservedHeadUuid,
+      );
+      if (preservedPos >= 0 && preservedPos < trimStartPos) {
+        trimStartPos = preservedPos;
+        log(
+          `Session trim: preserving segment from head_uuid=${preservedHeadUuid.slice(0, 8)} (pos ${preservedPos} < boundary ${lastBoundaryPos})`,
+        );
+      }
+    }
+
+    const removedRegion = nonEmptyLines.slice(0, trimStartPos);
+    const preservedSegment = nonEmptyLines.slice(trimStartPos, lastBoundaryPos);
+    const boundaryAndAfter = nonEmptyLines.slice(lastBoundaryPos);
+    const attachParentUuid = boundaryAndAfter[0]?.parsed
+      ? entryUuid(boundaryAndAfter[0].parsed)
+      : undefined;
+    const preservedLaunchLines = unfinishedLaunchLines(
+      removedRegion,
+      nonEmptyLines,
+      attachParentUuid,
+    );
+    if (preservedLaunchLines.length > 0) {
+      log(
+        `Session trim: preserving ${preservedLaunchLines.length} pending async_launched entries to prevent orphan detection`,
+      );
+    }
+
+    // Insert unfinished launches immediately before compact_boundary so a
+    // preserved_segment.head_uuid stays the first kept history line.
+    const trimmedLines = [
+      ...preservedSegment.map((e) => e.line),
+      ...preservedLaunchLines,
+      ...boundaryAndAfter.map((e) => e.line),
+    ];
+    const historyBeforeBoundary = trimStartPos;
+    const removedCount = historyBeforeBoundary - preservedLaunchLines.length;
+
+    if (historyBeforeBoundary < TRIM_MIN_ENTRIES) {
+      log(
+        `Session trim: only ${historyBeforeBoundary} entries before boundary, skipping`,
+      );
+      return;
+    }
+
+    const tmpPath = jsonlPath + '.trim-tmp';
+    fs.writeFileSync(tmpPath, trimmedLines.join('\n') + '\n');
+    fs.renameSync(tmpPath, jsonlPath);
+
+    const sizeBefore = Buffer.byteLength(content, 'utf-8');
+    const sizeAfter = fs.statSync(jsonlPath).size;
+    log(
+      `Session trim: ${nonEmptyLines.length} → ${trimmedLines.length} entries (removed ${removedCount}), ` +
+        `${(sizeBefore / 1024 / 1024).toFixed(1)}MB → ${(sizeAfter / 1024 / 1024).toFixed(1)}MB`,
+    );
+  } catch (err) {
+    log(
+      `Session trim failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/dingtalk.ts
+++ b/src/dingtalk.ts
@@ -130,6 +130,31 @@ export interface DingTalkGroupMessageSuccess {
   message?: string;
 }
 
+/** Timeout / 5xx / 429: the first send may already have left the client. */
+function isUncertainFormatFallbackError(err: unknown): boolean {
+  let current: unknown = err;
+  const seen = new Set<unknown>();
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const rec = current as Record<string, unknown>;
+    const code = String(rec.code ?? rec.errno ?? '');
+    const status = Number(rec.error_code ?? rec.statusCode ?? rec.status);
+    const message = String(rec.message ?? '');
+    if (
+      /ETIMEDOUT|ESOCKETTIMEDOUT|ECONNRESET|ECONNREFUSED|EPIPE|ENOTFOUND|EAI_AGAIN|UND_ERR_|timed out|AbortError/i.test(
+        `${code} ${message}`,
+      ) ||
+      status === 429 ||
+      (status >= 500 && status <= 599) ||
+      /HTTP failed \((429|5\d\d)\)/.test(message)
+    ) {
+      return true;
+    }
+    current = rec.cause ?? rec.error;
+  }
+  return false;
+}
+
 /** Validate the persistent groupMessages endpoint's transport and envelope. */
 export function parseDingTalkGroupMessageResponse(
   statusCode: number | undefined,
@@ -2187,7 +2212,14 @@ export function createDingTalkConnection(
             'sampleMarkdown',
             msgParam,
           );
-        } catch {
+        } catch (err) {
+          if (isUncertainFormatFallbackError(err)) {
+            throw err;
+          }
+          logger.debug(
+            { err, chatId },
+            'DingTalk markdown failed, fallback to plain',
+          );
           // Fall back to plain text
           const plainContent = markdownToPlainText(chunk);
           const plainMsgParam = JSON.stringify({ content: plainContent });

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -24,7 +24,10 @@ import {
   buildStreamingAgentCard,
 } from './feishu-cards/builder.js';
 import type { CardStatus, ToolCallStat } from './feishu-cards/types.js';
-import { formatFeishuUsageNote } from './feishu-usage-display.js';
+import {
+  formatFeishuUsageNote,
+  type FeishuUsageNoteInput,
+} from './feishu-usage-display.js';
 import {
   CARD_ELEMENT_IDS,
   statusHeadline,
@@ -2068,6 +2071,21 @@ export class StreamingCardController {
   /** True when finalize split content across multiple cards — patchUsageNote
    * must not rebuild a single card or it would overwrite the first card. */
   private finalizedAsSplit = false;
+  /** Handle to the LAST card produced by splitOnFinalize. Without it a split
+   * reply silently loses its usage note. `render` rather than a backend handle
+   * because the tail is the reused streaming card (updateCardFull) for a
+   * single-group split and a CardKitBackend continuation card otherwise. */
+  private lastSplitCard: {
+    render: (cardJson: object) => Promise<void>;
+    text: string;
+    state: Schema2State;
+    titlePrefix: string;
+    title?: string;
+  } | null = null;
+  /** Usage that arrived before finalize settled, parked for redelivery. */
+  private pendingUsage: FeishuUsageNoteInput | null = null;
+  /** True once complete() has finished writing the terminal card(s). */
+  private finalizeSettled = false;
   /** Serializes legacy im.v1.message.patch calls — that API has no sequence
    * number, so an in-flight「生成中」patch landing AFTER the terminal patch
    * would permanently revert the card to streaming state. */
@@ -2485,24 +2503,28 @@ export class StreamingCardController {
       this.emitLifecycle('failed', err);
       throw err;
     }
+
+    this.finalizeSettled = true;
+    if (this.pendingUsage) {
+      const parked = this.pendingUsage;
+      this.pendingUsage = null;
+      await this.patchUsageNote(parked);
+    }
   }
 
   /**
    * Patch a completed card to append a usage note at the bottom.
    * Called AFTER complete() because agent-runner emits usage after the final result.
    */
-  async patchUsageNote(usage: {
-    inputTokens: number;
-    outputTokens: number;
-    costUSD: number;
-    durationMs: number;
-    numTurns: number;
-    cacheReadInputTokens?: number;
-    cacheCreationInputTokens?: number;
-    reasoningTokens?: number;
-    modelUsage?: Record<string, { outputTokens?: number }>;
-  }): Promise<void> {
-    if (this.state !== 'completed') return;
+  async patchUsageNote(usage: FeishuUsageNoteInput): Promise<void> {
+    if (this.state === 'aborted' || this.state === 'error') {
+      this.pendingUsage = null;
+      return;
+    }
+    if (this.state !== 'completed' || !this.finalizeSettled) {
+      this.pendingUsage = usage;
+      return;
+    }
 
     try {
       if (this.backendMode === 'streaming' && this.streamingBackend) {
@@ -2510,24 +2532,67 @@ export class StreamingCardController {
         // would overwrite the first card with full text while continuation
         // cards remain. The explicit flag matters: for ASCII long replies the
         // truncated JSON is small, so a byte-size check alone never trips.
-        if (this.finalizedAsSplit) return;
+        if (this.finalizedAsSplit) {
+          await this.patchUsageNoteOnSplitTail(usage);
+          return;
+        }
         const cardJson = this.buildStructuredFinalCard('completed', usage);
         const cardSize = Buffer.byteLength(JSON.stringify(cardJson), 'utf-8');
-        if (cardSize > CARD_SIZE_LIMIT) return;
+        if (cardSize > CARD_SIZE_LIMIT) {
+          logger.warn(
+            { chatId: this.chatId, cardSize, limit: CARD_SIZE_LIMIT },
+            'Streaming card: usage note skipped, rebuilt card exceeds size limit',
+          );
+          return;
+        }
         await this.streamingBackend.updateCardFull(cardJson);
       } else if (this.messageId || this.multiCard) {
-        // For CardKit v1 / legacy: skip if multiCard has split content
-        if (this.multiCard && this.multiCard.getCardCount() > 1) return;
         const note = this.mergeFooterNote(formatFeishuUsageNote(usage));
         if (!note) return;
         await this.patchCard('completed', note);
       }
     } catch (err) {
-      logger.debug(
+      logger.warn(
         { err, chatId: this.chatId },
         'Streaming card: patchUsageNote failed (non-fatal)',
       );
     }
+  }
+
+  /**
+   * Re-render the tail card of a split finalize so the usage note still
+   * reaches the reader. Only the last card is touched.
+   */
+  private async patchUsageNoteOnSplitTail(
+    usage: FeishuUsageNoteInput,
+  ): Promise<void> {
+    const tail = this.lastSplitCard;
+    if (!tail) {
+      logger.warn(
+        { chatId: this.chatId, finalizedAsSplit: this.finalizedAsSplit },
+        'Streaming card: split usage note skipped, tail card handle missing',
+      );
+      return;
+    }
+    const note = this.mergeFooterNote(formatFeishuUsageNote(usage));
+    if (!note) return;
+    const cardJson = buildSchema2Card(
+      tail.text,
+      tail.state,
+      tail.titlePrefix,
+      tail.title,
+      undefined,
+      note,
+    );
+    const cardSize = Buffer.byteLength(JSON.stringify(cardJson), 'utf-8');
+    if (cardSize > CARD_SIZE_LIMIT) {
+      logger.warn(
+        { chatId: this.chatId, cardSize, limit: CARD_SIZE_LIMIT },
+        'Streaming card: split-tail usage note skipped, card exceeds size limit',
+      );
+      return;
+    }
+    await tail.render(cardJson);
   }
 
   /**
@@ -2540,6 +2605,7 @@ export class StreamingCardController {
     const creationInFlight =
       this.state === 'creating' ? this.creationPromise : null;
     this.state = 'aborted';
+    this.pendingUsage = null;
     this.flushCtrl.dispose();
     this.textFlushCtrl?.dispose();
     this.auxFlushCtrl?.dispose();
@@ -3388,6 +3454,14 @@ export class StreamingCardController {
         // override title so their first line stays in the body.
         const firstCard = buildSchema2Card(text, state, '');
         await backend.updateCardFull(firstCard);
+        if (isLast) {
+          this.lastSplitCard = {
+            render: (cardJson) => backend.updateCardFull(cardJson),
+            text,
+            state,
+            titlePrefix: '',
+          };
+        }
       } else {
         const contCard = new CardKitBackend(this.client);
         const contCardJson = buildSchema2Card(text, state, '(续) ', title);
@@ -3398,6 +3472,15 @@ export class StreamingCardController {
           this.replyInThread,
         );
         this.onCardCreated?.(newMsgId);
+        if (isLast) {
+          this.lastSplitCard = {
+            render: (cardJson) => contCard.updateCard(cardJson),
+            text,
+            state,
+            titlePrefix: '(续) ',
+            title,
+          };
+        }
       }
     }
   }

--- a/src/im-channel.ts
+++ b/src/im-channel.ts
@@ -342,11 +342,9 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
       options?: ChannelMessageDeliveryOptions,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Feishu channel not connected, skip sending message',
+        throw new Error(
+          `Feishu channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text, localImagePaths, options);
     },
@@ -359,11 +357,9 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Feishu channel not connected, skip sending image',
+        throw new Error(
+          `Feishu channel is not connected; image to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -403,11 +399,9 @@ export function createFeishuChannel(config: FeishuConnectionConfig): IMChannel {
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Feishu channel not connected, skip sending file',
+        throw new Error(
+          `Feishu channel is not connected; file to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -604,11 +598,9 @@ export function createTelegramChannel(
       localImagePaths?: string[],
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Telegram channel not connected, skip sending message',
+        throw new Error(
+          `Telegram channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text, localImagePaths);
     },
@@ -621,11 +613,9 @@ export function createTelegramChannel(
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Telegram channel not connected, skip sending image',
+        throw new Error(
+          `Telegram channel is not connected; image to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -636,11 +626,9 @@ export function createTelegramChannel(
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'Telegram channel not connected, skip sending file',
+        throw new Error(
+          `Telegram channel is not connected; file to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -739,11 +727,9 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       localImagePaths?: string[],
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'QQ channel not connected, skip sending message',
+        throw new Error(
+          `QQ channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text, localImagePaths);
     },
@@ -756,8 +742,9 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn({ chatId }, 'QQ channel not connected, skip sending image');
-        return;
+        throw new Error(
+          `QQ channel is not connected; image to ${chatId} was not sent`,
+        );
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -768,8 +755,9 @@ export function createQQChannel(config: QQConnectionConfig): IMChannel {
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn({ chatId }, 'QQ channel not connected, skip sending file');
-        return;
+        throw new Error(
+          `QQ channel is not connected; file to ${chatId} was not sent`,
+        );
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -1078,11 +1066,9 @@ export function createDingTalkChannel(
 
     async sendMessage(chatId: string, text: string): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'DingTalk channel not connected, skip sending message',
+        throw new Error(
+          `DingTalk channel is not connected; message to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendMessage(chatId, text);
     },
@@ -1099,11 +1085,9 @@ export function createDingTalkChannel(
       fileName?: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'DingTalk channel not connected, skip sending image',
+        throw new Error(
+          `DingTalk channel is not connected; image to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
@@ -1114,11 +1098,9 @@ export function createDingTalkChannel(
       fileName: string,
     ): Promise<void> {
       if (!inner) {
-        logger.warn(
-          { chatId },
-          'DingTalk channel not connected, skip sending file',
+        throw new Error(
+          `DingTalk channel is not connected; file to ${chatId} was not sent`,
         );
-        return;
       }
       await inner.sendFile(chatId, filePath, fileName);
     },
@@ -1242,17 +1224,29 @@ export function createDiscordChannel(
     },
 
     async sendMessage(chatId, text, localImagePaths?) {
-      if (!inner) return;
+      if (!inner) {
+        throw new Error(
+          `Discord channel is not connected; message to ${chatId} was not sent`,
+        );
+      }
       await inner.sendMessage(chatId, text, localImagePaths);
     },
 
     async sendFile(chatId, filePath, fileName) {
-      if (!inner) return;
+      if (!inner) {
+        throw new Error(
+          `Discord channel is not connected; file to ${chatId} was not sent`,
+        );
+      }
       await inner.sendFile(chatId, filePath, fileName);
     },
 
     async sendImage(chatId, imageBuffer, mimeType, caption?, fileName?) {
-      if (!inner) return;
+      if (!inner) {
+        throw new Error(
+          `Discord channel is not connected; image to ${chatId} was not sent`,
+        );
+      }
       await inner.sendImage(chatId, imageBuffer, mimeType, caption, fileName);
     },
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -231,6 +231,33 @@ export interface TelegramConnection {
 
 // ─── Shared Helpers (pure functions, no instance state) ────────
 
+/**
+ * Only real HTML parse failures should fall back to a second plain send.
+ * Timeout / 5xx / 429 / other transport errors are wrapped by grammy as
+ * HttpError (inner error on `.error`, not `.cause`) and must be rethrown so
+ * the already-attempted chunk is not duplicated.
+ */
+function isTelegramHtmlParseError(err: unknown): boolean {
+  let current: unknown = err;
+  const seen = new Set<unknown>();
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const rec = current as Record<string, unknown>;
+    const code = Number(rec.error_code);
+    const description = String(rec.description ?? rec.message ?? '');
+    if (
+      code === 400 &&
+      /parse entities|unclosed|unsupported start tag|can't find end tag/i.test(
+        description,
+      )
+    ) {
+      return true;
+    }
+    current = rec.cause ?? rec.error;
+  }
+  return false;
+}
+
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
@@ -1470,6 +1497,9 @@ export function createTelegramConnection(
               ...threadOptions,
             });
           } catch (err) {
+            if (!isTelegramHtmlParseError(err)) {
+              throw err;
+            }
             // HTML parse failed (e.g. unclosed tags), fallback to plain text
             logger.debug(
               { err, chatId },

--- a/tests/feishu-cardkit-controller.test.ts
+++ b/tests/feishu-cardkit-controller.test.ts
@@ -399,4 +399,195 @@ describe('Feishu CardKit streaming controller', () => {
       controller.dispose();
     },
   );
+
+  // Regression: finalize enters the split branch on raw text length as well as
+  // on card JSON size, and splitOnFinalize can still emit a SINGLE group. The
+  // tail is then the reused streaming card rather than a continuation card.
+  test('a split finalize that yields one group still lands the usage note on the tail card', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_split_tail',
+    });
+
+    const body = Array.from(
+      { length: 40 },
+      (_, i) => `paragraph ${i} ${'a'.repeat(370)}`,
+    ).join('\n\n');
+    expect(body.length).toBeGreaterThan(15000);
+    expect(Buffer.byteLength(body, 'utf-8')).toBeLessThan(16 * 1024);
+
+    controller.append(body);
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    await controller.complete(body);
+    expect(controller.currentState).toBe('completed');
+    expect((controller as any).finalizedAsSplit).toBe(true);
+    expect((controller as any).lastSplitCard).not.toBeNull();
+
+    mock.cardUpdate.mockClear();
+    await controller.patchUsageNote({
+      inputTokens: 1200,
+      outputTokens: 340,
+      costUSD: 0.42,
+      durationMs: 12000,
+      numTurns: 3,
+    });
+    await backend.drain();
+
+    const rendered = mock.cardUpdate.mock.calls
+      .map((call) => String(call[0].data.card.data))
+      .join('\n');
+    expect(rendered).toContain('💰');
+    expect(rendered).toContain('输入 1.2K');
+    expect(rendered).toContain('输出 340');
+    controller.dispose();
+  });
+
+  test('usage arriving while complete() is mid-flight still lands on the final card', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_usage_race',
+    });
+    controller.append('短回复正文');
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    const completing = controller.complete('短回复正文');
+    const patching = controller.patchUsageNote({
+      inputTokens: 800,
+      outputTokens: 120,
+      costUSD: 0.1,
+      durationMs: 5000,
+      numTurns: 2,
+    });
+    await Promise.all([completing, patching]);
+    await backend.drain();
+
+    const lastCard = String(
+      mock.cardUpdate.mock.calls.at(-1)![0].data.card.data,
+    );
+    expect(lastCard).toContain('meta_row');
+    expect(lastCard).toContain('输出 120');
+    expect(lastCard).toContain('输入 800');
+    controller.dispose();
+  });
+
+  test('split finalize plus usage arriving mid-complete still lands on the tail', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_split_race',
+    });
+    const body = Array.from(
+      { length: 40 },
+      (_, i) => `paragraph ${i} ${'a'.repeat(370)}`,
+    ).join('\n\n');
+    controller.append(body);
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    const completing = controller.complete(body);
+    const patching = controller.patchUsageNote({
+      inputTokens: 2100,
+      outputTokens: 880,
+      costUSD: 0.55,
+      durationMs: 18000,
+      numTurns: 4,
+    });
+    await Promise.all([completing, patching]);
+    await backend.drain();
+
+    expect((controller as any).finalizedAsSplit).toBe(true);
+    const rendered = mock.cardUpdate.mock.calls
+      .map((call) => String(call[0].data.card.data))
+      .join('\n');
+    expect(rendered).toContain('💰');
+    expect(rendered).toContain('输出 880');
+    controller.dispose();
+  });
+
+  test('multi-group split only patches the tail card with usage', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_split_groups',
+    });
+    const body = Array.from(
+      { length: 60 },
+      (_, i) => `block ${i} ${'b'.repeat(400)}`,
+    ).join('\n\n');
+    expect(Buffer.byteLength(body, 'utf-8')).toBeGreaterThan(16 * 1024);
+
+    controller.append(body);
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    await controller.complete(body);
+    expect((controller as any).finalizedAsSplit).toBe(true);
+    expect(mock.cardCreate.mock.calls.length).toBeGreaterThan(1);
+
+    const updatesBeforeUsage = mock.cardUpdate.mock.calls.length;
+    await controller.patchUsageNote({
+      inputTokens: 900,
+      outputTokens: 250,
+      costUSD: 0.2,
+      durationMs: 8000,
+      numTurns: 2,
+    });
+    await backend.drain();
+
+    const usageUpdates = mock.cardUpdate.mock.calls
+      .slice(updatesBeforeUsage)
+      .map((call) => String(call[0].data.card.data));
+    expect(usageUpdates.length).toBeGreaterThan(0);
+    expect(usageUpdates.some((card) => card.includes('💰'))).toBe(true);
+    expect(usageUpdates.at(-1)).toContain('输出 250');
+    controller.dispose();
+  });
+
+  test('aborted turns drop parked usage instead of patching later', async () => {
+    const mock = makeClient();
+    const controller = new StreamingCardController({
+      client: mock.client as any,
+      chatId: 'oc_abort_usage',
+    });
+    controller.append('进行中');
+    await vi.waitFor(() => expect(controller.currentState).toBe('streaming'));
+    const backend = (controller as any).streamingBackend as {
+      drain(): Promise<void>;
+    };
+    await backend.drain();
+
+    await controller.patchUsageNote({
+      inputTokens: 10,
+      outputTokens: 4,
+      costUSD: 0.01,
+      durationMs: 100,
+      numTurns: 1,
+    });
+    mock.cardUpdate.mockClear();
+    await controller.abort('stopped');
+    expect(controller.currentState).toBe('aborted');
+    expect((controller as any).pendingUsage).toBeNull();
+    const afterAbort = mock.cardUpdate.mock.calls
+      .map((call) => String(call[0].data.card.data))
+      .join('\n');
+    expect(afterAbort).not.toContain('💰');
+    controller.dispose();
+  });
 });

--- a/tests/im-channel-disconnect-send.test.ts
+++ b/tests/im-channel-disconnect-send.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { syntheticChannelProviderAck } from '../src/channel-outbox-runtime-scope.js';
+import type { IMChannel, IMChannelConnectOpts } from '../src/im-channel.js';
+
+const innerCalls = vi.hoisted(() => ({
+  sendMessage: 0,
+  sendImage: 0,
+  sendFile: 0,
+}));
+
+function createMockConnection() {
+  return {
+    async connect() {
+      return true;
+    },
+    async disconnect() {},
+    async stop() {},
+    async sendMessage() {
+      innerCalls.sendMessage += 1;
+    },
+    async sendImage() {
+      innerCalls.sendImage += 1;
+    },
+    async sendFile() {
+      innerCalls.sendFile += 1;
+    },
+    async sendChatAction() {},
+    async sendReaction() {},
+    async setTyping() {},
+    async clearAckReaction() {},
+    isConnected() {
+      return true;
+    },
+  };
+}
+
+vi.mock('../src/telegram.js', () => ({
+  createTelegramConnection: () => createMockConnection(),
+}));
+vi.mock('../src/qq.js', () => ({
+  createQQConnection: () => createMockConnection(),
+}));
+vi.mock('../src/dingtalk.js', () => ({
+  createDingTalkConnection: () => createMockConnection(),
+}));
+vi.mock('../src/discord.js', () => ({
+  createDiscordConnection: () => createMockConnection(),
+}));
+vi.mock('../src/feishu.js', () => ({
+  createFeishuConnection: () => createMockConnection(),
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const {
+  createTelegramChannel,
+  createQQChannel,
+  createDingTalkChannel,
+  createDiscordChannel,
+  createFeishuChannel,
+} = await import('../src/im-channel.js');
+
+const connectOpts: IMChannelConnectOpts = {
+  onReady: vi.fn(),
+  onNewChat: vi.fn(),
+};
+
+const cases: Array<{
+  name: string;
+  create: () => IMChannel;
+}> = [
+  {
+    name: 'Telegram',
+    create: () => createTelegramChannel({ botToken: 'token' }),
+  },
+  {
+    name: 'QQ',
+    create: () => createQQChannel({ appId: 'app', appSecret: 'secret' }),
+  },
+  {
+    name: 'DingTalk',
+    create: () =>
+      createDingTalkChannel({ clientId: 'client', clientSecret: 'secret' }),
+  },
+  {
+    name: 'Discord',
+    create: () => createDiscordChannel({ botToken: 'token' }),
+  },
+  {
+    name: 'Feishu',
+    create: () => createFeishuChannel({ appId: 'app', appSecret: 'secret' }),
+  },
+];
+
+/**
+ * Mirrors deliverScopedChannelOutput / sendImWithRetry: a void send that
+ * does not throw is treated as success and a synthetic delivered ACK is
+ * minted. After disconnect that must not happen.
+ */
+async function sendAndMintDeliveredAck(
+  send: () => Promise<void>,
+): Promise<string> {
+  await send();
+  return syntheticChannelProviderAck({
+    turnRunId: 'disconnect-send-test',
+    ordinal: 1,
+    payloadHash: 'payload',
+  });
+}
+
+describe('disconnect must not mint a delivered ACK', () => {
+  test.each(cases)(
+    '$name send after disconnect throws and does not mint a synthetic ACK',
+    async ({ create }) => {
+      innerCalls.sendMessage = 0;
+      innerCalls.sendImage = 0;
+      innerCalls.sendFile = 0;
+
+      const channel = create();
+      await expect(channel.connect(connectOpts)).resolves.toBe(true);
+      expect(channel.isConnected()).toBe(true);
+
+      await channel.sendMessage('chat-1', 'hello while connected');
+      expect(innerCalls.sendMessage).toBe(1);
+
+      await channel.disconnect();
+      expect(channel.isConnected()).toBe(false);
+
+      let mintedAck: string | undefined;
+      await expect(
+        sendAndMintDeliveredAck(async () => {
+          await channel.sendMessage('chat-1', 'hello after disconnect');
+          mintedAck = 'must-not-assign';
+        }),
+      ).rejects.toThrow('not connected');
+
+      expect(mintedAck).toBeUndefined();
+      expect(innerCalls.sendMessage).toBe(1);
+
+      await expect(
+        sendAndMintDeliveredAck(async () => {
+          await channel.sendImage?.(
+            'chat-1',
+            Buffer.from('image'),
+            'image/png',
+          );
+        }),
+      ).rejects.toThrow('not connected');
+      expect(innerCalls.sendImage).toBe(0);
+
+      await expect(
+        sendAndMintDeliveredAck(async () => {
+          await channel.sendFile?.('chat-1', '/tmp/file', 'file.txt');
+        }),
+      ).rejects.toThrow('not connected');
+      expect(innerCalls.sendFile).toBe(0);
+    },
+  );
+});

--- a/tests/im-format-fallback-timeout.test.ts
+++ b/tests/im-format-fallback-timeout.test.ts
@@ -1,0 +1,281 @@
+import { EventEmitter } from 'node:events';
+import https from 'node:https';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const telegramControls = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  stopPolling: null as (() => void) | null,
+}));
+
+vi.mock('grammy', () => ({
+  Bot: class {
+    api = {
+      config: { use: vi.fn() },
+      getMe: vi.fn().mockResolvedValue({ id: 1, username: 'fallback_bot' }),
+      sendMessage: telegramControls.sendMessage,
+    };
+    on() {
+      return this;
+    }
+    start(options: { onStart?: () => void }) {
+      options.onStart?.();
+      return new Promise<void>((resolve) => {
+        telegramControls.stopPolling = resolve;
+      });
+    }
+    stop() {
+      telegramControls.stopPolling?.();
+      telegramControls.stopPolling = null;
+    }
+  },
+  InputFile: class {},
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { createTelegramConnection } = await import('../src/telegram.js');
+const { createDingTalkConnection } = await import('../src/dingtalk.js');
+
+function grammyHttpTimeout(): Error {
+  const inner = new Error(
+    "Request to 'sendMessage' timed out after 30 seconds",
+  );
+  const err = new Error("Network request for 'sendMessage' failed!");
+  err.name = 'HttpError';
+  Object.assign(err, { error: inner });
+  return err;
+}
+
+function grammyParseEntitiesError(): Error {
+  const err = new Error(
+    "Call to 'sendMessage' failed! (400: can't parse entities)",
+  );
+  err.name = 'GrammyError';
+  Object.assign(err, {
+    error_code: 400,
+    description: "can't parse entities: unclosed start tag at byte offset 12",
+    method: 'sendMessage',
+    ok: false,
+  });
+  return err;
+}
+
+function grammyTooManyRequests(): Error {
+  const err = new Error(
+    "Call to 'sendMessage' failed! (429: Too Many Requests)",
+  );
+  err.name = 'GrammyError';
+  Object.assign(err, {
+    error_code: 429,
+    description: 'Too Many Requests: retry after 3',
+    method: 'sendMessage',
+    ok: false,
+  });
+  return err;
+}
+
+describe('Telegram HTML format fallback must not duplicate after timeout', () => {
+  let cleanup: Array<() => Promise<void>> = [];
+
+  beforeEach(() => {
+    cleanup = [];
+    telegramControls.stopPolling = null;
+    telegramControls.sendMessage.mockReset();
+  });
+
+  afterEach(async () => {
+    await Promise.allSettled(cleanup.map((fn) => fn()));
+  });
+
+  async function connectTelegram() {
+    const telegram = createTelegramConnection({ botToken: 'token' });
+    expect(
+      await telegram.connect({
+        onNewChat: vi.fn(),
+        isChatAuthorized: () => true,
+      }),
+    ).toBe(true);
+    cleanup.push(() => telegram.disconnect());
+    return telegram;
+  }
+
+  test('does not issue a second physical send when grammy wraps a 30s timeout as HttpError', async () => {
+    const telegram = await connectTelegram();
+    const physicalSends: Array<{ text: string; parseMode?: string }> = [];
+    telegramControls.sendMessage.mockImplementation(
+      async (
+        _chatId: number,
+        text: string,
+        extra?: { parse_mode?: string },
+      ) => {
+        physicalSends.push({ text, parseMode: extra?.parse_mode });
+        throw grammyHttpTimeout();
+      },
+    );
+
+    await expect(
+      telegram.sendMessage('12345', 'hello **world**'),
+    ).rejects.toMatchObject({ name: 'HttpError' });
+    expect(physicalSends).toHaveLength(1);
+    expect(physicalSends[0]?.parseMode).toBe('HTML');
+    expect(telegramControls.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test('still falls back to plain text on GrammyError 400 parse entities', async () => {
+    const telegram = await connectTelegram();
+    const physicalSends: Array<{ text: string; parseMode?: string }> = [];
+    telegramControls.sendMessage.mockImplementation(
+      async (
+        _chatId: number,
+        text: string,
+        extra?: { parse_mode?: string },
+      ) => {
+        physicalSends.push({ text, parseMode: extra?.parse_mode });
+        if (extra?.parse_mode === 'HTML') {
+          throw grammyParseEntitiesError();
+        }
+      },
+    );
+
+    await telegram.sendMessage('12345', 'hello **world**');
+    expect(physicalSends).toHaveLength(2);
+    expect(physicalSends[0]?.parseMode).toBe('HTML');
+    expect(physicalSends[1]?.parseMode).toBeUndefined();
+  });
+
+  test('does not plain-resend on GrammyError 429', async () => {
+    const telegram = await connectTelegram();
+    telegramControls.sendMessage.mockImplementation(async () => {
+      throw grammyTooManyRequests();
+    });
+
+    await expect(
+      telegram.sendMessage('12345', 'hello **world**'),
+    ).rejects.toMatchObject({ error_code: 429 });
+    expect(telegramControls.sendMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DingTalk markdown format fallback must not duplicate after timeout', () => {
+  let requestSpy: ReturnType<typeof vi.spyOn> | undefined;
+  const groupSends: Array<{ msgKey?: string; msgParam?: string }> = [];
+  let groupFailure: 'timeout' | 'http503' = 'timeout';
+
+  function timedOutAfterSend(): Error {
+    return Object.assign(new Error('connect ETIMEDOUT 203.0.113.10:443'), {
+      code: 'ETIMEDOUT',
+      errno: 'ETIMEDOUT',
+      syscall: 'connect',
+    });
+  }
+
+  beforeEach(() => {
+    groupSends.length = 0;
+    groupFailure = 'timeout';
+    requestSpy = vi
+      .spyOn(https, 'request')
+      .mockImplementation((options, callback) => {
+        const opts = typeof options === 'string' ? { path: options } : options;
+        const path = String(
+          opts && typeof opts === 'object' && 'path' in opts ? opts.path : '',
+        );
+        const req = new EventEmitter() as EventEmitter & {
+          write: (chunk: string) => boolean;
+          end: () => void;
+          destroy: () => void;
+          body: string;
+        };
+        req.body = '';
+        req.write = (chunk: string) => {
+          req.body += chunk;
+          return true;
+        };
+        req.destroy = () => undefined;
+        req.end = () => {
+          queueMicrotask(() => {
+            if (path.includes('gettoken')) {
+              const res = new Readable({
+                read() {
+                  this.push(
+                    Buffer.from(
+                      JSON.stringify({
+                        errcode: 0,
+                        access_token: 'dingtalk-token',
+                        expires_in: 7200,
+                      }),
+                    ),
+                  );
+                  this.push(null);
+                },
+              }) as Readable & { statusCode: number };
+              res.statusCode = 200;
+              (callback as ((res: typeof res) => void) | undefined)?.(res);
+              return;
+            }
+            if (path.includes('/v1.0/robot/groupMessages/send')) {
+              groupSends.push(
+                JSON.parse(req.body || '{}') as {
+                  msgKey?: string;
+                  msgParam?: string;
+                },
+              );
+              if (groupFailure === 'timeout') {
+                req.emit('error', timedOutAfterSend());
+                return;
+              }
+              const res = new Readable({
+                read() {
+                  this.push(Buffer.from('{"message":"internal error"}'));
+                  this.push(null);
+                },
+              }) as Readable & { statusCode: number };
+              res.statusCode = 503;
+              (callback as ((res: typeof res) => void) | undefined)?.(res);
+              return;
+            }
+            req.emit(
+              'error',
+              new Error(`unexpected https.request path: ${path}`),
+            );
+          });
+        };
+        return req as unknown as ReturnType<typeof https.request>;
+      });
+  });
+
+  afterEach(() => {
+    requestSpy?.mockRestore();
+  });
+
+  test('does not issue a second physical send when the first send times out after it was attempted', async () => {
+    const dingtalk = createDingTalkConnection({
+      clientId: 'ding-client',
+      clientSecret: 'ding-secret',
+    });
+
+    await expect(
+      dingtalk.sendMessage('dingtalk:group:cidXXXX', 'hello **world**'),
+    ).rejects.toMatchObject({ code: 'ETIMEDOUT' });
+
+    expect(groupSends).toHaveLength(1);
+    expect(groupSends[0]?.msgKey).toBe('sampleMarkdown');
+  });
+
+  test('does not plain-resend after HTTP failed (503)', async () => {
+    groupFailure = 'http503';
+    const dingtalk = createDingTalkConnection({
+      clientId: 'ding-client',
+      clientSecret: 'ding-secret',
+    });
+
+    await expect(
+      dingtalk.sendMessage('dingtalk:group:cidXXXX', 'hello **world**'),
+    ).rejects.toThrow(/HTTP failed \(503\)/);
+
+    expect(groupSends).toHaveLength(1);
+    expect(groupSends[0]?.msgKey).toBe('sampleMarkdown');
+  });
+});

--- a/tests/session-trim.test.ts
+++ b/tests/session-trim.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { trimSessionJsonl } from '../container/agent-runner/src/session-trim.js';
+
+const TASK_ID = 'agent-bg-research-1';
+const TASK_ID_2 = 'agent-bg-review-2';
+const LAUNCH_UUID = 'async-launch-uuid';
+const ASSISTANT_UUID = 'assistant-tool-use-uuid';
+const TOOL_USE_ID = 'toolu-task-1';
+
+function assistantToolUse(taskId = TASK_ID, uuid = ASSISTANT_UUID) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid: 'older-deleted',
+    message: {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: TOOL_USE_ID,
+          name: 'Task',
+          input: { description: taskId },
+        },
+      ],
+    },
+  };
+}
+
+function launchEntry(
+  taskId = TASK_ID,
+  status: 'async_launched' | 'remote_launched' = 'async_launched',
+  uuid = LAUNCH_UUID,
+) {
+  return {
+    type: 'user',
+    uuid,
+    parentUuid: ASSISTANT_UUID,
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: TOOL_USE_ID,
+          content: `Background agent launched: ${taskId}`,
+        },
+      ],
+    },
+    toolUseResult: {
+      status,
+      agentId: taskId,
+      taskId,
+    },
+  };
+}
+
+function dummyEntry(i: number) {
+  return {
+    type: 'user',
+    uuid: `dummy-${i}`,
+    parentUuid: i === 0 ? LAUNCH_UUID : `dummy-${i - 1}`,
+    message: { role: 'user', content: `dummy ${i}` },
+  };
+}
+
+function compactBoundary(headUuid?: string) {
+  return {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: 'compact-boundary-1',
+    compact_metadata: headUuid
+      ? {
+          trigger: 'auto',
+          preserved_segment: {
+            head_uuid: headUuid,
+            anchor_uuid: 'anchor-1',
+            tail_uuid: headUuid,
+          },
+        }
+      : { trigger: 'auto' },
+  };
+}
+
+function structuredTaskNotification(taskId: string) {
+  return {
+    type: 'user',
+    uuid: `task-notification-${taskId}`,
+    origin: { kind: 'task-notification' },
+    message: {
+      role: 'user',
+      origin: { kind: 'task-notification' },
+      content: `<task-notification><task-id>${taskId}</task-id><status>completed</status></task-notification>`,
+    },
+    task_id: taskId,
+  };
+}
+
+function assistantMentioningTask(taskId: string) {
+  return {
+    type: 'assistant',
+    uuid: 'assistant-mentions-task',
+    message: {
+      role: 'assistant',
+      content: `summary <task-notification><task-id>${taskId}</task-id></task-notification>`,
+    },
+  };
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-trim-test-'));
+});
+
+afterEach(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function writeJsonl(name: string, entries: object[]): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(
+    filePath,
+    entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+  );
+  return filePath;
+}
+
+function readJsonl(filePath: string): Record<string, unknown>[] {
+  return fs
+    .readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('trimSessionJsonl', () => {
+  test('keeps an unfinished async_launched Task and its assistant tool_use', () => {
+    const transcriptPath = writeJsonl('session.jsonl', [
+      assistantToolUse(),
+      launchEntry(),
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      compactBoundary(),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(kept.some((entry) => entry.uuid === ASSISTANT_UUID)).toBe(true);
+    expect(kept.some((entry) => entry.uuid === LAUNCH_UUID)).toBe(true);
+    const launch = kept.find((entry) => entry.uuid === LAUNCH_UUID)!;
+    expect(launch.parentUuid).toBe(ASSISTANT_UUID);
+    const assistant = kept.find((entry) => entry.uuid === ASSISTANT_UUID)!;
+    expect(assistant.parentUuid).toBe('compact-boundary-1');
+    expect(
+      kept.some((entry) => String(entry.uuid ?? '').startsWith('dummy-')),
+    ).toBe(false);
+    expect(
+      kept.some(
+        (entry) =>
+          entry.type === 'system' && entry.subtype === 'compact_boundary',
+      ),
+    ).toBe(true);
+  });
+
+  test('does not keep an async_launched line with a structured task-notification', () => {
+    const transcriptPath = writeJsonl('completed.jsonl', [
+      assistantToolUse(),
+      launchEntry(),
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      structuredTaskNotification(TASK_ID),
+      compactBoundary(),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(
+      kept.some(
+        (entry) =>
+          (entry.toolUseResult as { status?: string } | undefined)?.status ===
+          'async_launched',
+      ),
+    ).toBe(false);
+  });
+
+  test('does not treat assistant-pasted XML as a completion', () => {
+    const transcriptPath = writeJsonl('fake-xml.jsonl', [
+      assistantToolUse(),
+      launchEntry(),
+      assistantMentioningTask(TASK_ID),
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      compactBoundary(),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(kept.some((entry) => entry.uuid === LAUNCH_UUID)).toBe(true);
+  });
+
+  test('keeps a remote_launched line and two in-flight tasks', () => {
+    const secondAssistant = {
+      ...assistantToolUse(TASK_ID_2, 'assistant-2'),
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-task-2',
+            name: 'Task',
+            input: { description: TASK_ID_2 },
+          },
+        ],
+      },
+    };
+    const secondLaunch = {
+      ...launchEntry(TASK_ID_2, 'remote_launched', 'remote-launch-uuid'),
+      parentUuid: 'assistant-2',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu-task-2',
+            content: `Background agent launched: ${TASK_ID_2}`,
+          },
+        ],
+      },
+    };
+    const transcriptPath = writeJsonl('two-tasks.jsonl', [
+      assistantToolUse(),
+      launchEntry(),
+      secondAssistant,
+      secondLaunch,
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      compactBoundary(),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(kept.some((entry) => entry.uuid === LAUNCH_UUID)).toBe(true);
+    expect(kept.some((entry) => entry.uuid === 'remote-launch-uuid')).toBe(
+      true,
+    );
+    expect(
+      (
+        kept.find((entry) => entry.uuid === 'remote-launch-uuid')
+          ?.toolUseResult as { status?: string }
+      )?.status,
+    ).toBe('remote_launched');
+  });
+
+  test('task-notification after compact_boundary still drops the completed launch', () => {
+    const transcriptPath = writeJsonl('notify-after.jsonl', [
+      assistantToolUse(),
+      launchEntry(),
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      compactBoundary(),
+      structuredTaskNotification(TASK_ID),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(kept.some((entry) => entry.uuid === LAUNCH_UUID)).toBe(false);
+    expect(
+      kept.some(
+        (entry) =>
+          entry.type === 'system' && entry.subtype === 'compact_boundary',
+      ),
+    ).toBe(true);
+  });
+
+  test('does not insert unfinished launches before preserved_segment.head_uuid', () => {
+    const head = {
+      type: 'user',
+      uuid: 'preserved-head',
+      message: { role: 'user', content: 'keep me' },
+    };
+    const transcriptPath = writeJsonl('preserved.jsonl', [
+      assistantToolUse(),
+      launchEntry(),
+      ...Array.from({ length: 50 }, (_, i) => dummyEntry(i)),
+      head,
+      compactBoundary('preserved-head'),
+    ]);
+
+    trimSessionJsonl(transcriptPath, () => {});
+
+    const kept = readJsonl(transcriptPath);
+    expect(kept[0]?.uuid).toBe('preserved-head');
+    const launchIndex = kept.findIndex((entry) => entry.uuid === LAUNCH_UUID);
+    const headIndex = kept.findIndex(
+      (entry) => entry.uuid === 'preserved-head',
+    );
+    const boundaryIndex = kept.findIndex(
+      (entry) => entry.subtype === 'compact_boundary',
+    );
+    expect(headIndex).toBe(0);
+    expect(launchIndex).toBeGreaterThan(headIndex);
+    expect(launchIndex).toBeLessThan(boundaryIndex);
+    expect(kept.some((entry) => entry.uuid === ASSISTANT_UUID)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidate the production fixes from #667–#670, plus the review findings that blocked those PRs as-is.

- **Disconnect false ACK**: Telegram / QQ / DingTalk / Discord / Feishu `sendMessage` (and image/file) throw when there is no live connector, so `sendImWithRetry` cannot mint a synthetic delivered ACK.
- **Format fallback duplicates**: Telegram only plain-resends on GrammyError 400 parse failures; timeouts / 429 / 5xx rethrow. DingTalk does the same for ETIMEDOUT and HTTP 5xx/429.
- **Compact orphan Tasks**: `trimSessionJsonl` keeps unfinished `async_launched` / `remote_launched` records and their assistant `tool_use` partner, rewrites `parentUuid` onto `compact_boundary`, and inserts them after `preserved_segment.head_uuid`.
- **Feishu usage note**: split/oversized cards keep the usage line on the tail card; usage that arrives during `complete()` is parked and flushed after finalize; silent catch removed.

This supersedes the unmerged review comments on #667, #668, #669, and #670.

## Test plan

- [x] Local `make typecheck`, `make test` (3270 passed), `make build`
- [x] Focused regressions for disconnect ACK, grammy error shapes, session-trim UUID chain, Feishu usage race
- [x] Branch agent image `riba2534/happyclaw-agent:git-40f4bfe8e6b226152bd72015b30ae0400eac1572` published (did not move `latest`)
- [x] Mac mini detached deploy of `40f4bfe8`; health on localhost and both public URLs
- [x] Real Host Web Agent turn on `web:main` replied `ok`
- [x] ARM64 container image smoke on Mac mini