### PR TITLE
fix(agent-runner): ACK interrupt during internal continue

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -4398,6 +4398,31 @@ async function main(): Promise<void> {
             } catch {
               /* ignore */
             }
+            clearInterruptRequested();
+            if (autoContResult.pipedMessagesDuringQuery.length > 0) {
+              requeueIpcInputMessages(
+                IPC_INPUT_DIR,
+                autoContResult.pipedMessagesDuringQuery,
+              );
+            }
+            writeOutput({
+              status: 'stream',
+              result: null,
+              streamEvent: {
+                eventType: 'status',
+                statusText: 'interrupted',
+                queryRunId: containerInput.queryRunId,
+                turnId: containerInput.turnId,
+                sessionId,
+              },
+              newSessionId: sessionId,
+              turnId: containerInput.turnId,
+              sessionId,
+              ...(autoContResult.cancelledIpcReceipts?.length
+                ? { ipcReceipts: autoContResult.cancelledIpcReceipts }
+                : {}),
+              queryIdle: autoContResult.pipedMessagesDuringQuery.length === 0,
+            });
           }
           // Auto-continue can consume user IPC while it is running. A query
           // that ends without a healthy result leaves those messages in the
@@ -4539,6 +4564,31 @@ async function main(): Promise<void> {
           } catch {
             /* ignore */
           }
+          clearInterruptRequested();
+          if (contResult.pipedMessagesDuringQuery.length > 0) {
+            requeueIpcInputMessages(
+              IPC_INPUT_DIR,
+              contResult.pipedMessagesDuringQuery,
+            );
+          }
+          writeOutput({
+            status: 'stream',
+            result: null,
+            streamEvent: {
+              eventType: 'status',
+              statusText: 'interrupted',
+              queryRunId: containerInput.queryRunId,
+              turnId: containerInput.turnId,
+              sessionId,
+            },
+            newSessionId: sessionId,
+            turnId: containerInput.turnId,
+            sessionId,
+            ...(contResult.cancelledIpcReceipts?.length
+              ? { ipcReceipts: contResult.cancelledIpcReceipts }
+              : {}),
+            queryIdle: contResult.pipedMessagesDuringQuery.length === 0,
+          });
           break;
         }
         // 续写本身又被截断 → 带新结尾再续，直到写完或触顶

--- a/tests/continue-interrupt-ack.test.ts
+++ b/tests/continue-interrupt-ack.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const INDEX = path.resolve(__dirname, '../container/agent-runner/src/index.ts');
+
+describe('internal continue interrupt emits host interrupted ACK', () => {
+  const source = fs.readFileSync(INDEX, 'utf8');
+
+  test('auto-continue and truncation-continue both ACK interrupted', () => {
+    const autoAt = source.indexOf(
+      'Auto-continue query was interrupted by user',
+    );
+    const truncAt = source.indexOf(
+      'Truncation-continue query was interrupted by user',
+    );
+    expect(autoAt).toBeGreaterThan(-1);
+    expect(truncAt).toBeGreaterThan(-1);
+
+    const autoBlock = source.slice(autoAt, autoAt + 900);
+    const truncBlock = source.slice(truncAt, truncAt + 900);
+    expect(autoBlock).toContain("statusText: 'interrupted'");
+    expect(truncBlock).toContain("statusText: 'interrupted'");
+    expect(autoBlock).toContain('writeOutput');
+    expect(truncBlock).toContain('writeOutput');
+  });
+});


### PR DESCRIPTION
## Summary
- Main-query interrupt already emits `statusText: interrupted` (#421).
- Compaction auto-continue and truncation-continue only unlinked `_interrupt`, so the host never left `interrupting`.
- Emit the same ACK (and requeue piped IPC on truncation-continue).

## Test plan
- [ ] `tests/continue-interrupt-ack.test.ts` asserts both continue interrupt blocks write `statusText: interrupted`
- [ ] Confirm this PR is continue-interrupt ACK only on current `main`