### PR TITLE
fix(dingtalk): reject non-JSON C2C 2xx ACK bodies

### DIFF
--- a/src/dingtalk.ts
+++ b/src/dingtalk.ts
@@ -205,6 +205,42 @@ export function parseDingTalkGroupMessageResponse(
   return data;
 }
 
+export interface DingTalkC2cSendSuccess {
+  processQueryKey?: string;
+  errcode?: number;
+  errmsg?: string;
+}
+
+/** Validate C2C batchSend / sessionWebhook transport and JSON envelope. */
+export function parseDingTalkC2cSendResponse(
+  statusCode: number | undefined,
+  body: string,
+): DingTalkC2cSendSuccess {
+  if (!statusCode || statusCode < 200 || statusCode >= 300) {
+    throw new Error(
+      `DingTalk C2C send HTTP failed (${statusCode ?? 'unknown'}): ${body.slice(0, 200)}`,
+    );
+  }
+  if (!body.trim()) {
+    throw new Error('DingTalk C2C send returned an empty response');
+  }
+  let data: DingTalkC2cSendSuccess;
+  try {
+    data = JSON.parse(body) as DingTalkC2cSendSuccess;
+  } catch {
+    throw new Error('DingTalk C2C send returned invalid JSON');
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('DingTalk C2C send returned an invalid envelope');
+  }
+  if (data.errcode !== undefined && Number(data.errcode) !== 0) {
+    throw new Error(
+      `DingTalk C2C send API error: ${data.errcode} ${data.errmsg ?? ''}`,
+    );
+  }
+  return data;
+}
+
 interface DingTalkAccessToken {
   token: string;
   expiresAt: number;
@@ -745,15 +781,8 @@ export function createDingTalkConnection(
           res.on('data', (chunk: Buffer) => chunks.push(chunk));
           res.on('end', () => {
             const body = Buffer.concat(chunks).toString('utf-8');
-            if (res.statusCode && res.statusCode >= 400) {
-              reject(
-                new Error(`DingTalk HTTP failed (${res.statusCode}): ${body}`),
-              );
-              return;
-            }
-            // Also check DingTalk API-level errcode
             try {
-              const data = JSON.parse(body);
+              const data = parseDingTalkC2cSendResponse(res.statusCode, body);
               logger.info(
                 {
                   statusCode: res.statusCode,
@@ -762,16 +791,9 @@ export function createDingTalkConnection(
                 },
                 'DingTalk sendViaSessionWebhook response',
               );
-              if (data.errcode && data.errcode !== 0) {
-                reject(
-                  new Error(
-                    `DingTalk API error: ${data.errcode} ${data.errmsg}`,
-                  ),
-                );
-                return;
-              }
-            } catch {
-              // Not JSON, ignore
+            } catch (err) {
+              reject(err);
+              return;
             }
             resolve();
           });
@@ -812,26 +834,11 @@ export function createDingTalkConnection(
           res.on('data', (chunk: Buffer) => chunks.push(chunk));
           res.on('end', () => {
             const respBody = Buffer.concat(chunks).toString('utf8');
-            if (res.statusCode && res.statusCode >= 400) {
-              reject(
-                new Error(
-                  `DingTalk batchSend HTTP failed (${res.statusCode}): ${respBody}`,
-                ),
-              );
-              return;
-            }
             try {
-              const data = JSON.parse(respBody);
-              if (data.errcode && data.errcode !== 0) {
-                reject(
-                  new Error(
-                    `DingTalk batchSend API error: ${data.errcode} ${data.errmsg}`,
-                  ),
-                );
-                return;
-              }
-            } catch {
-              // Not JSON, ignore
+              parseDingTalkC2cSendResponse(res.statusCode, respBody);
+            } catch (err) {
+              reject(err);
+              return;
             }
             resolve();
           });

--- a/tests/dingtalk-c2c-ack.test.ts
+++ b/tests/dingtalk-c2c-ack.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseDingTalkC2cSendResponse } from '../src/dingtalk.js';
+
+describe('DingTalk C2C / sessionWebhook strict ACK', () => {
+  test.each(['', '<html>ok</html>', '{broken'])(
+    'rejects malformed 2xx response %j',
+    (body) => {
+      expect(() => parseDingTalkC2cSendResponse(200, body)).toThrow();
+    },
+  );
+
+  test('rejects HTTP failures', () => {
+    expect(() =>
+      parseDingTalkC2cSendResponse(
+        503,
+        JSON.stringify({ errcode: 0, errmsg: 'ok' }),
+      ),
+    ).toThrow('HTTP failed (503)');
+  });
+
+  test('rejects a non-zero errcode on HTTP 200', () => {
+    expect(() =>
+      parseDingTalkC2cSendResponse(
+        200,
+        JSON.stringify({ errcode: 88, errmsg: 'forbidden' }),
+      ),
+    ).toThrow('88');
+  });
+
+  test.each([{ processQueryKey: 'query-c2c-1' }, { errcode: 0, errmsg: 'ok' }])(
+    'accepts a recognized success envelope %#',
+    (response) => {
+      expect(
+        parseDingTalkC2cSendResponse(200, JSON.stringify(response)),
+      ).toEqual(response);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

`batchSendToUser` and leftover `sendViaSessionWebhook` only rejected `statusCode >= 400`, then catch-ignored non-JSON bodies and treated the send as success. HTTP 200 with `''`, `'<html>ok</html>'`, or `'{broken'` was ACKed as delivered.

`parseDingTalkC2cSendResponse` now requires a 2xx status and a parseable JSON envelope. Both send paths use it.

## Test plan

- [x] `tests/dingtalk-c2c-ack.test.ts`: `''`, `'<html>ok</html>'`, `'{broken'` at HTTP 200 must throw
- [x] Fail-then-pass vs current main

Signed-off-by: Tony Coder <407243179@qq.com>