### PR TITLE
fix(auth): require loopback for first-admin setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,7 @@ Web 持久设置 > 环境变量 > 代码默认值
 | `MAX_FILE_SIZE_MB`                   | `50`                              | Web/IM 入站文件上限                |
 | `CORS_ALLOWED_ORIGINS`               | 仅 localhost                      | WebSocket Origin 白名单            |
 | `TRUST_PROXY`                        | `false`                           | 是否信任反向代理来源头             |
+| `ALLOW_REMOTE_SETUP`                 | `false`                           | 允许远程创建首个管理员             |
 | `TZ`                                 | 系统时区                          | 调度时区                           |
 
 Provider 和渠道账号应优先通过 Web 配置。Legacy `/api/config/user-im/*` 只用于兼容，

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ make start
 
 首次访问按照向导完成：
 
-1. 创建第一个管理员账户。
+1. 创建第一个管理员账户。默认只能从本机（回环地址）调用 `POST /api/auth/setup`；若必须远程初始化，启动前设置 `ALLOW_REMOTE_SETUP=true`。
 2. 配置 Anthropic 官方账号或第三方 Claude 兼容 Provider。
 3. 可选添加飞书、Telegram、QQ、钉钉、微信、企业微信、Discord 或 WhatsApp 渠道账号。
 4. 进入工作台创建智能体、工作区和会话。
@@ -324,6 +324,7 @@ HappyClaw 优先通过 Web 设置管理配置，不要求用户维护一组庞�
 | `MAX_FILE_SIZE_MB`                   | `50`                              | Web 和 IM 入站文件大小上限                                                         |
 | `CORS_ALLOWED_ORIGINS`               | 仅 localhost                      | 公网部署的 WebSocket Origin 白名单                                                 |
 | `TRUST_PROXY`                        | `false`                           | 位于可信反向代理后时设为 `true`                                                    |
+| `ALLOW_REMOTE_SETUP`                 | `false`                           | 允许从非回环地址创建首个管理员；默认仅本机可调用 `POST /api/auth/setup`            |
 | `TZ`                                 | 系统时区                          | 日志与定时任务时区                                                                 |
 | `HTTPS_PROXY` / `HTTP_PROXY`         | 未设置                            | 独立配置 HTTPS/HTTP 出站代理；主进程与每个智能体容器都会使用，也接受对应的小写变量 |
 | `NO_PROXY`                           | 未设置                            | 独立配置不走代理的地址列表，也接受 `no_proxy`                                      |

--- a/docs/ACL-MATRIX.md
+++ b/docs/ACL-MATRIX.md
@@ -36,17 +36,17 @@
 
 ## 2. Public 接口
 
-| 路由                                 | 方法 | 附加条件               |
-| ------------------------------------ | ---- | ---------------------- |
-| `/api/auth/status`                   | GET  | 无                     |
-| `/api/auth/setup`                    | POST | 仅用户表为空           |
-| `/api/auth/login`                    | POST | 登录限流               |
-| `/api/auth/register/status`          | GET  | 无                     |
-| `/api/auth/register`                 | POST | 注册策略、邀请码、限流 |
-| `/api/auth/avatars/:filename`        | GET  | 仅允许受管头像路径     |
-| `/api/config/appearance/public`      | GET  | 只返回公开外观         |
-| `/api/config/brand-assets/:filename` | GET  | 仅允许受管品牌资源名   |
-| `/api/health`                        | GET  | 不返回敏感运行详情     |
+| 路由                                 | 方法 | 附加条件                                          |
+| ------------------------------------ | ---- | ------------------------------------------------- |
+| `/api/auth/status`                   | GET  | 无                                                |
+| `/api/auth/setup`                    | POST | 仅用户表为空且来自回环（或 `ALLOW_REMOTE_SETUP`） |
+| `/api/auth/login`                    | POST | 登录限流                                          |
+| `/api/auth/register/status`          | GET  | 无                                                |
+| `/api/auth/register`                 | POST | 注册策略、邀请码、限流                            |
+| `/api/auth/avatars/:filename`        | GET  | 仅允许受管头像路径                                |
+| `/api/config/appearance/public`      | GET  | 只返回公开外观                                    |
+| `/api/config/brand-assets/:filename` | GET  | 仅允许受管品牌资源名                              |
+| `/api/health`                        | GET  | 不返回敏感运行详情                                |
 
 `/ws` 不是 Public。Upgrade 时必须同时通过 Cookie Session 与 Origin 校验。
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,7 @@
 Public：
 
 - `GET /api/auth/status`
