### PR TITLE
fix(im): do not resend task notices after ETIMEDOUT-after-accept

### DIFF
--- a/src/im-send-retry-policy.ts
+++ b/src/im-send-retry-policy.ts
@@ -32,3 +32,55 @@ export function imSendFailurePolicy(error: unknown): ImSendFailurePolicy {
     countsTowardChannelRemoval: true,
   };
 }
+
+/**
+ * A timeout after the physical send started cannot prove the provider
+ * rejected the message. The request may already have been accepted.
+ */
+export function isUncertainAfterAcceptImError(error: unknown): boolean {
+  return errorChainHasCode(error, 'ETIMEDOUT');
+}
+
+export interface RetryUnscopedImSendOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  onAttemptFailure?: (error: unknown, attempt: number) => void;
+}
+
+/**
+ * Unscoped (no outbox) IM send. Pre-accept failures may still retry;
+ * an ETIMEDOUT after the physical send started must not resend.
+ */
+export async function retryUnscopedImSend(
+  send: () => Promise<void>,
+  options: RetryUnscopedImSendOptions = {},
+): Promise<{ ok: boolean; error?: unknown }> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const delayMs = options.delayMs ?? 2_000;
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      await send();
+      return { ok: true };
+    } catch (error) {
+      lastError = error;
+      options.onAttemptFailure?.(error, attempt);
+      // After the physical send started, ETIMEDOUT cannot prove rejection.
+      // Retrying would deliver a second visible copy of the same notice.
+      if (
+        isUncertainAfterAcceptImError(error) ||
+        !imSendFailurePolicy(error).retryable
+      ) {
+        return { ok: false, error };
+      }
+      if (attempt < maxAttempts - 1) {
+        await sleep(delayMs * (attempt + 1));
+      }
+    }
+  }
+  return { ok: false, error: lastError };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,11 @@ import {
 } from './config.js';
 import { detectImageMimeType } from './image-detector.js';
 import { interruptibleSleep } from './message-notifier.js';
