### PR TITLE
fix(dingtalk): persist inbound C2C audio and video

### DIFF
--- a/src/dingtalk.ts
+++ b/src/dingtalk.ts
@@ -1886,6 +1886,63 @@ export function createDingTalkConnection(
             logger.warn({ msgId }, 'DingTalk file download failed, skipping');
             return;
           }
+        } else if (data.msgtype === 'audio' && 'content' in data) {
+          // Official C2C: { duration, downloadCode, recognition }
+          interface AudioContent {
+            duration?: number;
+            downloadCode?: string;
+            recognition?: string;
+          }
+          const audioContent = (data as { content: AudioContent }).content;
+          const recognition = audioContent?.recognition?.trim();
+          content = recognition || '[语音消息]';
+        } else if (data.msgtype === 'video' && 'content' in data) {
+          // Official C2C: { duration, downloadCode, videoType }
+          interface VideoContent {
+            duration?: number;
+            downloadCode?: string;
+            videoType?: string;
+          }
+          const videoContent = (data as { content: VideoContent }).content;
+          const downloadCode = videoContent?.downloadCode;
+          const videoType =
+            (videoContent?.videoType || 'mp4').replace(/[^a-z0-9]/gi, '') ||
+            'mp4';
+          const fileName = `video.${videoType}`;
+          if (downloadCode) {
+            const fileBuffer = await downloadDingTalkFileByDownloadCode(
+              downloadCode,
+              data.robotCode ?? '',
+            );
+            if (fileBuffer) {
+              const groupFolder = opts.resolveGroupFolder?.(jid);
+              if (groupFolder) {
+                try {
+                  const savedPath = await saveDownloadedFile(
+                    groupFolder,
+                    'dingtalk',
+                    `video_${Date.now()}.${videoType}`,
+                    fileBuffer,
+                  );
+                  content = await buildFileContentBlock({
+                    fileName,
+                    savedRelPath: savedPath,
+                    groupFolder,
+                    prefixLabel: '视频',
+                  });
+                } catch (err) {
+                  logger.warn({ err }, 'Failed to save DingTalk video to disk');
+                  content = `[视频: ${sanitizeFileName(fileName)}（保存失败）]`;
+                }
+              } else {
+                content = `[视频: ${sanitizeFileName(fileName)}（未注册群组）]`;
+              }
+            } else {
+              content = '[视频消息]';
+            }
+          } else {
+            content = '[视频消息]';
+          }
         } else if (data.msgtype === 'image' && 'image' in data) {
           // Image message via contentUrl (legacy/native format)
           const contentUrl = (data as DingTalkRobotMessage).image?.contentUrl;

--- a/tests/dingtalk-c2c-audio-video.test.ts
+++ b/tests/dingtalk-c2c-audio-video.test.ts
@@ -1,0 +1,276 @@
+import { EventEmitter } from 'node:events';
+import https from 'node:https';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const inbound = vi.hoisted(() => ({
+  listener: null as null | ((downstream: { data: string }) => Promise<void>),
+  storeMessageDirect: vi.fn(),
+  notifyNewImMessage: vi.fn(),
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('dingtalk-stream', () => ({
+  DWClient: class {
+    registerCallbackListener(
+      _topic: string,
+      fn: (downstream: { data: string }) => Promise<void>,
+    ) {
+      inbound.listener = fn;
+    }
+    async connect() {}
+    disconnect() {}
+    socketCallBackResponse() {}
+  },
+  TOPIC_ROBOT: 'dingtalk::robot',
+}));
+
+vi.mock('../src/db.js', () => ({
+  storeChatMetadata: vi.fn(),
+  storeMessageDirect: inbound.storeMessageDirect,
+}));
+
+vi.mock('../src/message-notifier.js', () => ({
+  notifyNewImMessage: inbound.notifyNewImMessage,
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: inbound.logger,
+}));
+
+import { createDingTalkConnection } from '../src/dingtalk.js';
+
+function jpegBuffer(): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+    Buffer.alloc(600, 1),
+  ]);
+}
+
+function mockDingTalkHttpsDownloads() {
+  return vi
+    .spyOn(https, 'request')
+    .mockImplementation((options: any, cb?: any) => {
+      const path =
+        typeof options === 'object' && options
+          ? String(options.path || '')
+          : '';
+      const req = new EventEmitter() as EventEmitter & {
+        write: () => void;
+        end: () => void;
+      };
+      req.write = () => {};
+      req.end = () => {
+        let body: Buffer;
+        if (path.includes('/gettoken')) {
+          body = Buffer.from(
+            JSON.stringify({
+              errcode: 0,
+              access_token: 'tok',
+              expires_in: 7200,
+            }),
+          );
+        } else if (path.includes('/messageFiles/download')) {
+          body = Buffer.from(
+            JSON.stringify({ downloadUrl: 'https://cdn.example/blob' }),
+          );
+        } else {
+          body = jpegBuffer();
+        }
+        const res = new EventEmitter() as EventEmitter & {
+          statusCode: number;
+          headers: Record<string, string>;
+        };
+        res.statusCode = 200;
+        res.headers = {};
+        cb?.(res);
+        res.emit('data', body);
+        res.emit('end');
+      };
+      return req as any;
+    });
+}
+
+function mockDingTalkHttpsCdnFail() {
+  return vi.spyOn(https, 'request').mockImplementation(() => {
+    const req = new EventEmitter() as EventEmitter & {
+      write: () => void;
+      end: () => void;
+    };
+    req.write = () => {};
+    req.end = () => {
+      req.emit('error', new Error('cdn unavailable'));
+    };
+    return req as any;
+  });
+}
+
+describe('DingTalk C2C inbound audio/video', () => {
+  let connection: ReturnType<typeof createDingTalkConnection> | null = null;
+  let httpsSpy: ReturnType<typeof mockDingTalkHttpsDownloads> | null = null;
+
+  beforeEach(() => {
+    inbound.listener = null;
+    inbound.storeMessageDirect.mockReset();
+    inbound.notifyNewImMessage.mockReset();
+    inbound.logger.debug.mockReset();
+    inbound.logger.info.mockReset();
+    inbound.logger.warn.mockReset();
+    inbound.logger.error.mockReset();
+  });
+
+  afterEach(async () => {
+    httpsSpy?.mockRestore();
+    httpsSpy = null;
+    if (connection) {
+      await connection.disconnect();
+      connection = null;
+    }
+  });
+
+  async function connect(authorized: boolean) {
+    connection = createDingTalkConnection({
+      clientId: 'app-key',
+      clientSecret: 'app-secret',
+    });
+    const ok = await connection.connect({
+      onNewChat: vi.fn(),
+      isChatAuthorized: () => authorized,
+    });
+    expect(ok).toBe(true);
+    expect(typeof inbound.listener).toBe('function');
+    return inbound.listener!;
+  }
+
+  function downstream(msg: Record<string, unknown>, msgId: string) {
+    return {
+      data: JSON.stringify({
+        msgId,
+        conversationId: 'cid-1',
+        conversationType: '1',
+        senderId: 'user-1',
+        senderNick: 'Ada',
+        createAt: Date.now(),
+        robotCode: 'robot-1',
+        ...msg,
+      }),
+    };
+  }
+
+  async function fireAndWait(
+    listener: (d: { data: string }) => Promise<void>,
+    msg: Record<string, unknown>,
+    msgId: string,
+  ) {
+    const pending = listener(downstream(msg, msgId));
+    await vi.waitFor(() => {
+      expect(inbound.storeMessageDirect).toHaveBeenCalled();
+    });
+    await pending;
+  }
+
+  test('paired C2C audio persists recognition and notifies', async () => {
+    const listener = await connect(true);
+    await fireAndWait(
+      listener,
+      {
+        msgtype: 'audio',
+        content: {
+          duration: 2000,
+          downloadCode: 'audio-code',
+          recognition: '你好',
+        },
+      },
+      'audio-1',
+    );
+    expect(inbound.storeMessageDirect.mock.calls[0][4]).toBe('你好');
+    expect(inbound.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('paired C2C audio without recognition persists [语音消息]', async () => {
+    const listener = await connect(true);
+    await fireAndWait(
+      listener,
+      {
+        msgtype: 'audio',
+        content: {
+          duration: 2000,
+          downloadCode: 'audio-code',
+          recognition: '',
+        },
+      },
+      'audio-empty',
+    );
+    expect(inbound.storeMessageDirect.mock.calls[0][4]).toBe('[语音消息]');
+    expect(inbound.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('paired C2C video persists [视频消息] when CDN GET fails', async () => {
+    httpsSpy = mockDingTalkHttpsCdnFail();
+    const listener = await connect(true);
+    await fireAndWait(
+      listener,
+      {
+        msgtype: 'video',
+        content: {
+          duration: 4000,
+          downloadCode: 'video-code',
+          videoType: 'mp4',
+        },
+      },
+      'video-1',
+    );
+    expect(inbound.storeMessageDirect.mock.calls[0][4]).toBe('[视频消息]');
+    expect(inbound.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('paired C2C picture still persists', async () => {
+    httpsSpy = mockDingTalkHttpsDownloads();
+    const listener = await connect(true);
+    await fireAndWait(
+      listener,
+      {
+        msgtype: 'picture',
+        content: { downloadCode: 'pic-code' },
+      },
+      'pic-1',
+    );
+    expect(inbound.storeMessageDirect).toHaveBeenCalled();
+    expect(inbound.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('paired C2C file still persists', async () => {
+    httpsSpy = mockDingTalkHttpsDownloads();
+    const listener = await connect(true);
+    await fireAndWait(
+      listener,
+      {
+        msgtype: 'file',
+        content: { downloadCode: 'file-code', fileName: 'notes.pdf' },
+      },
+      'file-1',
+    );
+    expect(inbound.storeMessageDirect.mock.calls[0][4]).toMatch(/文件|notes/);
+    expect(inbound.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('unauthorized C2C audio does not persist', async () => {
+    const listener = await connect(false);
+    await listener(
+      downstream(
+        {
+          msgtype: 'audio',
+          content: { recognition: '你好', downloadCode: 'x' },
+        },
+        'audio-unauth',
+      ),
+    );
+    await vi.waitFor(() => {
+      expect(inbound.logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ jid: expect.any(String) }),
+        'DingTalk chat not authorized',
+      );
+    });
+    expect(inbound.storeMessageDirect).not.toHaveBeenCalled();
+    expect(inbound.notifyNewImMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `handleRobotMessage` only branched text/richText/picture/file/image. Official C2C `audio` (`recognition`, `downloadCode`) and `video` (`downloadCode`, `videoType`) fell through to the empty-content return, so paired voice notes and videos never reached persist/notify/Agent.
- Audio persists the recognition transcript (or `[语音消息]`). Video uses the existing `downloadDingTalkFileByDownloadCode` path and still persists `[视频消息]` when the CDN GET is unavailable.
- DingTalk inbound types only. Does not stack HTTPS hang #680, ACK #681, outbound sampleVideo #683, or inbound GET timeout (HOLD).

## Test plan
- [x] Paired C2C `msgtype: audio` with `recognition: '你好'` → store+notify
- [x] Paired C2C `msgtype: video` → store+notify (`[视频…]`)
- [x] Paired C2C picture/file still persist
- [x] Unauthorized C2C audio does not persist