### PR TITLE
fix(im): time out inbound Telegram/QQ media downloads

### DIFF
--- a/src/im-media-download.ts
+++ b/src/im-media-download.ts
@@ -1,0 +1,69 @@
+import http from 'node:http';
+import https from 'node:https';
+
+import { MAX_FILE_SIZE } from './im-downloader.js';
+
+/** Match QQ's outbound API budget so a blackhole CDN cannot hold an admitted turn. */
+export const IM_MEDIA_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+export interface DownloadHttpsBufferOptions {
+  agent?: http.Agent | https.Agent;
+  timeoutMs?: number;
+  maxBytes?: number;
+  followRedirects?: boolean;
+  oversizedMessage?: string;
+}
+
+export function downloadHttpsBuffer(
+  url: string,
+  options: DownloadHttpsBufferOptions = {},
+): Promise<Buffer> {
+  const timeoutMs = options.timeoutMs ?? IM_MEDIA_DOWNLOAD_TIMEOUT_MS;
+  const maxBytes = options.maxBytes ?? MAX_FILE_SIZE;
+  const followRedirects = options.followRedirects === true;
+  const oversizedMessage =
+    options.oversizedMessage ?? 'File exceeds MAX_FILE_SIZE';
+
+  return new Promise<Buffer>((resolve, reject) => {
+    const doRequest = (reqUrl: string, redirectCount: number) => {
+      if (redirectCount > 5) {
+        reject(new Error('Too many redirects'));
+        return;
+      }
+      const parsed = new URL(reqUrl);
+      const protocol = parsed.protocol === 'https:' ? https : http;
+      const req = protocol.get(reqUrl, { agent: options.agent }, (res) => {
+        if (
+          followRedirects &&
+          res.statusCode &&
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
+          res.resume();
+          doRequest(res.headers.location, redirectCount + 1);
+          return;
+        }
+        const chunks: Buffer[] = [];
+        let total = 0;
+        res.on('data', (chunk: Buffer) => {
+          total += chunk.length;
+          if (total > maxBytes) {
+            res.destroy(new Error(oversizedMessage));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(
+          new Error(`IM media download timed out after ${timeoutMs}ms`),
+        );
+      });
+    };
+    doRequest(url, 0);
+  });
+}

--- a/src/qq.ts
+++ b/src/qq.ts
@@ -11,7 +11,6 @@
  */
 import crypto from 'crypto';
 import fs from 'node:fs';
-import http from 'node:http';
 import https from 'node:https';
 import WebSocket from 'ws';
 import {
@@ -22,7 +21,8 @@ import {
 } from './db.js';
 import { notifyNewImMessage } from './message-notifier.js';
 import { logger } from './logger.js';
-import { saveDownloadedFile, MAX_FILE_SIZE } from './im-downloader.js';
+import { saveDownloadedFile } from './im-downloader.js';
+import { downloadHttpsBuffer } from './im-media-download.js';
 import { detectImageMimeTypeStrict } from './image-detector.js';
 import path from 'node:path';
 import {
@@ -1072,41 +1072,8 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
 
   async function downloadQQAttachment(url: string): Promise<Buffer | null> {
     try {
-      const buffer = await new Promise<Buffer>((resolve, reject) => {
-        const doRequest = (reqUrl: string, redirectCount: number = 0) => {
-          if (redirectCount > 5) {
-            reject(new Error('Too many redirects'));
-            return;
-          }
-          const parsedUrl = new URL(reqUrl);
-          const protocol = parsedUrl.protocol === 'https:' ? https : http;
-          protocol
-            .get(reqUrl, (res) => {
-              if (
-                res.statusCode &&
-                res.statusCode >= 300 &&
-                res.statusCode < 400 &&
-                res.headers.location
-              ) {
-                doRequest(res.headers.location, redirectCount + 1);
-                return;
-              }
-              const chunks: Buffer[] = [];
-              let total = 0;
-              res.on('data', (chunk: Buffer) => {
-                total += chunk.length;
-                if (total > MAX_FILE_SIZE) {
-                  res.destroy(new Error('File exceeds MAX_FILE_SIZE'));
-                  return;
-                }
-                chunks.push(chunk);
-              });
-              res.on('end', () => resolve(Buffer.concat(chunks)));
-              res.on('error', reject);
-            })
-            .on('error', reject);
-        };
-        doRequest(url);
+      const buffer = await downloadHttpsBuffer(url, {
+        followRedirects: true,
       });
 
       if (buffer.length === 0) return null;

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,7 +1,7 @@
 import { Bot, InputFile } from 'grammy';
 import crypto from 'crypto';
 import fsPromises from 'node:fs/promises';
-import https from 'node:https';
+import { downloadHttpsBuffer } from './im-media-download.js';
 import { Agent as HttpsAgent } from 'node:https';
 import { ProxyAgent } from 'proxy-agent';
 import { storeChatMetadata, storeMessageDirect, updateChatName } from './db.js';
@@ -419,25 +419,9 @@ export function createTelegramConnection(
       }
 
       const url = `https://api.telegram.org/file/bot${config.botToken}/${filePath}`;
-      const buffer = await new Promise<Buffer>((resolve, reject) => {
-        https
-          .get(url, { agent: telegramApiAgent }, (res) => {
-            const chunks: Buffer[] = [];
-            let total = 0;
-            res.on('data', (chunk: Buffer) => {
-              total += chunk.length;
-              if (total > MAX_FILE_SIZE) {
-                res.destroy(
-                  new Error('File exceeds MAX_FILE_SIZE during download'),
-                );
-                return;
-              }
-              chunks.push(chunk);
-            });
-            res.on('end', () => resolve(Buffer.concat(chunks)));
-            res.on('error', reject);
-          })
-          .on('error', reject);
+      const buffer = await downloadHttpsBuffer(url, {
+        agent: telegramApiAgent,
+        oversizedMessage: 'File exceeds MAX_FILE_SIZE during download',
       });
 
       // 使用 file_path 中的最后一段作为文件名（若无则用 originalFilename）
@@ -495,25 +479,9 @@ export function createTelegramConnection(
         return null;
       }
       const url = `https://api.telegram.org/file/bot${config.botToken}/${filePath}`;
-      const buffer = await new Promise<Buffer>((resolve, reject) => {
-        https
-          .get(url, { agent: telegramApiAgent }, (res) => {
-            const chunks: Buffer[] = [];
-            let total = 0;
-            res.on('data', (chunk: Buffer) => {
-              total += chunk.length;
-              if (total > MAX_FILE_SIZE) {
-                res.destroy(
-                  new Error('Photo exceeds MAX_FILE_SIZE during download'),
-                );
-                return;
-              }
-              chunks.push(chunk);
-            });
-            res.on('end', () => resolve(Buffer.concat(chunks)));
-            res.on('error', reject);
-          })
-          .on('error', reject);
+      const buffer = await downloadHttpsBuffer(url, {
+        agent: telegramApiAgent,
+        oversizedMessage: 'Photo exceeds MAX_FILE_SIZE during download',
       });
       if (buffer.length === 0) {
         logger.warn({ fileId }, 'Empty response from Telegram photo download');

--- a/tests/im-media-download-timeout.test.ts
+++ b/tests/im-media-download-timeout.test.ts
@@ -1,0 +1,89 @@
+import net from 'node:net';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { downloadHttpsBuffer } from '../src/im-media-download.js';
+
+function trackClose(server: net.Server): () => Promise<void> {
+  const sockets = new Set<net.Socket>();
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  return async () => {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  };
+}
+
+async function listenBlackhole(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const server = net.createServer();
+  const close = trackClose(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('blackhole server has no TCP port');
+  }
+  return { port: addr.port, close };
+}
+
+describe('Inbound IM media download timeout against a blackhole peer', () => {
+  const closers: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(closers.splice(0).map((close) => close()));
+  }, 3000);
+
+  test('Telegram-style GET rejects instead of hanging', async () => {
+    const blackhole = await listenBlackhole();
+    closers.push(blackhole.close);
+    const started = Date.now();
+
+    await expect(
+      downloadHttpsBuffer(`http://127.0.0.1:${blackhole.port}/file/bot/photo`, {
+        timeoutMs: 250,
+      }),
+    ).rejects.toThrow(/timed out/i);
+
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  test('QQ-style redirect GET also times out on the follow-up hop', async () => {
+    const blackhole = await listenBlackhole();
+    closers.push(blackhole.close);
+
+    const redirector = net.createServer((socket) => {
+      socket.write(
+        'HTTP/1.1 302 Found\r\n' +
+          `Location: http://127.0.0.1:${blackhole.port}/cdn\r\n` +
+          'Content-Length: 0\r\n\r\n',
+      );
+      socket.end();
+    });
+    closers.push(trackClose(redirector));
+    await new Promise<void>((resolve, reject) => {
+      redirector.once('error', reject);
+      redirector.listen(0, '127.0.0.1', () => resolve());
+    });
+    const raddr = redirector.address();
+    if (!raddr || typeof raddr === 'string') {
+      throw new Error('redirector has no TCP port');
+    }
+
+    const started = Date.now();
+    await expect(
+      downloadHttpsBuffer(`http://127.0.0.1:${raddr.port}/attach`, {
+        timeoutMs: 250,
+        followRedirects: true,
+      }),
+    ).rejects.toThrow(/timed out/i);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
## Summary
- Admitted Telegram/QQ photo and file handlers awaited `https.get` with no `req.setTimeout`.
- A blackhole CDN held `ProcessingLock` for the 5-minute TTL and never persisted or started an Agent turn.
- Shared `downloadHttpsBuffer` (30s, same class as QQ outbound / Feishu resource timeout) now wraps those GETs, including QQ redirects.

## Test plan
- [ ] `tests/im-media-download-timeout.test.ts`: blackhole TCP rejects `/timed out/i` in <2s
- [ ] Same file: 302 to a blackhole also times out on the follow-up hop
- [ ] Confirm this PR is inbound TG/QQ download only on current `main` (not stacked on #680–#684; no WeChat send hang)