### PR TITLE
fix(telegram): honor /pair captions on photo and document

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -105,6 +105,26 @@ export function buildTelegramRouteJid(
     : base;
 }
 
+/** Caption or text `/pair CODE` — Telegram puts media captions on `caption`, not `text`. */
+export function matchTelegramPairCode(text: string | undefined): string | null {
+  if (!text) return null;
+  const match = text.trim().match(/^\/pair\s+(\S+)/i);
+  return match?.[1] ?? null;
+}
+
+export async function attemptTelegramCaptionPair(
+  caption: string | undefined,
+  onPairAttempt:
+    | ((jid: string, chatName: string, code: string) => Promise<boolean>)
+    | undefined,
+  jid: string,
+  chatName: string,
+): Promise<boolean | null> {
+  const code = matchTelegramPairCode(caption);
+  if (!code || !onPairAttempt) return null;
+  return onPairAttempt(jid, chatName, code);
+}
+
 export interface TelegramProviderTarget {
   chatId: number;
   messageThreadId?: number;
@@ -671,9 +691,9 @@ export function createTelegramConnection(
             const text = ctx.message.text;
 
             // ── /pair <code> command ──
-            const pairMatch = text.match(/^\/pair\s+(\S+)/i);
-            if (pairMatch && opts.onPairAttempt) {
-              const code = pairMatch[1];
+            const pairCode = matchTelegramPairCode(text);
+            if (pairCode && opts.onPairAttempt) {
+              const code = pairCode;
               try {
                 const success = await opts.onPairAttempt(jid, chatName, code);
                 if (success) {
@@ -932,6 +952,52 @@ export function createTelegramConnection(
                 .join(' ') || 'Unknown';
 
             if (!opts.isChatAuthorized(jid)) {
+              const paired = await attemptTelegramCaptionPair(
+                ctx.message.caption,
+                opts.onPairAttempt,
+                jid,
+                chatName,
+              );
+              if (paired !== null) {
+                try {
+                  const success = paired;
+                  if (success) {
+                    const forumState = await prepareTelegramForumPairing(
+                      jid,
+                      ctx.chat as TelegramChatDescriptor,
+                      (id) => bot!.api.getChat(id),
+                      opts.onNativeContextDetected,
+                    );
+                    if (forumState === 'thread_ready') {
+                      nativeContextReported.add(jid);
+                    }
+                    await ctx.reply(
+                      forumState === 'thread_unavailable'
+                        ? 'Pairing succeeded, but Telegram Forum routing could not be initialized. In Web settings, bind this channel to a default workspace before sending topic messages; do not bind it to a fixed session.'
+                        : 'Pairing successful! This chat is now connected.',
+                    );
+                  } else {
+                    await ctx.reply(
+                      'Invalid or expired pairing code. Please generate a new code from the web settings page.',
+                    );
+                  }
+                } catch (err) {
+                  logger.error({ err, jid }, 'Error during pair attempt');
+                  await ctx.reply(
+                    'Pairing failed due to an internal error. Please try again.',
+                  );
+                }
+                return;
+              }
+              const now = Date.now();
+              const lastReject = rejectTimestamps.get(jid) ?? 0;
+              if (now - lastReject >= REJECT_COOLDOWN_MS) {
+                rejectTimestamps.set(jid, now);
+                await ctx.reply(
+                  'This chat is not yet paired. Please send /pair <code> to connect.\n' +
+                    'You can generate a pairing code from the web settings page.',
+                );
+              }
               logger.debug(
                 { jid },
                 'Unauthorized Telegram chat (photo), ignoring',
@@ -1122,6 +1188,52 @@ export function createTelegramConnection(
                 .join(' ') || 'Unknown';
 
             if (!opts.isChatAuthorized(jid)) {
+              const paired = await attemptTelegramCaptionPair(
+                ctx.message.caption,
+                opts.onPairAttempt,
+                jid,
+                chatName,
+              );
+              if (paired !== null) {
+                try {
+                  const success = paired;
+                  if (success) {
+                    const forumState = await prepareTelegramForumPairing(
+                      jid,
+                      ctx.chat as TelegramChatDescriptor,
+                      (id) => bot!.api.getChat(id),
+                      opts.onNativeContextDetected,
+                    );
+                    if (forumState === 'thread_ready') {
+                      nativeContextReported.add(jid);
+                    }
+                    await ctx.reply(
+                      forumState === 'thread_unavailable'
+                        ? 'Pairing succeeded, but Telegram Forum routing could not be initialized. In Web settings, bind this channel to a default workspace before sending topic messages; do not bind it to a fixed session.'
+                        : 'Pairing successful! This chat is now connected.',
+                    );
+                  } else {
+                    await ctx.reply(
+                      'Invalid or expired pairing code. Please generate a new code from the web settings page.',
+                    );
+                  }
+                } catch (err) {
+                  logger.error({ err, jid }, 'Error during pair attempt');
+                  await ctx.reply(
+                    'Pairing failed due to an internal error. Please try again.',
+                  );
+                }
+                return;
+              }
+              const now = Date.now();
+              const lastReject = rejectTimestamps.get(jid) ?? 0;
+              if (now - lastReject >= REJECT_COOLDOWN_MS) {
+                rejectTimestamps.set(jid, now);
+                await ctx.reply(
+                  'This chat is not yet paired. Please send /pair <code> to connect.\n' +
+                    'You can generate a pairing code from the web settings page.',
+                );
+              }
               logger.debug(
                 { jid },
                 'Unauthorized Telegram chat (document), ignoring',

--- a/tests/telegram-media-pair.test.ts
+++ b/tests/telegram-media-pair.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  attemptTelegramCaptionPair,
+  matchTelegramPairCode,
+} from '../src/telegram.js';
+
+describe('matchTelegramPairCode', () => {
+  test('reads /pair from text or caption', () => {
+    expect(matchTelegramPairCode('/pair ABC123')).toBe('ABC123');
+    expect(matchTelegramPairCode('/PAIR xyz')).toBe('xyz');
+    expect(matchTelegramPairCode('  /pair code-1  ')).toBe('code-1');
+  });
+
+  test('rejects missing or non-pair captions', () => {
+    expect(matchTelegramPairCode(undefined)).toBeNull();
+    expect(matchTelegramPairCode('')).toBeNull();
+    expect(matchTelegramPairCode('hello')).toBeNull();
+    expect(matchTelegramPairCode('/start')).toBeNull();
+    expect(matchTelegramPairCode('not /pair CODE')).toBeNull();
+  });
+});
+
+describe('unauthorized photo caption /pair reaches onPairAttempt', () => {
+  test('attemptTelegramCaptionPair calls onPairAttempt with the code', async () => {
+    const onPairAttempt = vi.fn(async () => true);
+    await expect(
+      attemptTelegramCaptionPair(
+        '/pair ABC123',
+        onPairAttempt,
+        'telegram:99',
+        'Ada',
+      ),
+    ).resolves.toBe(true);
+    expect(onPairAttempt).toHaveBeenCalledWith('telegram:99', 'Ada', 'ABC123');
+  });
+
+  test('plain photo caption does not pair', async () => {
+    const onPairAttempt = vi.fn(async () => true);
+    await expect(
+      attemptTelegramCaptionPair(
+        'just a photo',
+        onPairAttempt,
+        'telegram:99',
+        'Ada',
+      ),
+    ).resolves.toBeNull();
+    expect(onPairAttempt).not.toHaveBeenCalled();
+  });
+});
+
+describe('Telegram photo/document pairing leftover', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/telegram.ts'),
+    'utf8',
+  );
+
+  test('photo and document unauthorized paths call attemptTelegramCaptionPair', () => {
+    const photoAt = source.indexOf("bot.on('message:photo'");
+    const docAt = source.indexOf("bot.on('message:document'");
+    const memberAt = source.indexOf("bot.on('my_chat_member'");
+    expect(photoAt).toBeGreaterThan(-1);
+    expect(docAt).toBeGreaterThan(photoAt);
+    expect(memberAt).toBeGreaterThan(docAt);
+    const photoBlock = source.slice(photoAt, docAt);
+    const docBlock = source.slice(docAt, memberAt);
+    expect(photoBlock).toContain('attemptTelegramCaptionPair');
+    expect(docBlock).toContain('attemptTelegramCaptionPair');
+    expect(photoBlock).toContain('This chat is not yet paired');
+    expect(docBlock).toContain('This chat is not yet paired');
+  });
+});


### PR DESCRIPTION
## Summary
- Unauthorized `message:photo` / `message:document` returned silently. A `/pair CODE` caption never reached `onPairAttempt` (text already does).
- Photo/document now run the same pairing attempt on the caption, and send the existing unpaired hint (with cooldown) otherwise.
- Separate from inbound video/voice handlers; this PR only changes pairing.

## Test plan
- [x] `matchTelegramPairCode('/pair ABC123')` → `ABC123`
- [x] unauthorized photo caption `/pair CODE` calls `onPairAttempt`
- [x] plain caption does not pair
- [x] source tripwire: photo and document unauthorized paths call `attemptTelegramCaptionPair`