### PR TITLE
fix(wechat): download inbound video (and voice) CDN media

### DIFF
--- a/src/wechat.ts
+++ b/src/wechat.ts
@@ -60,9 +60,9 @@ const MESSAGE_TYPE_BOT = 2;
 // iLink message item types
 const MESSAGE_ITEM_TYPE_TEXT = 1;
 const MESSAGE_ITEM_TYPE_IMAGE = 2;
-// const MESSAGE_ITEM_TYPE_VOICE = 3;
+const MESSAGE_ITEM_TYPE_VOICE = 3;
 const MESSAGE_ITEM_TYPE_FILE = 4;
-// const MESSAGE_ITEM_TYPE_VIDEO = 5;
+const MESSAGE_ITEM_TYPE_VIDEO = 5;
 
 // iLink message state
 // const MESSAGE_STATE_NEW = 0;
@@ -358,11 +358,11 @@ function extractTextContent(items: MessageItem[]): string {
       if (!item.image_item?.media?.encrypt_query_param) {
         parts.push('(image)');
       }
-    } else if (item.type === 3 /* VOICE */) {
+    } else if (item.type === MESSAGE_ITEM_TYPE_VOICE) {
       // Voice: prefer speech-to-text transcription
       if (item.voice_item?.text) {
         parts.push(item.voice_item.text);
-      } else {
+      } else if (!item.voice_item?.media?.encrypt_query_param) {
         parts.push('(voice)');
       }
     } else if (item.type === MESSAGE_ITEM_TYPE_FILE) {
@@ -371,8 +371,10 @@ function extractTextContent(items: MessageItem[]): string {
       if (!item.file_item?.media?.encrypt_query_param) {
         parts.push(`(file: ${item.file_item?.file_name ?? 'unknown'})`);
       }
-    } else if (item.type === 5 /* VIDEO */) {
-      parts.push('(video)');
+    } else if (item.type === MESSAGE_ITEM_TYPE_VIDEO) {
+      if (!item.video_item?.media?.encrypt_query_param) {
+        parts.push('(video)');
+      }
     }
   }
   return parts.join('\n').trim();
@@ -866,6 +868,38 @@ export function createWeChatConnection(
     }
   }
 
