### PR TITLE
fix(dingtalk): send video/voice with sampleVideo/sampleAudio

### DIFF
--- a/src/dingtalk.ts
+++ b/src/dingtalk.ts
@@ -205,6 +205,40 @@ export function parseDingTalkGroupMessageResponse(
   return data;
 }
 
+/** Map uploaded media type to the DingTalk robot msgKey + body.
+ * sampleFile is documents only; video/voice need sampleVideo / sampleAudio. */
+export function buildDingTalkFileSendPayload(
+  mediaType: string,
+  mediaId: string,
+  fileName: string,
+  ext: string,
+): { msgKey: string; msgParam: Record<string, string> } {
+  if (mediaType === 'image') {
+    return { msgKey: 'sampleImageMsg', msgParam: { photoURL: mediaId } };
+  }
+  if (mediaType === 'voice') {
+    return {
+      msgKey: 'sampleAudio',
+      msgParam: { mediaId, duration: '1' },
+    };
+  }
+  if (mediaType === 'video') {
+    return {
+      msgKey: 'sampleVideo',
+      msgParam: {
+        duration: '1',
+        videoMediaId: mediaId,
+        videoType: ext || 'mp4',
+        picMediaId: mediaId,
+      },
+    };
+  }
+  return {
+    msgKey: 'sampleFile',
+    msgParam: { mediaId, fileName, fileType: ext },
+  };
+}
+
 interface DingTalkAccessToken {
   token: string;
   expiresAt: number;
@@ -1322,11 +1356,24 @@ export function createDingTalkConnection(
     mediaId: string,
     fileName: string,
     fileType: string,
+    mediaType = 'file',
   ): Promise<void> {
     try {
       const token = await getAccessToken();
-      const msgParam = JSON.stringify({ mediaId, fileName, fileType });
-      await batchSendToUser([userId], robotCode, token, 'sampleFile', msgParam);
+      const payload = buildDingTalkFileSendPayload(
+        mediaType,
+        mediaId,
+        fileName,
+        fileType,
+      );
+      const msgParam = JSON.stringify(payload.msgParam);
+      await batchSendToUser(
+        [userId],
+        robotCode,
+        token,
+        payload.msgKey,
+        msgParam,
+      );
       logger.info({ userId, mediaId, fileName }, 'DingTalk file message sent');
     } catch (err) {
       logger.error(
@@ -2383,25 +2430,17 @@ export function createDingTalkConnection(
       if (isGroup && openConversationId) {
         // Send via persistent groupMessages API
         try {
-          if (mediaType === 'image') {
-            const msgParam = JSON.stringify({ photoURL: mediaId });
-            await sendViaGroupMessagesAPI(
-              openConversationId,
-              'sampleImageMsg',
-              msgParam,
-            );
-          } else {
-            const msgParam = JSON.stringify({
-              mediaId,
-              fileName,
-              fileType: ext,
-            });
-            await sendViaGroupMessagesAPI(
-              openConversationId,
-              'sampleFile',
-              msgParam,
-            );
-          }
+          const payload = buildDingTalkFileSendPayload(
+            mediaType,
+            mediaId,
+            fileName,
+            ext,
+          );
+          await sendViaGroupMessagesAPI(
+            openConversationId,
+            payload.msgKey,
+            JSON.stringify(payload.msgParam),
+          );
           logger.info(
             { chatId, fileName, mediaId },
             'DingTalk group file sent via persistent API',
@@ -2435,6 +2474,7 @@ export function createDingTalkConnection(
             mediaId,
             fileName,
             ext,
+            mediaType,
           );
         }
         logger.info(

--- a/tests/dingtalk-sendfile-media-msgkey.test.ts
+++ b/tests/dingtalk-sendfile-media-msgkey.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildDingTalkFileSendPayload } from '../src/dingtalk.js';
+
+describe('DingTalk sendFile uses media-native robot msgKeys', () => {
+  test('mp4 uses sampleVideo with videoMediaId, not sampleFile', () => {
+    const payload = buildDingTalkFileSendPayload(
+      'video',
+      'media-video-1',
+      'clip.mp4',
+      'mp4',
+    );
+    expect(payload.msgKey).toBe('sampleVideo');
+    expect(payload.msgParam).toEqual({
+      duration: '1',
+      videoMediaId: 'media-video-1',
+      videoType: 'mp4',
+      picMediaId: 'media-video-1',
+    });
+  });
+
+  test('amr/mp3/wav use sampleAudio with mediaId + duration', () => {
+    for (const ext of ['amr', 'mp3', 'wav']) {
+      const payload = buildDingTalkFileSendPayload(
+        'voice',
+        'media-voice-1',
+        `voice.${ext}`,
+        ext,
+      );
+      expect(payload.msgKey).toBe('sampleAudio');
+      expect(payload.msgParam).toEqual({
+        mediaId: 'media-voice-1',
+        duration: '1',
+      });
+    }
+  });
+
+  test('documents still use sampleFile', () => {
+    const payload = buildDingTalkFileSendPayload(
+      'file',
+      'media-doc-1',
+      'notes.pdf',
+      'pdf',
+    );
+    expect(payload.msgKey).toBe('sampleFile');
+    expect(payload.msgParam).toEqual({
+      mediaId: 'media-doc-1',
+      fileName: 'notes.pdf',
+      fileType: 'pdf',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `sendFile` uploaded `.mp4` / amr-mp3-wav as `video`/`voice`, then sent `sampleFile` (the document template).
- Use `sampleVideo` (`videoMediaId`) and `sampleAudio` (`mediaId` + `duration`) instead. Documents stay `sampleFile`.

## Test plan
- [ ] `tests/dingtalk-sendfile-media-msgkey.test.ts`: mp4 → sampleVideo; amr/mp3/wav → sampleAudio; pdf → sampleFile
- [ ] Confirm this PR is sendFile msgKey only on current `main`