### PR TITLE
fix(provider): distinguish upstream stalls from account verdicts

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -1796,6 +1796,7 @@ async function runQueryAttempt(
     rateLimitResetsAt?: number,
     failureNotice?: string,
     rateLimitScope: 'account' | 'model' = 'account',
+    livenessTimeout = false,
   ): void => {
     if (providerFailurePublished) return;
     providerFailurePublished = true;
@@ -1819,6 +1820,7 @@ async function runQueryAttempt(
         PROVIDER_FALLBACK_MODELS.activeModelOverride,
       ),
       ...(!emitOutput ? { providerFailureMaintenance: true } : {}),
+      ...(livenessTimeout ? { providerLivenessTimeout: true } : {}),
       finalizationReason: 'error',
       ...(emitOutput && ipcReceipts.length > 0 ? { ipcReceipts } : {}),
       ...(sourceKindOverride ? { sourceKind: sourceKindOverride } : {}),
@@ -2629,10 +2631,18 @@ async function runQueryAttempt(
     firstResponseWatchdog = new SdkFirstResponseWatchdog(
       SDK_FIRST_RESPONSE_TIMEOUT_MS,
       (phase, timeoutMs) => {
-        log(
-          `No model response event within ${timeoutMs}ms (${phase}); marking provider unhealthy`,
+        // WARN, not info: the host only forwards warn-and-above from the runner,
+        // and this line is the sole diagnostic for a liveness stall.
+        logWarn(
+          `No model response event within ${timeoutMs}ms (${phase}); reporting a transient liveness timeout (account health untouched)`,
         );
-        publishProviderAccountFailure('server_error');
+        publishProviderAccountFailure(
+          'server_error',
+          undefined,
+          undefined,
+          'account',
+          true,
+        );
         processor.discardPendingTextOutput();
         processor.cleanup();
         stream.end();

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -112,10 +112,11 @@ import {
 } from './provider-runtime.js';
 import { resolveAgentSdkEffort } from './agent-effort.js';
 import {
+  classifyProviderAssistantError,
   decideProviderLimitAction,
-  isAccountProviderAssistantError,
   ProviderFallbackModelState,
   ProviderFallbackTurnLedger,
+  type ProviderFailureClass,
   type ProviderFallbackRetryTurn,
 } from './provider-fallback.js';
 import {
@@ -1791,13 +1792,31 @@ async function runQueryAttempt(
     if (emitOutput) writeOutput(output);
   };
   let providerFailurePublished = false;
-  const publishProviderAccountFailure = (
-    error: SDKAssistantMessageError,
-    rateLimitResetsAt?: number,
-    failureNotice?: string,
-    rateLimitScope: 'account' | 'model' = 'account',
-    livenessTimeout = false,
-  ): void => {
+  /**
+   * Publish one provider failure control signal.
+   *
+   * `failureClass` — not the SDK error name — is what the host reads to decide
+   * whether the account is quarantined, whether the input is replayed, and
+   * which notice the user eventually sees. It is required so that no future
+   * call site can silently inherit the account-verdict disposition the way the
+   * liveness watchdog once did by borrowing the `server_error` label.
+   */
+  const publishProviderFailure = (options: {
+    error: SDKAssistantMessageError;
+    failureClass: ProviderFailureClass;
+    rateLimitResetsAt?: number;
+    failureNotice?: string;
+    rateLimitScope?: 'account' | 'model';
+    livenessTimeout?: boolean;
+  }): void => {
+    const {
+      error,
+      failureClass,
+      rateLimitResetsAt,
+      failureNotice,
+      rateLimitScope = 'account',
+      livenessTimeout = false,
+    } = options;
     if (providerFailurePublished) return;
     providerFailurePublished = true;
     // Produce the exact receipt candidates for a terminal host projection.
@@ -1809,6 +1828,7 @@ async function runQueryAttempt(
       result: null,
       newSessionId,
       providerFailure: true,
+      providerFailureClass: failureClass,
       ...(typeof rateLimitResetsAt === 'number' &&
       Number.isFinite(rateLimitResetsAt)
         ? { providerRateLimitResetsAt: rateLimitResetsAt }
@@ -1825,12 +1845,40 @@ async function runQueryAttempt(
       ...(emitOutput && ipcReceipts.length > 0 ? { ipcReceipts } : {}),
       ...(sourceKindOverride ? { sourceKind: sourceKindOverride } : {}),
     };
-    log(`Publishing provider failure control signal (${error})`);
+    log(
+      `Publishing provider failure control signal (${error}, class=${failureClass})`,
+    );
     if (emitOutput) {
       emit(output);
     } else {
       writeOutput(outputCorrelation.correlate(output));
     }
+  };
+  /**
+   * Tell the user, once, that the answer they are about to read came from the
+   * fallback model rather than the one they configured.
+   *
+   * Without this the downgrade is invisible: the turn is silently re-run on a
+   * weaker tier and the reply is indistinguishable from a primary-model reply,
+   * so a user reading it has no way to know the quality bar moved or that their
+   * primary model needs attention. It is a standalone out-of-band notice, never
+   * the answer — `provider_fallback_notice` keeps it out of the primary reply
+   * slot so it cannot be mistaken for a delivered result.
+   *
+   * `ProviderFallbackModelState` latches on activation, so this fires at most
+   * once per runner process even across warm IPC turns.
+   */
+  const emitModelFallbackNotice = (): void => {
+    if (!emitOutput) return;
+    emit({
+      status: 'success',
+      result:
+        `⚠️ 主模型 ${PROVIDER_FALLBACK_MODELS.primaryModel} 已达用量上限，` +
+        `本轮起改用备用模型 ${PROVIDER_FALLBACK_MODELS.fallbackModel} 回复。` +
+        `回答质量可能与平时不同；如需恢复，请等待用量重置或在「模型配置」中调整。`,
+      newSessionId: undefined,
+      sourceKind: 'provider_fallback_notice',
+    });
   };
   let firstResponseWatchdog: SdkFirstResponseWatchdog | undefined;
 
@@ -2636,13 +2684,11 @@ async function runQueryAttempt(
         logWarn(
           `No model response event within ${timeoutMs}ms (${phase}); reporting a transient liveness timeout (account health untouched)`,
         );
-        publishProviderAccountFailure(
-          'server_error',
-          undefined,
-          undefined,
-          'account',
-          true,
-        );
+        publishProviderFailure({
+          error: 'server_error',
+          failureClass: 'transient',
+          livenessTimeout: true,
+        });
         processor.discardPendingTextOutput();
         processor.cleanup();
         stream.end();
@@ -2717,7 +2763,11 @@ async function runQueryAttempt(
                 info.resetsAt ?? 'none'
               }); marking provider unhealthy immediately`,
             );
-            publishProviderAccountFailure('rate_limit', info.resetsAt);
+            publishProviderFailure({
+              error: 'rate_limit',
+              failureClass: 'account',
+              rateLimitResetsAt: info.resetsAt,
+            });
             processor.discardPendingTextOutput();
             processor.cleanup();
             assistantTextTracker.reset();
@@ -2749,6 +2799,7 @@ async function runQueryAttempt(
             log(
               `Model-specific rate limit rejected; retrying current turn with fallback model ${PROVIDER_FALLBACK_MODELS.fallbackModel}`,
             );
+            emitModelFallbackNotice();
             writeOutput({
               status: 'stream',
               result: null,
@@ -2788,12 +2839,13 @@ async function runQueryAttempt(
               info.resetsAt ?? 'none'
             }); quarantining profile for failover`,
           );
-          publishProviderAccountFailure(
-            'rate_limit',
-            info.resetsAt,
-            MODEL_LIMIT_EXHAUSTED_NOTICE,
-            'model',
-          );
+          publishProviderFailure({
+            error: 'rate_limit',
+            failureClass: 'account',
+            rateLimitResetsAt: info.resetsAt,
+            failureNotice: MODEL_LIMIT_EXHAUSTED_NOTICE,
+            rateLimitScope: 'model',
+          });
           processor.discardPendingTextOutput();
           processor.cleanup();
           assistantTextTracker.reset();
@@ -3009,11 +3061,16 @@ async function runQueryAttempt(
       if (message.type === 'assistant' && 'uuid' in message) {
         const assistantError = (message as { error?: SDKAssistantMessageError })
           .error;
-        if (isAccountProviderAssistantError(assistantError)) {
+        const assistantErrorClass =
+          classifyProviderAssistantError(assistantError);
+        if (assistantError && assistantErrorClass) {
           log(
-            `Assistant provider error (${assistantError}); marking provider unhealthy`,
+            `Assistant provider error (${assistantError}); classified as ${assistantErrorClass}`,
           );
-          publishProviderAccountFailure(assistantError);
+          publishProviderFailure({
+            error: assistantError,
+            failureClass: assistantErrorClass,
+          });
           processor.discardPendingTextOutput();
           processor.cleanup();
           assistantTextTracker.reset();
@@ -3200,7 +3257,10 @@ async function runQueryAttempt(
           log(
             'Account rate limit recognized from compatibility text; marking provider unhealthy',
           );
-          publishProviderAccountFailure('rate_limit');
+          publishProviderFailure({
+            error: 'rate_limit',
+            failureClass: 'account',
+          });
           emitResultUsage(resultMsg, containerInput.turnId || generateTurnId());
           assistantBatchFlushedSinceLastResult = false;
           processor.discardPendingTextOutput();
@@ -3236,6 +3296,7 @@ async function runQueryAttempt(
           log(
             `Primary model hit a model-specific limit; retrying current turn with fallback model ${PROVIDER_FALLBACK_MODELS.fallbackModel}`,
           );
+          emitModelFallbackNotice();
           writeOutput({
             status: 'stream',
             result: null,
@@ -3263,12 +3324,12 @@ async function runQueryAttempt(
           log(
             'Model tiers exhausted on this account; quarantining profile for failover',
           );
-          publishProviderAccountFailure(
-            'rate_limit',
-            undefined,
-            textResult?.trim() || MODEL_LIMIT_EXHAUSTED_NOTICE,
-            'model',
-          );
+          publishProviderFailure({
+            error: 'rate_limit',
+            failureClass: 'account',
+            failureNotice: textResult?.trim() || MODEL_LIMIT_EXHAUSTED_NOTICE,
+            rateLimitScope: 'model',
+          });
           emitResultUsage(resultMsg, containerInput.turnId || generateTurnId());
           assistantBatchFlushedSinceLastResult = false;
           processor.discardPendingTextOutput();
@@ -4080,7 +4141,7 @@ async function main(): Promise<void> {
         resumeAt = queryResult.lastAssistantUuid;
       }
       if (queryResult.providerAccountFailure) {
-        log('Account provider failure emitted; exiting runner');
+        log('Provider failure control signal emitted; exiting runner');
         forceExitWithSafetyNet(0);
         return;
       }

--- a/container/agent-runner/src/provider-fallback.ts
+++ b/container/agent-runner/src/provider-fallback.ts
@@ -149,26 +149,70 @@ export function isProviderLimitNotice(result: string | null): boolean {
   return classifyProviderLimitNotice(result) !== null;
 }
 
+/**
+ * What a provider failure actually says about the account, which is what
+ * decides the disposition.
+ *
+ * - `account`: a verdict on this OAuth profile. Quarantine it and let the pool
+ *   decide whether another account can replay the input.
+ * - `transient`: the upstream or the transport misbehaved. The account was
+ *   never judged, so its health must not change and the input stays replayable
+ *   on the same provider within a bounded budget.
+ * - `config`: the request itself is unserviceable as configured. No account can
+ *   satisfy it, so failing over or retrying only burns turns; end visibly and
+ *   point at the configuration.
+ */
+export type ProviderFailureClass = 'account' | 'transient' | 'config';
+
+/** A verdict on the profile: quarantine and fail over. */
 const ACCOUNT_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
   'authentication_failed',
   'oauth_org_not_allowed',
   'billing_error',
+  // A bare `rate_limit` assistant error carries no rateLimitType, so its blast
+  // radius is unknown. classifyProviderRateLimitType() already fails safe as
+  // account-wide for an unknown type; stay consistent with it here.
   'rate_limit',
+]);
+
+/**
+ * Upstream/transport noise. `overloaded` is a 529 from Anthropic's own edge and
+ * `server_error` is a 5xx — neither is evidence that this account is out of
+ * quota, yet both used to quarantine it and retire the user's input.
+ */
+const TRANSIENT_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
   'overloaded',
-  'model_not_found',
   'server_error',
+]);
+
+/**
+ * `model_not_found` means the configured model name is not servable by this
+ * endpoint. Every account in the pool would be asked for the same model, so
+ * failover is guaranteed to fail the same way — and quarantining accounts for
+ * it would empty the pool over a typo.
+ */
+const CONFIG_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
+  'model_not_found',
 ]);
 
 /**
  * Third-party Anthropic-compatible endpoints can emit an AssistantMessage
  * carrying `error` without ever following it with rate_limit_event/result.
- * Treat provider/account failures as terminal control-plane signals instead of
- * waiting indefinitely for a Result that may never arrive.
+ * Every recognized error therefore has to terminate the SDK attempt rather than
+ * wait indefinitely for a Result that may never arrive — but only the returned
+ * class decides what happens to the account and to the user's input.
+ *
+ * @returns the failure class, or undefined when the error is not a provider
+ * failure at all and normal processing should continue.
  */
-export function isAccountProviderAssistantError(
+export function classifyProviderAssistantError(
   error: SDKAssistantMessageError | undefined,
-): error is SDKAssistantMessageError {
-  return !!error && ACCOUNT_PROVIDER_ASSISTANT_ERRORS.has(error);
+): ProviderFailureClass | undefined {
+  if (!error) return undefined;
+  if (ACCOUNT_PROVIDER_ASSISTANT_ERRORS.has(error)) return 'account';
+  if (TRANSIENT_PROVIDER_ASSISTANT_ERRORS.has(error)) return 'transient';
+  if (CONFIG_PROVIDER_ASSISTANT_ERRORS.has(error)) return 'config';
+  return undefined;
 }
 
 /**

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -367,6 +367,12 @@ export interface ContainerOutput {
    */
   providerFailureClass?: 'account' | 'transient' | 'config';
   /**
+   * Host-set: arrived as `transient` and was rewritten to `account` once its
+   * replay budget was spent and the same input failed transiently again. The
+   * runner never sets this; it only ever reports what it observed.
+   */
+  providerFailureEscalatedFrom?: 'transient';
+  /**
    * Set by the host after it quarantines the failed provider and checks the
    * remaining pool. The agent runner itself only emits providerFailure.
    */

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -363,6 +363,13 @@ export interface ContainerOutput {
    * completed. The host quarantines it without replaying or notifying again.
    */
   providerFailureMaintenance?: boolean;
+  /**
+   * The SDK stream produced no model response event within the liveness
+   * deadline. This is a transport/upstream stall, NOT evidence that the account
+   * is out of quota: the host must not quarantine the profile or clear the
+   * session, and it must keep the durable input replayable while retries remain.
+   */
+  providerLivenessTimeout?: boolean;
   streamEvent?: StreamEvent;
   /**
    * Immutable identity of the user input turn that produced this output.

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -352,6 +352,21 @@ export interface ContainerOutput {
   /** The model that was actually in use when the limit was reported. */
   providerRateLimitModel?: string;
   /**
+   * What the failure says about the account, which is what the host's
+   * disposition is keyed on:
+   *
+   * - `account` — a verdict on this profile: quarantine it and let the pool
+   *   decide whether another account replays the input.
+   * - `transient` — upstream/transport noise: never touch account health, keep
+   *   the durable input replayable on the same provider within its budget.
+   * - `config` — unserviceable as configured: end visibly without quarantining,
+   *   because every account would fail the same way.
+   *
+   * Absent on outputs from an older runner; the host then falls back to the
+   * pre-classification behaviour of treating the failure as `account`.
+   */
+  providerFailureClass?: 'account' | 'transient' | 'config';
+  /**
    * Set by the host after it quarantines the failed provider and checks the
    * remaining pool. The agent runner itself only emits providerFailure.
    */
@@ -365,9 +380,10 @@ export interface ContainerOutput {
   providerFailureMaintenance?: boolean;
   /**
    * The SDK stream produced no model response event within the liveness
-   * deadline. This is a transport/upstream stall, NOT evidence that the account
-   * is out of quota: the host must not quarantine the profile or clear the
-   * session, and it must keep the durable input replayable while retries remain.
+   * deadline. Always accompanied by `providerFailureClass: 'transient'`, which
+   * is what suppresses the quarantine and keeps the input replayable; this flag
+   * only distinguishes a silent stall from a reported upstream error so the
+   * user-facing wording can name the right cause.
    */
   providerLivenessTimeout?: boolean;
   streamEvent?: StreamEvent;
@@ -388,6 +404,7 @@ export interface ContainerOutput {
     | 'sdk_send_message'
     | 'proactive_sdk_fallback'
     | 'input_rejection_warning'
+    | 'provider_fallback_notice'
     | 'interrupt_partial'
     | 'overflow_partial'
     | 'compact_partial'

--- a/src/agent-runtime-contracts.ts
+++ b/src/agent-runtime-contracts.ts
@@ -15,6 +15,7 @@ export interface ContainerOutput {
   providerFailureTerminal?: boolean;
   providerFailureRetrying?: boolean;
   providerFailureMaintenance?: boolean;
+  providerLivenessTimeout?: boolean;
   streamEvent?: StreamEvent;
   readonly inputTurnId?: string;
   turnId?: string;

--- a/src/agent-runtime-contracts.ts
+++ b/src/agent-runtime-contracts.ts
@@ -13,6 +13,7 @@ export interface ContainerOutput {
   providerRateLimitScope?: 'account' | 'model';
   providerRateLimitModel?: string;
   providerFailureClass?: 'account' | 'transient' | 'config';
+  providerFailureEscalatedFrom?: 'transient';
   providerFailureTerminal?: boolean;
   providerFailureRetrying?: boolean;
   providerFailureMaintenance?: boolean;

--- a/src/agent-runtime-contracts.ts
+++ b/src/agent-runtime-contracts.ts
@@ -12,6 +12,7 @@ export interface ContainerOutput {
   providerFailureNotice?: string;
   providerRateLimitScope?: 'account' | 'model';
   providerRateLimitModel?: string;
+  providerFailureClass?: 'account' | 'transient' | 'config';
   providerFailureTerminal?: boolean;
   providerFailureRetrying?: boolean;
   providerFailureMaintenance?: boolean;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -76,9 +76,11 @@ import {
 } from './db.js';
 import { isApiError } from './agent-output-parser.js';
 import {
-  LivenessRetryLedger,
-  PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
-  resolveLivenessRetryKey,
+  DEFAULT_MAX_TRANSIENT_RETRIES,
+  TransientRetryLedger,
+  resolveProviderFailureClass,
+  resolveTerminalProviderFailureNotice,
+  resolveTransientRetryKey,
 } from './provider-failure.js';
 import type { ClaudeProviderConfig } from './runtime-config.js';
 import {
@@ -525,13 +527,18 @@ function quarantineFromOutput(
     | 'providerRateLimitScope'
     | 'providerRateLimitModel'
     | 'providerRateLimitResetsAt'
+    | 'providerFailureClass'
     | 'providerLivenessTimeout'
   >,
 ): void {
-  // A liveness stall says nothing about the account: the stream simply produced
-  // no model event in time. Quarantining here is what turned an upstream/network
-  // hiccup into a fake "quota exhausted" verdict for single-account pools.
-  if (output.providerLivenessTimeout) return;
+  // Only an account-class verdict may change account health.
+  //
+  // A transient failure says nothing about the account — the stream stalled, or
+  // the upstream returned 529/5xx — and quarantining on it is what turned an
+  // upstream hiccup into a fake "quota exhausted" verdict for single-account
+  // pools. A config failure would fail identically on every account, so
+  // quarantining would drain the whole pool over one unservable model name.
+  if (resolveProviderFailureClass(output) !== 'account') return;
   // Fail safe: a model-scope report with no model name cannot be recorded as a
   // tier quarantine, and silently dropping it would let the same failing pair
   // be selected forever. Degrade to an account-scope quarantine instead.
@@ -567,20 +574,32 @@ function poolCanStillServe(): boolean {
   return !!fallbackModel && providerPool.hasCandidateForTier(fallbackModel);
 }
 
-/** Host-process replay budget; each liveness retry runs a fresh runner. */
-const livenessRetries = new LivenessRetryLedger();
+/** Host-process replay budget; each transient retry runs a fresh runner. */
+const transientRetries = new TransientRetryLedger();
 
 function applyProviderFailureDisposition(
   output: ContainerOutput,
   selectedProfileId: string | null,
   allowFailover = true,
 ): boolean {
-  // Liveness stalls never consult the pool: no account was judged, so the only
-  // question is whether this input still has a retry left.
-  if (output.providerLivenessTimeout) {
-    const terminal = !livenessRetries.consume(resolveLivenessRetryKey(output));
+  const failureClass = resolveProviderFailureClass(output);
+  // Transient failures never consult the pool: no account was judged, so the
+  // only question is whether this input still has a retry left. This is
+  // identical for single- and multi-account installs by design — a 529 is not a
+  // reason to move the conversation to a different account.
+  if (failureClass === 'transient') {
+    const terminal = !transientRetries.consume(
+      resolveTransientRetryKey(output),
+    );
     applyKnownProviderFailureDisposition(output, terminal);
     return terminal;
+  }
+  // A config failure is terminal on arrival. Every account would be asked for
+  // the same unservable model, so a retry and a failover both just reproduce
+  // it — and neither would tell the user what to actually fix.
+  if (failureClass === 'config') {
+    applyKnownProviderFailureDisposition(output, true);
+    return true;
   }
   providerPool.refreshFromConfig(getEnabledProviders(), getBalancingConfig());
   providerPool.refreshRecoveryState();
@@ -605,10 +624,11 @@ function applyKnownProviderFailureDisposition(
   output.providerFailureTerminal = terminal;
   output.inputTurnCompleted = terminal;
   // Set here rather than in the disposition helper so every path that forces a
-  // liveness stall terminal — including the scheduled replay loop's
-  // no-progress bail-out — reports the stall instead of a quota verdict.
-  if (terminal && output.providerLivenessTimeout) {
-    output.providerFailureNotice = PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE;
+  // non-account failure terminal — including the scheduled replay loop's
+  // no-progress bail-out — names the real cause instead of a quota verdict.
+  if (terminal) {
+    const notice = resolveTerminalProviderFailureNotice(output);
+    if (notice) output.providerFailureNotice = notice;
   }
 }
 
@@ -3586,8 +3606,21 @@ export async function runAgentWithModelFallback(
     : Math.max(1, enabledProviders.length + fallbackOnlyCombinations);
   let lastOutput: ContainerOutput | undefined;
   let availabilityState = providerPool.getAvailabilityStateKey();
+  // A transient replay is not a distinct combination — it re-runs the same
+  // (account, tier) on purpose — so it must not consume the combination budget.
+  // Without this a single-account install computes maxAttempts = 1 and a
+  // scheduled task could never use the retry the disposition granted it, while
+  // adding the headroom up front would instead hand a pinned Agent a second
+  // attempt it must not get for an account failure. Granted only after an
+  // observed transient failure, and capped independently of the per-input
+  // ledger that is the real bound.
+  let transientReplayBudget = 0;
 
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+  for (
+    let attempt = 0;
+    attempt < maxAttempts + transientReplayBudget;
+    attempt += 1
+  ) {
     let completedInputBeforeProviderFailure = false;
     let attemptedProviderId: string | null = null;
     const gatedOnOutput = onOutput
@@ -3647,8 +3680,23 @@ export async function runAgentWithModelFallback(
     }
 
     const nextAvailabilityState = providerPool.getAvailabilityStateKey();
+    // A transient failure deliberately leaves availability untouched, so the
+    // no-progress guard below would read "nothing changed" and stop — burning
+    // the replay budget the disposition just granted without ever using it.
+    // Reaching here already proves the failure was non-terminal, i.e. the
+    // bounded ledger allowed one more attempt, so the same-provider replay this
+    // guard normally prevents is exactly the intended behaviour here.
+    const replayableTransient =
+      resolveProviderFailureClass(lastOutput) === 'transient';
+    if (
+      replayableTransient &&
+      transientReplayBudget < DEFAULT_MAX_TRANSIENT_RETRIES
+    ) {
+      transientReplayBudget += 1;
+    }
     if (
       attemptedProviderId !== null &&
+      !replayableTransient &&
       nextAvailabilityState === availabilityState
     ) {
       logger.error(
@@ -3670,7 +3718,9 @@ export async function runAgentWithModelFallback(
         attempt: attempt + 1,
         maxAttempts,
       },
-      'Scheduled task provider failed; retrying the same prompt on another provider',
+      replayableTransient
+        ? 'Scheduled task hit a transient provider failure; replaying the same prompt on the same provider'
+        : 'Scheduled task provider failed; retrying the same prompt on another provider',
     );
   }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -577,7 +577,13 @@ function poolCanStillServe(): boolean {
 /** Host-process replay budget; each transient retry runs a fresh runner. */
 const transientRetries = new TransientRetryLedger();
 
-function applyProviderFailureDisposition(
+/**
+ * Exported for tests: the transient escalation spans this function, the
+ * host-process retry ledger and the provider pool, so asserting it on source
+ * text alone would not prove that a second failure actually quarantines the
+ * account or that the pool then decides failover.
+ */
+export function applyProviderFailureDisposition(
   output: ContainerOutput,
   selectedProfileId: string | null,
   allowFailover = true,

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -588,11 +588,29 @@ function applyProviderFailureDisposition(
   // identical for single- and multi-account installs by design — a 529 is not a
   // reason to move the conversation to a different account.
   if (failureClass === 'transient') {
-    const terminal = !transientRetries.consume(
-      resolveTransientRetryKey(output),
-    );
-    applyKnownProviderFailureDisposition(output, terminal);
-    return terminal;
+    if (transientRetries.consume(resolveTransientRetryKey(output))) {
+      applyKnownProviderFailureDisposition(output, false);
+      return false;
+    }
+    // The replay is spent and the same input failed transiently again.
+    //
+    // "Transient" is a claim that the upstream will be back shortly, and two
+    // consecutive failures spanning both liveness deadlines are evidence
+    // against it. Measured against the stub upstream, a 401 and a 429 are both
+    // retried silently by the CLI until the watchdog fires, so they are
+    // indistinguishable from a stall on first sight — refusing to ever escalate
+    // would leave a dead key or an exhausted quota permanently un-quarantined
+    // and strand a multi-account pool on its one broken profile.
+    //
+    // Escalating rewrites the class, so everything downstream — the quarantine
+    // here, the pool disposition below, the session-clearing guard, and the
+    // notice — treats it as the account verdict it now looks like.
+    output.providerFailureClass = 'account';
+    output.providerFailureEscalatedFrom = 'transient';
+    if (selectedProfileId !== null) {
+      quarantineFromOutput(selectedProfileId, output);
+    }
+    // fall through to the account disposition
   }
   // A config failure is terminal on arrival. Every account would be asked for
   // the same unservable model, so a retry and a failover both just reproduce

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -613,6 +613,17 @@ export function applyProviderFailureDisposition(
     // notice — treats it as the account verdict it now looks like.
     output.providerFailureClass = 'account';
     output.providerFailureEscalatedFrom = 'transient';
+    // WARN, not info: this is the one line that says an account was taken out
+    // of rotation for repeated silence rather than for anything the upstream
+    // actually reported, and it is the only in-log evidence that the
+    // escalation fired at all.
+    logger.warn(
+      {
+        providerId: selectedProfileId,
+        livenessTimeout: output.providerLivenessTimeout === true,
+      },
+      'Transient provider failure repeated after its replay; escalating to an account verdict and quarantining',
+    );
     if (selectedProfileId !== null) {
       quarantineFromOutput(selectedProfileId, output);
     }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -75,6 +75,11 @@ import {
   setSessionProviderId,
 } from './db.js';
 import { isApiError } from './agent-output-parser.js';
+import {
+  LivenessRetryLedger,
+  PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
+  resolveLivenessRetryKey,
+} from './provider-failure.js';
 import type { ClaudeProviderConfig } from './runtime-config.js';
 import {
   loadManagedMcpLayers,
@@ -520,8 +525,13 @@ function quarantineFromOutput(
     | 'providerRateLimitScope'
     | 'providerRateLimitModel'
     | 'providerRateLimitResetsAt'
+    | 'providerLivenessTimeout'
   >,
 ): void {
+  // A liveness stall says nothing about the account: the stream simply produced
+  // no model event in time. Quarantining here is what turned an upstream/network
+  // hiccup into a fake "quota exhausted" verdict for single-account pools.
+  if (output.providerLivenessTimeout) return;
   // Fail safe: a model-scope report with no model name cannot be recorded as a
   // tier quarantine, and silently dropping it would let the same failing pair
   // be selected forever. Degrade to an account-scope quarantine instead.
@@ -557,11 +567,21 @@ function poolCanStillServe(): boolean {
   return !!fallbackModel && providerPool.hasCandidateForTier(fallbackModel);
 }
 
+/** Host-process replay budget; each liveness retry runs a fresh runner. */
+const livenessRetries = new LivenessRetryLedger();
+
 function applyProviderFailureDisposition(
   output: ContainerOutput,
   selectedProfileId: string | null,
   allowFailover = true,
 ): boolean {
+  // Liveness stalls never consult the pool: no account was judged, so the only
+  // question is whether this input still has a retry left.
+  if (output.providerLivenessTimeout) {
+    const terminal = !livenessRetries.consume(resolveLivenessRetryKey(output));
+    applyKnownProviderFailureDisposition(output, terminal);
+    return terminal;
+  }
   providerPool.refreshFromConfig(getEnabledProviders(), getBalancingConfig());
   providerPool.refreshRecoveryState();
   // Ask the pool across both dimensions. A model wall leaves the account
@@ -584,6 +604,12 @@ function applyKnownProviderFailureDisposition(
   output.result = null;
   output.providerFailureTerminal = terminal;
   output.inputTurnCompleted = terminal;
+  // Set here rather than in the disposition helper so every path that forces a
+  // liveness stall terminal — including the scheduled replay loop's
+  // no-progress bail-out — reports the stall instead of a quota verdict.
+  if (terminal && output.providerLivenessTimeout) {
+    output.providerFailureNotice = PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE;
+  }
 }
 
 export interface VolumeMount {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8868,7 +8868,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           await streamingSession.abort(heldNote).catch(() => {});
         } else if (providerFailoverPending) {
           await streamingSession
-            .abort('模型服务切换中，正在重试')
+            .abort('模型服务暂时异常，正在重试')
             .catch(() => {});
         } else if (hadError || !output || output.status === 'error') {
           await streamingSession.abort('处理出错').catch(() => {});
@@ -15629,7 +15629,19 @@ async function processAgentConversation(
 
     // #549: a provider switch surfaced as a failure clears the agent session so
     // the next turn starts fresh on the newly-selected provider.
-    if (output.providerFailure) {
+    //
+    // Only when a switch can actually happen. A liveness stall judged no account
+    // at all, and a single-provider pool has nothing to switch to — clearing the
+    // session there just destroys the conversation for nothing.
+    if (
+      output.providerFailure &&
+      !output.providerLivenessTimeout &&
+      willClearSessionOnProviderSwitch(
+        effectiveGroup.folder,
+        agentId,
+        agentProfile?.model_config_id,
+      )
+    ) {
       try {
         deleteSession(effectiveGroup.folder, agentId);
         currentAgentSessionId = undefined;
@@ -16963,7 +16975,7 @@ async function processAgentConversation(
           await agentStreamingSession.abort(heldNote).catch(() => {});
         } else if (agentProviderFailoverPending) {
           await agentStreamingSession
-            .abort('模型服务切换中，正在重试')
+            .abort('模型服务暂时异常，正在重试')
             .catch(() => {});
         } else if (hadError) {
           await agentStreamingSession.abort('处理出错').catch(() => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,10 @@ import {
 } from './stuck-runner-recovery.js';
 import { resolveFeishuCliBoundAccountId } from './feishu-cli-runtime.js';
 import { isValidWorkspaceFolderName } from './workspace-folder.js';
-import { PROVIDER_FAILURE_USER_NOTICE } from './provider-failure.js';
+import {
+  PROVIDER_FAILURE_USER_NOTICE,
+  resolveProviderFailureClass,
+} from './provider-failure.js';
 import {
   closeDatabase,
   createTask,
@@ -15630,12 +15633,12 @@ async function processAgentConversation(
     // #549: a provider switch surfaced as a failure clears the agent session so
     // the next turn starts fresh on the newly-selected provider.
     //
-    // Only when a switch can actually happen. A liveness stall judged no account
-    // at all, and a single-provider pool has nothing to switch to — clearing the
-    // session there just destroys the conversation for nothing.
+    // Only when a switch can actually happen. Transient and config failures
+    // judged no account at all, and a single-provider pool has nothing to switch
+    // to — clearing the session there just destroys the conversation for nothing.
     if (
       output.providerFailure &&
-      !output.providerLivenessTimeout &&
+      resolveProviderFailureClass(output) === 'account' &&
       willClearSessionOnProviderSwitch(
         effectiveGroup.folder,
         agentId,

--- a/src/provider-failure.ts
+++ b/src/provider-failure.ts
@@ -8,6 +8,61 @@ export const PROVIDER_FAILURE_USER_NOTICE =
 export const PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE =
   '⚠️ 模型服务本轮长时间没有任何响应，重试后仍未恢复，本次请求未被执行。这通常是上游暂时不可用或网络中断，与账号额度无关。请稍后重新发送。';
 
+/**
+ * A reported upstream error (529/5xx). Same disposition as a stall, but the
+ * upstream did answer, so the wording must not claim it went silent.
+ */
+export const PROVIDER_TRANSIENT_FAILURE_USER_NOTICE =
+  '⚠️ 模型服务上游暂时不可用（过载或服务端错误），重试后仍未恢复，本次请求未被执行。这与账号额度无关。请稍后重新发送。';
+
+/**
+ * A configuration verdict, not a capacity one. Retrying and failing over both
+ * re-send the same unserviceable model name, so the user has to act.
+ */
+export const PROVIDER_MODEL_CONFIG_USER_NOTICE =
+  '⚠️ 当前配置的模型在该服务端不存在或不可用，本次请求未被执行。这不是额度问题，重试或切换账号都无法解决，请在「模型配置」中检查模型名称。';
+
+/** Failure classes as reported by the agent runner. */
+export type ProviderFailureClass = 'account' | 'transient' | 'config';
+
+/** The subset of an output that determines the failure class and its notice. */
+export interface ProviderFailureClassification {
+  readonly providerFailureClass?: ProviderFailureClass;
+  readonly providerLivenessTimeout?: boolean;
+}
+
+/**
+ * Resolve the class a failure must be dispositioned as.
+ *
+ * Defaults to `account` when the field is absent so that an output framed by an
+ * older runner keeps its historical disposition rather than silently gaining
+ * the never-quarantine transient path. `providerLivenessTimeout` is honoured on
+ * its own for the same reason: a batch-1 runner emits the stall flag without a
+ * class, and that stall must still avoid the quarantine.
+ */
+export function resolveProviderFailureClass(
+  output: ProviderFailureClassification,
+): ProviderFailureClass {
+  if (output.providerFailureClass) return output.providerFailureClass;
+  return output.providerLivenessTimeout ? 'transient' : 'account';
+}
+
+/**
+ * The notice for a failure that has become terminal, or undefined when the
+ * caller's own notice (an upstream limit text, or the generic pool notice)
+ * should stand.
+ */
+export function resolveTerminalProviderFailureNotice(
+  output: ProviderFailureClassification,
+): string | undefined {
+  const failureClass = resolveProviderFailureClass(output);
+  if (failureClass === 'config') return PROVIDER_MODEL_CONFIG_USER_NOTICE;
+  if (failureClass !== 'transient') return undefined;
+  return output.providerLivenessTimeout
+    ? PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE
+    : PROVIDER_TRANSIENT_FAILURE_USER_NOTICE;
+}
+
 export interface ProviderFailureHealth {
   profileId: string;
   healthy: boolean;
@@ -42,8 +97,8 @@ export function resolveProviderFailureDisposition(
   };
 }
 
-/** The identity fields a liveness replay budget can be keyed on. */
-export interface LivenessRetryIdentity {
+/** The identity fields a transient replay budget can be keyed on. */
+export interface TransientRetryIdentity {
   readonly inputTurnId?: string;
   readonly ipcReceipts?: ReadonlyArray<{ cursor: { id: string } }>;
 }
@@ -57,31 +112,31 @@ export interface LivenessRetryIdentity {
  * cursor survives replay, so prefer it. Cold turns already use the message id as
  * their ContainerInput.turnId, so they are stable either way.
  */
-export function resolveLivenessRetryKey(
-  output: LivenessRetryIdentity,
+export function resolveTransientRetryKey(
+  output: TransientRetryIdentity,
 ): string | undefined {
   return output.ipcReceipts?.[0]?.cursor?.id || output.inputTurnId;
 }
 
-/** Same-provider replay budget for one liveness stall. */
-export const DEFAULT_MAX_LIVENESS_RETRIES = 1;
-const DEFAULT_MAX_TRACKED_LIVENESS_TURNS = 512;
+/** Same-provider replay budget for one transient provider failure. */
+export const DEFAULT_MAX_TRANSIENT_RETRIES = 1;
+const DEFAULT_MAX_TRACKED_TRANSIENT_TURNS = 512;
 
 /**
- * Bounded same-provider replay budget for liveness stalls, keyed by durable
- * input turn.
+ * Bounded same-provider replay budget for transient provider failures — both
+ * silent stalls and reported upstream errors — keyed by durable input turn.
  *
- * A stall judged no account, so the right answer is to run the same input
- * again rather than retire it. Each retry is a fresh runner, so the ledger must
- * live in the long-lived host process. It is what stops a permanently wedged
- * upstream from replaying one input forever.
+ * A transient failure judged no account, so the right answer is to run the same
+ * input again rather than retire it. Each retry is a fresh runner, so the ledger
+ * must live in the long-lived host process. It is what stops a permanently
+ * wedged upstream from replaying one input forever.
  */
-export class LivenessRetryLedger {
+export class TransientRetryLedger {
   private readonly used = new Map<string, number>();
 
   constructor(
-    private readonly maxRetries: number = DEFAULT_MAX_LIVENESS_RETRIES,
-    private readonly maxTracked: number = DEFAULT_MAX_TRACKED_LIVENESS_TURNS,
+    private readonly maxRetries: number = DEFAULT_MAX_TRANSIENT_RETRIES,
+    private readonly maxTracked: number = DEFAULT_MAX_TRACKED_TRANSIENT_TURNS,
   ) {}
 
   /**

--- a/src/provider-failure.ts
+++ b/src/provider-failure.ts
@@ -22,6 +22,14 @@ export const PROVIDER_TRANSIENT_FAILURE_USER_NOTICE =
 export const PROVIDER_MODEL_CONFIG_USER_NOTICE =
   '⚠️ 当前配置的模型在该服务端不存在或不可用，本次请求未被执行。这不是额度问题，重试或切换账号都无法解决，请在「模型配置」中检查模型名称。';
 
+/**
+ * A transient failure that repeated after its replay was spent. The account has
+ * been quarantined by then, so the wording must not promise that retrying now
+ * will work — it has to point at the account.
+ */
+export const PROVIDER_TRANSIENT_ESCALATED_USER_NOTICE =
+  '⚠️ 模型服务连续两轮完全没有响应，已暂时停用该账号并尝试切换其他可用账号。若只配置了一个账号，请检查该账号的密钥是否失效、额度是否耗尽，或稍后再试。';
+
 /** Failure classes as reported by the agent runner. */
 export type ProviderFailureClass = 'account' | 'transient' | 'config';
 
@@ -29,6 +37,15 @@ export type ProviderFailureClass = 'account' | 'transient' | 'config';
 export interface ProviderFailureClassification {
   readonly providerFailureClass?: ProviderFailureClass;
   readonly providerLivenessTimeout?: boolean;
+  /**
+   * Host-set: this output arrived as `transient` and was rewritten to `account`
+   * after its replay budget was spent.
+   *
+   * Recorded explicitly rather than inferred from `account + livenessTimeout`.
+   * Inferring a disposition from an unrelated flag is exactly how a stall came
+   * to masquerade as a quota verdict in the first place.
+   */
+  readonly providerFailureEscalatedFrom?: 'transient';
 }
 
 /**
@@ -57,6 +74,9 @@ export function resolveTerminalProviderFailureNotice(
 ): string | undefined {
   const failureClass = resolveProviderFailureClass(output);
   if (failureClass === 'config') return PROVIDER_MODEL_CONFIG_USER_NOTICE;
+  if (output.providerFailureEscalatedFrom === 'transient') {
+    return PROVIDER_TRANSIENT_ESCALATED_USER_NOTICE;
+  }
   if (failureClass !== 'transient') return undefined;
   return output.providerLivenessTimeout
     ? PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE

--- a/src/provider-failure.ts
+++ b/src/provider-failure.ts
@@ -1,6 +1,13 @@
 export const PROVIDER_FAILURE_USER_NOTICE =
   '⚠️ 当前模型服务额度已用尽或暂时不可用，本次处理已停止。请稍后重试，或联系管理员切换可用模型。';
 
+/**
+ * A liveness stall is not an account verdict, so it must not reuse the quota
+ * wording. It is only surfaced after the bounded same-provider retry is spent.
+ */
+export const PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE =
+  '⚠️ 模型服务本轮长时间没有任何响应，重试后仍未恢复，本次请求未被执行。这通常是上游暂时不可用或网络中断，与账号额度无关。请稍后重新发送。';
+
 export interface ProviderFailureHealth {
   profileId: string;
   healthy: boolean;
@@ -33,4 +40,75 @@ export function resolveProviderFailureDisposition(
     retryElsewhere,
     terminal: !retryElsewhere,
   };
+}
+
+/** The identity fields a liveness replay budget can be keyed on. */
+export interface LivenessRetryIdentity {
+  readonly inputTurnId?: string;
+  readonly ipcReceipts?: ReadonlyArray<{ cursor: { id: string } }>;
+}
+
+/**
+ * A replay-stable identity for the input turn behind an output.
+ *
+ * `inputTurnId` is the IPC deliveryId for a warm turn, and that is a fresh UUID
+ * on every hand-off — keying the retry budget on it would reset the budget on
+ * each replay and never converge. The durable message id carried by the receipt
+ * cursor survives replay, so prefer it. Cold turns already use the message id as
+ * their ContainerInput.turnId, so they are stable either way.
+ */
+export function resolveLivenessRetryKey(
+  output: LivenessRetryIdentity,
+): string | undefined {
+  return output.ipcReceipts?.[0]?.cursor?.id || output.inputTurnId;
+}
+
+/** Same-provider replay budget for one liveness stall. */
+export const DEFAULT_MAX_LIVENESS_RETRIES = 1;
+const DEFAULT_MAX_TRACKED_LIVENESS_TURNS = 512;
+
+/**
+ * Bounded same-provider replay budget for liveness stalls, keyed by durable
+ * input turn.
+ *
+ * A stall judged no account, so the right answer is to run the same input
+ * again rather than retire it. Each retry is a fresh runner, so the ledger must
+ * live in the long-lived host process. It is what stops a permanently wedged
+ * upstream from replaying one input forever.
+ */
+export class LivenessRetryLedger {
+  private readonly used = new Map<string, number>();
+
+  constructor(
+    private readonly maxRetries: number = DEFAULT_MAX_LIVENESS_RETRIES,
+    private readonly maxTracked: number = DEFAULT_MAX_TRACKED_LIVENESS_TURNS,
+  ) {}
+
+  /**
+   * @returns true when one more same-provider attempt is still allowed.
+   *
+   * Without a durable turn identity there is nothing to bound a replay with, so
+   * this fails closed rather than risk an unbounded loop.
+   */
+  consume(inputTurnId: string | undefined): boolean {
+    if (!inputTurnId) return false;
+    const spent = this.used.get(inputTurnId) ?? 0;
+    if (spent >= this.maxRetries) {
+      this.used.delete(inputTurnId);
+      return false;
+    }
+    // Turns that later succeed never come back to clear their entry, so evict
+    // in insertion order instead of leaking one entry per stall.
+    if (!this.used.has(inputTurnId) && this.used.size >= this.maxTracked) {
+      const oldest = this.used.keys().next().value;
+      if (oldest !== undefined) this.used.delete(oldest);
+    }
+    this.used.set(inputTurnId, spent + 1);
+    return true;
+  }
+
+  /** Test/diagnostic hook: number of turns currently holding a spent retry. */
+  get trackedTurnCount(): number {
+    return this.used.size;
+  }
 }

--- a/src/reply-delivery.ts
+++ b/src/reply-delivery.ts
@@ -78,6 +78,10 @@ export function isGenuineReplyResult(info: ReplyResultInfo): boolean {
   if (info.holdReason) return false;
   if (
     info.sourceKind === 'input_rejection_warning' ||
+    // A model-fallback notice is emitted *before* the retry produces the real
+    // answer. Counting it as a delivered reply would let a later error skip the
+    // retry, leaving the user with the notice and no answer at all.
+    info.sourceKind === 'provider_fallback_notice' ||
     info.sourceKind === 'overflow_partial' ||
     info.sourceKind === 'compact_partial'
   ) {
@@ -119,7 +123,10 @@ export function shouldFinalizeScheduledGroupPrimaryResult(
 export function occupiesPrimaryReplyDeliverySlot(
   sourceKind?: string | null,
 ): boolean {
-  return sourceKind !== 'input_rejection_warning';
+  return (
+    sourceKind !== 'input_rejection_warning' &&
+    sourceKind !== 'provider_fallback_notice'
+  );
 }
 
 export function resolveHeldReplyDbText(input: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,6 +497,12 @@ export type MessageSourceKind =
   | 'sdk_send_message'
   | 'proactive_sdk_fallback'
   | 'input_rejection_warning'
+  /**
+   * Standalone notice that the primary model hit a model-scope wall and the
+   * turn is being answered by the configured fallback model instead. Like
+   * 'input_rejection_warning' it is an out-of-band notice, never the answer.
+   */
+  | 'provider_fallback_notice'
   | 'interrupt_partial'
   | 'overflow_partial'
   | 'compact_partial'

--- a/tests/e2e/provider-failure-upstream.mjs
+++ b/tests/e2e/provider-failure-upstream.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+// E2E: what the agent runner actually decides for each upstream failure mode.
+//
+// Why this exists
+// ---------------
+// The provider failure classification is a claim about upstream behaviour:
+// that an overloaded/server error arrives as an SDK assistant error, that a
+// bad model name is distinguishable from a quota wall, and so on. Unit tests
+// can only check the classifier against inputs we invented. This harness
+// checks the inputs themselves, by standing up a fake Anthropic-compatible
+// endpoint and running the real runner against it.
+//
+// It is what showed that a 401 and a 429 are retried silently by the Claude
+// CLI until the liveness watchdog fires, so both reach the host looking exactly
+// like a stall — which is why a repeated transient failure has to escalate to
+// an account verdict instead of being trusted indefinitely.
+//
+// Not part of `npm test`: it needs the built runner and the stall scenarios
+// each burn the full 60s liveness deadline.
+//
+// Usage:
+//   npm run build            # or: npm --prefix container/agent-runner run build
+//   node tests/e2e/provider-failure-upstream.mjs            # every scenario
+//   node tests/e2e/provider-failure-upstream.mjs fast       # skip the 60s ones
+//   node tests/e2e/provider-failure-upstream.mjs http:404 hang
+//
+// Exit code is non-zero if any scenario deviates from its expectation.
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const RUNNER = path.join(
+  REPO_ROOT,
+  'container',
+  'agent-runner',
+  'dist',
+  'index.js',
+);
+const START = '---HAPPYCLAW_OUTPUT_START---';
+const END = '---HAPPYCLAW_OUTPUT_END---';
+const MODEL = 'stub-model';
+
+// Measured on Claude Code 2.1.238. `expect` is the providerFailureClass the
+// runner must report; null means the turn has to succeed normally.
+const SCENARIOS = [
+  { mode: 'ok', expect: null, slow: false, note: 'healthy turn' },
+  {
+    mode: 'http:404',
+    expect: 'config',
+    slow: false,
+    note: 'unservable model name',
+  },
+  {
+    mode: 'hang',
+    expect: 'transient',
+    slow: true,
+    note: 'upstream never responds',
+  },
+  { mode: 'http:529', expect: 'transient', slow: true, note: 'overloaded' },
+  { mode: 'http:500', expect: 'transient', slow: true, note: 'server error' },
+  // 401/429 are NOT account-classified here: the CLI retries them silently, so
+  // the runner only ever sees the watchdog. The host is what escalates a
+  // repeated transient failure into the account verdict these deserve.
+  {
+    mode: 'http:401',
+    expect: 'transient',
+    slow: true,
+    note: 'auth failure, retried by the CLI',
+  },
+  {
+    mode: 'http:429',
+    expect: 'transient',
+    slow: true,
+    note: 'rate limit, retried by the CLI',
+  },
+];
+
+// ── fake upstream ──────────────────────────────────────────────────────────
+
+function startStub() {
+  let mode = 'ok';
+  const okEvents = (text) => [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_stub',
+        type: 'message',
+        role: 'assistant',
+        model: MODEL,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 1 },
+    },
+    { type: 'message_stop' },
+  ];
+
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      if (req.url === '/__mode' && req.method === 'POST') {
+        try {
+          mode = JSON.parse(body).mode;
+        } catch {
+          /* keep previous */
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ mode }));
+      }
+      // Token counting is CLI housekeeping, not the turn under test — always
+      // answer it, or `hang` would stall on the wrong request.
+      if (
+        req.url.includes('/count_tokens') ||
+        !req.url.includes('/v1/messages')
+      ) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ input_tokens: 100 }));
+      }
+      if (mode === 'hang') return; // never respond
+      if (mode.startsWith('http:')) {
+        const status = Number(mode.split(':')[1] || 500);
+        const type =
+          status === 529
+            ? 'overloaded_error'
+            : status === 429
+              ? 'rate_limit_error'
+              : status === 404
+                ? 'not_found_error'
+                : status === 401
+                  ? 'authentication_error'
+                  : 'api_error';
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        return res.end(
+          JSON.stringify({
+            type: 'error',
+            error: { type, message: `stub ${status}` },
+          }),
+        );
+      }
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+      for (const e of okEvents('STUB_OK'))
+        res.write(`event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`);
+      res.end();
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () =>
+      resolve({
+        server,
+        port: server.address().port,
+        setMode: (m) => (mode = m),
+      }),
+    );
+  });
+}
+
+// ── runner driver ──────────────────────────────────────────────────────────
+
+function parseFrames(buf) {
+  const out = [];
+  for (let i = 0; ; ) {
+    const s = buf.indexOf(START, i);
+    if (s === -1) break;
+    const e = buf.indexOf(END, s);
+    if (e === -1) break;
+    try {
+      out.push(JSON.parse(buf.slice(s + START.length, e).trim()));
+    } catch {
+      /* ignore an unparsable frame; the assertions below only read known ones */
+    }
+    i = e + END.length;
+  }
+  return out;
+}
+
+async function runScenario({ mode, port, timeoutMs, tmp }) {
+  const ipcDir = path.join(tmp, 'ipc');
+  const workDir = path.join(tmp, 'workspace');
+  fs.mkdirSync(ipcDir, { recursive: true });
+  fs.mkdirSync(workDir, { recursive: true });
+
+  // Inherit the environment the real runner gets (the Claude CLI needs more
+  // than PATH/HOME), but strip every real provider credential first so this
+  // harness can only ever reach the stub.
+  const env = { ...process.env };
+  for (const k of Object.keys(env)) {
+    if (/^(ANTHROPIC_|CLAUDE_|AWS_|GOOGLE_|VERTEX_)/.test(k)) delete env[k];
+  }
+  env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${port}`;
+  env.ANTHROPIC_API_KEY = 'stub-key-not-a-real-credential';
+  env.ANTHROPIC_MODEL = MODEL;
+  env.HAPPYCLAW_WORKSPACE_IPC = ipcDir;
+  env.HAPPYCLAW_AGENT_RUNNER_MODE = 'development';
+
+  const child = spawn(process.execPath, [RUNNER], {
+    cwd: workDir,
+    env,
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+  let stdout = '';
+  child.stdout.on('data', (d) => (stdout += d));
+  child.stdin.end(
+    JSON.stringify({
+      prompt: 'reply with exactly: STUB_PROBE',
+      groupFolder: 'hc-stub',
+      chatJid: 'web:hc-stub',
+      isMain: false,
+      isHome: false,
+      isAdminHome: false,
+      turnId: `stub-${mode.replace(/[^a-z0-9]/gi, '-')}`,
+    }),
+  );
+
+  const startedAt = Date.now();
+  // A healthy runner parks waiting for the next IPC message, so the success
+  // case is expected to be killed here rather than to exit on its own.
+  const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
+  await new Promise((r) => child.on('exit', r));
+  clearTimeout(timer);
+
+  const frames = parseFrames(stdout);
+  const failure = frames.find((f) => f.providerFailure);
+  const answered = frames.find(
+    (f) => f.sourceKind === 'sdk_final' && typeof f.result === 'string',
+  );
+  return {
+    elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+    actual: failure ? (failure.providerFailureClass ?? '(unclassified)') : null,
+    livenessTimeout: failure?.providerLivenessTimeout === true,
+    answer: answered?.result?.slice(0, 40),
+  };
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+const argv = process.argv.slice(2);
+const selected = argv.includes('fast')
+  ? SCENARIOS.filter((s) => !s.slow)
+  : argv.length
+    ? SCENARIOS.filter((s) => argv.includes(s.mode))
+    : SCENARIOS;
+
+if (!fs.existsSync(RUNNER)) {
+  console.error(
+    `agent-runner is not built: ${RUNNER}\nRun: npm --prefix container/agent-runner run build`,
+  );
+  process.exit(1);
+}
+if (!selected.length) {
+  console.error(
+    `No scenario matched. Known: ${SCENARIOS.map((s) => s.mode).join(', ')}`,
+  );
+  process.exit(1);
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hc-provider-e2e-'));
+const stub = await startStub();
+console.log(`stub upstream on 127.0.0.1:${stub.port}, scratch dir ${tmp}\n`);
+
+let failed = 0;
+for (const scenario of selected) {
+  stub.setMode(scenario.mode);
+  const timeoutMs = scenario.slow ? 95_000 : 40_000;
+  const r = await runScenario({
+    mode: scenario.mode,
+    port: stub.port,
+    timeoutMs,
+    tmp,
+  });
+  const ok = r.actual === scenario.expect;
+  if (!ok) failed += 1;
+  const detail =
+    scenario.expect === null
+      ? `answer=${JSON.stringify(r.answer)}`
+      : `class=${r.actual}${r.livenessTimeout ? ' +livenessTimeout' : ''}`;
+  console.log(
+    `${ok ? 'PASS' : 'FAIL'}  ${scenario.mode.padEnd(12)} ${String(r.elapsedSec).padStart(3)}s  ` +
+      `expect=${scenario.expect ?? 'no failure'}  ${detail}  (${scenario.note})`,
+  );
+}
+
+stub.server.close();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log(
+  `\n${selected.length - failed}/${selected.length} scenarios matched expectation`,
+);
+process.exit(failed ? 1 : 0);

--- a/tests/provider-failure-class.test.ts
+++ b/tests/provider-failure-class.test.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'vitest';
+
+import {
+  PROVIDER_FAILURE_USER_NOTICE,
+  PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
+  PROVIDER_MODEL_CONFIG_USER_NOTICE,
+  PROVIDER_TRANSIENT_FAILURE_USER_NOTICE,
+  resolveProviderFailureClass,
+  resolveTerminalProviderFailureNotice,
+} from '../src/provider-failure.js';
+
+const hostRunner = readFileSync('src/container-runner.ts', 'utf8');
+const hostIndex = readFileSync('src/index.ts', 'utf8');
+const agentRunner = readFileSync('container/agent-runner/src/index.ts', 'utf8');
+
+describe('provider failure class resolution', () => {
+  test('honours the class the runner reported', () => {
+    expect(
+      resolveProviderFailureClass({ providerFailureClass: 'transient' }),
+    ).toBe('transient');
+    expect(
+      resolveProviderFailureClass({ providerFailureClass: 'config' }),
+    ).toBe('config');
+    expect(
+      resolveProviderFailureClass({ providerFailureClass: 'account' }),
+    ).toBe('account');
+  });
+
+  test('an unclassified failure keeps the historical account disposition', () => {
+    // A runner built before the classification still frames outputs without the
+    // field. Defaulting to `transient` there would silently stop quarantining a
+    // genuinely dead account, so the safe default is the old behaviour.
+    expect(resolveProviderFailureClass({})).toBe('account');
+  });
+
+  test('a batch-1 stall flag alone still avoids the account verdict', () => {
+    // The liveness flag shipped one commit before the class did. An output
+    // carrying only the flag must keep the never-quarantine disposition rather
+    // than regress to the quota verdict the flag was introduced to remove.
+    expect(resolveProviderFailureClass({ providerLivenessTimeout: true })).toBe(
+      'transient',
+    );
+  });
+});
+
+describe('terminal provider failure notices', () => {
+  test('each class names its own cause and none reuses the quota wording', () => {
+    const notices = [
+      PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
+      PROVIDER_TRANSIENT_FAILURE_USER_NOTICE,
+      PROVIDER_MODEL_CONFIG_USER_NOTICE,
+    ];
+    expect(new Set(notices).size).toBe(notices.length);
+    for (const notice of notices) {
+      expect(notice).not.toBe(PROVIDER_FAILURE_USER_NOTICE);
+      expect(notice).not.toContain('额度已用尽');
+    }
+    // A config failure is the one case the user must act on, so it has to say
+    // what to fix instead of suggesting a retry.
+    expect(PROVIDER_MODEL_CONFIG_USER_NOTICE).toContain('模型配置');
+    expect(PROVIDER_MODEL_CONFIG_USER_NOTICE).not.toContain('请稍后重新发送');
+  });
+
+  test('a silent stall and a reported upstream error are worded apart', () => {
+    expect(
+      resolveTerminalProviderFailureNotice({
+        providerFailureClass: 'transient',
+        providerLivenessTimeout: true,
+      }),
+    ).toBe(PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE);
+    expect(
+      resolveTerminalProviderFailureNotice({
+        providerFailureClass: 'transient',
+      }),
+    ).toBe(PROVIDER_TRANSIENT_FAILURE_USER_NOTICE);
+  });
+
+  test('a config failure gets the configuration notice', () => {
+    expect(
+      resolveTerminalProviderFailureNotice({ providerFailureClass: 'config' }),
+    ).toBe(PROVIDER_MODEL_CONFIG_USER_NOTICE);
+  });
+
+  test('an account failure keeps whatever notice the caller already resolved', () => {
+    // Account walls carry the upstream limit text or the generic pool notice;
+    // overwriting them here would discard the reset time the user needs.
+    expect(
+      resolveTerminalProviderFailureNotice({ providerFailureClass: 'account' }),
+    ).toBeUndefined();
+    expect(resolveTerminalProviderFailureNotice({})).toBeUndefined();
+  });
+});
+
+describe('host disposition is keyed on the class, not on individual flags', () => {
+  test('only an account verdict may change account health', () => {
+    expect(hostRunner).toContain(
+      "if (resolveProviderFailureClass(output) !== 'account') return;",
+    );
+    // The pre-classification guard checked one concrete flag, so every later
+    // non-account failure would have slipped past it into the quarantine.
+    expect(hostRunner).not.toContain(
+      'if (output.providerLivenessTimeout) return;',
+    );
+  });
+
+  test('transient failures are replayed and never consult the pool', () => {
+    expect(hostRunner).toMatch(
+      /if \(failureClass === 'transient'\) \{[\s\S]*?transientRetries\.consume\(resolveTransientRetryKey\(output\)\)/,
+    );
+    // Ordering matters: refreshFromConfig/poolCanStillServe must stay below the
+    // transient branch, or a 529 would still be answered by a failover.
+    const transientBranch = hostRunner.indexOf(
+      "if (failureClass === 'transient')",
+    );
+    const poolRefresh = hostRunner.indexOf('providerPool.refreshFromConfig(');
+    expect(transientBranch).toBeGreaterThan(-1);
+    expect(poolRefresh).toBeGreaterThan(transientBranch);
+  });
+
+  test('config failures end immediately without a quarantine or a retry', () => {
+    expect(hostRunner).toMatch(
+      /if \(failureClass === 'config'\) \{[\s\S]*?applyKnownProviderFailureDisposition\(output, true\);[\s\S]*?return true;/,
+    );
+  });
+
+  test('a session is cleared only for a real account switch', () => {
+    expect(hostIndex).toContain(
+      "resolveProviderFailureClass(output) === 'account' &&",
+    );
+    expect(hostIndex).not.toContain('!output.providerLivenessTimeout &&');
+  });
+});
+
+describe('model fallback is visible to the user', () => {
+  test('every activation path announces the downgrade before retrying', () => {
+    const activations = agentRunner.match(
+      /PROVIDER_FALLBACK_MODELS\.activateForScope\(/g,
+    );
+    expect(activations?.length).toBe(2);
+    // A silent downgrade is indistinguishable from a primary-model reply, so
+    // both retry paths must announce it — not just the structured one.
+    expect(agentRunner.match(/emitModelFallbackNotice\(\);/g)?.length).toBe(2);
+    expect(agentRunner).toContain("sourceKind: 'provider_fallback_notice'");
+  });
+
+  test('the notice names both models so the user can act on it', () => {
+    expect(agentRunner).toContain('PROVIDER_FALLBACK_MODELS.primaryModel');
+    expect(agentRunner).toMatch(
+      /emitModelFallbackNotice[\s\S]{0,900}PROVIDER_FALLBACK_MODELS\.fallbackModel/,
+    );
+  });
+
+  test('the notice is emitted before the retry marker, not after the answer', () => {
+    // The notice has to precede providerFailureRetrying: emitting it later
+    // would put it after the fallback answer the user is reading.
+    for (const marker of agentRunner.matchAll(
+      /emitModelFallbackNotice\(\);/g,
+    )) {
+      const after = agentRunner.slice(
+        marker.index ?? 0,
+        (marker.index ?? 0) + 400,
+      );
+      expect(after).toContain('providerFailureRetrying: true');
+    }
+  });
+});

--- a/tests/provider-failure-class.test.ts
+++ b/tests/provider-failure-class.test.ts
@@ -146,20 +146,30 @@ describe('host disposition is keyed on the class, not on individual flags', () =
   });
 
   test('a repeated transient failure escalates to an account verdict', () => {
-    // The escalation must rewrite the class BEFORE quarantining, or
-    // quarantineFromOutput's own `!== 'account'` guard would skip the very
-    // quarantine the escalation exists to perform.
-    expect(hostRunner).toMatch(
-      /output\.providerFailureClass = 'account';\s*output\.providerFailureEscalatedFrom = 'transient';\s*if \(selectedProfileId !== null\) \{\s*quarantineFromOutput\(selectedProfileId, output\);/,
+    // Ordering, asserted by position rather than adjacency so that inserting a
+    // log line between the steps does not read as a regression:
+    //
+    //   class rewrite  ->  quarantine  ->  pool disposition
+    //
+    // The rewrite must come first or quarantineFromOutput's own `!== 'account'`
+    // guard skips the very quarantine the escalation exists to perform, and the
+    // pool step must come last or a multi-account install never fails over.
+    // The behavioural proof lives in provider-transient-escalation.test.ts;
+    // this only pins the order the two functions have to be called in.
+    const rewrite = hostRunner.indexOf(
+      "output.providerFailureClass = 'account';",
     );
-    // And it must fall through to the pool logic rather than returning early,
-    // so a multi-account install still fails over on the escalated verdict.
     const escalation = hostRunner.indexOf(
       "output.providerFailureEscalatedFrom = 'transient';",
     );
+    const quarantine = hostRunner.indexOf(
+      'quarantineFromOutput(selectedProfileId, output);',
+    );
     const poolRefresh = hostRunner.indexOf('providerPool.refreshFromConfig(');
-    expect(escalation).toBeGreaterThan(-1);
-    expect(poolRefresh).toBeGreaterThan(escalation);
+    expect(rewrite).toBeGreaterThan(-1);
+    expect(escalation).toBeGreaterThan(rewrite);
+    expect(quarantine).toBeGreaterThan(escalation);
+    expect(poolRefresh).toBeGreaterThan(quarantine);
   });
 
   test('the first transient failure still replays without touching the account', () => {

--- a/tests/provider-failure-class.test.ts
+++ b/tests/provider-failure-class.test.ts
@@ -5,6 +5,7 @@ import {
   PROVIDER_FAILURE_USER_NOTICE,
   PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
   PROVIDER_MODEL_CONFIG_USER_NOTICE,
+  PROVIDER_TRANSIENT_ESCALATED_USER_NOTICE,
   PROVIDER_TRANSIENT_FAILURE_USER_NOTICE,
   resolveProviderFailureClass,
   resolveTerminalProviderFailureNotice,
@@ -82,6 +83,32 @@ describe('terminal provider failure notices', () => {
     ).toBe(PROVIDER_MODEL_CONFIG_USER_NOTICE);
   });
 
+  test('an escalated transient failure says the account was taken out, not that quota ran out', () => {
+    const notice = resolveTerminalProviderFailureNotice({
+      providerFailureClass: 'account',
+      providerFailureEscalatedFrom: 'transient',
+      providerLivenessTimeout: true,
+    });
+    expect(notice).toBe(PROVIDER_TRANSIENT_ESCALATED_USER_NOTICE);
+    // By this point the account is quarantined, so telling the user to just
+    // resend would be a lie — the next message would fail the same way.
+    expect(notice).toContain('已暂时停用该账号');
+    expect(notice).not.toBe(PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE);
+    expect(notice).not.toBe(PROVIDER_FAILURE_USER_NOTICE);
+  });
+
+  test('escalation is recorded explicitly, never inferred from the stall flag', () => {
+    // `account` + `livenessTimeout` happens to be the escalation signature, but
+    // reading a disposition off an unrelated flag is the original defect. A
+    // stall flag with no escalation marker must not select the escalated notice.
+    expect(
+      resolveTerminalProviderFailureNotice({
+        providerFailureClass: 'account',
+        providerLivenessTimeout: true,
+      }),
+    ).toBeUndefined();
+  });
+
   test('an account failure keeps whatever notice the caller already resolved', () => {
     // Account walls carry the upstream limit text or the generic pool notice;
     // overwriting them here would discard the reset time the user needs.
@@ -116,6 +143,29 @@ describe('host disposition is keyed on the class, not on individual flags', () =
     const poolRefresh = hostRunner.indexOf('providerPool.refreshFromConfig(');
     expect(transientBranch).toBeGreaterThan(-1);
     expect(poolRefresh).toBeGreaterThan(transientBranch);
+  });
+
+  test('a repeated transient failure escalates to an account verdict', () => {
+    // The escalation must rewrite the class BEFORE quarantining, or
+    // quarantineFromOutput's own `!== 'account'` guard would skip the very
+    // quarantine the escalation exists to perform.
+    expect(hostRunner).toMatch(
+      /output\.providerFailureClass = 'account';\s*output\.providerFailureEscalatedFrom = 'transient';\s*if \(selectedProfileId !== null\) \{\s*quarantineFromOutput\(selectedProfileId, output\);/,
+    );
+    // And it must fall through to the pool logic rather than returning early,
+    // so a multi-account install still fails over on the escalated verdict.
+    const escalation = hostRunner.indexOf(
+      "output.providerFailureEscalatedFrom = 'transient';",
+    );
+    const poolRefresh = hostRunner.indexOf('providerPool.refreshFromConfig(');
+    expect(escalation).toBeGreaterThan(-1);
+    expect(poolRefresh).toBeGreaterThan(escalation);
+  });
+
+  test('the first transient failure still replays without touching the account', () => {
+    expect(hostRunner).toMatch(
+      /if \(transientRetries\.consume\(resolveTransientRetryKey\(output\)\)\) \{\s*applyKnownProviderFailureDisposition\(output, false\);\s*return false;\s*\}/,
+    );
   });
 
   test('config failures end immediately without a quarantine or a retry', () => {

--- a/tests/provider-liveness-timeout.test.ts
+++ b/tests/provider-liveness-timeout.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  DEFAULT_MAX_LIVENESS_RETRIES,
+  LivenessRetryLedger,
+  PROVIDER_FAILURE_USER_NOTICE,
+  PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
+  resolveLivenessRetryKey,
+} from '../src/provider-failure.js';
+
+describe('liveness retry ledger', () => {
+  test('grants exactly one same-provider replay per input turn', () => {
+    const ledger = new LivenessRetryLedger();
+    expect(DEFAULT_MAX_LIVENESS_RETRIES).toBe(1);
+    expect(ledger.consume('turn-a')).toBe(true);
+    expect(ledger.consume('turn-a')).toBe(false);
+  });
+
+  test('budgets are independent per input turn', () => {
+    const ledger = new LivenessRetryLedger();
+    expect(ledger.consume('turn-a')).toBe(true);
+    expect(ledger.consume('turn-b')).toBe(true);
+    expect(ledger.consume('turn-a')).toBe(false);
+    expect(ledger.consume('turn-b')).toBe(false);
+  });
+
+  test('a spent turn stops occupying the ledger', () => {
+    const ledger = new LivenessRetryLedger();
+    ledger.consume('turn-a');
+    expect(ledger.trackedTurnCount).toBe(1);
+    ledger.consume('turn-a');
+    expect(ledger.trackedTurnCount).toBe(0);
+  });
+
+  test('fails closed without a durable turn identity', () => {
+    const ledger = new LivenessRetryLedger();
+    expect(ledger.consume(undefined)).toBe(false);
+    expect(ledger.consume('')).toBe(false);
+    expect(ledger.trackedTurnCount).toBe(0);
+  });
+
+  test('honours a larger retry budget', () => {
+    const ledger = new LivenessRetryLedger(3);
+    expect(ledger.consume('turn-a')).toBe(true);
+    expect(ledger.consume('turn-a')).toBe(true);
+    expect(ledger.consume('turn-a')).toBe(true);
+    expect(ledger.consume('turn-a')).toBe(false);
+  });
+
+  test('evicts in insertion order instead of growing without bound', () => {
+    const ledger = new LivenessRetryLedger(1, 2);
+    ledger.consume('turn-a');
+    ledger.consume('turn-b');
+    expect(ledger.trackedTurnCount).toBe(2);
+
+    // Turns that later succeed never clear their entry, so a third distinct
+    // stall must evict the oldest rather than push the ledger past its cap.
+    ledger.consume('turn-c');
+    expect(ledger.trackedTurnCount).toBe(2);
+
+    // 'turn-a' was evicted, so it reads as a fresh turn with a full budget.
+    expect(ledger.consume('turn-a')).toBe(true);
+    // 'turn-c' is still tracked and stays spent.
+    expect(ledger.consume('turn-c')).toBe(false);
+  });
+});
+
+describe('liveness retry key', () => {
+  test('prefers the durable message id over the per-hand-off deliveryId', () => {
+    expect(
+      resolveLivenessRetryKey({
+        inputTurnId: 'delivery-uuid-1',
+        ipcReceipts: [{ cursor: { id: 'msg-1' } }],
+      }),
+    ).toBe('msg-1');
+  });
+
+  test('a replayed turn keeps its budget even as the deliveryId rotates', () => {
+    const ledger = new LivenessRetryLedger();
+    // Warm turn: deliveryId is a fresh UUID per IPC hand-off.
+    const warm = {
+      inputTurnId: 'delivery-uuid-1',
+      ipcReceipts: [{ cursor: { id: 'msg-1' } }],
+    };
+    // The replay spawns a cold runner, whose ContainerInput.turnId is the
+    // durable message id. Both must resolve to the same budget.
+    const cold = { inputTurnId: 'msg-1' };
+
+    expect(ledger.consume(resolveLivenessRetryKey(warm))).toBe(true);
+    expect(ledger.consume(resolveLivenessRetryKey(cold))).toBe(false);
+  });
+
+  test('falls back to inputTurnId for a cold, non-IPC turn', () => {
+    expect(resolveLivenessRetryKey({ inputTurnId: 'msg-2' })).toBe('msg-2');
+    expect(resolveLivenessRetryKey({})).toBeUndefined();
+    expect(resolveLivenessRetryKey({ ipcReceipts: [] })).toBeUndefined();
+  });
+});
+
+describe('liveness timeout user notice', () => {
+  test('never reuses the quota wording', () => {
+    expect(PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE).not.toBe(
+      PROVIDER_FAILURE_USER_NOTICE,
+    );
+    expect(PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE).not.toContain('额度已用尽');
+    expect(PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE).toContain('与账号额度无关');
+  });
+});

--- a/tests/provider-liveness-timeout.test.ts
+++ b/tests/provider-liveness-timeout.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, test } from 'vitest';
 
 import {
-  DEFAULT_MAX_LIVENESS_RETRIES,
-  LivenessRetryLedger,
+  DEFAULT_MAX_TRANSIENT_RETRIES,
+  TransientRetryLedger,
   PROVIDER_FAILURE_USER_NOTICE,
   PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
-  resolveLivenessRetryKey,
+  resolveTransientRetryKey,
 } from '../src/provider-failure.js';
 
 describe('liveness retry ledger', () => {
   test('grants exactly one same-provider replay per input turn', () => {
-    const ledger = new LivenessRetryLedger();
-    expect(DEFAULT_MAX_LIVENESS_RETRIES).toBe(1);
+    const ledger = new TransientRetryLedger();
+    expect(DEFAULT_MAX_TRANSIENT_RETRIES).toBe(1);
     expect(ledger.consume('turn-a')).toBe(true);
     expect(ledger.consume('turn-a')).toBe(false);
   });
 
   test('budgets are independent per input turn', () => {
-    const ledger = new LivenessRetryLedger();
+    const ledger = new TransientRetryLedger();
     expect(ledger.consume('turn-a')).toBe(true);
     expect(ledger.consume('turn-b')).toBe(true);
     expect(ledger.consume('turn-a')).toBe(false);
@@ -25,7 +25,7 @@ describe('liveness retry ledger', () => {
   });
 
   test('a spent turn stops occupying the ledger', () => {
-    const ledger = new LivenessRetryLedger();
+    const ledger = new TransientRetryLedger();
     ledger.consume('turn-a');
     expect(ledger.trackedTurnCount).toBe(1);
     ledger.consume('turn-a');
@@ -33,14 +33,14 @@ describe('liveness retry ledger', () => {
   });
 
   test('fails closed without a durable turn identity', () => {
-    const ledger = new LivenessRetryLedger();
+    const ledger = new TransientRetryLedger();
     expect(ledger.consume(undefined)).toBe(false);
     expect(ledger.consume('')).toBe(false);
     expect(ledger.trackedTurnCount).toBe(0);
   });
 
   test('honours a larger retry budget', () => {
-    const ledger = new LivenessRetryLedger(3);
+    const ledger = new TransientRetryLedger(3);
     expect(ledger.consume('turn-a')).toBe(true);
     expect(ledger.consume('turn-a')).toBe(true);
     expect(ledger.consume('turn-a')).toBe(true);
@@ -48,7 +48,7 @@ describe('liveness retry ledger', () => {
   });
 
   test('evicts in insertion order instead of growing without bound', () => {
-    const ledger = new LivenessRetryLedger(1, 2);
+    const ledger = new TransientRetryLedger(1, 2);
     ledger.consume('turn-a');
     ledger.consume('turn-b');
     expect(ledger.trackedTurnCount).toBe(2);
@@ -68,7 +68,7 @@ describe('liveness retry ledger', () => {
 describe('liveness retry key', () => {
   test('prefers the durable message id over the per-hand-off deliveryId', () => {
     expect(
-      resolveLivenessRetryKey({
+      resolveTransientRetryKey({
         inputTurnId: 'delivery-uuid-1',
         ipcReceipts: [{ cursor: { id: 'msg-1' } }],
       }),
@@ -76,7 +76,7 @@ describe('liveness retry key', () => {
   });
 
   test('a replayed turn keeps its budget even as the deliveryId rotates', () => {
-    const ledger = new LivenessRetryLedger();
+    const ledger = new TransientRetryLedger();
     // Warm turn: deliveryId is a fresh UUID per IPC hand-off.
     const warm = {
       inputTurnId: 'delivery-uuid-1',
@@ -86,14 +86,14 @@ describe('liveness retry key', () => {
     // durable message id. Both must resolve to the same budget.
     const cold = { inputTurnId: 'msg-1' };
 
-    expect(ledger.consume(resolveLivenessRetryKey(warm))).toBe(true);
-    expect(ledger.consume(resolveLivenessRetryKey(cold))).toBe(false);
+    expect(ledger.consume(resolveTransientRetryKey(warm))).toBe(true);
+    expect(ledger.consume(resolveTransientRetryKey(cold))).toBe(false);
   });
 
   test('falls back to inputTurnId for a cold, non-IPC turn', () => {
-    expect(resolveLivenessRetryKey({ inputTurnId: 'msg-2' })).toBe('msg-2');
-    expect(resolveLivenessRetryKey({})).toBeUndefined();
-    expect(resolveLivenessRetryKey({ ipcReceipts: [] })).toBeUndefined();
+    expect(resolveTransientRetryKey({ inputTurnId: 'msg-2' })).toBe('msg-2');
+    expect(resolveTransientRetryKey({})).toBeUndefined();
+    expect(resolveTransientRetryKey({ ipcReceipts: [] })).toBeUndefined();
   });
 });
 

--- a/tests/provider-model-fallback-contract.test.ts
+++ b/tests/provider-model-fallback-contract.test.ts
@@ -64,7 +64,7 @@ describe('provider fallback source contracts', () => {
       'Model tiers exhausted on this account; quarantining profile for failover',
     );
     expect(agentRunner).toMatch(
-      /publishProviderAccountFailure\(\s*'rate_limit',\s*info\.resetsAt,\s*MODEL_LIMIT_EXHAUSTED_NOTICE,/,
+      /publishProviderFailure\(\{\s*error: 'rate_limit',\s*failureClass: 'account',\s*rateLimitResetsAt: info\.resetsAt,\s*failureNotice: MODEL_LIMIT_EXHAUSTED_NOTICE,/,
     );
     expect(agentRunner).not.toContain('pendingRejectedRateLimit');
   });
@@ -83,10 +83,13 @@ describe('provider fallback source contracts', () => {
 
   test('a synthetic assistant provider error cannot park the SDK stream', () => {
     expect(agentRunner).toContain(
-      'isAccountProviderAssistantError(assistantError)',
+      'classifyProviderAssistantError(assistantError)',
     );
-    expect(agentRunner).toContain(
-      'publishProviderAccountFailure(assistantError)',
+    // The published class must come from the classifier, never a hard-coded
+    // label: borrowing 'server_error' is exactly how the liveness watchdog
+    // inherited the account-verdict disposition it had no business having.
+    expect(agentRunner).toMatch(
+      /publishProviderFailure\(\{\s*error: assistantError,\s*failureClass: assistantErrorClass,\s*\}\)/,
     );
     expect(agentRunner).toContain(
       'const ipcReceipts = ipcDeliveryTracker.completeNextTurn()',
@@ -123,8 +126,8 @@ describe('provider fallback source contracts', () => {
     expect(hostRunner).toMatch(
       /hasCandidateForTier\(primaryTier\)[\s\S]*?hasCandidateForTier\(fallbackModel\)/,
     );
-    expect(agentRunner).toContain(
-      "publishProviderAccountFailure('rate_limit', info.resetsAt)",
+    expect(agentRunner).toMatch(
+      /publishProviderFailure\(\{\s*error: 'rate_limit',\s*failureClass: 'account',\s*rateLimitResetsAt: info\.resetsAt,\s*\}\)/,
     );
     expect(hostRunner).toMatch(
       /providerPool\.refreshFromConfig\([\s\S]*?providerPool\.refreshRecoveryState\(\)/,

--- a/tests/provider-model-fallback.test.ts
+++ b/tests/provider-model-fallback.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  classifyProviderAssistantError,
   classifyProviderLimitNotice,
   classifyProviderRateLimitType,
   decideProviderLimitAction,
-  isAccountProviderAssistantError,
   isProviderLimitNotice,
   ProviderFallbackModelState,
   ProviderFallbackTurnLedger,
@@ -143,14 +143,49 @@ describe('provider model fallback lifecycle', () => {
   });
 
   test('fails fast on synthetic assistant provider errors without a Result', () => {
-    expect(isAccountProviderAssistantError('rate_limit')).toBe(true);
-    expect(isAccountProviderAssistantError('billing_error')).toBe(true);
-    expect(isAccountProviderAssistantError('authentication_failed')).toBe(true);
-    expect(isAccountProviderAssistantError('overloaded')).toBe(true);
-    expect(isAccountProviderAssistantError('server_error')).toBe(true);
-    expect(isAccountProviderAssistantError('invalid_request')).toBe(false);
-    expect(isAccountProviderAssistantError('max_output_tokens')).toBe(false);
-    expect(isAccountProviderAssistantError(undefined)).toBe(false);
+    // Every recognized error still terminates the attempt; only the class,
+    // and therefore the disposition, differs.
+    for (const error of [
+      'rate_limit',
+      'billing_error',
+      'authentication_failed',
+      'oauth_org_not_allowed',
+      'overloaded',
+      'server_error',
+      'model_not_found',
+    ] as const) {
+      expect(classifyProviderAssistantError(error)).toBeDefined();
+    }
+    expect(classifyProviderAssistantError('invalid_request')).toBeUndefined();
+    expect(classifyProviderAssistantError('max_output_tokens')).toBeUndefined();
+    expect(classifyProviderAssistantError(undefined)).toBeUndefined();
+  });
+
+  test('only a verdict on the profile is classified as an account failure', () => {
+    expect(classifyProviderAssistantError('authentication_failed')).toBe(
+      'account',
+    );
+    expect(classifyProviderAssistantError('oauth_org_not_allowed')).toBe(
+      'account',
+    );
+    expect(classifyProviderAssistantError('billing_error')).toBe('account');
+    // A bare rate_limit carries no rateLimitType, so it fails safe as
+    // account-wide — matching classifyProviderRateLimitType's unknown default.
+    expect(classifyProviderAssistantError('rate_limit')).toBe('account');
+  });
+
+  test('upstream noise never becomes an account verdict', () => {
+    // A 529 from the edge and a 5xx from the server say nothing about this
+    // account's quota. Classifying them as `account` is what quarantined the
+    // only profile of a single-account install and retired the user's input.
+    expect(classifyProviderAssistantError('overloaded')).toBe('transient');
+    expect(classifyProviderAssistantError('server_error')).toBe('transient');
+  });
+
+  test('an unservable model name is a config failure, not a quota one', () => {
+    // Every account would be asked for the same model, so quarantining on this
+    // would drain the whole pool over one bad model name.
+    expect(classifyProviderAssistantError('model_not_found')).toBe('config');
   });
 
   test('structured rejection wins over text and preserves model-only errors without fallback', () => {

--- a/tests/provider-scheduled-fallback.test.ts
+++ b/tests/provider-scheduled-fallback.test.ts
@@ -44,6 +44,8 @@ vi.mock('../src/runtime-config.js', async () => {
 const { runAgentWithModelFallback } =
   await import('../src/container-runner.js');
 const { providerPool } = await import('../src/provider-pool.js');
+const { PROVIDER_TRANSIENT_FAILURE_USER_NOTICE } =
+  await import('../src/provider-failure.js');
 type AgentRunner = import('../src/container-runner.js').AgentRunner;
 type ContainerOutput = import('../src/container-runner.js').ContainerOutput;
 
@@ -224,6 +226,82 @@ describe('scheduled provider fallback', () => {
 
     expect(runFn).toHaveBeenCalledTimes(1);
     expect(output).toMatchObject({ providerFailure: true });
+  });
+
+  const scheduledInput = (prompt: string) => ({
+    prompt,
+    groupFolder: group.folder,
+    chatJid: group.jid,
+    isMain: false,
+    isHome: false,
+    isAdminHome: false,
+    isScheduledTask: true,
+  });
+
+  test('replays a transient failure on the same provider instead of stopping', async () => {
+    for (const provider of mocks.enabledProviders) {
+      providerPool.resetHealth(provider.id);
+    }
+    // A transient failure deliberately leaves availability untouched. The
+    // no-progress guard reads that as "nothing changed" and used to stop after
+    // a single attempt, spending the granted retry without ever running it.
+    let attempts = 0;
+    const runFn = vi.fn(async (): Promise<ContainerOutput> => {
+      attempts += 1;
+      return {
+        status: 'success',
+        result: null,
+        providerFailure: true,
+        providerFailureClass: 'transient',
+        // Mirrors the per-input ledger, which lives inside the real runner and
+        // is bypassed by this mock: one replay, then terminal.
+        providerFailureTerminal: attempts > 1,
+      };
+    });
+
+    await runAgentWithModelFallback(
+      runFn as unknown as AgentRunner,
+      group,
+      scheduledInput('upstream is having a moment'),
+      () => {},
+    );
+
+    expect(runFn).toHaveBeenCalledTimes(2);
+    // Neither the account nor any tier may be quarantined by upstream noise.
+    for (const provider of mocks.enabledProviders) {
+      expect(providerPool.getHealthStatus(provider.id).healthy).toBe(true);
+    }
+  });
+
+  test('a permanently transient upstream stays bounded and gets its own notice', async () => {
+    for (const provider of mocks.enabledProviders) {
+      providerPool.resetHealth(provider.id);
+    }
+    const runFn = vi.fn(
+      async (): Promise<ContainerOutput> => ({
+        status: 'success',
+        result: null,
+        providerFailure: true,
+        providerFailureClass: 'transient',
+        providerFailureTerminal: false,
+      }),
+    );
+
+    const output = await runAgentWithModelFallback(
+      runFn as unknown as AgentRunner,
+      group,
+      scheduledInput('upstream never recovers'),
+      () => {},
+    );
+
+    // The transient headroom must not become an unbounded replay loop even
+    // when every attempt reports non-terminal.
+    expect(runFn.mock.calls.length).toBeLessThanOrEqual(6);
+    expect(output.providerFailureTerminal).toBe(true);
+    expect(output.providerFailureNotice).toBe(
+      PROVIDER_TRANSIENT_FAILURE_USER_NOTICE,
+    );
+    expect(output.providerFailureNotice).not.toContain('额度已用尽');
   });
 
   test('does not replay a scheduled prompt after its durable input completed', async () => {

--- a/tests/provider-transient-escalation.test.ts
+++ b/tests/provider-transient-escalation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// Two enabled accounts so the escalated verdict has somewhere to fail over to;
+// individual tests narrow this to one account where that is the case under test.
+const mocks = vi.hoisted(() => ({
+  enabledProviders: [
+    {
+      id: 'escalation-a',
+      enabled: true,
+      weight: 1,
+      anthropicModel: 'primary-model',
+    },
+    {
+      id: 'escalation-b',
+      enabled: true,
+      weight: 1,
+      anthropicModel: 'primary-model',
+    },
+  ],
+  fallbackModel: '',
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../src/runtime-config.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../src/runtime-config.js')
+  >('../src/runtime-config.js');
+  return {
+    ...actual,
+    getEnabledProviders: () => mocks.enabledProviders,
+    getSystemSettings: () => ({
+      ...actual.getSystemSettings(),
+      fallbackModel: mocks.fallbackModel,
+    }),
+  };
+});
+
+const { applyProviderFailureDisposition } =
+  await import('../src/container-runner.js');
+const { providerPool } = await import('../src/provider-pool.js');
+const {
+  PROVIDER_TRANSIENT_ESCALATED_USER_NOTICE,
+  PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
+} = await import('../src/provider-failure.js');
+type ContainerOutput = import('../src/container-runner.js').ContainerOutput;
+
+/** One liveness stall for a given durable input, as the runner would frame it. */
+function stall(messageId: string): ContainerOutput {
+  return {
+    status: 'success',
+    result: null,
+    providerFailure: true,
+    providerFailureClass: 'transient',
+    providerLivenessTimeout: true,
+    providerRateLimitScope: 'account',
+    // The ledger keys on the durable message id carried by the receipt cursor,
+    // which is what survives a replay.
+    ipcReceipts: [
+      {
+        deliveryId: `delivery-${Math.random()}`,
+        chatJid: 'web:x',
+        cursor: { id: messageId },
+      },
+    ],
+  } as ContainerOutput;
+}
+
+function resetPool(): void {
+  for (const p of mocks.enabledProviders) providerPool.resetHealth(p.id);
+}
+
+describe('transient failure escalation', () => {
+  test('the first stall replays without judging the account', () => {
+    resetPool();
+    const first = stall('msg-first-only');
+    const terminal = applyProviderFailureDisposition(first, 'escalation-a');
+
+    expect(terminal).toBe(false);
+    expect(first.providerFailureTerminal).toBe(false);
+    // Not retired: the durable input must stay replayable.
+    expect(first.inputTurnCompleted).toBe(false);
+    expect(first.providerFailureClass).toBe('transient');
+    expect(first.providerFailureEscalatedFrom).toBeUndefined();
+    expect(providerPool.getHealthStatus('escalation-a').healthy).toBe(true);
+  });
+
+  test('a second stall on the same input quarantines the account and fails over', () => {
+    resetPool();
+    const id = 'msg-escalates';
+    applyProviderFailureDisposition(stall(id), 'escalation-a');
+
+    const second = stall(id);
+    const terminal = applyProviderFailureDisposition(second, 'escalation-a');
+
+    expect(second.providerFailureClass).toBe('account');
+    expect(second.providerFailureEscalatedFrom).toBe('transient');
+    // The rewrite has to happen before quarantineFromOutput, whose own guard
+    // skips anything that is not account-class.
+    expect(providerPool.getHealthStatus('escalation-a').healthy).toBe(false);
+    // The other account is untouched, so the input replays there instead of
+    // ending — this is the multi-account failover the escalation restores.
+    expect(providerPool.getHealthStatus('escalation-b').healthy).toBe(true);
+    expect(terminal).toBe(false);
+    expect(second.inputTurnCompleted).toBe(false);
+  });
+
+  test('the budget is per input, so an unrelated message still gets its replay', () => {
+    resetPool();
+    const id = 'msg-a';
+    applyProviderFailureDisposition(stall(id), 'escalation-a');
+    applyProviderFailureDisposition(stall(id), 'escalation-a');
+
+    resetPool();
+    const other = stall('msg-b');
+    expect(applyProviderFailureDisposition(other, 'escalation-a')).toBe(false);
+    expect(other.providerFailureClass).toBe('transient');
+    expect(providerPool.getHealthStatus('escalation-a').healthy).toBe(true);
+  });
+
+  test('a single-account pool ends with the escalated notice, not the stall one', () => {
+    const saved = mocks.enabledProviders;
+    mocks.enabledProviders = [saved[0]];
+    try {
+      resetPool();
+      const id = 'msg-single-account';
+      const first = stall(id);
+      expect(applyProviderFailureDisposition(first, 'escalation-a')).toBe(
+        false,
+      );
+      // While it is still transient the user is told it is a stall.
+      expect(first.providerFailureNotice).toBeUndefined();
+
+      const second = stall(id);
+      const terminal = applyProviderFailureDisposition(second, 'escalation-a');
+
+      expect(terminal).toBe(true);
+      expect(second.inputTurnCompleted).toBe(true);
+      expect(second.providerFailureNotice).toBe(
+        PROVIDER_TRANSIENT_ESCALATED_USER_NOTICE,
+      );
+      // Inviting a resend would be wrong: the account is quarantined now.
+      expect(second.providerFailureNotice).not.toBe(
+        PROVIDER_LIVENESS_TIMEOUT_USER_NOTICE,
+      );
+      expect(providerPool.getHealthStatus('escalation-a').healthy).toBe(false);
+    } finally {
+      mocks.enabledProviders = saved;
+      resetPool();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The SDK first-response watchdog reported every stall through `publishProviderAccountFailure`, so a transport stall was indistinguishable from a quota verdict. On a single-provider pool that made every stall terminal — which ACKed the user's durable input with no answer and no replay, deleted the conversation-agent session, and surfaced a "quota exhausted" notice for something that was neither a quota nor an account problem.

- **Give a stall its own disposition.** A liveness timeout no longer touches account health, keeps the input replayable through one bounded retry per durable message id, and only clears the session when a provider switch can actually happen.
- **Classify provider failures.** `ACCOUNT_PROVIDER_ASSISTANT_ERRORS` held seven unrelated errors and quarantined the account for all of them. Split into `account` / `transient` (`overloaded`, `server_error`) / `config` (`model_not_found`), carried on the wire as `providerFailureClass`, which the host now keys every decision on. Absent on an older runner's output, where it defaults to `account` so the historical behaviour is preserved.
- **Escalate a repeated transient failure** — the non-obvious one, see below.
- **Surface the model fallback.** A model-scope wall silently re-ran the turn on the fallback tier and emitted only host-control metadata, so a downgraded reply was indistinguishable from a primary-model one. Both activation paths now emit a standalone notice naming both models, under a `provider_fallback_notice` source kind that cannot occupy the primary reply slot.

## Why the escalation exists

`tests/e2e/provider-failure-upstream.mjs` (added here) runs the real agent runner against a stub Anthropic-compatible upstream. Measured on Claude Code 2.1.238:

| upstream behaviour | reported class | time |
| --- | --- | --- |
| never responds | `transient` | 66s |
| HTTP 529 / 500 | `transient` | 66s |
| HTTP 401 | `transient` | 66s |
| HTTP 429 | `transient` | 66s |
| HTTP 404 | `config` | 8s |

The CLI retries 401 and 429 silently until the watchdog fires, so at the runner boundary a dead key and an exhausted quota look exactly like a stall. Trusting the transient claim indefinitely would leave both un-quarantined forever and strand a multi-account pool on its one broken profile — trading a wrong mechanism that produced the right outcome for the reverse.

So the claim is bounded rather than trusted: once the replay budget is spent and the same durable input fails transiently again, the class is rewritten to `account`, the profile is quarantined, and the pool decides failover. This is the one disposition with no corresponding upstream evidence, so it also logs at WARN.

## Notes

- No schema change.
- `publishProviderAccountFailure` becomes `publishProviderFailure` with a **required** `failureClass`. Its five positional parameters were how the original defect happened: the watchdog needed the fifth, so it passed `'server_error'` as the first and silently inherited the account disposition.
- The e2e harness is deliberately outside `npm test`: it needs the built runner, and each stall scenario burns the full 60s deadline.
- `npm test` 384 files / 3276 tests green; `make typecheck`, `make build`, `npm run docs:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
