### PR TITLE
fix(host): keep IPC debt when internal continue reports idle

### DIFF
--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -1155,9 +1155,18 @@ export class GroupQueue {
     return committed;
   }
 
-  markRunnerQueryIdle(groupJid: string): void {
+  markRunnerQueryIdle(
+    groupJid: string,
+    options?: { preserveIpcDebt?: boolean },
+  ): void {
     const state = this.resolveActiveState(groupJid);
     if (!state?.active || !state.queryInFlight) return;
+    // Truncation/compaction continues report queryIdle even though they
+    // refused later user IPC (acceptIpc=false). Wiping the #618/#622 debt
+    // clock here hides a leftover IPC file from stuck recovery.
+    if (options?.preserveIpcDebt) {
+      return;
+    }
     const completedQueryId = state.queryId;
     state.queryInFlight = false;
     state.ipcOwedSinceAt = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9813,7 +9813,10 @@ async function runAgent(
       output.queryIdle === true ||
       (isInterruptStatus && output.queryIdle !== false)
     ) {
-      queue.markRunnerQueryIdle(chatJid);
+      const preserveIpcDebt =
+        output.sourceKind === 'truncation_continue' ||
+        output.sourceKind === 'auto_continue';
+      queue.markRunnerQueryIdle(chatJid, { preserveIpcDebt });
     }
     // 仅从成功的输出中更新 session ID；
     // error 输出可能携带 stale ID，会覆盖流式传递的有效 session
@@ -15624,7 +15627,10 @@ async function processAgentConversation(
         output.streamEvent.statusText === 'interrupted' &&
         output.queryIdle !== false)
     ) {
-      queue.markRunnerQueryIdle(virtualJid);
+      const preserveIpcDebt =
+        output.sourceKind === 'truncation_continue' ||
+        output.sourceKind === 'auto_continue';
+      queue.markRunnerQueryIdle(virtualJid, { preserveIpcDebt });
     }
 
     // #549: a provider switch surfaced as a failure clears the agent session so

--- a/tests/group-queue-stuck-recovery.test.ts
+++ b/tests/group-queue-stuck-recovery.test.ts
@@ -354,4 +354,42 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
 
     expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
   });
+  test('internal-continue idle does not wipe unpaid IPC debt', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    const owedAt = Date.now() - IDLE_THRESHOLD_MS - 1000;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: owedAt,
+      lastActivityAt: owedAt,
+    });
+
+    q.markRunnerQueryIdle(jid, { preserveIpcDebt: true });
+
+    expect(getState(q, jid).queryInFlight).toBe(true);
+    expect(getState(q, jid).ipcOwedSinceAt).toBe(owedAt);
+    const stuck = q.getStuckPendingGroups(IDLE_THRESHOLD_MS);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].reason).toBe('ipc_injected');
+  });
+
+  test('ordinary query idle still clears IPC debt', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - 1000,
+      lastActivityAt: Date.now() - 1000,
+    });
+
+    q.markRunnerQueryIdle(jid);
+
+    expect(getState(q, jid).queryInFlight).toBe(false);
+    expect(getState(q, jid).ipcOwedSinceAt).toBeNull();
+    expect(q.getStuckPendingGroups(IDLE_THRESHOLD_MS)).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Truncation/compaction continues run with `acceptIpc=false`, so a follow-up written in that window stays on disk.
- Their `queryIdle: true` still called `markRunnerQueryIdle`, which cleared `ipcOwedSinceAt` and hid the leftover from stuck recovery.
- Skip the idle wipe when `sourceKind` is `truncation_continue` or `auto_continue`.

## Test plan
- [ ] `tests/group-queue-stuck-recovery.test.ts`: `preserveIpcDebt` keeps `queryInFlight` + `ipcOwedSinceAt`; ordinary idle still clears
- [ ] Confirm this PR is IPC-debt only on current `main` (not stacked on #680/#681)