### PR TITLE
feat: make stuck-runner force-restart ceiling configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1274,10 +1274,24 @@ const EMPTY_CURSOR: MessageCursor = { timestamp: '', id: '' };
 const terminalWarmupInFlight = new Set<string>();
 const STUCK_RUNNER_CHECK_INTERVAL_POLLS = 15;
 const STUCK_RUNNER_IDLE_MS = 3 * 60 * 1000;
-// Recovery grace is bounded at 10 minutes. IPC-injected work measures this
+// Recovery grace ceiling, default 10 minutes. IPC-injected work measures this
 // against its dedicated debt clock so ordinary runner output cannot postpone
 // the ceiling; other candidates use their uninterrupted idle age (#618).
-const STUCK_RUNNER_FORCE_RESTART_MS = 10 * 60 * 1000;
+// Configurable because the right value depends on workload: hosts running
+// long interactive turns (multi-file edits plus test suites, deep research)
+// can legitimately exceed 10 minutes of continuous activity and get
+// force-restarted mid-work. Operators should keep it below CONTAINER_TIMEOUT
+// so graceful replay still precedes the hard run timeout; genuinely dead
+// runners are caught by the 3-minute idle path regardless.
+const stuckRunnerMinutesRaw = Number(
+  process.env.STUCK_RUNNER_FORCE_RESTART_MINUTES,
+);
+const STUCK_RUNNER_FORCE_RESTART_MS =
+  (Number.isFinite(stuckRunnerMinutesRaw) && stuckRunnerMinutesRaw > 0
+    ? stuckRunnerMinutesRaw
+    : 10) *
+  60 *
+  1000;
 let stuckRunnerCheckCounter = 0;
 
 // OOM auto-recovery: track consecutive OOM (exit code 137) exits per folder.
@@ -7284,8 +7298,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   }
 
   let output:
-    | { status: 'success' | 'error' | 'closed'; error?: string }
-    | undefined;
+    { status: 'success' | 'error' | 'closed'; error?: string } | undefined;
   let activeSessionId = getSession(effectiveGroup.folder) || undefined;
   // currentSourceJid: tells the agent-runner which IM chat the latest user
   // message came from, so per-channel MCP tools (discord_*, etc.) can detect
@@ -7594,9 +7607,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                   : se.usage;
                 heldCardUsage = null;
                 void target.patchUsageNote(merged);
-              } else if (
-                !(se.eventType === 'text_delta' && !se.parentToolUseId)
-              ) {
+              } else if (!(
+                se.eventType === 'text_delta' && !se.parentToolUseId
+              )) {
                 feedStreamEventToCard(
                   streamingSession,
                   se,
@@ -8257,8 +8270,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               let streamingCardAttachmentsDelivered = true;
               let cardHeldThisResult = false;
               let pendingStreamingCardCompletion:
-                | NonNullable<typeof outputStreamingSession>
-                | undefined;
+                NonNullable<typeof outputStreamingSession> | undefined;
               if (holdReason) {
                 heldCardParts.push(heldPartText);
                 cardHeldThisResult = true;
@@ -10544,9 +10556,7 @@ function startIpcWatcher(): void {
               let messageDeliveryUncertain = false;
               let nativeDeliveryAcknowledged = false;
               let stagedDisposition:
-                | 'staged_progress'
-                | 'staged_final'
-                | undefined;
+                'staged_progress' | 'staged_final' | undefined;
               const isTaskIpcMessage = Boolean(durableTaskRun);
               const frozenIpcMode = resolveFrozenIpcInteractionMode(
                 data.interactionMode,
@@ -12328,11 +12338,7 @@ async function processTaskIpc(
               ...base,
               query: data.query,
               kind: data.kind as
-                | 'fact'
-                | 'decision'
-                | 'lesson'
-                | 'open_loop'
-                | undefined,
+                'fact' | 'decision' | 'lesson' | 'open_loop' | undefined,
               limit: data.limit,
               maxChars: data.maxChars,
             });
@@ -12353,11 +12359,7 @@ async function processTaskIpc(
               ...base,
               query: data.query ?? '',
               kind: data.kind as
-                | 'fact'
-                | 'decision'
-                | 'lesson'
-                | 'open_loop'
-                | undefined,
+                'fact' | 'decision' | 'lesson' | 'open_loop' | undefined,
               limit: data.limit,
             });
             break;
@@ -13139,9 +13141,7 @@ async function processTaskIpc(
         data.schedule_value !== undefined
       ) {
         const newType = (data.schedule_type ?? task.schedule_type) as
-          | 'cron'
-          | 'interval'
-          | 'once';
+          'cron' | 'interval' | 'once';
         const newValue = data.schedule_value ?? task.schedule_value;
         try {
           updatedNextRun = computeNextRunForSchedule(newType, newValue);
@@ -16281,8 +16281,7 @@ async function processAgentConversation(
         let agentCardAttachmentsDelivered = true;
         let agentStaticImDelivered = false;
         let pendingAgentCardCompletion:
-          | NonNullable<typeof outputAgentStreamingSession>
-          | undefined;
+          NonNullable<typeof outputAgentStreamingSession> | undefined;
         if (holdReason) {
           // 挂起：不定稿，正文进 heldAgentParts，有卡片则状态行提示，后续
           // turn 的流式增量继续追加到同一张卡（Sub 路径 session 本就不轮换）。


### PR DESCRIPTION
## 动机

`STUCK_RUNNER_FORCE_RESTART_MS` 目前硬编码 10 分钟（#618 有意设的恢复上限）。但这个上限的合理值**取决于负载形态**：跑长交互回合的宿主（一轮里多文件编辑 + 跑测试套件、深度调研），runner 可以合法地连续忙超过 10 分钟，然后被 watchdog 在干活中途强杀。我们生产环境 2026-08-15 反复踩到，此后一直本地补丁跑 25 分钟。

## 改动

新增环境变量 `STUCK_RUNNER_FORCE_RESTART_MINUTES`，**默认值保持 10 —— 不设置则零行为变化**，纯配置口。非法值（NaN / ≤0）回落默认。

没有做成 Web 设置项：这是低层 watchdog 参数，且近期 #672/#678 在做设置面收敛，env-only 与 `LOGIN_LOCKOUT_MINUTES` 等既有惯例一致。

## 安全性

- 真正死掉的 runner 不受影响：CPU 安静后仍走 3 分钟 idle 路径快速回收
- 注释里提醒运维者把值保持在 `CONTAINER_TIMEOUT` 以下，保证优雅 replay 先于硬超时
- IPC debt clock 语义（#618）不变，只是上限可调

🤖 Generated with [Claude Code](https://claude.com/claude-code)
