### PR TITLE
fix(wechat): claim multi-chunk text one sendmessage at a time

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -10961,6 +10961,10 @@ export type WeChatContextTokenClaimResult =
   | { status: 'claimed'; record: StoredWeChatContextToken }
   | { status: 'missing' | 'changed' | 'expired' | 'quota_exhausted' };
 
+export type WeChatContextTokenReleaseResult =
+  | { status: 'released'; record: StoredWeChatContextToken }
+  | { status: 'missing' | 'changed' };
+
 /** List only one channel account's reply credentials; tokens never cross accounts. */
 export function listWeChatContextTokens(
   channelAccountId: string,
@@ -11118,6 +11122,70 @@ export function claimWeChatContextToken(input: {
           ...record,
           send_count: sendCount,
           last_sent_at_ms: input.nowMs,
+        },
+      };
+    })
+    .immediate();
+}
+
+/**
+ * Return unused sendmessage reservations when a later chunk never received a
+ * provider ACK. Compare-and-swap on the same generation as claim so a concurrent
+ * inbound refresh cannot have its quota rewritten by a stale batch.
+ */
+export function releaseWeChatContextToken(input: {
+  channelAccountId: string;
+  userId: string;
+  expectedToken: string;
+  expectedRefreshedAtMs: number;
+  expectedSourceMessageId?: string | null;
+  releaseCount: number;
+}): WeChatContextTokenReleaseResult {
+  if (!Number.isInteger(input.releaseCount) || input.releaseCount <= 0) {
+    throw new Error('WeChat context_token releaseCount must be positive');
+  }
+  return db
+    .transaction((): WeChatContextTokenReleaseResult => {
+      const record = db
+        .prepare(
+          `SELECT channel_account_id, user_id, context_token, refreshed_at_ms,
+                  source_message_id, source_sequence, send_count, last_sent_at_ms
+           FROM wechat_context_tokens
+           WHERE channel_account_id = ? AND user_id = ?`,
+        )
+        .get(input.channelAccountId, input.userId) as
+        | StoredWeChatContextToken
+        | undefined;
+      if (!record) return { status: 'missing' };
+      if (
+        record.context_token !== input.expectedToken ||
+        record.refreshed_at_ms !== input.expectedRefreshedAtMs ||
+        (input.expectedSourceMessageId !== undefined &&
+          record.source_message_id !== input.expectedSourceMessageId)
+      ) {
+        return { status: 'changed' };
+      }
+      if (record.send_count < input.releaseCount) {
+        return { status: 'changed' };
+      }
+      const sendCount = record.send_count - input.releaseCount;
+      db.prepare(
+        `UPDATE wechat_context_tokens
+         SET send_count = ?
+         WHERE channel_account_id = ? AND user_id = ?
+           AND context_token = ? AND refreshed_at_ms = ?`,
+      ).run(
+        sendCount,
+        input.channelAccountId,
+        input.userId,
+        input.expectedToken,
+        input.expectedRefreshedAtMs,
+      );
+      return {
+        status: 'released',
+        record: {
+          ...record,
+          send_count: sendCount,
         },
       };
     })

--- a/src/wechat-context-token.ts
+++ b/src/wechat-context-token.ts
@@ -3,9 +3,11 @@ import {
   deleteWeChatContextToken,
   isDatabaseInitialized,
   listWeChatContextTokens,
+  releaseWeChatContextToken,
   upsertWeChatContextToken,
   type StoredWeChatContextToken,
   type WeChatContextTokenClaimResult,
+  type WeChatContextTokenReleaseResult,
 } from './db.js';
 
 // Tencent does not publish a stable machine-readable contract for these
@@ -38,6 +40,15 @@ export interface WeChatContextTokenClaimInput {
   nowMs: number;
 }
 
+export interface WeChatContextTokenReleaseInput {
+  accountId: string;
+  userId: string;
+  expectedToken: string;
+  expectedRefreshedAtMs: number;
+  expectedSourceMessageId?: string | null;
+  releaseCount: number;
+}
+
 export interface WeChatContextTokenStore {
   list(accountId: string): WeChatContextTokenRecord[];
   upsert(input: {
@@ -53,6 +64,11 @@ export interface WeChatContextTokenStore {
   ):
     | { status: 'claimed'; record: WeChatContextTokenRecord }
     | { status: 'missing' | 'changed' | 'expired' | 'quota_exhausted' };
+  release(
+    input: WeChatContextTokenReleaseInput,
+  ):
+    | { status: 'released'; record: WeChatContextTokenRecord }
+    | { status: 'missing' | 'changed' };
   delete(input: {
     accountId: string;
     userId: string;
@@ -108,6 +124,14 @@ function fromClaim(
     : result;
 }
 
+function fromRelease(
+  result: WeChatContextTokenReleaseResult,
+): ReturnType<WeChatContextTokenStore['release']> {
+  return result.status === 'released'
+    ? { status: 'released', record: fromStored(result.record) }
+    : result;
+}
+
 export function createDatabaseWeChatContextTokenStore(): WeChatContextTokenStore | null {
   if (!isDatabaseInitialized()) return null;
   return {
@@ -135,6 +159,17 @@ export function createDatabaseWeChatContextTokenStore(): WeChatContextTokenStore
           maxSendCount: input.maxSendCount,
           maxAgeMs: input.maxAgeMs,
           nowMs: input.nowMs,
+        }),
+      ),
+    release: (input) =>
+      fromRelease(
+        releaseWeChatContextToken({
+          channelAccountId: input.accountId,
+          userId: input.userId,
+          expectedToken: input.expectedToken,
+          expectedRefreshedAtMs: input.expectedRefreshedAtMs,
+          expectedSourceMessageId: input.expectedSourceMessageId,
+          releaseCount: input.releaseCount,
         }),
       ),
     delete: (input) =>
@@ -343,6 +378,51 @@ export class WeChatContextTokenManager {
       throw new WeChatContextTokenError(result.status, userId);
     }
     throw new WeChatContextTokenError('missing', userId);
+  }
+
+  release(record: WeChatContextTokenRecord, releaseCount = 1): boolean {
+    if (!Number.isInteger(releaseCount) || releaseCount <= 0) {
+      throw new Error('WeChat context_token releaseCount must be positive');
+    }
+    const current = this.cache.get(record.userId);
+    if (
+      !current ||
+      current.token !== record.token ||
+      current.refreshedAtMs !== record.refreshedAtMs ||
+      (current.sourceMessageId ?? null) !== (record.sourceMessageId ?? null) ||
+      current.sendCount < releaseCount
+    ) {
+      return false;
+    }
+
+    if (!this.accountId || !this.store) {
+      this.cache.set(record.userId, {
+        ...current,
+        sendCount: current.sendCount - releaseCount,
+      });
+      return true;
+    }
+
+    const result = this.store.release({
+      accountId: this.accountId,
+      userId: record.userId,
+      expectedToken: record.token,
+      expectedRefreshedAtMs: record.refreshedAtMs,
+      expectedSourceMessageId: record.sourceMessageId ?? null,
+      releaseCount,
+    });
+    if (result.status === 'released') {
+      this.cache.set(record.userId, result.record);
+      return true;
+    }
+    if (result.status === 'changed') {
+      const latest = this.store
+        .list(this.accountId)
+        .find((candidate) => candidate.userId === record.userId);
+      if (latest) this.cache.set(record.userId, latest);
+      else this.cache.delete(record.userId);
+    }
+    return false;
   }
 
   peek(userId: string): WeChatContextTokenRecord | undefined {

--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -31,6 +31,7 @@ import { resolveAdmittedChannelRoute } from './channel-admission.js';
 import { createWeChatHttpDispatcher } from './wechat-http.js';
 import {
   createDatabaseWeChatContextTokenStore,
+  WeChatContextTokenError,
   WeChatContextTokenManager,
   type WeChatContextTokenRecord,
   type WeChatContextTokenStore,
@@ -717,14 +718,46 @@ export function createWeChatConnection(
     }
   }
 
+  const deliveredManagedText = new Map<
+    string,
+    { token: string; text: string; sentChunks: number }
+  >();
+
   async function sendManagedText(userId: string, text: string): Promise<void> {
-    const chunks = splitTextChunks(markdownToPlainText(text), MSG_SPLIT_LIMIT);
-    const record = contextTokens.claim(userId, chunks.length);
-    await sendWithReservedContext(record, async () => {
-      for (const chunk of chunks) {
-        await sendMessageApi(userId, record.token, chunk);
+    const plain = markdownToPlainText(text);
+    const chunks = splitTextChunks(plain, MSG_SPLIT_LIMIT);
+    const preview = contextTokens.peek(userId);
+    if (!preview) {
+      throw new WeChatContextTokenError('missing', userId);
+    }
+
+    const prior = deliveredManagedText.get(userId);
+    const resumeFrom =
+      prior && prior.token === preview.token && prior.text === plain
+        ? Math.min(prior.sentChunks, chunks.length)
+        : 0;
+
+    for (let index = resumeFrom; index < chunks.length; index++) {
+      const record = contextTokens.claim(userId, 1);
+      try {
+        await sendWithReservedContext(record, async () => {
+          await sendMessageApi(userId, record.token, chunks[index]!);
+        });
+        deliveredManagedText.set(userId, {
+          token: record.token,
+          text: plain,
+          sentChunks: index + 1,
+        });
+      } catch (error) {
+        if (isWeChatContextTokenRejection(error)) {
+          deliveredManagedText.delete(userId);
+        } else if (!(error instanceof WeChatApiError)) {
+          contextTokens.release(record, 1);
+        }
+        throw error;
       }
-    });
+    }
+    deliveredManagedText.delete(userId);
   }
 
   async function getTypingTicket(
@@ -1450,6 +1483,7 @@ export function createWeChatConnection(
 
       dedup.clear();
       contextTokens.clearMemory();
+      deliveredManagedText.clear();
       knownJids.clear();
       rejectTimestamps.clear();
       logger.info(logContext, 'WeChat iLink poller disconnected');

--- a/tests/schema-v70-wechat-context-token.test.ts
+++ b/tests/schema-v70-wechat-context-token.test.ts
@@ -199,4 +199,63 @@ describe.sequential('schema v71 WeChat context_token generations', () => {
       expect.arrayContaining(['source_message_id', 'source_sequence']),
     );
   });
+
+  test('releases unused sendmessage reservations without rewriting a newer generation', () => {
+    db.initDatabase();
+    const account = db.createChannelAccount({
+      id: 'wechat-release-account',
+      owner_user_id: 'owner',
+      provider: 'wechat',
+      name: 'WeChat',
+      secret_ref: 'channel-account:wechat-release-account',
+    });
+    db.upsertWeChatContextToken({
+      channelAccountId: account.id,
+      userId: 'peer',
+      contextToken: 'live-token',
+      refreshedAtMs: 5_000,
+      sourceMessageId: 'message-1',
+      sourceSequence: 1,
+    });
+    expect(
+      db.claimWeChatContextToken({
+        channelAccountId: account.id,
+        userId: 'peer',
+        expectedToken: 'live-token',
+        expectedRefreshedAtMs: 5_000,
+        expectedSourceMessageId: 'message-1',
+        claimCount: 2,
+        maxSendCount: 10,
+        maxAgeMs: 100_000,
+        nowMs: 6_000,
+      }),
+    ).toMatchObject({ status: 'claimed', record: { send_count: 2 } });
+    expect(
+      db.releaseWeChatContextToken({
+        channelAccountId: account.id,
+        userId: 'peer',
+        expectedToken: 'live-token',
+        expectedRefreshedAtMs: 5_000,
+        expectedSourceMessageId: 'message-1',
+        releaseCount: 1,
+      }),
+    ).toMatchObject({ status: 'released', record: { send_count: 1 } });
+    expect(db.listWeChatContextTokens(account.id)[0]).toMatchObject({
+      send_count: 1,
+    });
+    expect(
+      db.releaseWeChatContextToken({
+        channelAccountId: account.id,
+        userId: 'peer',
+        expectedToken: 'stale-token',
+        expectedRefreshedAtMs: 5_000,
+        expectedSourceMessageId: 'message-1',
+        releaseCount: 1,
+      }),
+    ).toEqual({ status: 'changed' });
+    expect(db.listWeChatContextTokens(account.id)[0]).toMatchObject({
+      send_count: 1,
+      context_token: 'live-token',
+    });
+  });
 });

--- a/tests/wechat-context-token-connection.test.ts
+++ b/tests/wechat-context-token-connection.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type {
   WeChatContextTokenClaimInput,
   WeChatContextTokenRecord,
+  WeChatContextTokenReleaseInput,
   WeChatContextTokenStore,
 } from '../src/wechat-context-token.js';
 
@@ -76,6 +77,30 @@ class SharedStore implements WeChatContextTokenStore {
     };
     this.record = claimed;
     return { status: 'claimed', record: { ...claimed } };
+  }
+
+  release(
+    input: WeChatContextTokenReleaseInput,
+  ):
+    | { status: 'released'; record: WeChatContextTokenRecord }
+    | { status: 'missing' | 'changed' } {
+    const record = this.record;
+    if (!record) return { status: 'missing' };
+    if (
+      record.token !== input.expectedToken ||
+      record.refreshedAtMs !== input.expectedRefreshedAtMs ||
+      (input.expectedSourceMessageId !== undefined &&
+        (record.sourceMessageId ?? null) !== input.expectedSourceMessageId) ||
+      record.sendCount < input.releaseCount
+    ) {
+      return { status: 'changed' };
+    }
+    const released = {
+      ...record,
+      sendCount: record.sendCount - input.releaseCount,
+    };
+    this.record = released;
+    return { status: 'released', record: { ...released } };
   }
 
   delete(input: {
@@ -172,6 +197,83 @@ describe('WeChat connection durable context_token integration', () => {
     } finally {
       fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
     }
+
+    await connection.disconnect();
+  });
+
+  test('multi-chunk send does not burn unused slots or resend a delivered prefix after a mid-batch 502', async () => {
+    const store = new SharedStore();
+    store.record = {
+      accountId: 'account',
+      userId: 'peer',
+      token: 'durable-secret',
+      refreshedAtMs: Date.now(),
+      sourceMessageId: 'inbound-1',
+      sourceSequence: 1,
+      sendCount: 0,
+      lastSentAtMs: null,
+    };
+    const dispatcher = {
+      close: vi.fn(async () => undefined),
+    } as unknown as Dispatcher;
+    const attemptedTexts: string[] = [];
+    const ackedTexts: string[] = [];
+    let sendAttempts = 0;
+    const fetchMock = vi.fn(
+      async (
+        url: string,
+        init?: { body?: unknown; signal?: AbortSignal | null },
+      ) => {
+        if (url.includes('sendmessage')) {
+          sendAttempts += 1;
+          const body = JSON.parse(String(init?.body));
+          const text = String(body.msg.item_list[0].text_item.text);
+          attemptedTexts.push(text);
+          if (sendAttempts === 2) {
+            return new Response('bad gateway', {
+              status: 502,
+              statusText: 'Bad Gateway',
+            });
+          }
+          ackedTexts.push(text);
+          return Response.json({ ret: 0 });
+        }
+        return waitUntilAborted(init?.signal);
+      },
+    );
+    const connection = createWeChatConnection(
+      {
+        botToken: 'bot-token',
+        ilinkBotId: 'bot-id',
+        logContext: { accountId: 'account' },
+      },
+      {
+        fetch: fetchMock as typeof fetch,
+        createDispatcher: () => dispatcher,
+        contextTokenStore: store,
+      },
+    );
+    await connection.connect({ onNewChat: vi.fn() });
+
+    const longText = 'A'.repeat(2500);
+    await expect(connection.sendMessage('peer', longText)).rejects.toThrow(
+      'HTTP 502',
+    );
+
+    const prefix = ackedTexts[0];
+    expect(prefix.length).toBeGreaterThan(0);
+    expect(prefix.length).toBeLessThan(longText.length);
+    expect(attemptedTexts).toHaveLength(2);
+    expect(store.record?.sendCount).toBe(1);
+    expect(attemptedTexts.filter((text) => text === prefix)).toHaveLength(1);
+
+    await expect(connection.sendMessage('peer', longText)).resolves.toBe(
+      undefined,
+    );
+    expect(attemptedTexts.filter((text) => text === prefix)).toHaveLength(1);
+    expect(ackedTexts.join('')).toBe(longText);
+    expect(store.record?.sendCount).toBe(2);
+    expect(sendAttempts).toBe(3);
 
     await connection.disconnect();
   });

--- a/tests/wechat-context-token.test.ts
+++ b/tests/wechat-context-token.test.ts
@@ -6,6 +6,7 @@ import {
   WeChatContextTokenManager,
   type WeChatContextTokenClaimInput,
   type WeChatContextTokenRecord,
+  type WeChatContextTokenReleaseInput,
   type WeChatContextTokenStore,
 } from '../src/wechat-context-token.js';
 
@@ -68,6 +69,31 @@ class MemoryStore implements WeChatContextTokenStore {
     };
     this.rows.set(key, claimed);
     return { status: 'claimed', record: { ...claimed } };
+  }
+
+  release(
+    input: WeChatContextTokenReleaseInput,
+  ):
+    | { status: 'released'; record: WeChatContextTokenRecord }
+    | { status: 'missing' | 'changed' } {
+    const key = this.key(input.accountId, input.userId);
+    const record = this.rows.get(key);
+    if (!record) return { status: 'missing' };
+    if (
+      record.token !== input.expectedToken ||
+      record.refreshedAtMs !== input.expectedRefreshedAtMs ||
+      (input.expectedSourceMessageId !== undefined &&
+        (record.sourceMessageId ?? null) !== input.expectedSourceMessageId) ||
+      record.sendCount < input.releaseCount
+    ) {
+      return { status: 'changed' };
+    }
+    const released = {
+      ...record,
+      sendCount: record.sendCount - input.releaseCount,
+    };
+    this.rows.set(key, released);
+    return { status: 'released', record: { ...released } };
   }
 
   delete(input: {
@@ -255,6 +281,37 @@ describe('WeChat context_token lifecycle', () => {
       token: 'new-token',
       sendCount: 0,
       sourceMessageId: 'message-2',
+    });
+  });
+
+  test('releases unused reservations on the current generation only', () => {
+    const store = new MemoryStore();
+    const manager = new WeChatContextTokenManager({
+      accountId: 'account',
+      store,
+      now: () => 10_000,
+    });
+    manager.refresh('peer', 'token', 10_000, {
+      messageId: 'message-1',
+      sequence: 1,
+    });
+    const claimed = manager.claim('peer', 2);
+    expect(claimed.sendCount).toBe(2);
+    expect(manager.release(claimed, 1)).toBe(true);
+    expect(manager.peek('peer')).toMatchObject({
+      token: 'token',
+      sendCount: 1,
+    });
+    expect(store.rows.values().next().value).toMatchObject({ sendCount: 1 });
+
+    manager.refresh('peer', 'token-2', 10_001, {
+      messageId: 'message-2',
+      sequence: 2,
+    });
+    expect(manager.release(claimed, 1)).toBe(false);
+    expect(manager.peek('peer')).toMatchObject({
+      token: 'token-2',
+      sendCount: 0,
     });
   });
 });


### PR DESCRIPTION
## Summary

`sendManagedText` reserved `chunks.length` context_token slots before any `sendmessage`. A 502 on a later chunk burned unused quota and a retry resent the already-acked prefix.

Claim one slot immediately before each chunk, release unacked HTTP failures, and resume from the delivered prefix for the same token+text. Sibling of #639/#649, not a redo.

## Test plan

- [x] ~2500-char message splits; first chunk ret:0, second 502 → no duplicate prefix / unused-slot burn
- [x] Fail-then-pass vs current main

Signed-off-by: Tony Coder <407243179@qq.com>