### PR TITLE
fix(whatsapp): persist inbound Lottie stickers (proto 74)

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -576,8 +576,11 @@ export function createWhatsAppConnection(
 
     let buffer: Buffer;
     try {
+      // Baileys downloadMediaMessage reads msg.message and does not peel
+      // lottieStickerMessage (proto 74 / #2776 unmerged). Reconstruct so the
+      // unwrapped inner sticker is what the downloader sees.
       buffer = await downloadMediaMessage(
-        msg,
+        { ...msg, message: content },
         'buffer',
         {},
         {
@@ -1121,13 +1124,19 @@ export function unwrapMessageContent(content: proto.IMessage): proto.IMessage {
     // wrap too. Missing any of these drops the message — e.g. a PDF WITH a
     // caption (documentWithCaptionMessage) would extract no text and detect no
     // media, while the same PDF without a caption (bare documentMessage) works.
+    const lottieSticker = (
+      inner as proto.IMessage & {
+        lottieStickerMessage?: { message?: proto.IMessage | null } | null;
+      }
+    ).lottieStickerMessage?.message;
     const next =
       inner.ephemeralMessage?.message ||
       inner.viewOnceMessage?.message ||
       inner.viewOnceMessageV2?.message ||
       inner.viewOnceMessageV2Extension?.message ||
       inner.documentWithCaptionMessage?.message ||
-      inner.editedMessage?.message;
+      inner.editedMessage?.message ||
+      lottieSticker;
     if (!next) break;
     inner = next;
   }
@@ -1177,7 +1186,7 @@ export function normalizeTimestamp(
 }
 
 interface DetectedMedia {
-  kind: 'image' | 'video' | 'audio' | 'document';
+  kind: 'image' | 'video' | 'audio' | 'document' | 'sticker';
   label: string;
   defaultExt: string;
   node: {
@@ -1219,6 +1228,14 @@ function detectMedia(content: proto.IMessage): DetectedMedia | null {
       label: '文档',
       defaultExt: '',
       node: content.documentMessage as DetectedMedia['node'],
+    };
+  }
+  if (content.stickerMessage) {
+    return {
+      kind: 'sticker',
+      label: '贴纸',
+      defaultExt: '.webp',
+      node: content.stickerMessage as DetectedMedia['node'],
     };
   }
   return null;

--- a/tests/whatsapp-inbound-lottie-sticker.test.ts
+++ b/tests/whatsapp-inbound-lottie-sticker.test.ts
@@ -1,0 +1,207 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const harness = vi.hoisted(() => {
+  type Listener = (value: any) => unknown;
+  function createSocket() {
+    const listeners = new Map<string, Listener[]>();
+    return {
+      listeners,
+      ev: {
+        on: vi.fn((event: string, listener: Listener) => {
+          const entries = listeners.get(event) ?? [];
+          entries.push(listener);
+          listeners.set(event, entries);
+        }),
+      },
+      ws: { on: vi.fn(), isConnecting: false },
+      user: { id: '19990001111:7@s.whatsapp.net', name: 'Test bot' },
+      sendMessage: vi.fn(async () => undefined),
+      sendPresenceUpdate: vi.fn(async () => undefined),
+      groupMetadata: vi.fn(async () => ({ subject: 'Test group' })),
+      end: vi.fn(),
+      logout: vi.fn(async () => undefined),
+      updateMediaMessage: vi.fn(),
+      async emit(event: string, value: unknown) {
+        await Promise.all(
+          (listeners.get(event) ?? []).map((listener) => listener(value)),
+        );
+      },
+    };
+  }
+  return { sockets: [] as ReturnType<typeof createSocket>[], createSocket };
+});
+
+const downloadMediaMessage = vi.hoisted(() =>
+  vi.fn(async () => Buffer.from('lottie-webp-bytes')),
+);
+
+vi.mock('baileys', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    downloadMediaMessage,
+    makeWASocket: vi.fn(() => {
+      const socket = harness.createSocket();
+      harness.sockets.push(socket);
+      return socket;
+    }),
+    useMultiFileAuthState: vi.fn(async () => ({
+      state: { creds: {}, keys: {} },
+      saveCreds: vi.fn(async () => undefined),
+    })),
+    fetchLatestBaileysVersion: vi.fn(async () => ({
+      version: [2, 3000, 1],
+      isLatest: true,
+    })),
+  };
+});
+
+const db = vi.hoisted(() => ({
+  storeChatMetadata: vi.fn(),
+  storeMessageDirect: vi.fn(),
+  updateChatName: vi.fn(),
+  getRegisteredGroup: vi.fn(),
+  getDefaultChannelAccount: vi.fn(),
+  getLegacyChannelAccount: vi.fn(),
+  getChannelAccount: vi.fn(),
+  getUserById: vi.fn(),
+  isDatabaseInitialized: vi.fn(() => false),
+}));
+vi.mock('../src/db.js', () => db);
+
+const notify = vi.hoisted(() => ({ notifyNewImMessage: vi.fn() }));
+vi.mock('../src/message-notifier.js', () => notify);
+vi.mock('../src/web.js', () => ({ broadcastNewMessage: vi.fn() }));
+vi.mock('../src/im-downloader.js', () => ({
+  saveDownloadedFile: vi.fn(async (_folder, _ch, fileName) => `ws/${fileName}`),
+  FileTooLargeError: class FileTooLargeError extends Error {},
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    child: vi.fn(() => ({
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock('qrcode', () => ({
+  default: { toDataURL: vi.fn(async () => 'data:image/png;base64,test') },
+}));
+vi.mock('proxy-agent', () => ({
+  ProxyAgent: class {
+    destroy() {}
+  },
+}));
+
+const { createWhatsAppConnection } = await import('../src/whatsapp.js');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'whatsapp-inbound-lottie-'));
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function upsertMessage(
+  remoteJid: string,
+  id: string,
+  message: Record<string, unknown>,
+) {
+  return {
+    key: { remoteJid, id, fromMe: false },
+    message,
+    pushName: 'Ada',
+    messageTimestamp: Math.floor(Date.now() / 1000),
+  };
+}
+
+function lottieStickerPayload() {
+  return {
+    lottieStickerMessage: {
+      message: {
+        stickerMessage: {
+          mimetype: 'image/webp',
+          url: 'https://mmg.whatsapp.net/lottie.enc',
+          isLottie: true,
+          isAnimated: true,
+        },
+      },
+    },
+  };
+}
+
+async function connect(authorized: boolean) {
+  const connection = createWhatsAppConnection({
+    accountId: authorized ? 'bot-ok' : 'bot-deny',
+    authDir: path.join(root, authorized ? 'bot-ok' : 'bot-deny'),
+  });
+  await connection.connect({
+    onNewChat: vi.fn(),
+    isChatAuthorized: () => authorized,
+    resolveGroupFolder: () => '/tmp/wa-ws',
+    resolveEffectiveChatJid: (jid: string) => ({
+      effectiveJid: jid,
+      agentId: null,
+    }),
+  });
+  return { socket: harness.sockets.at(-1)! };
+}
+
+describe('WhatsApp inbound lottieStickerMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.sockets.length = 0;
+    downloadMediaMessage.mockResolvedValue(Buffer.from('lottie-webp-bytes'));
+  });
+
+  test('authorized lottie sticker persists, downloads, and notifies', async () => {
+    const { socket } = await connect(true);
+    await socket.emit('messages.upsert', {
+      type: 'notify',
+      messages: [
+        upsertMessage(
+          '15559876543@s.whatsapp.net',
+          'lottie-1',
+          lottieStickerPayload(),
+        ),
+      ],
+    });
+    expect(downloadMediaMessage).toHaveBeenCalled();
+    const passed = downloadMediaMessage.mock.calls[0][0] as {
+      message?: { stickerMessage?: unknown; lottieStickerMessage?: unknown };
+    };
+    expect(passed.message?.stickerMessage).toBeTruthy();
+    expect(passed.message?.lottieStickerMessage).toBeUndefined();
+    expect(db.storeMessageDirect).toHaveBeenCalled();
+    expect(String(db.storeMessageDirect.mock.calls[0][4])).toMatch(/贴纸/);
+    expect(notify.notifyNewImMessage).toHaveBeenCalled();
+  });
+
+  test('unauthorized lottie sticker does not persist', async () => {
+    const { socket } = await connect(false);
+    await socket.emit('messages.upsert', {
+      type: 'notify',
+      messages: [
+        upsertMessage(
+          '15559876543@s.whatsapp.net',
+          'lottie-deny',
+          lottieStickerPayload(),
+        ),
+      ],
+    });
+    expect(db.storeMessageDirect).not.toHaveBeenCalled();
+    expect(notify.notifyNewImMessage).not.toHaveBeenCalled();
+    expect(downloadMediaMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Premium/Lottie stickers arrive as `lottieStickerMessage` (proto 74 FutureProofMessage). `unwrapMessageContent` never peeled that wrapper, so authorized chats hit the empty-content gate and never persisted or downloaded.

- Peel `lottieStickerMessage` in `unwrapMessageContent`
- Persist the inner sticker via `tryHandleMediaMessage` (label 贴纸, `.webp`)
- Reconstruct `{ ...msg, message: inner }` before `downloadMediaMessage` (baileys #2776 unmerged)
- Does not retouch bare `stickerMessage` (#690), Event/invite (#699), ptv, or outbound

## Test plan
- [x] Live `messages.upsert` lottie sticker persists, downloads, and notifies
- [x] Download is given the unwrapped inner `stickerMessage`
- [x] Unauthorized lottie sticker does not persist

SHA: `fb215d55e73b05ff02c722059f02b423497ecc62`