### PR TITLE
fix(whatsapp): send video and audio as native media

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -1069,12 +1069,10 @@ export function createWhatsAppConnection(
       const jid = stripChannelPrefix(chatId);
       try {
         const buf = await readFile(filePath);
-        const mime = guessMimeType(fileName) || 'application/octet-stream';
-        await sock.sendMessage(jid, {
-          document: buf,
-          mimetype: mime,
-          fileName,
-        });
+        await sock.sendMessage(
+          jid,
+          buildWhatsAppSendFileContent(buf, fileName),
+        );
       } catch (err) {
         logger.error(
           { err, feature: 'whatsapp', chatId, filePath },
@@ -1365,6 +1363,27 @@ export function stripLeadingWhatsAppBotMention(
  * Covers WhatsApp-relevant types: image/video/audio/document.
  * Returns null when unknown so caller can fall back to a sensible default.
  */
+
+export type WhatsAppSendFileContent =
+  | { video: Buffer; mimetype: string }
+  | { audio: Buffer; mimetype: string }
+  | { document: Buffer; mimetype: string; fileName: string };
+
+/** Pick Baileys' native video/audio envelope from guessMimeType; PDFs stay document. */
+export function buildWhatsAppSendFileContent(
+  buf: Buffer,
+  fileName: string,
+): WhatsAppSendFileContent {
+  const mime = guessMimeType(fileName) || 'application/octet-stream';
+  if (mime.startsWith('video/')) {
+    return { video: buf, mimetype: mime };
+  }
+  if (mime.startsWith('audio/')) {
+    return { audio: buf, mimetype: mime };
+  }
+  return { document: buf, mimetype: mime, fileName };
+}
+
 export function guessMimeType(fileName: string): string | null {
   const m = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
   if (!m) return null;

--- a/tests/whatsapp-helpers.test.ts
+++ b/tests/whatsapp-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   extractMessageText,
   extFromMime,
   guessMimeType,
+  buildWhatsAppSendFileContent,
   isMentioningBot,
   isWhatsAppSelfParticipant,
   normalizeTimestamp,
@@ -514,5 +515,52 @@ describe('stripLeadingWhatsAppBotMention', () => {
     expect(
       stripLeadingWhatsAppBotMention('@15551234567', trustedMention, SELF),
     ).toBe('@15551234567');
+  });
+});
+
+describe('buildWhatsAppSendFileContent', () => {
+  const buf = Buffer.from('x');
+
+  test('mp4/mov/webm use native video', () => {
+    expect(buildWhatsAppSendFileContent(buf, 'clip.mp4')).toEqual({
+      video: buf,
+      mimetype: 'video/mp4',
+    });
+    expect(buildWhatsAppSendFileContent(buf, 'clip.MOV')).toEqual({
+      video: buf,
+      mimetype: 'video/quicktime',
+    });
+    expect(buildWhatsAppSendFileContent(buf, 'clip.webm')).toEqual({
+      video: buf,
+      mimetype: 'video/webm',
+    });
+  });
+
+  test('ogg/mp3/wav use native audio', () => {
+    expect(buildWhatsAppSendFileContent(buf, 'voice.ogg')).toEqual({
+      audio: buf,
+      mimetype: 'audio/ogg',
+    });
+    expect(buildWhatsAppSendFileContent(buf, 'track.mp3')).toEqual({
+      audio: buf,
+      mimetype: 'audio/mpeg',
+    });
+    expect(buildWhatsAppSendFileContent(buf, 'wave.wav')).toEqual({
+      audio: buf,
+      mimetype: 'audio/wav',
+    });
+  });
+
+  test('pdf and unknown stay document', () => {
+    expect(buildWhatsAppSendFileContent(buf, 'notes.pdf')).toEqual({
+      document: buf,
+      mimetype: 'application/pdf',
+      fileName: 'notes.pdf',
+    });
+    expect(buildWhatsAppSendFileContent(buf, 'blob.bin')).toEqual({
+      document: buf,
+      mimetype: 'application/octet-stream',
+      fileName: 'blob.bin',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `sendFile` always wrapped the buffer as `{ document }`, so `clip.mp4` / `voice.ogg` arrived as a file chip instead of an inline player.
- `guessMimeType` already classified video/audio; use Baileys `{ video }` / `{ audio }` when the mime says so. PDF and unknown stay `document`.
- WhatsApp only. Does not retouch DingTalk #683 or Feishu #400.

## Test plan
- [x] `clip.mp4` → `{ video, mimetype: 'video/mp4' }` (not document)
- [x] `voice.ogg` → `{ audio, mimetype: 'audio/ogg' }`
- [x] `notes.pdf` stays `{ document }`