+  async function processVoiceOrVideoItem(
+    item: MessageItem,
+    kind: 'voice' | 'video',
+    msgIdentifier: string,
+    groupFolder: string | undefined,
+  ): Promise<string | null> {
+    const media =
+      kind === 'video' ? item.video_item?.media : item.voice_item?.media;
+    const fallback = kind === 'video' ? '[视频消息]' : '[语音消息]';
+    const fileName =
+      kind === 'video'
+        ? `wechat_vid_${msgIdentifier}.mp4`
+        : `wechat_voice_${msgIdentifier}.silk`;
+    try {
+      const result = await downloadCdnMediaItem(
+        media,
+        groupFolder,
+        kind,
+        () => fileName,
+      );
+      if (result?.savedPath) {
+        return kind === 'video'
+          ? `[视频: ${result.savedPath}]`
+          : `[语音: ${result.savedPath}]`;
+      }
+      return fallback;
+    } catch (err) {
+      logger.warn({ err, kind }, `WeChat ${kind} download/decrypt failed`);
+      return fallback;
+    }
+  }
+
   async function processFileItem(
     item: MessageItem,
     groupFolder: string | undefined,
@@ -1078,6 +1112,28 @@ export function createWeChatConnection(
           } else if (item.type === MESSAGE_ITEM_TYPE_FILE) {
             mediaPromises.push(
               processFileItem(item, groupFolder).then((label) => {
+                if (label) textPrefixes.push(label);
+              }),
+            );
+          } else if (item.type === MESSAGE_ITEM_TYPE_VIDEO) {
+            mediaPromises.push(
+              processVoiceOrVideoItem(
+                item,
+                'video',
+                msgId.slice(-8),
+                groupFolder,
+              ).then((label) => {
+                if (label) textPrefixes.push(label);
+              }),
+            );
+          } else if (item.type === MESSAGE_ITEM_TYPE_VOICE) {
+            mediaPromises.push(
+              processVoiceOrVideoItem(
+                item,
+                'voice',
+                msgId.slice(-8),
+                groupFolder,
+              ).then((label) => {
                 if (label) textPrefixes.push(label);
               }),
             );

--- a/tests/wechat-inbound-video-cdn.test.ts
+++ b/tests/wechat-inbound-video-cdn.test.ts
@@ -1,0 +1,180 @@
+import type { Dispatcher } from 'undici';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const crypto = vi.hoisted(() => ({
+  downloadAndDecryptMedia: vi.fn(async () => Buffer.from('media-bytes')),
+  uploadMediaBuffer: vi.fn(),
+}));
+const downloader = vi.hoisted(() => ({
+  saveDownloadedFile: vi.fn(async (_folder, _ch, fileName) => `ws/${fileName}`),
+  MAX_FILE_SIZE: 20 * 1024 * 1024,
+}));
+const db = vi.hoisted(() => ({
+  storeChatMetadata: vi.fn(),
+  storeMessageDirect: vi.fn(),
+  updateChatName: vi.fn(),
+}));
+const notify = vi.hoisted(() => ({ notifyNewImMessage: vi.fn() }));
+
+vi.mock('../src/wechat-crypto.js', () => crypto);
+vi.mock('../src/im-downloader.js', () => downloader);
+vi.mock('../src/db.js', () => db);
+vi.mock('../src/message-notifier.js', () => notify);
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { createWeChatConnection } = await import('../src/wechat.js');
+
+function jsonResponse(body: unknown) {
+  return Response.json(body);
+}
+
+function inboundMsg(item: Record<string, unknown>, id: string) {
+  return {
+    message_id: id,
+    from_user_id: 'wxid_user1',
+    create_time_ms: Date.now(),
+    context_token: 'tok',
+    item_list: [item],
+  };
+}
+
+async function connectAndDrain(fetchMock: ReturnType<typeof vi.fn>) {
+  const close = vi.fn(async () => undefined);
+  const connection = createWeChatConnection(
+    {
+      botToken: 'secret-token',
+      ilinkBotId: 'bot-identity@example',
+    },
+    {
+      fetch: fetchMock as typeof fetch,
+      createDispatcher: () => ({ close }) as unknown as Dispatcher,
+      random: () => 0.5,
+      now: () => Date.now(),
+    },
+  );
+  await connection.connect({
+    onNewChat: vi.fn(),
+    isChatAuthorized: () => true,
+    resolveGroupFolder: () => '/tmp/wechat-ws',
+    resolveEffectiveChatJid: (jid: string) => ({
+      effectiveJid: jid,
+      agentId: null,
+    }),
+  });
+  await vi.waitFor(() => expect(db.storeMessageDirect).toHaveBeenCalled());
+  await connection.disconnect();
+  return connection;
+}
+
+describe('WeChat inbound video CDN persist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    crypto.downloadAndDecryptMedia.mockResolvedValue(
+      Buffer.from('media-bytes'),
+    );
+    downloader.saveDownloadedFile.mockImplementation(
+      async (_folder, _ch, fileName) => `ws/${fileName}`,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('type-5 video-only persists a workspace file', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          get_updates_buf: 'c1',
+          msgs: [
+            inboundMsg(
+              {
+                type: 5,
+                video_item: {
+                  media: {
+                    encrypt_query_param: 'q-video',
+                    aes_key: 'k-video',
+                  },
+                },
+              },
+              'vid-1',
+            ),
+          ],
+        }),
+      )
+      .mockImplementation(() =>
+        jsonResponse({ get_updates_buf: 'c2', msgs: [] }),
+      );
+    await connectAndDrain(fetchMock);
+    expect(crypto.downloadAndDecryptMedia).toHaveBeenCalled();
+    expect(downloader.saveDownloadedFile).toHaveBeenCalled();
+    expect(String(db.storeMessageDirect.mock.calls[0][4])).toMatch(/视频/);
+    expect(String(db.storeMessageDirect.mock.calls[0][4])).toMatch(/ws\//);
+    expect(notify.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('type 2 image still downloads', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          get_updates_buf: 'c1',
+          msgs: [
+            inboundMsg(
+              {
+                type: 2,
+                image_item: {
+                  media: {
+                    encrypt_query_param: 'q-img',
+                    aes_key: 'k-img',
+                  },
+                },
+              },
+              'img-1',
+            ),
+          ],
+        }),
+      )
+      .mockImplementation(() =>
+        jsonResponse({ get_updates_buf: 'c2', msgs: [] }),
+      );
+    await connectAndDrain(fetchMock);
+    expect(crypto.downloadAndDecryptMedia).toHaveBeenCalled();
+    expect(downloader.saveDownloadedFile).toHaveBeenCalled();
+  });
+
+  test('type 4 PDF still downloads', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          get_updates_buf: 'c1',
+          msgs: [
+            inboundMsg(
+              {
+                type: 4,
+                file_item: {
+                  file_name: 'notes.pdf',
+                  media: {
+                    encrypt_query_param: 'q-pdf',
+                    aes_key: 'k-pdf',
+                  },
+                },
+              },
+              'pdf-1',
+            ),
+          ],
+        }),
+      )
+      .mockImplementation(() =>
+        jsonResponse({ get_updates_buf: 'c2', msgs: [] }),
+      );
+    await connectAndDrain(fetchMock);
+    expect(crypto.downloadAndDecryptMedia).toHaveBeenCalled();
+    expect(downloader.saveDownloadedFile).toHaveBeenCalled();
+    expect(String(db.storeMessageDirect.mock.calls[0][4])).toMatch(/文件/);
+  });
+});

