### PR TITLE
fix(task): do not resend unscoped send_image/send_file after ETIMEDOUT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -276,6 +276,11 @@ import {
   CHANNEL_RELIABILITY_TERMINAL_STATUSES,
 } from './channel-reliability-store.js';
 import { ChannelTurnRuntime } from './channel-turn-runtime.js';
+import {
+  retryTaskNotification as deliverRetryTaskNotification,
+  sendTaskFileWithRetry as deliverTaskFileWithRetry,
+  sendTaskImageWithRetry as deliverTaskImageWithRetry,
+} from './unscoped-task-media-outbox.js';
 import { resolveStickyChannelOwner } from './channel-session-owner.js';
 import { migrateLegacyWhatsAppAuthDir } from './whatsapp-auth.js';
 import {
@@ -3262,24 +3267,22 @@ async function sendTaskImageWithRetry(
   fileName?: string,
   outbox?: ChannelOutboxDeliveryRef,
 ): Promise<boolean> {
-  if (!imManager.isChannelAvailableForJid(targetJid)) return false;
-  const scoped = await deliverScopedChannelOutput(targetJid, outbox, {
-    kind: 'image',
-    payload: {
-      mimeType,
-      caption: caption ?? null,
-      fileName: fileName ?? null,
-      contentHash: crypto
-        .createHash('sha256')
-        .update(imageBuffer)
-        .digest('hex'),
+  return deliverTaskImageWithRetry(
+    targetJid,
+    imageBuffer,
+    mimeType,
+    caption,
+    fileName,
+    outbox,
+    {
+      isChannelAvailable: (jid) => imManager.isChannelAvailableForJid(jid),
+      sendImage: (jid, buffer, mime, cap, name) =>
+        imManager.sendImage(jid, buffer, mime, cap, name),
+      sendFile: (jid, filePath, name) =>
+        imManager.sendFile(jid, filePath, name),
+      resolveRoute: resolveDurableChannelRoute,
+      deliverScoped: deliverScopedChannelOutput,
     },
-    send: () =>
-      imManager.sendImage(targetJid, imageBuffer, mimeType, caption, fileName),
-  });
-  if (scoped !== null) return scoped;
-  return retryImOperation('send_task_image', targetJid, () =>
-    imManager.sendImage(targetJid, imageBuffer, mimeType, caption, fileName),
   );
 }
 
@@ -3289,22 +3292,14 @@ async function sendTaskFileWithRetry(
   fileName: string,
   outbox?: ChannelOutboxDeliveryRef,
 ): Promise<boolean> {
-  if (!imManager.isChannelAvailableForJid(targetJid)) return false;
-  const scoped = await deliverScopedChannelOutput(targetJid, outbox, {
-    kind: 'file',
-    payload: {
-      fileName,
-      contentHash: crypto
-        .createHash('sha256')
-        .update(fs.readFileSync(filePath))
-        .digest('hex'),
-    },
-    send: () => imManager.sendFile(targetJid, filePath, fileName),
+  return deliverTaskFileWithRetry(targetJid, filePath, fileName, outbox, {
+    isChannelAvailable: (jid) => imManager.isChannelAvailableForJid(jid),
+    sendImage: (jid, buffer, mime, cap, name) =>
+      imManager.sendImage(jid, buffer, mime, cap, name),
+    sendFile: (jid, destPath, name) => imManager.sendFile(jid, destPath, name),
+    resolveRoute: resolveDurableChannelRoute,
+    deliverScoped: deliverScopedChannelOutput,
   });
-  if (scoped !== null) return scoped;
-  return retryImOperation('send_task_file', targetJid, () =>
-    imManager.sendFile(targetJid, filePath, fileName),
-  );
 }
 
 /**
@@ -21884,38 +21879,24 @@ async function main(): Promise<void> {
           payload.kind === 'im_channel_image' ||
           payload.kind === 'im_channel_file'
         ) {
-          const workspaceRoot = path.resolve(
-            GROUPS_DIR,
-            payload.workspaceFolder,
+          success = await deliverRetryTaskNotification(
+            {
+              ...payload,
+              targetJid: targetJid!,
+            },
+            {
+              groupsDir: GROUPS_DIR,
+              isRealpathInside,
+              isChannelAvailable: (jid) =>
+                imManager.isChannelAvailableForJid(jid),
+              sendImage: (jid, buffer, mime, cap, name) =>
+                imManager.sendImage(jid, buffer, mime, cap, name),
+              sendFile: (jid, destPath, name) =>
+                imManager.sendFile(jid, destPath, name),
+              resolveRoute: resolveDurableChannelRoute,
+              deliverScoped: deliverScopedChannelOutput,
+            },
           );
-          const resolvedPath = path.resolve(workspaceRoot, payload.filePath);
-          if (
-            resolvedPath !== workspaceRoot &&
-            !resolvedPath.startsWith(`${workspaceRoot}${path.sep}`)
-          ) {
-            throw new Error('Persisted notification path left its workspace');
-          }
-          if (!isRealpathInside(resolvedPath, workspaceRoot)) {
-            throw new Error('Persisted notification file is unavailable');
-          }
-          if (
-            payload.kind === 'im_image' ||
-            payload.kind === 'im_channel_image'
-          ) {
-            success = await sendTaskImageWithRetry(
-              targetJid!,
-              fs.readFileSync(resolvedPath),
-              payload.mimeType,
-              payload.caption,
-              payload.fileName,
-            );
-          } else {
-            success = await sendTaskFileWithRetry(
-              targetJid!,
-              resolvedPath,
-              payload.fileName,
-            );
-          }
         } else {
           throw new Error(
             `Unsupported direct notification kind: ${payload.kind}`,

--- a/src/unscoped-task-media-outbox.ts
+++ b/src/unscoped-task-media-outbox.ts
@@ -1,0 +1,368 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { deliverChannelOutboxItem } from './channel-outbox-delivery.js';
+import {
+  semanticChannelOutboxIdentity,
+  stableChannelOutboxOrdinal,
+  syntheticChannelProviderAck,
+} from './channel-outbox-runtime-scope.js';
+import {
+  getUncertainChannelOutboxForTurn,
+  type ChannelRouteSnapshot,
+} from './channel-reliability-store.js';
+import { ChannelTurnRuntime } from './channel-turn-runtime.js';
+import { logger } from './logger.js';
+
+export type UnscopedTaskMediaKind = 'image' | 'file';
+
+export interface SendUnscopedTaskMediaInput {
+  route: ChannelRouteSnapshot | null;
+  kind: UnscopedTaskMediaKind;
+  payload: unknown;
+  send: () => Promise<void>;
+}
+
+export interface TaskMediaSendDeps {
+  isChannelAvailable: (targetJid: string) => boolean;
+  sendImage: (
+    targetJid: string,
+    imageBuffer: Buffer,
+    mimeType: string,
+    caption?: string,
+    fileName?: string,
+  ) => Promise<void>;
+  sendFile: (
+    targetJid: string,
+    filePath: string,
+    fileName: string,
+  ) => Promise<void>;
+  resolveRoute: (targetJid: string) => ChannelRouteSnapshot | null;
+  deliverScoped?: (
+    targetJid: string,
+    outbox: any,
+    input: {
+      kind: UnscopedTaskMediaKind;
+      payload: unknown;
+      send: () => Promise<void>;
+    },
+  ) => Promise<boolean | null>;
+}
+
+export type RetryTaskNotificationKind =
+  | 'im_image'
+  | 'im_file'
+  | 'im_channel_image'
+  | 'im_channel_file';
+
+export interface RetryTaskNotificationPayload {
+  kind: RetryTaskNotificationKind;
+  targetJid: string;
+  workspaceFolder: string;
+  filePath: string;
+  mimeType?: string;
+  caption?: string;
+  fileName?: string;
+}
+
+export interface RetryTaskNotificationDeps extends TaskMediaSendDeps {
+  groupsDir: string;
+  isRealpathInside: (resolvedPath: string, workspaceRoot: string) => boolean;
+}
+
+export interface RetryTaskNoticeMediaInput {
+  kind: UnscopedTaskMediaKind;
+  targetJid: string;
+  filePath: string;
+  mimeType?: string;
+  caption?: string;
+  fileName: string;
+  sendImage: (
+    targetJid: string,
+    imageBuffer: Buffer,
+    mimeType: string,
+    caption?: string,
+    fileName?: string,
+  ) => Promise<void>;
+  sendFile: (
+    targetJid: string,
+    filePath: string,
+    fileName: string,
+  ) => Promise<void>;
+  isChannelAvailable: (targetJid: string) => boolean;
+  resolveRoute: (targetJid: string) => ChannelRouteSnapshot | null;
+}
+
+function payloadContentHash(payload: unknown): string {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'contentHash' in payload &&
+    typeof (payload as { contentHash?: unknown }).contentHash === 'string' &&
+    (payload as { contentHash: string }).contentHash
+  ) {
+    return (payload as { contentHash: string }).contentHash;
+  }
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(payload ?? null))
+    .digest('hex');
+}
+
+function stableTaskMediaExternalId(
+  route: ChannelRouteSnapshot,
+  kind: UnscopedTaskMediaKind,
+  payload: unknown,
+): string {
+  return [
+    'unscoped-task-media',
+    kind,
+    route.sourceJid,
+    payloadContentHash(payload),
+  ].join(':');
+}
+
+export async function sendUnscopedTaskMedia(
+  input: SendUnscopedTaskMediaInput,
+): Promise<boolean> {
+  if (!input.route) {
+    try {
+      await input.send();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const route = input.route;
+  const runtime = ChannelTurnRuntime.start({
+    ...route,
+    externalMessageId: stableTaskMediaExternalId(
+      route,
+      input.kind,
+      input.payload,
+    ),
+  });
+
+  try {
+    if (runtime.executionDisposition !== 'execute') {
+      return false;
+    }
+
+    const uncertainSibling = getUncertainChannelOutboxForTurn(runtime.runId);
+    if (uncertainSibling) {
+      runtime.interrupt(
+        'Unscoped task media delivery is uncertain; manual reconciliation required',
+      );
+      return false;
+    }
+
+    const semanticIdentity = semanticChannelOutboxIdentity({
+      route,
+      kind: input.kind,
+      payload: input.payload,
+    });
+    const ordinal = stableChannelOutboxOrdinal(semanticIdentity);
+    const result = await deliverChannelOutboxItem({
+      provider: route.provider,
+      accountId: route.accountId,
+      sourceJid: route.sourceJid,
+      chatId: route.chatId,
+      rootId: route.rootId,
+      threadId: route.threadId,
+      turnRunId: runtime.runId,
+      ordinal,
+      kind: input.kind,
+      payload: input.payload,
+      idempotencyKey: `${runtime.runId}:${semanticIdentity}`,
+      owner: `happyclaw-outbox:${process.pid}:${runtime.runId}`,
+      delivery: {
+        mode: 'single',
+        send: async ({ item }) => {
+          await input.send();
+          return {
+            providerMessageId: syntheticChannelProviderAck({
+              turnRunId: runtime.runId,
+              ordinal,
+              payloadHash: item.payloadHash,
+            }),
+          };
+        },
+      },
+    });
+
+    if (result.status === 'delivered') {
+      runtime.markFinalizing();
+      runtime.complete();
+      return true;
+    }
+
+    if (result.status === 'uncertain') {
+      runtime.interrupt(
+        'Unscoped task media delivery is uncertain; manual reconciliation required',
+      );
+      logger.warn(
+        {
+          sourceJid: route.sourceJid,
+          turnRunId: runtime.runId,
+          outboxItemId: result.itemId,
+          error: result.error,
+        },
+        'Channel delivery outcome is uncertain; automatic replay blocked',
+      );
+      return false;
+    }
+
+    logger.warn(
+      {
+        sourceJid: route.sourceJid,
+        turnRunId: runtime.runId,
+        outboxItemId: result.itemId,
+        outboxStatus: result.status,
+        error: result.error,
+      },
+      'Durable channel delivery did not complete',
+    );
+    return false;
+  } finally {
+    runtime.dispose();
+  }
+}
+
+export async function sendTaskImageWithRetry(
+  targetJid: string,
+  imageBuffer: Buffer,
+  mimeType: string,
+  caption: string | undefined,
+  fileName: string | undefined,
+  outbox: unknown,
+  deps: TaskMediaSendDeps,
+): Promise<boolean> {
+  if (!deps.isChannelAvailable(targetJid)) return false;
+
+  const payload = {
+    mimeType,
+    caption: caption ?? null,
+    fileName: fileName ?? null,
+    contentHash: crypto.createHash('sha256').update(imageBuffer).digest('hex'),
+  };
+  const send = () =>
+    deps.sendImage(targetJid, imageBuffer, mimeType, caption, fileName);
+
+  if (outbox != null && deps.deliverScoped) {
+    const scoped = await deps.deliverScoped(targetJid, outbox, {
+      kind: 'image',
+      payload,
+      send,
+    });
+    if (scoped !== null) return scoped;
+  }
+
+  return sendUnscopedTaskMedia({
+    route: deps.resolveRoute(targetJid),
+    kind: 'image',
+    payload,
+    send,
+  });
+}
+
+export async function sendTaskFileWithRetry(
+  targetJid: string,
+  filePath: string,
+  fileName: string,
+  outbox: unknown,
+  deps: TaskMediaSendDeps,
+): Promise<boolean> {
+  if (!deps.isChannelAvailable(targetJid)) return false;
+
+  const payload = {
+    fileName,
+    contentHash: crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(filePath))
+      .digest('hex'),
+  };
+  const send = () => deps.sendFile(targetJid, filePath, fileName);
+
+  if (outbox != null && deps.deliverScoped) {
+    const scoped = await deps.deliverScoped(targetJid, outbox, {
+      kind: 'file',
+      payload,
+      send,
+    });
+    if (scoped !== null) return scoped;
+  }
+
+  return sendUnscopedTaskMedia({
+    route: deps.resolveRoute(targetJid),
+    kind: 'file',
+    payload,
+    send,
+  });
+}
+
+export async function retryTaskNotification(
+  payload: RetryTaskNotificationPayload,
+  deps: RetryTaskNotificationDeps,
+): Promise<boolean> {
+  const workspaceRoot = path.resolve(deps.groupsDir, payload.workspaceFolder);
+  const resolvedPath = path.resolve(workspaceRoot, payload.filePath);
+  if (
+    resolvedPath !== workspaceRoot &&
+    !resolvedPath.startsWith(`${workspaceRoot}${path.sep}`)
+  ) {
+    throw new Error('Persisted notification path left its workspace');
+  }
+  if (!deps.isRealpathInside(resolvedPath, workspaceRoot)) {
+    throw new Error('Persisted notification file is unavailable');
+  }
+
+  if (payload.kind === 'im_image' || payload.kind === 'im_channel_image') {
+    const imageBuffer = fs.readFileSync(resolvedPath);
+    const mimeType = payload.mimeType ?? 'image/png';
+    return sendTaskImageWithRetry(
+      payload.targetJid,
+      imageBuffer,
+      mimeType,
+      payload.caption,
+      payload.fileName,
+      undefined,
+      deps,
+    );
+  }
+
+  return sendTaskFileWithRetry(
+    payload.targetJid,
+    resolvedPath,
+    payload.fileName ?? path.basename(resolvedPath),
+    undefined,
+    deps,
+  );
+}
+
+/** @deprecated Use sendTaskImageWithRetry / sendTaskFileWithRetry / retryTaskNotification */
+export async function retryTaskNoticeMedia(
+  input: RetryTaskNoticeMediaInput,
+): Promise<boolean> {
+  if (input.kind === 'image') {
+    const imageBuffer = fs.readFileSync(input.filePath);
+    const mimeType = input.mimeType ?? 'image/png';
+    return sendTaskImageWithRetry(
+      input.targetJid,
+      imageBuffer,
+      mimeType,
+      input.caption,
+      input.fileName,
+      undefined,
+      input,
+    );
+  }
+  return sendTaskFileWithRetry(
+    input.targetJid,
+    input.filePath,
+    input.fileName,
+    undefined,
+    input,
+  );
+}

--- a/tests/task-notice-media-etimeout.test.ts
+++ b/tests/task-notice-media-etimeout.test.ts
@@ -1,0 +1,278 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'task-notice-media-'));
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const workspaceFolder = 'notice-ws';
+const workspaceRoot = path.join(groupsDir, workspaceFolder);
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(workspaceRoot, { recursive: true });
+
+vi.mock('../src/config.js', () => ({
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+const { retryTaskNotification, sendTaskFileWithRetry, sendTaskImageWithRetry } =
+  await import('../src/unscoped-task-media-outbox.js');
+
+const route = {
+  provider: 'feishu',
+  accountId: 'bot-primary',
+  sourceJid: 'feishu:bot-primary:chat-1#root:root-1#thread:thread-1',
+  chatId: 'chat-1',
+  rootId: 'root-1',
+  threadId: 'thread-1',
+};
+
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const imageRel = 'notice.png';
+const fileRel = 'notice.bin';
+const imageAbs = path.join(workspaceRoot, imageRel);
+const fileAbs = path.join(workspaceRoot, fileRel);
+fs.writeFileSync(imageAbs, PNG_1X1);
+fs.writeFileSync(fileAbs, Buffer.from('task-notice-file'));
+
+beforeAll(() => db.initDatabase());
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function etimedoutAfterAccept(): NodeJS.ErrnoException {
+  const error = new Error(
+    'ETIMEDOUT after provider accepted the task notice',
+  ) as NodeJS.ErrnoException;
+  error.code = 'ETIMEDOUT';
+  return error;
+}
+
+function isRealpathInside(target: string, roots: string | string[]): boolean {
+  const rootList = Array.isArray(roots) ? roots : [roots];
+  let realTarget: string;
+  try {
+    realTarget = fs.realpathSync(target);
+  } catch {
+    return false;
+  }
+  return rootList.some((candidate) => {
+    try {
+      const realRoot = fs.realpathSync(candidate);
+      return (
+        realTarget === realRoot ||
+        realTarget.startsWith(`${realRoot}${path.sep}`)
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+function makeRoute(chatId: string) {
+  return {
+    provider: 'feishu',
+    accountId: 'bot-primary',
+    sourceJid: `feishu:bot-primary:${chatId}#root:root-1#thread:thread-1`,
+    chatId,
+    rootId: 'root-1',
+    threadId: 'thread-1',
+  };
+}
+
+function mediaDeps(
+  sendImage: () => Promise<void>,
+  sendFile: () => Promise<void>,
+  activeRoute = route,
+) {
+  return {
+    isChannelAvailable: () => true,
+    resolveRoute: () => activeRoute,
+    sendImage,
+    sendFile,
+    groupsDir,
+    isRealpathInside,
+  };
+}
+
+describe('unscoped task notice media without outbox', () => {
+  test('retryTaskNotification image ETIMEDOUT-after-accept stays 1 copy across scheduler retry', async () => {
+    let sends = 0;
+    const sendImage = async () => {
+      sends += 1;
+      if (sends === 1) throw etimedoutAfterAccept();
+    };
+    const sendFile = async () => {
+      throw new Error('sendFile must not run for image notices');
+    };
+    const deps = mediaDeps(sendImage, sendFile);
+    const payload = {
+      kind: 'im_image' as const,
+      targetJid: route.sourceJid,
+      workspaceFolder,
+      filePath: imageRel,
+      mimeType: 'image/png',
+      fileName: 'notice.png',
+    };
+    const first = await retryTaskNotification(payload, deps);
+    const second = await retryTaskNotification(payload, deps);
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(sends).toBe(1);
+  });
+
+  test('retryTaskNotification file ETIMEDOUT-after-accept stays 1 copy across scheduler retry', async () => {
+    let sends = 0;
+    const sendFile = async () => {
+      sends += 1;
+      if (sends === 1) throw etimedoutAfterAccept();
+    };
+    const sendImage = async () => {
+      throw new Error('sendImage must not run for file notices');
+    };
+    const deps = mediaDeps(sendImage, sendFile);
+    const payload = {
+      kind: 'im_file' as const,
+      targetJid: route.sourceJid,
+      workspaceFolder,
+      filePath: fileRel,
+      fileName: 'notice.bin',
+    };
+    const first = await retryTaskNotification(payload, deps);
+    const second = await retryTaskNotification(payload, deps);
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(sends).toBe(1);
+  });
+
+  test('unscoped sendTaskImageWithRetry ETIMEDOUT-after-accept stays 1 copy', async () => {
+    let sends = 0;
+    const helperRoute = makeRoute('chat-image-helper');
+    const helperPng = Buffer.concat([PNG_1X1, Buffer.from([0x00])]);
+    const sendImage = async () => {
+      sends += 1;
+      if (sends === 1) throw etimedoutAfterAccept();
+    };
+    const sendFile = async () => {
+      throw new Error('sendFile must not run for image notices');
+    };
+    const deps = mediaDeps(sendImage, sendFile, helperRoute);
+    const first = await sendTaskImageWithRetry(
+      helperRoute.sourceJid,
+      helperPng,
+      'image/png',
+      undefined,
+      'helper.png',
+      undefined,
+      deps,
+    );
+    const second = await sendTaskImageWithRetry(
+      helperRoute.sourceJid,
+      helperPng,
+      'image/png',
+      undefined,
+      'helper.png',
+      undefined,
+      deps,
+    );
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(sends).toBe(1);
+  });
+
+  test('unscoped sendTaskFileWithRetry ETIMEDOUT-after-accept stays 1 copy', async () => {
+    let sends = 0;
+    const helperRoute = makeRoute('chat-file-helper');
+    const helperAbs = path.join(workspaceRoot, 'helper.bin');
+    fs.writeFileSync(helperAbs, Buffer.from('task-notice-file-helper'));
+    const sendFile = async () => {
+      sends += 1;
+      if (sends === 1) throw etimedoutAfterAccept();
+    };
+    const sendImage = async () => {
+      throw new Error('sendImage must not run for file notices');
+    };
+    const deps = mediaDeps(sendImage, sendFile, helperRoute);
+    const first = await sendTaskFileWithRetry(
+      helperRoute.sourceJid,
+      helperAbs,
+      'helper.bin',
+      undefined,
+      deps,
+    );
+    const second = await sendTaskFileWithRetry(
+      helperRoute.sourceJid,
+      helperAbs,
+      'helper.bin',
+      undefined,
+      deps,
+    );
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(sends).toBe(1);
+  });
+
+  test('route=null ECONNREFUSED sends once via sendTaskImageWithRetry', async () => {
+    let sends = 0;
+    const refused = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    });
+    const ok = await sendTaskImageWithRetry(
+      'whatsapp:unrouted',
+      PNG_1X1,
+      'image/png',
+      undefined,
+      'no-route.png',
+      undefined,
+      {
+        isChannelAvailable: () => true,
+        resolveRoute: () => null,
+        sendImage: async () => {
+          sends += 1;
+          throw refused;
+        },
+        sendFile: async () => {
+          throw new Error('sendFile must not run for image notices');
+        },
+      },
+    );
+    expect(ok).toBe(false);
+    expect(sends).toBe(1);
+  });
+
+  test('isRealpathInside rejects a path that escapes the workspace', async () => {
+    const escapeRel = path.join('..', 'outside.png');
+    fs.writeFileSync(path.join(groupsDir, 'outside.png'), PNG_1X1);
+    await expect(
+      retryTaskNotification(
+        {
+          kind: 'im_image',
+          targetJid: route.sourceJid,
+          workspaceFolder,
+          filePath: escapeRel,
+          mimeType: 'image/png',
+          fileName: 'outside.png',
+        },
+        mediaDeps(
+          async () => {
+            throw new Error('must not send escaped image');
+          },
+          async () => {
+            throw new Error('must not send escaped file');
+          },
+        ),
+      ),
+    ).rejects.toThrow(/left its workspace|unavailable/);
+  });
+});


### PR DESCRIPTION
## Summary
Unscoped scheduled-task `send_image` / `send_file` omitted an outbox, so `deliverScopedChannelOutput` returned null and `retryImOperation` resent on ETIMEDOUT-after-accept (up to 3 copies). `retryTaskNotification` could add more.

Fence only the unscoped helpers with a local outbox (same uncertain / no auto-replay as conversation IPC). Conversation IPC, streaming-card callers, and the #676 text path are unchanged.

## Test plan
- [x] `retryTaskNotification` image + file: stub `sendImage`/`sendFile` ETIMEDOUT-after-accept, second scheduler retry does not send again
- [x] Unscoped `sendTaskImageWithRetry` / `sendTaskFileWithRetry` without outbox: fail-then-pass stub stays 1 physical send
- [x] No outbox / no route: ECONNREFUSED still sends at most once