-import { imSendFailurePolicy } from './im-send-retry-policy.js';
+import {
+  imSendFailurePolicy,
+  isUncertainAfterAcceptImError,
+  retryUnscopedImSend,
+} from './im-send-retry-policy.js';
 import { createIpcSendDeduplicator } from './ipc-send-dedup.js';
 import {
   acknowledgeIpcReplyTurn,
@@ -2945,13 +2949,31 @@ async function sendImWithRetry(
       if (delivered !== true) ok = false;
     }
   } else {
-    ok = await retryImOperation(
-      'send_message',
-      imJid,
+    // Task/notice sends have no outbox fence. An ETIMEDOUT after the
+    // provider accepted the request must not physically resend.
+    const result = await retryUnscopedImSend(
       () =>
         imManager.sendMessage(imJid, text, localImagePaths, deliveryOptions),
-      sendFailure,
+      {
+        maxAttempts: IM_SEND_MAX_RETRIES,
+        delayMs: IM_SEND_RETRY_DELAY_MS,
+        onAttemptFailure: (err, attempt) => {
+          sendFailure.error = err;
+          logger.warn(
+            { imJid, attempt, label: 'send_message', err },
+            'IM operation attempt failed',
+          );
+        },
+      },
     );
+    if (result.error !== undefined) sendFailure.error = result.error;
+    ok = result.ok;
+    if (!ok) {
+      logger.error(
+        { imJid, label: 'send_message' },
+        'IM operation failed after all retries',
+      );
+    }
   }
   if (ok) {
     imSendFailCounts.delete(imJid);
@@ -2960,6 +2982,7 @@ async function sendImWithRetry(
   // `uncertain` is not evidence that the channel is unhealthy. In particular,
   // do not auto-unbind a Bot merely because its ACK was lost after acceptance.
   if (durableScoped) return false;
+  if (isUncertainAfterAcceptImError(sendFailure.error)) return false;
   // Missing/expired/quota-exhausted WeChat context is a user-refreshable
   // delivery prerequisite, not evidence that the chat itself is dead.
   if (!imSendFailurePolicy(sendFailure.error).countsTowardChannelRemoval) {

--- a/tests/im-send-retry-policy.test.ts
+++ b/tests/im-send-retry-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
-import { imSendFailurePolicy } from '../src/im-send-retry-policy.js';
+import {
+  imSendFailurePolicy,
+  isUncertainAfterAcceptImError,
+} from '../src/im-send-retry-policy.js';
 import { WeChatContextTokenError } from '../src/wechat-context-token.js';
 
 describe('imSendFailurePolicy', () => {
@@ -31,5 +34,20 @@ describe('imSendFailurePolicy', () => {
       retryable: true,
       countsTowardChannelRemoval: true,
     });
+  });
+
+  test('treats ETIMEDOUT in the error chain as uncertain after accept', () => {
+    const timeout = Object.assign(new Error('socket hang up'), {
+      code: 'ETIMEDOUT',
+    });
+    expect(isUncertainAfterAcceptImError(timeout)).toBe(true);
+    expect(
+      isUncertainAfterAcceptImError(
+        new Error('adapter failed', { cause: timeout }),
+      ),
+    ).toBe(true);
+    expect(isUncertainAfterAcceptImError(new Error('connection reset'))).toBe(
+      false,
+    );
   });
 });

--- a/tests/task-notice-etimeout-resend.test.ts
+++ b/tests/task-notice-etimeout-resend.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { retryUnscopedImSend } from '../src/im-send-retry-policy.js';
+
+function etimedoutAfterAccept(): NodeJS.ErrnoException {
+  const error = new Error(
+    'ETIMEDOUT after provider accepted the task notice',
+  ) as NodeJS.ErrnoException;
+  error.code = 'ETIMEDOUT';
+  return error;
+}
+
+describe('unscoped task notice send without outbox', () => {
+  test('ETIMEDOUT-after-accept on a task notice stays 1 copy (no extra physical resend)', async () => {
+    let copies = 0;
+    const result = await retryUnscopedImSend(
+      async () => {
+        // The provider accepted and delivered the notice. Only the ACK
+        // timed out. Another attempt would be a second visible copy.
+        copies += 1;
+        throw etimedoutAfterAccept();
+      },
+      { sleep: async () => {} },
+    );
+
+    expect(copies).toBe(1);
+    expect(result.ok).toBe(false);
+    expect((result.error as NodeJS.ErrnoException | undefined)?.code).toBe(
+      'ETIMEDOUT',
+    );
+  });
+
+  test('pre-accept transport failures may still retry', async () => {
+    let attempts = 0;
+    const refused = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    });
+    const result = await retryUnscopedImSend(
+      async () => {
+        attempts += 1;
+        throw refused;
+      },
+      { sleep: async () => {} },
+    );
+
+    expect(attempts).toBe(3);
+    expect(result.ok).toBe(false);
+  });
+
+  test('sendImWithRetry else-branch and retryTaskNotification use the unscoped helper', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/index.ts'),
+      'utf8',
+    );
+    const sendStart = source.indexOf('async function sendImWithRetry(');
+    const sendEnd = source.indexOf(
+      'const CHANNEL_MANUAL_RECONCILIATION_NOTICE',
+      sendStart,
+    );
+    expect(sendStart).toBeGreaterThanOrEqual(0);
+    expect(sendEnd).toBeGreaterThan(sendStart);
+    const sendImWithRetry = source.slice(sendStart, sendEnd);
+    const elseBranch = sendImWithRetry.slice(
+      sendImWithRetry.indexOf('} else {'),
+    );
+    expect(elseBranch).toContain('retryUnscopedImSend(');
+    expect(elseBranch).not.toContain('retryImOperation(');
+
+    const retryStart = source.indexOf(
+      'retryTaskNotification: async (payload) => {',
+    );
+    const retryEnd = source.indexOf(
+      'assistantName: ASSISTANT_NAME',
+      retryStart,
+    );
+    expect(retryStart).toBeGreaterThanOrEqual(0);
+    expect(retryEnd).toBeGreaterThan(retryStart);
+    const retryTaskNotification = source.slice(retryStart, retryEnd);
+    expect(retryTaskNotification).toContain('success = await sendImWithRetry(');
+    expect(retryTaskNotification).toContain(
+      'success = await sendImWithRetry(targetJid!, payload.text, [])',
+    );
+
+    // Scheduled-task IPC notices also go through the unscoped path.
+    expect(source).toContain('sendImWithRetry(targetJid, data.text, [])');
+  });
+});


### PR DESCRIPTION
## Summary

Unscoped `sendImWithRetry` (no outbox) used `retryImOperation`, so a task/notice whose provider accepted the request but whose ACK timed out could physically resend up to 3 copies.

Fence that path the same way durable outbox treats uncertain-after-sending.

## Test plan

- [x] ETIMEDOUT-after-accept on a task notice stays 1 copy
- [x] Fail-then-pass vs current main

Signed-off-by: Tony Coder <407243179@qq.com>