--- a/tests/wechat-inbound-video-cdn.test.ts
+++ b/tests/wechat-inbound-video-cdn.test.ts
@@ -27,8 +27,13 @@ vi.mock('../src/logger.js', () => ({
 
 const { createWeChatConnection } = await import('../src/wechat.js');
 
-function jsonResponse(body: unknown) {
-  return Response.json(body);
+function waitUntilAborted(signal?: AbortSignal | null): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const abort = () =>
+      reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+    if (signal?.aborted) return abort();
+    signal?.addEventListener('abort', abort, { once: true });
+  });
 }
 
 function inboundMsg(item: Record<string, unknown>, id: string) {
@@ -41,6 +46,17 @@ function inboundMsg(item: Record<string, unknown>, id: string) {
   };
 }
 
+function fetchOnceThenHang(firstBody: unknown): ReturnType<typeof vi.fn> {
+  let first = true;
+  return vi.fn(async (_url: string, init?: { signal?: AbortSignal | null }) => {
+    if (first) {
+      first = false;
+      return Response.json(firstBody);
+    }
+    return waitUntilAborted(init?.signal);
+  });
+}
+
 async function connectAndDrain(fetchMock: ReturnType<typeof vi.fn>) {
   const close = vi.fn(async () => undefined);
   const connection = createWeChatConnection(
@@ -51,21 +67,25 @@ async function connectAndDrain(fetchMock: ReturnType<typeof vi.fn>) {
     {
       fetch: fetchMock as typeof fetch,
       createDispatcher: () => ({ close }) as unknown as Dispatcher,
+      contextTokenStore: null,
       random: () => 0.5,
       now: () => Date.now(),
     },
   );
-  await connection.connect({
-    onNewChat: vi.fn(),
-    isChatAuthorized: () => true,
-    resolveGroupFolder: () => '/tmp/wechat-ws',
-    resolveEffectiveChatJid: (jid: string) => ({
-      effectiveJid: jid,
-      agentId: null,
-    }),
-  });
-  await vi.waitFor(() => expect(db.storeMessageDirect).toHaveBeenCalled());
-  await connection.disconnect();
+  try {
+    await connection.connect({
+      onNewChat: vi.fn(),
+      isChatAuthorized: () => true,
+      resolveGroupFolder: () => '/tmp/wechat-ws',
+      resolveEffectiveChatJid: (jid: string) => ({
+        effectiveJid: jid,
+        agentId: null,
+      }),
+    });
+    await vi.waitFor(() => expect(db.storeMessageDirect).toHaveBeenCalled());
+  } finally {
+    await connection.disconnect();
+  }
   return connection;
 }
 
@@ -85,30 +105,23 @@ describe('WeChat inbound video CDN persist', () => {
   });
 
   test('type-5 video-only persists a workspace file', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          get_updates_buf: 'c1',
-          msgs: [
-            inboundMsg(
-              {
-                type: 5,
-                video_item: {
-                  media: {
-                    encrypt_query_param: 'q-video',
-                    aes_key: 'k-video',
-                  },
-                },
+    const fetchMock = fetchOnceThenHang({
+      get_updates_buf: 'c1',
+      msgs: [
+        inboundMsg(
+          {
+            type: 5,
+            video_item: {
+              media: {
+                encrypt_query_param: 'q-video',
+                aes_key: 'k-video',
               },
-              'vid-1',
-            ),
-          ],
-        }),
-      )
-      .mockImplementation(() =>
-        jsonResponse({ get_updates_buf: 'c2', msgs: [] }),
-      );
+            },
+          },
+          'vid-1',
+        ),
+      ],
+    });
     await connectAndDrain(fetchMock);
     expect(crypto.downloadAndDecryptMedia).toHaveBeenCalled();
     expect(downloader.saveDownloadedFile).toHaveBeenCalled();
@@ -118,61 +131,47 @@ describe('WeChat inbound video CDN persist', () => {
   });
 
   test('type 2 image still downloads', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          get_updates_buf: 'c1',
-          msgs: [
-            inboundMsg(
-              {
-                type: 2,
-                image_item: {
-                  media: {
-                    encrypt_query_param: 'q-img',
-                    aes_key: 'k-img',
-                  },
-                },
+    const fetchMock = fetchOnceThenHang({
+      get_updates_buf: 'c1',
+      msgs: [
+        inboundMsg(
+          {
+            type: 2,
+            image_item: {
+              media: {
+                encrypt_query_param: 'q-img',
+                aes_key: 'k-img',
               },
-              'img-1',
-            ),
-          ],
-        }),
-      )
-      .mockImplementation(() =>
-        jsonResponse({ get_updates_buf: 'c2', msgs: [] }),
-      );
+            },
+          },
+          'img-1',
+        ),
+      ],
+    });
     await connectAndDrain(fetchMock);
     expect(crypto.downloadAndDecryptMedia).toHaveBeenCalled();
     expect(downloader.saveDownloadedFile).toHaveBeenCalled();
   });
 
   test('type 4 PDF still downloads', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          get_updates_buf: 'c1',
-          msgs: [
-            inboundMsg(
-              {
-                type: 4,
-                file_item: {
-                  file_name: 'notes.pdf',
-                  media: {
-                    encrypt_query_param: 'q-pdf',
-                    aes_key: 'k-pdf',
-                  },
-                },
+    const fetchMock = fetchOnceThenHang({
+      get_updates_buf: 'c1',
+      msgs: [
+        inboundMsg(
+          {
+            type: 4,
+            file_item: {
+              file_name: 'notes.pdf',
+              media: {
+                encrypt_query_param: 'q-pdf',
+                aes_key: 'k-pdf',
               },
-              'pdf-1',
-            ),
-          ],
-        }),
-      )
-      .mockImplementation(() =>
-        jsonResponse({ get_updates_buf: 'c2', msgs: [] }),
-      );
+            },
+          },
+          'pdf-1',
+        ),
+      ],
+    });
     await connectAndDrain(fetchMock);
     expect(crypto.downloadAndDecryptMedia).toHaveBeenCalled();
     expect(downloader.saveDownloadedFile).toHaveBeenCalled();

--- a/tests/wechat-inbound-video-cdn.test.ts
+++ b/tests/wechat-inbound-video-cdn.test.ts
@@ -13,6 +13,7 @@ const db = vi.hoisted(() => ({
   storeChatMetadata: vi.fn(),
   storeMessageDirect: vi.fn(),
   updateChatName: vi.fn(),
+  isDatabaseInitialized: () => false,
 }));
 const notify = vi.hoisted(() => ({ notifyNewImMessage: vi.fn() }));
 


### PR DESCRIPTION
## Summary
Type 5 inbound items only pushed a `(video)` stub. They never called `downloadCdnMediaItem` or `saveDownloadedFile`, so video-only chats never persisted a workspace file.

- Type 5 downloads `video_item.media` and persists `[视频: path]`
- Type 3 shares the same persist branch
- Image (type 2) and file (type 4) stay on their existing download paths
- Does not retouch `sendFile`

## Test plan
- [x] Live getupdates type-5 video-only persists a workspace file
- [x] Type 2 image still downloads
- [x] Type 4 PDF still downloads

SHA: `fbb4e391c0f653e50af6e5cd5c420e0fa733c9fe`