-- `POST /api/auth/setup`，仅用户表为空时可用
+- `POST /api/auth/setup`，仅用户表为空且来自回环地址时可用；远程初始化需 `ALLOW_REMOTE_SETUP=true`
 - `POST /api/auth/login`
 - `GET /api/auth/register/status`
 - `POST /api/auth/register`

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -239,3 +239,78 @@ export function sessionExpiresAt(): string {
 export function isSessionExpired(expiresAt: string): boolean {
   return new Date(expiresAt).getTime() < Date.now();
 }
+
+// --- First-admin setup origin ---
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  return value === '1' || value === 'true';
+}
+
+/**
+ * True for IPv4 127.0.0.0/8, IPv6 ::1, IPv4-mapped loopback, and localhost.
+ * Used by first-admin setup so a remote host cannot steal the initial admin
+ * by hitting a publicly bound port.
+ */
+export function isLoopbackAddress(ip: string | null | undefined): boolean {
+  if (!ip || typeof ip !== 'string') return false;
+  let value = ip.trim().toLowerCase();
+  if (!value) return false;
+  if (value.startsWith('[') && value.endsWith(']')) {
+    value = value.slice(1, -1);
+  }
+  const zone = value.indexOf('%');
+  if (zone !== -1) value = value.slice(0, zone);
+
+  if (value === 'localhost' || value === 'localhost.') return true;
+  if (value === '::1') return true;
+
+  if (/^127(?:\.(?:\d{1,3})){3}$/.test(value)) {
+    return value.split('.').every((part) => {
+      const n = Number(part);
+      return n >= 0 && n <= 255;
+    });
+  }
+
+  // Node may emit ::ffff:127.0.0.1 or ::ffff:7f00:1
+  if (value.startsWith('::ffff:')) {
+    const mapped = value.slice('::ffff:'.length);
+    if (mapped.includes('.')) return isLoopbackAddress(mapped);
+    const hex = mapped.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (!hex) return false;
+    return ((parseInt(hex[1], 16) >> 8) & 0xff) === 127;
+  }
+
+  return false;
+}
+
+function getDirectRemoteAddress(c: any): string {
+  return (
+    c?.env?.incoming?.socket?.remoteAddress ||
+    c?.env?.remoteAddr ||
+    c?.req?.raw?.socket?.remoteAddress ||
+    ''
+  );
+}
+
+/**
+ * First-admin setup is loopback-only unless ALLOW_REMOTE_SETUP=1/true.
+ *
+ * X-Forwarded-For is untrusted unless the TCP peer is also loopback (a local
+ * reverse proxy). A remote client spoofing XFF: 127.0.0.1 is rejected.
+ * When the peer is loopback and XFF names a remote client, the request is
+ * treated as remote.
+ */
+export function isLocalInitialSetupAllowed(c: any): boolean {
+  if (isTruthyEnvFlag(process.env.ALLOW_REMOTE_SETUP)) return true;
+
+  const socketIp = getDirectRemoteAddress(c);
+  if (!isLoopbackAddress(socketIp)) return false;
+
+  const xff = c?.req?.header?.('x-forwarded-for');
+  if (xff) {
+    const originalClient = xff.split(',')[0]?.trim();
+    if (originalClient && !isLoopbackAddress(originalClient)) return false;
+  }
+
+  return true;
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -51,6 +51,7 @@ import {
   validateUsername,
   validatePassword,
   generateUserId,
+  isLocalInitialSetupAllowed,
 } from '../auth.js';
 import type { AuthUser, User, UserPublic } from '../types.js';
 import { logger } from '../logger.js';
@@ -134,8 +135,21 @@ authRoutes.get('/status', (c) => {
   return c.json({ initialized });
 });
 
-// Public: initial admin setup (only when no users exist)
+// Public: initial admin setup (only when no users exist, and only from
+// loopback unless ALLOW_REMOTE_SETUP=1/true). createInitialAdminUser is
+// already atomic, but a remote host that can hit the port first could
+// still steal the first admin without this origin check.
 authRoutes.post('/setup', async (c) => {
+  if (!isLocalInitialSetupAllowed(c)) {
+    return c.json(
+      {
+        error:
+          'Initial setup must be performed from the host (loopback). Set ALLOW_REMOTE_SETUP=true to allow remote first-admin creation.',
+      },
+      403,
+    );
+  }
+
   const body = await c.req.json().catch(() => ({}));
   const { username: rawUsername, password } = body as {
     username?: string;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { isLocalInitialSetupAllowed, isLoopbackAddress } from '../src/auth.js';
+
+afterEach(() => {
+  delete process.env.ALLOW_REMOTE_SETUP;
+});
+
+function setupRequest(options: {
+  remoteAddress?: string;
+  remoteAddr?: string;
+  forwardedFor?: string;
+}): Parameters<typeof isLocalInitialSetupAllowed>[0] {
+  const headers: Record<string, string> = {};
+  if (options.forwardedFor !== undefined) {
+    headers['x-forwarded-for'] = options.forwardedFor;
+  }
+  return {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+      raw:
+        options.remoteAddress !== undefined
+          ? { socket: { remoteAddress: options.remoteAddress } }
+          : undefined,
+    },
+    env:
+      options.remoteAddress !== undefined || options.remoteAddr !== undefined
+        ? {
+            incoming:
+              options.remoteAddress !== undefined
+                ? { socket: { remoteAddress: options.remoteAddress } }
+                : undefined,
+            remoteAddr: options.remoteAddr,
+          }
+        : undefined,
+  };
+}
+
+describe('isLoopbackAddress', () => {
+  test.each([
+    ['127.0.0.1', true, 'IPv4 loopback'],
+    ['127.255.255.254', true, '127/8 boundary'],
+    ['::1', true, 'IPv6 loopback'],
+    ['[::1]', true, 'bracketed IPv6 loopback'],
+    ['::1%lo0', true, 'IPv6 loopback with zone id'],
+    ['::ffff:127.0.0.1', true, 'IPv4-mapped dotted loopback'],
+    ['::ffff:7f00:1', true, 'IPv4-mapped hex loopback'],
+    ['localhost', true, 'localhost name'],
+    ['8.8.8.8', false, 'public IPv4'],
+    ['10.0.0.1', false, 'RFC1918 is not loopback'],
+    ['192.168.1.10', false, 'LAN is not loopback'],
+    ['::ffff:8.8.8.8', false, 'IPv4-mapped public'],
+    ['2001:db8::1', false, 'public IPv6'],
+    ['', false, 'empty'],
+    [null, false, 'null'],
+    ['not-an-ip', false, 'garbage'],
+    ['127.0.0.256', false, 'invalid IPv4 octet'],
+  ])('%s → %s (%s)', (ip, expected) => {
+    expect(isLoopbackAddress(ip)).toBe(expected);
+  });
+});
+
+describe('isLocalInitialSetupAllowed', () => {
+  test('allows a direct loopback client', () => {
+    expect(
+      isLocalInitialSetupAllowed(setupRequest({ remoteAddress: '127.0.0.1' })),
+    ).toBe(true);
+    expect(
+      isLocalInitialSetupAllowed(setupRequest({ remoteAddress: '::1' })),
+    ).toBe(true);
+  });
+
+  test('rejects a remote TCP peer even if X-Forwarded-For claims loopback', () => {
+    expect(
+      isLocalInitialSetupAllowed(
+        setupRequest({
+          remoteAddress: '203.0.113.10',
+          forwardedFor: '127.0.0.1',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('rejects a remote client forwarded by a local proxy', () => {
+    expect(
+      isLocalInitialSetupAllowed(
+        setupRequest({
+          remoteAddress: '127.0.0.1',
+          forwardedFor: '203.0.113.10',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('allows a loopback client forwarded by a local proxy', () => {
+    expect(
+      isLocalInitialSetupAllowed(
+        setupRequest({
+          remoteAddress: '127.0.0.1',
+          forwardedFor: '::1, 127.0.0.1',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test('rejects an unknown or missing peer address', () => {
+    expect(isLocalInitialSetupAllowed(setupRequest({}))).toBe(false);
+  });
+
+  test('ALLOW_REMOTE_SETUP=1 allows a remote peer', () => {
+    process.env.ALLOW_REMOTE_SETUP = '1';
+    expect(
+      isLocalInitialSetupAllowed(
+        setupRequest({ remoteAddress: '203.0.113.10' }),
+      ),
+    ).toBe(true);
+  });
+
+  test('ALLOW_REMOTE_SETUP=true allows a remote peer', () => {
+    process.env.ALLOW_REMOTE_SETUP = 'true';
+    expect(
+      isLocalInitialSetupAllowed(
+        setupRequest({ remoteAddress: '203.0.113.10' }),
+      ),
+    ).toBe(true);
+  });
+
+  test('ALLOW_REMOTE_SETUP=yes is not an escape hatch', () => {
+    process.env.ALLOW_REMOTE_SETUP = 'yes';
+    expect(
+      isLocalInitialSetupAllowed(
+        setupRequest({ remoteAddress: '203.0.113.10' }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('POST /api/auth/setup origin guard', () => {
+  test('setup handler refuses remote first-admin unless the request is loopback', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/routes/auth.ts'),
+      'utf8',
+    );
+    const setupIdx = source.indexOf("authRoutes.post('/setup'");
+    const helperIdx = source.indexOf('isLocalInitialSetupAllowed(c)', setupIdx);
+    const createIdx = source.indexOf('createInitialAdminUser(', setupIdx);
+
+    expect(setupIdx).toBeGreaterThan(-1);
+    expect(helperIdx).toBeGreaterThan(setupIdx);
+    expect(createIdx).toBeGreaterThan(helperIdx);
+    expect(source).toContain('ALLOW_REMOTE_SETUP');
+  });
+});


### PR DESCRIPTION
## Problem

`POST /api/auth/setup` is public while the user table is empty. `createInitialAdminUser` is already atomic (`already_initialized`), but any host that can reach the bound port before the owner can still win the first-admin race.

## Change

- `src/auth.ts`: `isLoopbackAddress` / `isLocalInitialSetupAllowed`
  - Allow only loopback TCP peers (`127.0.0.0/8`, `::1`, IPv4-mapped loopback).
  - Treat `X-Forwarded-For` as untrusted unless the TCP peer is also loopback (local reverse proxy).
  - Escape hatch: `ALLOW_REMOTE_SETUP=1` or `true`.
- `src/routes/auth.ts`: setup handler returns 403 unless the origin check passes, before hashing or creating the user.
- Tests in `tests/auth.test.ts`.

No OAuth, CLI proxy, protocol translation, model routing, or provider gateway changes.

Based on official main (`d02e3a6` / #704). Not stacked on #705.
