### PR TITLE
fix(telegram): send video/audio via sendFile instead of document chips

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1646,13 +1646,25 @@ export function createTelegramConnection(
           );
         }
 
-        await bot.api.sendDocument(
-          target.chatId,
-          new InputFile(filePath, fileName),
-          target.messageThreadId
-            ? { message_thread_id: target.messageThreadId }
-            : {},
-        );
+        const inputFile = new InputFile(filePath, fileName);
+        const threadOptions = target.messageThreadId
+          ? { message_thread_id: target.messageThreadId }
+          : {};
+        const ext = (fileName.split('.').pop() || '').toLowerCase();
+        if (ext === 'mp4' || ext === 'mov' || ext === 'webm') {
+          await bot.api.sendVideo(target.chatId, inputFile, threadOptions);
+        } else if (
+          ext === 'ogg' ||
+          ext === 'opus' ||
+          ext === 'mp3' ||
+          ext === 'wav' ||
+          ext === 'm4a' ||
+          ext === 'aac'
+        ) {
+          await bot.api.sendAudio(target.chatId, inputFile, threadOptions);
+        } else {
+          await bot.api.sendDocument(target.chatId, inputFile, threadOptions);
+        }
 
         logger.info(
           { chatId, filePath, fileName, size: stat.size },

--- a/tests/telegram-sendfile-media.test.ts
+++ b/tests/telegram-sendfile-media.test.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+const api = vi.hoisted(() => ({
+  sendDocument: vi.fn(async () => ({})),
+  sendVideo: vi.fn(async () => ({})),
+  sendAudio: vi.fn(async () => ({})),
+  getMe: vi.fn(async () => ({ id: 1, username: 'sendfile_bot' })),
+  config: { use: vi.fn() },
+  stop: null as (() => void) | null,
+}));
+
+vi.mock('grammy', () => ({
+  Bot: class {
+    api = {
+      config: api.config,
+      getMe: api.getMe,
+      sendDocument: api.sendDocument,
+      sendVideo: api.sendVideo,
+      sendAudio: api.sendAudio,
+    };
+    on() {
+      return this;
+    }
+    start(options: { onStart?: () => void }) {
+      options.onStart?.();
+      return new Promise<void>((resolve) => {
+        api.stop = resolve;
+      });
+    }
+    stop() {
+      api.stop?.();
+      api.stop = null;
+    }
+  },
+  InputFile: class {
+    constructor(
+      public filePath: string,
+      public fileName: string,
+    ) {}
+  },
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { createTelegramConnection } = await import('../src/telegram.js');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'telegram-sendfile-'));
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function touch(name: string): string {
+  const filePath = path.join(root, name);
+  fs.writeFileSync(filePath, 'x');
+  return filePath;
+}
+
+describe('Telegram sendFile media routing (live connection)', () => {
+  let connection: ReturnType<typeof createTelegramConnection> | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.stop = null;
+  });
+
+  afterEach(async () => {
+    if (connection) {
+      await connection.disconnect();
+      connection = null;
+    }
+  });
+
+  async function connect() {
+    connection = createTelegramConnection({ botToken: 'test-token' });
+    const ok = await connection.connect({
+      onNewChat: vi.fn(),
+      isChatAuthorized: () => true,
+    });
+    expect(ok).toBe(true);
+    return connection;
+  }
+
+  test('sendFile(clip.mp4) uses sendVideo, not sendDocument', async () => {
+    const conn = await connect();
+    await conn.sendFile('424242', touch('clip.mp4'), 'clip.mp4');
+    expect(api.sendVideo).toHaveBeenCalledOnce();
+    expect(api.sendVideo.mock.calls[0][0]).toBe(424242);
+    expect(api.sendDocument).not.toHaveBeenCalled();
+    expect(api.sendAudio).not.toHaveBeenCalled();
+  });
+
+  test('sendFile(voice.ogg) uses sendAudio, not sendDocument', async () => {
+    const conn = await connect();
+    await conn.sendFile('424242', touch('voice.ogg'), 'voice.ogg');
+    expect(api.sendAudio).toHaveBeenCalledOnce();
+    expect(api.sendDocument).not.toHaveBeenCalled();
+    expect(api.sendVideo).not.toHaveBeenCalled();
+  });
+
+  test('sendFile(notes.pdf) stays sendDocument', async () => {
+    const conn = await connect();
+    await conn.sendFile('424242', touch('notes.pdf'), 'notes.pdf');
+    expect(api.sendDocument).toHaveBeenCalledOnce();
+    expect(api.sendVideo).not.toHaveBeenCalled();
+    expect(api.sendAudio).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
`sendFile` always called `sendDocument`. `clip.mp4` and `voice.ogg` went out as file chips (user must download; no inline player). `sendImage` already branches GIF/photo/document; `sendFile` never got the sibling.

- mp4/mov/webm → `sendVideo`
- ogg/opus/mp3/wav/m4a/aac → `sendAudio`
- other extensions stay `sendDocument`
- Outbound only — does not touch inbound native media (#686)

## Test plan
- [x] Live `createTelegramConnection().connect()` + `sendFile`
- [x] `clip.mp4` hits `sendVideo`, not `sendDocument`
- [x] `voice.ogg` hits `sendAudio`
- [x] `notes.pdf` stays `sendDocument`

SHA: `c01aa3ba277193cfdc86f81ee24405d2072d7311`