### PR TITLE
fix(im): do not resend a full copy when stream finalize edit fails

### DIFF
--- a/src/dingtalk-streaming-card.ts
+++ b/src/dingtalk-streaming-card.ts
@@ -403,7 +403,11 @@ export class DingTalkStreamingCardController {
         { err: err.message, cardId: this.cardInstanceId },
         'DingTalk AI Card finalize failed, degrading',
       );
-      await this.tryFallback(finalText);
+      // The card already has streamed preview content. A plain sendMessage
+      // would deliver a second full copy of the same reply.
+      if (!this.inputingStarted) {
+        await this.tryFallback(finalText);
+      }
       this.state = 'error';
     }
   }

--- a/src/discord-streaming-edit.ts
+++ b/src/discord-streaming-edit.ts
@@ -14,12 +14,7 @@
  * preserving code fence state across splits.
  */
 
-import type {
-  TextChannel,
-  DMChannel,
-  NewsChannel,
-  Message,
-} from 'discord.js';
+import type { TextChannel, DMChannel, NewsChannel, Message } from 'discord.js';
 import { logger } from './logger.js';
 
 // ─── Constants ───────────────────────────────────────────────
@@ -173,7 +168,11 @@ export class DiscordStreamingEditController {
         { err: err.message },
         'Discord streaming edit finalize failed, degrading',
       );
-      await this.tryFallback(finalText);
+      // A preview is already visible on the existing message. Sending the
+      // full text again via fallback would duplicate the reply.
+      if (this.lastPushedContent == null) {
+        await this.tryFallback(finalText);
+      }
       this.state = 'error';
     }
   }
