### PR TITLE
fix(qq): require official id on send 2xx ACK

### DIFF
--- a/src/qq.ts
+++ b/src/qq.ts
@@ -380,6 +380,18 @@ export function validateQQGatewayUrl(value: string): string {
 
 // ─── Factory Function ───────────────────────────────────────────
 
+/** Official v2 C2C/group send success is `{ id, timestamp }`. */
+export function requireQQOfficialSendId(data: unknown): { id: string } {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('QQ send response is not a JSON object');
+  }
+  const id = (data as { id?: unknown }).id;
+  if (id == null || String(id).trim() === '') {
+    throw new Error('QQ send response missing official id');
+  }
+  return { id: String(id) };
+}
+
 export function createQQConnection(config: QQConnectionConfig): QQConnection {
   // Token state
   let tokenInfo: TokenInfo | null = null;
@@ -692,11 +704,16 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         ? `/v2/users/${openid}/messages`
         : `/v2/groups/${openid}/messages`;
 
-    await apiRequest('POST', endpoint, {
-      markdown: { content },
-      msg_type: 2, // markdown
-      msg_seq: msgSeq,
-    });
+    const sent = await apiRequest<{ id?: string; timestamp?: string }>(
+      'POST',
+      endpoint,
+      {
+        markdown: { content },
+        msg_type: 2, // markdown
+        msg_seq: msgSeq,
+      },
+    );
+    requireQQOfficialSendId(sent);
   }
 
   // ─── Image Sending ───────────────────────────────────────
@@ -772,12 +789,17 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         ? `/v2/users/${openid}/messages`
         : `/v2/groups/${openid}/messages`;
 
-    await apiRequest('POST', endpoint, {
-      msg_type: 7, // rich media
-      media: { file_info: fileInfo },
-      content: caption || '',
-      msg_seq: msgSeq,
-    });
+    const sent = await apiRequest<{ id?: string; timestamp?: string }>(
+      'POST',
+      endpoint,
+      {
+        msg_type: 7, // rich media
+        media: { file_info: fileInfo },
+        content: caption || '',
+        msg_seq: msgSeq,
+      },
+    );
+    requireQQOfficialSendId(sent);
   }
 
   // ─── Chunked File Upload ─────────────────────────────────────
@@ -1060,12 +1082,17 @@ export function createQQConnection(config: QQConnectionConfig): QQConnection {
         ? `/v2/users/${openid}/messages`
         : `/v2/groups/${openid}/messages`;
 
-    await apiRequest('POST', endpoint, {
-      msg_type: 7,
-      media: { file_info: fileInfo },
-      content: '',
-      msg_seq: msgSeq,
-    });
+    const sent = await apiRequest<{ id?: string; timestamp?: string }>(
+      'POST',
+      endpoint,
+      {
+        msg_type: 7,
+        media: { file_info: fileInfo },
+        content: '',
+        msg_seq: msgSeq,
+      },
+    );
+    requireQQOfficialSendId(sent);
   }
 
   // ─── File Download ─────────────────────────────────────────

--- a/tests/qq-send-official-ack.test.ts
+++ b/tests/qq-send-official-ack.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { syntheticChannelProviderAck } from '../src/channel-outbox-runtime-scope.js';
+
+const https = vi.hoisted(() => {
+  let messageBody = JSON.stringify({
+    id: 'official-1',
+    timestamp: '2026-08-27T00:00:00Z',
+  });
+  return {
+    setMessageBody(body: string) {
+      messageBody = body;
+    },
+    request: vi.fn(
+      (
+        opts: { hostname?: string; path?: string },
+        cb: (res: {
+          statusCode: number;
+          on: (event: string, fn: (...args: any[]) => void) => unknown;
+        }) => void,
+      ) => {
+        const path = String(opts.path || '');
+        const hostname = String(opts.hostname || '');
+        const isToken =
+          hostname.includes('bots.qq.com') ||
+          path.includes('getAppAccessToken');
+        const isMessages = path.includes('/messages');
+        const payload = isToken
+          ? JSON.stringify({ access_token: 'qq-token', expires_in: 7200 })
+          : isMessages
+            ? messageBody
+            : JSON.stringify({ file_info: 'file-info-1', ttl: 600 });
+        const res = {
+          statusCode: 200,
+          on(event: string, fn: (...args: any[]) => void) {
+            if (event === 'data') fn(Buffer.from(payload));
+            if (event === 'end') fn();
+            return res;
+          },
+        };
+        return {
+          on: vi.fn(),
+          setTimeout: vi.fn(),
+          write: vi.fn(),
+          end() {
+            cb(res);
+          },
+          destroy: vi.fn(),
+        };
+      },
+    ),
+  };
+});
+
+vi.mock('node:https', () => ({ default: https, request: https.request }));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { createQQConnection } = await import('../src/qq.js');
+
+describe('QQ send official ACK (outbox)', () => {
+  let connection: ReturnType<typeof createQQConnection> | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    https.setMessageBody(
+      JSON.stringify({ id: 'official-1', timestamp: '2026-08-27T00:00:00Z' }),
+    );
+    connection = createQQConnection({ appId: 'app', appSecret: 'secret' });
+  });
+
+  afterEach(async () => {
+    if (connection) {
+      await connection.disconnect();
+      connection = null;
+    }
+  });
+
+  async function sendViaOutbox(text = 'hello') {
+    let delivered: string | null = null;
+    try {
+      await connection!.sendMessage('c2c:user-openid', text);
+      delivered = syntheticChannelProviderAck({
+        turnRunId: 'turn-1',
+        ordinal: 1,
+        payloadHash: 'payload',
+      });
+    } catch (err) {
+      return { delivered, error: err };
+    }
+    return { delivered, error: null };
+  }
+
+  test.each(['', '<html>ok</html>', '{broken'])(
+    '200 %j throws and outbox is not delivered',
+    async (body) => {
+      https.setMessageBody(body);
+      const result = await sendViaOutbox();
+      expect(result.error).toBeTruthy();
+      expect(result.delivered).toBeNull();
+    },
+  );
+
+  test('200 {id, timestamp} still delivers', async () => {
+    const result = await sendViaOutbox();
+    expect(result.error).toBeNull();
+    expect(result.delivered).toMatch(/^happyclaw-synthetic:/);
+  });
+});


### PR DESCRIPTION
## Summary
QQ `apiRequest` treated empty/HTML/broken-JSON 2xx as success (`{}`). `sendQQMessage` / `sendQQImageMessage` / `sendQQFileMessage` returned void without an official id, so outbox minted `happyclaw-synthetic:*` and marked delivered while the user saw silence.

- Text/image/file send now requires official v2 `{ id, timestamp }`
- Empty, `<html>ok</html>`, and `{broken` 2xx throw so outbox retries
- Shared `apiRequest` still accepts empty 2xx on void helpers such as `upload_part_finish`
- Does not retouch HEARTBEAT_ACK, inbound GET, or #696 quota/typing

## Test plan
- [x] Live `createQQConnection.sendMessage` + outbox wrapper: empty/HTML/broken 2xx throws and is not delivered
- [x] `200 {id, timestamp}` still delivers

SHA: `75ed615039b3f820e69c86ba1a669020fe135393`