### PR TITLE
fix(telegram): persist inbound video, voice, audio, and animation

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,6 +1,7 @@
-import { Bot, InputFile } from 'grammy';
+import { Bot, InputFile, type Context } from 'grammy';
 import crypto from 'crypto';
 import fsPromises from 'node:fs/promises';
+import http from 'node:http';
 import https from 'node:https';
 import { Agent as HttpsAgent } from 'node:https';
 import { ProxyAgent } from 'proxy-agent';
@@ -103,6 +104,259 @@ export function buildTelegramRouteJid(
   return Number.isSafeInteger(messageThreadId) && messageThreadId! > 0
     ? `${base}#thread:${messageThreadId}`
     : base;
+}
+
+export type TelegramNativeMediaKind = 'video' | 'voice' | 'audio' | 'animation';
+
+export interface TelegramNativeFile {
+  fileId: string;
+  fileName: string;
+  fileSize?: number;
+  kind: TelegramNativeMediaKind;
+}
+
+/**
+ * Native Telegram media that is NOT message:photo / message:document.
+ * Video-button MP4, voice notes, audio files, and GIF/animation never
+ * carry `document` unless the user picked "Send as file".
+ */
+export function telegramNativeFileFromMessage(message: {
+  video?: { file_id: string; file_name?: string; file_size?: number };
+  voice?: { file_id: string; file_size?: number };
+  audio?: { file_id: string; file_name?: string; file_size?: number };
+  animation?: { file_id: string; file_name?: string; file_size?: number };
+}): TelegramNativeFile | null {
+  if (message.video) {
+    return {
+      fileId: message.video.file_id,
+      fileName: message.video.file_name || 'video.mp4',
+      fileSize: message.video.file_size,
+      kind: 'video',
+    };
+  }
+  if (message.voice) {
+    return {
+      fileId: message.voice.file_id,
+      fileName: 'voice.ogg',
+      fileSize: message.voice.file_size,
+      kind: 'voice',
+    };
+  }
+  if (message.audio) {
+    return {
+      fileId: message.audio.file_id,
+      fileName: message.audio.file_name || 'audio.mp3',
+      fileSize: message.audio.file_size,
+      kind: 'audio',
+    };
+  }
+  if (message.animation) {
+    return {
+      fileId: message.animation.file_id,
+      fileName: message.animation.file_name || 'animation.mp4',
+      fileSize: message.animation.file_size,
+      kind: 'animation',
+    };
+  }
+  return null;
+}
+
+export const TELEGRAM_NATIVE_MEDIA_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/** Timed GET for native video/voice/audio/animation. Do not import #685 helper. */
+export function downloadTelegramHttpsBuffer(
+  url: string,
+  options: {
+    timeoutMs?: number;
+    maxBytes?: number;
+    agent?: http.Agent | https.Agent;
+  } = {},
+): Promise<Buffer> {
+  const timeoutMs =
+    options.timeoutMs ?? TELEGRAM_NATIVE_MEDIA_DOWNLOAD_TIMEOUT_MS;
+  const maxBytes = options.maxBytes ?? MAX_FILE_SIZE;
+  return new Promise<Buffer>((resolve, reject) => {
+    const protocol = new URL(url).protocol === 'https:' ? https : http;
+    const req = protocol.get(url, { agent: options.agent }, (res) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      res.on('data', (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > maxBytes) {
+          res.destroy(new Error('File exceeds MAX_FILE_SIZE during download'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      res.on('end', () => resolve(Buffer.concat(chunks)));
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(
+        new Error(
+          `Telegram native media download timed out after ${timeoutMs}ms`,
+        ),
+      );
+    });
+  });
+}
+
+export function persistTelegramNativeMediaMessage(input: {
+  id?: string;
+  targetJid: string;
+  sourceJid: string;
+  senderId: string;
+  senderName: string;
+  text: string;
+  timestamp: string;
+  agentId?: string;
+  storeMessageDirect: (
+    id: string,
+    chatJid: string,
+    sender: string,
+    senderName: string,
+    content: string,
+    timestamp: string,
+    isFromMe: boolean,
+    extra?: { sourceJid?: string },
+  ) => void;
+  notifyNewImMessage: () => void;
+  onMessagePersisted?: (
+    chatJid: string,
+    message: {
+      id: string;
+      chat_jid: string;
+      source_jid: string;
+      sender: string;
+      sender_name: string;
+      content: string;
+      timestamp: string;
+      is_from_me: boolean;
+    },
+    agentId?: string,
+  ) => void;
+}): string {
+  const id = input.id ?? crypto.randomUUID();
+  input.storeMessageDirect(
+    id,
+    input.targetJid,
+    input.senderId,
+    input.senderName,
+    input.text,
+    input.timestamp,
+    false,
+    { sourceJid: input.sourceJid },
+  );
+  input.onMessagePersisted?.(
+    input.targetJid,
+    {
+      id,
+      chat_jid: input.targetJid,
+      source_jid: input.sourceJid,
+      sender: input.senderId,
+      sender_name: input.senderName,
+      content: input.text,
+      timestamp: input.timestamp,
+      is_from_me: false,
+    },
+    input.agentId,
+  );
+  input.notifyNewImMessage();
+  return id;
+}
+
+export type TelegramNativeMediaHandlerCtx = {
+  message?: {
+    message_id: number;
+    date: number;
+    message_thread_id?: number;
+    caption?: string;
+    video?: { file_id: string; file_name?: string; file_size?: number };
+    voice?: { file_id: string; file_size?: number };
+    audio?: { file_id: string; file_name?: string; file_size?: number };
+    animation?: { file_id: string; file_name?: string; file_size?: number };
+  };
+  chat?: {
+    id: number;
+    title?: string;
+    first_name?: string;
+    last_name?: string;
+  };
+  from?: { id?: number; first_name?: string; last_name?: string };
+};
+
+/** Handler body for message:video|voice|audio|animation. Tests invoke this. */
+export async function handleTelegramNativeMediaUpdate(
+  ctx: TelegramNativeMediaHandlerCtx,
+  hooks: {
+    isChatAuthorized: (jid: string) => boolean;
+    storeMessageDirect: (
+      id: string,
+      chatJid: string,
+      sender: string,
+      senderName: string,
+      content: string,
+      timestamp: string,
+      isFromMe: boolean,
+      extra?: { sourceJid?: string },
+    ) => void;
+    notifyNewImMessage: () => void;
+    onMessagePersisted?: (
+      chatJid: string,
+      message: {
+        id: string;
+        chat_jid: string;
+        source_jid: string;
+        sender: string;
+        sender_name: string;
+        content: string;
+        timestamp: string;
+        is_from_me: boolean;
+      },
+      agentId?: string,
+    ) => void;
+    onNewChat?: (jid: string, name: string) => void;
+    downloadRelPath?: (file: TelegramNativeFile) => Promise<string | null>;
+  },
+): Promise<'stored' | 'unauthorized' | 'ignored'> {
+  const tgMessage = ctx.message;
+  const tgChat = ctx.chat;
+  if (!tgMessage || !tgChat) return 'ignored';
+  const file = telegramNativeFileFromMessage(tgMessage);
+  if (!file) return 'ignored';
+  const chatId = String(tgChat.id);
+  const routeJid = buildTelegramRouteJid(chatId, tgMessage.message_thread_id);
+  const jid = channelConversationJid(routeJid);
+  if (!hooks.isChatAuthorized(jid)) return 'unauthorized';
+  const chatName =
+    tgChat.title ||
+    [tgChat.first_name, tgChat.last_name].filter(Boolean).join(' ') ||
+    `Telegram ${chatId}`;
+  hooks.onNewChat?.(jid, chatName);
+  const relPath = hooks.downloadRelPath
+    ? await hooks.downloadRelPath(file)
+    : `telegram/${file.fileName}`;
+  const fileText = relPath
+    ? `[文件: ${relPath}]`
+    : `[文件下载失败: ${file.fileName}]`;
+  const caption = tgMessage.caption;
+  const text = caption ? `${fileText}\n${caption}` : fileText;
+  const senderName =
+    [ctx.from?.first_name, ctx.from?.last_name].filter(Boolean).join(' ') ||
+    'Unknown';
+  persistTelegramNativeMediaMessage({
+    targetJid: jid,
+    sourceJid: routeJid,
+    senderId: ctx.from?.id ? `tg:${ctx.from.id}` : 'tg:unknown',
+    senderName,
+    text,
+    timestamp: new Date(tgMessage.date * 1000).toISOString(),
+    storeMessageDirect: hooks.storeMessageDirect,
+    notifyNewImMessage: hooks.notifyNewImMessage,
+    onMessagePersisted: hooks.onMessagePersisted,
+  });
+  return 'stored';
 }
 
 export interface TelegramProviderTarget {
@@ -1284,6 +1538,204 @@ export function createTelegramConnection(
           logger.error({ err }, 'Error handling Telegram document');
         }
       });
+
+      // ── message:video|voice|audio|animation（原生媒体，不是 "Send as file"）──
+      const handleNativeTelegramMedia = async (ctx: Context): Promise<void> => {
+        try {
+          const tgMessage = ctx.message;
+          const tgChat = ctx.chat;
+          if (!tgMessage || !tgChat) return;
+          const file = telegramNativeFileFromMessage(tgMessage);
+          if (!file) return;
+          const msgId = String(tgMessage.message_id) + ':' + String(tgChat.id);
+          if (isGloballyStale(tgMessage.date * 1000)) return;
+          if (dedup.isDuplicate(msgId)) return;
+          if (!processingLock.acquire(msgId)) return;
+          dedup.markSeen(msgId);
+          try {
+            if (isStaleMessage(tgMessage.date, opts.ignoreMessagesBefore))
+              return;
+
+            const chatId = String(tgChat.id);
+            const routeJid =
+              opts.normalizeIncomingJid?.(
+                buildTelegramRouteJid(chatId, tgMessage.message_thread_id),
+              ) ?? buildTelegramRouteJid(chatId, tgMessage.message_thread_id);
+            const jid = channelConversationJid(routeJid);
+            const messageMeta = telegramMessageMeta(tgMessage);
+            const chatName =
+              tgChat.title ||
+              [tgChat.first_name, tgChat.last_name].filter(Boolean).join(' ') ||
+              `Telegram ${chatId}`;
+            const senderName =
+              [ctx.from?.first_name, ctx.from?.last_name]
+                .filter(Boolean)
+                .join(' ') || 'Unknown';
+
+            if (!opts.isChatAuthorized(jid)) {
+              logger.debug(
+                { jid, kind: file.kind },
+                'Unauthorized Telegram chat (native media), ignoring',
+              );
+              return;
+            }
+
+            const resolvedRoute = resolveAdmittedChannelRoute(
+              routeJid,
+              opts.resolveEffectiveChatJid
+                ? () => opts.resolveEffectiveChatJid!(jid, messageMeta)
+                : undefined,
+            );
+            if (!resolvedRoute) {
+              logger.warn(
+                { jid, routeJid, kind: file.kind },
+                'Telegram native media dropped: binding resolver rejected route',
+              );
+              return;
+            }
+            const { targetJid, routing: agentRouting } = resolvedRoute;
+            const sourceJid = agentRouting?.sourceJid ?? routeJid;
+
+            await reportNativeContext(opts, jid, tgMessage.message_thread_id);
+            storeChatMetadata(jid, new Date().toISOString());
+            updateChatName(jid, chatName);
+            opts.onNewChat(jid, chatName);
+
+            const originalFilename = file.fileName;
+            const safeFilename = sanitizeImFilename(originalFilename);
+
+            if (file.fileSize !== undefined && file.fileSize > MAX_FILE_SIZE) {
+              const text = `[文件过大，未下载: ${safeFilename}]`;
+              const timestamp = new Date(tgMessage.date * 1000).toISOString();
+              const senderId = ctx.from?.id
+                ? `tg:${ctx.from.id}`
+                : 'tg:unknown';
+              persistTelegramNativeMediaMessage({
+                targetJid,
+                sourceJid,
+                senderId,
+                senderName,
+                text,
+                timestamp,
+                agentId: agentRouting?.agentId ?? undefined,
+                storeMessageDirect,
+                notifyNewImMessage,
+                onMessagePersisted: opts.onMessagePersisted,
+              });
+              return;
+            }
+
+            const groupFolder = opts.resolveGroupFolder?.(jid);
+            let fileText: string;
+
+            if (!groupFolder) {
+              fileText = `[文件下载失败: 无法确定工作目录]`;
+            } else if (!bot) {
+              fileText = `[文件下载失败: ${safeFilename}]`;
+            } else {
+              try {
+                const tgFile = await bot.api.getFile(file.fileId);
+                const filePath = tgFile.file_path;
+                if (!filePath) {
+                  fileText = `[文件下载失败: ${safeFilename}]`;
+                } else {
+                  const url = `https://api.telegram.org/file/bot${config.botToken}/${filePath}`;
+                  const buffer = await downloadTelegramHttpsBuffer(url, {
+                    agent: telegramApiAgent,
+                    timeoutMs: TELEGRAM_NATIVE_MEDIA_DOWNLOAD_TIMEOUT_MS,
+                  });
+                  const pathBasename = filePath.split('/').pop() || '';
+                  const effectiveName =
+                    originalFilename || pathBasename || `file_${file.fileId}`;
+                  const relPath = await saveDownloadedFile(
+                    groupFolder,
+                    'telegram',
+                    effectiveName,
+                    buffer,
+                  );
+                  fileText = relPath
+                    ? `[文件: ${relPath}]`
+                    : `[文件下载失败: ${safeFilename}]`;
+                }
+              } catch (err) {
+                logger.warn(
+                  { err, fileId: file.fileId, kind: file.kind },
+                  'Failed to download Telegram native media',
+                );
+                fileText = `[文件下载失败: ${safeFilename}]`;
+              }
+            }
+
+            const id = crypto.randomUUID();
+            ackReactions
+              .attach(
+                processingIndicatorKey(extractProviderTarget(sourceJid), id),
+                async () => {
+                  try {
+                    await ctx.react('👀');
+                    return {
+                      chatId: tgChat.id,
+                      messageId: tgMessage.message_id,
+                    };
+                  } catch (err) {
+                    logger.debug(
+                      { err, msgId },
+                      'Failed to add Telegram reaction',
+                    );
+                    return null;
+                  }
+                },
+                async (handle) => {
+                  if (!bot) throw new Error('Telegram bot is not initialized');
+                  await bot.api.setMessageReaction(
+                    handle.chatId,
+                    handle.messageId,
+                    [],
+                  );
+                },
+              )
+              .catch(() => {});
+            const timestamp = new Date(tgMessage.date * 1000).toISOString();
+            storeChatMetadata(targetJid, timestamp);
+            await handleTelegramNativeMediaUpdate(
+              { message: tgMessage, chat: tgChat, from: ctx.from },
+              {
+                isChatAuthorized: () => true,
+                storeMessageDirect,
+                notifyNewImMessage,
+                onMessagePersisted: opts.onMessagePersisted,
+                downloadRelPath: async () => {
+                  const match = /^\[文件: (.+)\]$/.exec(fileText);
+                  return match ? match[1] : null;
+                },
+              },
+            );
+
+            if (agentRouting?.agentId) {
+              opts.onAgentMessage?.(jid, agentRouting.agentId);
+            }
+
+            logger.info(
+              {
+                jid,
+                sender: senderName,
+                msgId,
+                kind: file.kind,
+                routed: !!agentRouting,
+              },
+              'Telegram native media stored',
+            );
+          } finally {
+            processingLock.release(msgId);
+          }
+        } catch (err) {
+          logger.error({ err }, 'Error handling Telegram native media');
+        }
+      };
+      bot.on('message:video', handleNativeTelegramMedia);
+      bot.on('message:voice', handleNativeTelegramMedia);
+      bot.on('message:audio', handleNativeTelegramMedia);
+      bot.on('message:animation', handleNativeTelegramMedia);
 
       // ── my_chat_member: Bot 加入/离开群聊检测 ──
       bot.on('my_chat_member', async (ctx) => {

--- a/tests/telegram-native-media.test.ts
+++ b/tests/telegram-native-media.test.ts
@@ -1,0 +1,279 @@
+import net from 'node:net';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const inbound = vi.hoisted(() => ({
+  handlers: new Map<string, (ctx: unknown) => Promise<void>>(),
+  storeMessageDirect: vi.fn(),
+  notifyNewImMessage: vi.fn(),
+  stop: null as (() => void) | null,
+}));
+
+vi.mock('grammy', () => ({
+  Bot: class {
+    api = {
+      config: { use: vi.fn() },
+      getMe: vi.fn(async () => ({ id: 1, username: 'media_bot' })),
+      getFile: vi.fn(async () => ({})),
+      setMessageReaction: vi.fn(async () => {}),
+    };
+    on(filter: string, fn: (ctx: unknown) => Promise<void>) {
+      inbound.handlers.set(filter, fn);
+      return this;
+    }
+    start(options: { onStart?: () => void }) {
+      options.onStart?.();
+      return new Promise<void>((resolve) => {
+        inbound.stop = resolve;
+      });
+    }
+    stop() {
+      inbound.stop?.();
+      inbound.stop = null;
+    }
+  },
+  InputFile: class {},
+}));
+
+vi.mock('../src/db.js', () => ({
+  storeChatMetadata: vi.fn(),
+  storeMessageDirect: inbound.storeMessageDirect,
+  updateChatName: vi.fn(),
+}));
+
+vi.mock('../src/message-notifier.js', () => ({
+  notifyNewImMessage: inbound.notifyNewImMessage,
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  createTelegramConnection,
+  downloadTelegramHttpsBuffer,
+  handleTelegramNativeMediaUpdate,
+  telegramNativeFileFromMessage,
+} from '../src/telegram.js';
+
+describe('telegramNativeFileFromMessage', () => {
+  test('picks video, voice, audio, and animation', () => {
+    expect(
+      telegramNativeFileFromMessage({
+        video: { file_id: 'v1', file_name: 'clip.mp4', file_size: 12 },
+      }),
+    ).toEqual({
+      fileId: 'v1',
+      fileName: 'clip.mp4',
+      fileSize: 12,
+      kind: 'video',
+    });
+    expect(
+      telegramNativeFileFromMessage({
+        voice: { file_id: 'vo1', file_size: 3 },
+      }),
+    ).toEqual({
+      fileId: 'vo1',
+      fileName: 'voice.ogg',
+      fileSize: 3,
+      kind: 'voice',
+    });
+    expect(
+      telegramNativeFileFromMessage({
+        audio: { file_id: 'a1', file_name: 'song.mp3', file_size: 8 },
+      }),
+    ).toEqual({
+      fileId: 'a1',
+      fileName: 'song.mp3',
+      fileSize: 8,
+      kind: 'audio',
+    });
+    expect(
+      telegramNativeFileFromMessage({
+        animation: { file_id: 'g1', file_size: 4 },
+      }),
+    ).toEqual({
+      fileId: 'g1',
+      fileName: 'animation.mp4',
+      fileSize: 4,
+      kind: 'animation',
+    });
+  });
+
+  test('ignores empty messages', () => {
+    expect(telegramNativeFileFromMessage({})).toBeNull();
+  });
+});
+
+describe('handleTelegramNativeMediaUpdate (message:video)', () => {
+  test('authorized video stores and notifies', async () => {
+    const storeMessageDirect = vi.fn();
+    const notifyNewImMessage = vi.fn();
+    const onMessagePersisted = vi.fn();
+    const result = await handleTelegramNativeMediaUpdate(
+      {
+        message: {
+          message_id: 7,
+          date: 1_777_000_000,
+          video: { file_id: 'v1', file_name: 'clip.mp4', file_size: 12 },
+        },
+        chat: { id: 99, title: 'Ada' },
+        from: { id: 9, first_name: 'Ada' },
+      },
+      {
+        isChatAuthorized: () => true,
+        storeMessageDirect,
+        notifyNewImMessage,
+        onMessagePersisted,
+        downloadRelPath: async () => 'telegram/clip.mp4',
+      },
+    );
+    expect(result).toBe('stored');
+    expect(storeMessageDirect).toHaveBeenCalled();
+    expect(storeMessageDirect.mock.calls[0][4]).toBe(
+      '[文件: telegram/clip.mp4]',
+    );
+    expect(notifyNewImMessage).toHaveBeenCalledTimes(1);
+    expect(onMessagePersisted).toHaveBeenCalledTimes(1);
+  });
+
+  test('unauthorized video does not persist', async () => {
+    const storeMessageDirect = vi.fn();
+    const notifyNewImMessage = vi.fn();
+    const result = await handleTelegramNativeMediaUpdate(
+      {
+        message: {
+          message_id: 8,
+          date: 1_777_000_000,
+          video: { file_id: 'v2', file_name: 'clip.mp4' },
+        },
+        chat: { id: 99 },
+      },
+      {
+        isChatAuthorized: () => false,
+        storeMessageDirect,
+        notifyNewImMessage,
+      },
+    );
+    expect(result).toBe('unauthorized');
+    expect(storeMessageDirect).not.toHaveBeenCalled();
+    expect(notifyNewImMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('native media download timeout', () => {
+  const closers: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    await Promise.allSettled(closers.splice(0).map((close) => close()));
+  }, 3000);
+
+  test('times out against a blackhole peer', async () => {
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+    });
+    closers.push(async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') {
+      throw new Error('no port');
+    }
+    const started = Date.now();
+    await expect(
+      downloadTelegramHttpsBuffer(`http://127.0.0.1:${addr.port}/file`, {
+        timeoutMs: 250,
+      }),
+    ).rejects.toThrow(/timed out/i);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+});
+
+describe('Telegram native media inbound listeners', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/telegram.ts'),
+    'utf8',
+  );
+
+  test('registers video/voice/audio/animation handlers that persist', () => {
+    for (const kind of ['video', 'voice', 'audio', 'animation']) {
+      expect(source).toContain(`bot.on('message:${kind}'`);
+    }
+    expect(source).toContain('handleNativeTelegramMedia');
+    expect(source).toContain('handleTelegramNativeMediaUpdate');
+    expect(source).toContain('const tgMessage = ctx.message');
+    expect(source).not.toContain('const message = message');
+    expect(source).toContain('downloadTelegramHttpsBuffer');
+    expect(source).not.toContain("from './im-media-download.js'");
+  });
+
+  let connection: ReturnType<typeof createTelegramConnection> | null = null;
+
+  beforeEach(() => {
+    inbound.handlers.clear();
+    inbound.storeMessageDirect.mockReset();
+    inbound.notifyNewImMessage.mockReset();
+    inbound.stop = null;
+  });
+
+  afterEach(async () => {
+    if (connection) {
+      await connection.disconnect();
+      connection = null;
+    }
+  }, 8000);
+
+  async function connectAuthorized(authorized: boolean) {
+    connection = createTelegramConnection({ botToken: 'test-token' });
+    const ok = await connection.connect({
+      onNewChat: vi.fn(),
+      isChatAuthorized: () => authorized,
+    });
+    expect(ok).toBe(true);
+    return connection;
+  }
+
+  function videoCtx(messageId: number) {
+    return {
+      message: {
+        message_id: messageId,
+        date: Math.floor(Date.now() / 1000),
+        video: { file_id: 'v1', file_name: 'clip.mp4', file_size: 12 },
+      },
+      chat: { id: 42, title: 'Ada' },
+      from: { id: 9, first_name: 'Ada' },
+      react: async () => {},
+    };
+  }
+
+  test('connect() registers runtime bot.on listeners and video persist+notify', async () => {
+    await connectAuthorized(true);
+    for (const kind of ['video', 'voice', 'audio', 'animation']) {
+      expect(typeof inbound.handlers.get(`message:${kind}`)).toBe('function');
+    }
+    const handler = inbound.handlers.get('message:video');
+    expect(handler).toBeTypeOf('function');
+    await handler!(videoCtx(101));
+    expect(inbound.storeMessageDirect).toHaveBeenCalled();
+    expect(inbound.storeMessageDirect.mock.calls[0][4]).toMatch(/\[文件/);
+    expect(inbound.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('inbound video listener skips unauthorized chats', async () => {
+    await connectAuthorized(false);
+    const handler = inbound.handlers.get('message:video');
+    expect(handler).toBeTypeOf('function');
+    await handler!(videoCtx(202));
+    expect(inbound.storeMessageDirect).not.toHaveBeenCalled();
+    expect(inbound.notifyNewImMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Grammy only registered `message:text|photo|document`. A Video-button MP4, voice note, audio file, or GIF/animation never reached `storeMessageDirect` / `notifyNewImMessage` / Agent.
- Add `message:video|voice|audio|animation` handlers that persist like document.
- Native-media CDN GET uses its own 30s `req.setTimeout`. This does **not** import or stack #685 (`im-media-download.ts` is not on main).

## Test plan
- [x] `telegramNativeFileFromMessage` picks video/voice/audio/animation
- [x] `persistTelegramNativeMediaMessage` calls store + notify (message:video path)
- [x] timed GET rejects a blackhole peer in <2s
- [x] source tripwire: four `bot.on('message:…')` registrations; no `im-media-download` import