@@ -183,8 +182,7 @@ export class DiscordStreamingEditController {
     this.clearFlushTimer();
 
     const displayText = this.accumulatedText
-      ? this.accumulatedText +
-        `\n\n> ⚠️ 已中断: ${reason ?? '用户取消'}`
+      ? this.accumulatedText + `\n\n> ⚠️ 已中断: ${reason ?? '用户取消'}`
       : `⚠️ 已中断: ${reason ?? '用户取消'}`;
 
     if (this.messages.length === 0) {
@@ -194,9 +192,7 @@ export class DiscordStreamingEditController {
 
     try {
       const lastMsg = this.messages[this.messages.length - 1];
-      const truncated = displayText.slice(
-        -(DISCORD_MSG_LIMIT),
-      );
+      const truncated = displayText.slice(-DISCORD_MSG_LIMIT);
       await lastMsg.edit(truncated);
     } catch (err: any) {
       logger.debug(
@@ -361,11 +357,7 @@ export class DiscordStreamingEditController {
     if (display.length > 0) {
       const lines = display.map((d) => {
         const icon =
-          d.status === 'running'
-            ? '🔄'
-            : d.status === 'complete'
-              ? '✅'
-              : '❌';
+          d.status === 'running' ? '🔄' : d.status === 'complete' ? '✅' : '❌';
         const summary = d.summary
           ? `  ${d.summary.length > MAX_TOOL_SUMMARY_CHARS ? d.summary.slice(0, MAX_TOOL_SUMMARY_CHARS) + '...' : d.summary}`
           : '';
@@ -470,7 +462,10 @@ export class DiscordStreamingEditController {
     this.flushTimer = setTimeout(() => {
       this.flushTimer = null;
       this.doFlush().catch((err: any) => {
-        logger.debug({ err: err.message }, 'Discord streaming edit flush failed');
+        logger.debug(
+          { err: err.message },
+          'Discord streaming edit flush failed',
+        );
       });
     }, delay);
   }
@@ -501,8 +496,7 @@ export class DiscordStreamingEditController {
     // During streaming, if content exceeds limit, truncate from the beginning
     // (full split only happens on complete())
     if (content.length > DISCORD_MSG_LIMIT) {
-      const truncated =
-        '...' + content.slice(-(DISCORD_MSG_LIMIT - 3));
+      const truncated = '...' + content.slice(-(DISCORD_MSG_LIMIT - 3));
       await this.editLastMessage(truncated);
     } else {
       await this.editLastMessage(content);

--- a/src/qq-streaming-card.ts
+++ b/src/qq-streaming-card.ts
@@ -230,7 +230,11 @@ export class QQStreamingController {
         { err: err.message, openid: this.openid },
         'QQ streaming finalize failed, using fallback',
       );
-      await this.tryFallback(finalText);
+      // Stream already started (preview is visible). A plain send would
+      // deliver a second full copy of the same reply.
+      if (this.sentChunkCount === 0) {
+        await this.tryFallback(finalText);
+      }
       this.state = 'completed';
     }
   }

--- a/src/wecom-streaming.ts
+++ b/src/wecom-streaming.ts
@@ -222,7 +222,11 @@ export class WeComStreamingController {
         { err: err?.message, chatId: this.chatId },
         'WeCom streaming finalize failed, using fallback',
       );
-      await this.tryFallback(finalBody);
+      // Preview bubble already exists. A plain sendMessage would deliver a
+      // second full copy of the same reply.
+      if (this.sentChunkCount === 0) {
+        await this.tryFallback(finalBody);
+      }
       this.state = 'completed';
     }
   }

--- a/tests/dingtalk-streaming-finalize-no-second-copy.test.ts
+++ b/tests/dingtalk-streaming-finalize-no-second-copy.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const dingtalkHttps = vi.hoisted(() => {
+  let failFinalize = false;
+  const requests: Array<{
+    hostname: string;
+    path: string;
+    method: string;
+    body?: Record<string, unknown>;
+  }> = [];
+
+  return {
+    requests,
+    setFailFinalize(value: boolean) {
+      failFinalize = value;
+    },
+    reset() {
+      failFinalize = false;
+      requests.length = 0;
+    },
+    request(options: any, cb: (res: any) => void) {
+      const chunks: Buffer[] = [];
+      const req = {
+        on() {
+          return req;
+        },
+        write(data: string) {
+          chunks.push(Buffer.from(data));
+        },
+        end() {
+          const bodyStr = Buffer.concat(chunks).toString('utf-8');
+          let body: Record<string, unknown> | undefined;
+          try {
+            body = bodyStr ? JSON.parse(bodyStr) : undefined;
+          } catch {
+            body = undefined;
+          }
+          requests.push({
+            hostname: options.hostname,
+            path: options.path,
+            method: options.method,
+            body,
+          });
+
+          let payload: Record<string, unknown> = { success: true };
+          if (options.hostname === 'oapi.dingtalk.com') {
+            payload = {
+              errcode: 0,
+              access_token: 'tok',
+              expires_in: 7200,
+            };
+          } else if (
+            String(options.path).includes('/card/streaming') &&
+            body?.isFinalize &&
+            failFinalize
+          ) {
+            payload = { code: 'InternalError', message: 'finalize failed' };
+          }
+
+          const listeners: Record<string, Array<(arg?: unknown) => void>> = {
+            data: [],
+            end: [],
+            error: [],
+          };
+          const res = {
+            statusCode: 200,
+            on(event: string, handler: (arg?: unknown) => void) {
+              (listeners[event] ??= []).push(handler);
+              return res;
+            },
+          };
+          queueMicrotask(() => {
+            cb(res);
+            queueMicrotask(() => {
+              const buf = Buffer.from(JSON.stringify(payload));
+              for (const handler of listeners.data) handler(buf);
+              for (const handler of listeners.end) handler();
+            });
+          });
+        },
+      };
+      return req;
+    },
+  };
+});
+
+vi.mock('node:https', () => ({
+  default: { request: dingtalkHttps.request },
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  DingTalkStreamingCardController,
+  type DingTalkStreamingCardConfig,
+  type DingTalkCardTarget,
+} from '../src/dingtalk-streaming-card.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  dingtalkHttps.reset();
+});
+
+describe('DingTalk streaming finalize must not send a second full copy', () => {
+  test('preview flush + failed finalize does not fallback-send', async () => {
+    vi.useFakeTimers();
+    dingtalkHttps.setFailFinalize(false);
+
+    const fallbackSend = vi.fn(async () => {});
+    const config: DingTalkStreamingCardConfig = {
+      clientId: 'test_client_id',
+      clientSecret: 'test_client_secret',
+    };
+    const target: DingTalkCardTarget = {
+      type: 'group',
+      openConversationId: 'cidXXXX',
+    };
+    const ctrl = new DingTalkStreamingCardController(config, target, {
+      fallbackSend,
+    });
+
+    ctrl.append('Hello from the preview');
+    await vi.advanceTimersByTimeAsync(600);
+    await vi.waitFor(() => {
+      expect(
+        dingtalkHttps.requests.some((req) =>
+          String(req.path).includes('/card/streaming'),
+        ),
+      ).toBe(true);
+    });
+    expect(fallbackSend).not.toHaveBeenCalled();
+
+    dingtalkHttps.setFailFinalize(true);
+    await ctrl.complete('Hello from the preview — final');
+
+    expect(
+      dingtalkHttps.requests.some(
+        (req) =>
+          String(req.path).includes('/card/streaming') &&
+          req.body?.isFinalize === true,
+      ),
+    ).toBe(true);
+    expect(fallbackSend).not.toHaveBeenCalled();
+  });
+});

--- a/tests/streaming-finalize-no-second-copy.test.ts
+++ b/tests/streaming-finalize-no-second-copy.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { DiscordStreamingEditController } from '../src/discord-streaming-edit.js';
+import { QQStreamingController } from '../src/qq-streaming-card.js';
+import { WeComStreamingController } from '../src/wecom-streaming.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('streaming finalize must not send a second full copy', () => {
+  test('Discord: preview flush + failed final edit does not fallback-send', async () => {
+    vi.useFakeTimers();
+
+    const fallbackSend = vi.fn(async () => {});
+    let editCount = 0;
+    const message = {
+      id: 'msg-preview',
+      edit: vi.fn(async (_content: string) => {
+        editCount += 1;
+        // First edit is the preview flush; the finalize edit fails.
+        if (editCount > 1) throw new Error('discord finalize edit failed');
+        return message;
+      }),
+    };
+    const channel = {
+      send: vi.fn(async (_content: string) => message),
+    };
+
+    const ctrl = new DiscordStreamingEditController(channel as any, {
+      fallbackSend,
+    });
+    ctrl.append('Hello from the preview');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(channel.send).toHaveBeenCalledTimes(1);
+    expect(message.edit).toHaveBeenCalledTimes(1);
+    expect(fallbackSend).not.toHaveBeenCalled();
+
+    await ctrl.complete('Hello from the preview — final');
+
+    expect(message.edit).toHaveBeenCalledTimes(2);
+    expect(fallbackSend).not.toHaveBeenCalled();
+    expect(channel.send).toHaveBeenCalledTimes(1);
+  });
+
+  test('Discord: failed finalize without a flushed preview still fallback-sends', async () => {
+    const fallbackSend = vi.fn(async () => {});
+    const message = {
+      id: 'msg-placeholder',
+      edit: vi.fn(async () => {
+        throw new Error('discord finalize edit failed');
+      }),
+    };
+    const channel = {
+      send: vi.fn(async (_content: string) => message),
+    };
+
+    const ctrl = new DiscordStreamingEditController(channel as any, {
+      fallbackSend,
+    });
+    await ctrl.complete('Only the final text');
+
+    expect(fallbackSend).toHaveBeenCalledTimes(1);
+    expect(fallbackSend).toHaveBeenCalledWith('Only the final text');
+  });
+
+  test('QQ: preview flush + failed DONE chunk does not fallback-send', async () => {
+    vi.useFakeTimers();
+
+    const fallbackSend = vi.fn(async () => {});
+    const streamCalls: Array<{ input_state: number; content_raw: string }> = [];
+    const sendStreamChunk = vi.fn(async (_openid: string, params: any) => {
+      streamCalls.push({
+        input_state: params.input_state,
+        content_raw: params.content_raw,
+      });
+      if (params.input_state === 10) {
+        throw new Error('qq finalize DONE failed');
+      }
+      return { id: 'stream-msg-1' };
+    });
+
+    const ctrl = new QQStreamingController({
+      openid: 'user-openid',
+      msgSeq: 1,
+      sendStreamChunk,
+      fallbackSend,
+      passiveMsgId: 'passive-1',
+    });
+    ctrl.append('Hello from the preview');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(streamCalls).toHaveLength(1);
+    expect(streamCalls[0].input_state).toBe(1);
+    expect(fallbackSend).not.toHaveBeenCalled();
+
+    await ctrl.complete('Hello from the preview — final');
+
+    expect(streamCalls.some((c) => c.input_state === 10)).toBe(true);
+    expect(fallbackSend).not.toHaveBeenCalled();
+  });
+
+  test('WeCom: preview flush + failed DONE stream does not fallback-send', async () => {
+    vi.useFakeTimers();
+
+    const fallbackSend = vi.fn(async () => {});
+    const streamCalls: Array<{ content: string; finish: boolean }> = [];
+    const sendStream = vi.fn(async (content: string, finish: boolean) => {
+      streamCalls.push({ content, finish });
+      if (finish) throw new Error('wecom finalize DONE failed');
+    });
+
+    const ctrl = new WeComStreamingController({
+      chatId: 'chat-1',
+      sendStream,
+      fallbackSend,
+    });
+    ctrl.append('Hello from the preview');
+    await vi.advanceTimersByTimeAsync(800);
+
+    expect(streamCalls).toEqual([
+      { content: 'Hello from the preview', finish: false },
+    ]);
+    expect(fallbackSend).not.toHaveBeenCalled();
+
+    await ctrl.complete('Hello from the preview — final');
+
+    expect(streamCalls).toContainEqual({
+      content: 'Hello from the preview — final',
+      finish: true,
+    });
+    expect(fallbackSend).not.toHaveBeenCalled();
+  });
+
+  test('WeCom: failed finalize without a flushed preview still fallback-sends', async () => {
+    const fallbackSend = vi.fn(async () => {});
+    const sendStream = vi.fn(async () => {
+      throw new Error('wecom finalize DONE failed');
+    });
+
+    const ctrl = new WeComStreamingController({
+      chatId: 'chat-1',
+      sendStream,
+      fallbackSend,
+    });
+    await ctrl.complete('Only the final text');
+
+    expect(fallbackSend).toHaveBeenCalledTimes(1);
+    expect(fallbackSend).toHaveBeenCalledWith('Only the final text');
+  });
+});


### PR DESCRIPTION
## Summary

After a streaming preview is already visible, a failed finalize/edit called `tryFallback()` and sent the complete reply again on Discord, DingTalk, QQ, and WeCom.

Keep the preview and only fallback when no preview was delivered.

## Test plan

- [x] `tests/streaming-finalize-no-second-copy.test.ts`: flush preview, fail final edit, assert no second full send
- [x] Fail-then-pass vs current main

Signed-off-by: Tony Coder <407243179@qq.com>