### PR TITLE
fix(feishu): rewrite orphan cards from persisted assistant text

### DIFF
--- a/src/channel-reliability-recovery.ts
+++ b/src/channel-reliability-recovery.ts
@@ -1,5 +1,7 @@
+import { channelConversationJid } from './channel-address.js';
 import {
   claimStreamingCardRecovery,
+  completeRecoveredChannelTurnRun,
   finalizeStreamingCardRecord,
   getChannelTurnRun,
   getStreamingCardRecord,
@@ -9,8 +11,11 @@ import {
   interruptExpiredChannelTurnRuns,
   listAllNonterminalStreamingCards,
   releaseStreamingCardRecovery,
+  type ChannelTurnRun,
   type StreamingCardRecord,
 } from './channel-reliability-store.js';
+import { getMessagesPage } from './db.js';
+import { streamingCardSnapshotText } from './feishu-streaming-card.js';
 import { logger } from './logger.js';
 
 export interface StreamingCardReconciler {
@@ -30,6 +35,78 @@ interface ReconciliationPassOptions {
 const MISSING_PROVIDER_IDENTITY_ERROR = manualReconciliationError(
   'Streaming card creation was interrupted before provider identity was persisted; manual reconciliation required',
 );
+
+function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+  return [
+    ...new Set(values.map((value) => value?.trim() ?? '').filter(Boolean)),
+  ];
+}
+
+function turnResultText(result: unknown): string {
+  if (typeof result === 'string') return result.trim();
+  if (!result || typeof result !== 'object') return '';
+  const record = result as { text?: unknown; content?: unknown };
+  if (typeof record.text === 'string' && record.text.trim()) {
+    return record.text.trim();
+  }
+  if (typeof record.content === 'string' && record.content.trim()) {
+    return record.content.trim();
+  }
+  return '';
+}
+
+/**
+ * Prefer the conversation's stored assistant reply over the leftover card
+ * snapshot. The snapshot is only an orphan copy of what the dead process
+ * last flushed.
+ */
+export function resolveStreamingCardRecoveryBody(
+  card: Pick<StreamingCardRecord, 'sourceJid' | 'createdAt' | 'snapshot'>,
+  turn: ChannelTurnRun | undefined,
+): { body: string; persisted: boolean } {
+  const sessionId = turn?.sessionId?.trim() || '';
+  const turnId = turn?.correlationId?.trim() || '';
+  const since = turn?.startedAt || turn?.createdAt || card.createdAt;
+  const chatJids = uniqueNonEmpty([
+    card.sourceJid,
+    channelConversationJid(card.sourceJid),
+  ]);
+
+  for (const chatJid of chatJids) {
+    const recent = getMessagesPage(chatJid, undefined, 40);
+    const matched = recent.find((message) => {
+      if (!message.is_from_me || !message.content.trim()) return false;
+      if (sessionId && message.session_id === sessionId) return true;
+      if (turnId && message.turn_id === turnId) return true;
+      return false;
+    });
+    if (matched) {
+      return { body: matched.content.trim(), persisted: true };
+    }
+  }
+
+  const fromTurn = turnResultText(turn?.result);
+  if (fromTurn) {
+    return { body: fromTurn, persisted: true };
+  }
+
+  if (since) {
+    for (const chatJid of chatJids) {
+      const recent = getMessagesPage(chatJid, undefined, 20);
+      const matched = recent.find(
+        (message) =>
+          message.is_from_me &&
+          message.content.trim().length > 0 &&
+          message.timestamp >= since,
+      );
+      if (matched) {
+        return { body: matched.content.trim(), persisted: true };
+      }
+    }
+  }
+
+  return { body: streamingCardSnapshotText(card.snapshot), persisted: false };
+}
 
 async function reconcileChannelReliabilityPass(
   reconciler: StreamingCardReconciler,
@@ -127,25 +204,58 @@ async function reconcileChannelReliabilityPass(
       continue;
     }
     try {
-      const result = await reconciler.reconcileStreamingCard(claimed);
-      const final = finalizeStreamingCardRecord(claimed.id, claimed.revision, {
-        status: 'aborted',
-        version: result.version,
+      const recovered = resolveStreamingCardRecoveryBody(claimed, turn);
+      const recoveredComplete =
+        recovered.persisted || turn?.status === 'completed';
+      const snapshotBase =
+        claimed.snapshot && typeof claimed.snapshot === 'object'
+          ? (claimed.snapshot as Record<string, unknown>)
+          : {};
+      const result = await reconciler.reconcileStreamingCard({
+        ...claimed,
         snapshot: {
-          ...(claimed.snapshot && typeof claimed.snapshot === 'object'
-            ? claimed.snapshot
-            : {}),
+          ...snapshotBase,
+          ...(recovered.body ? { text: recovered.body } : {}),
           recovery: {
-            reason: 'process_interrupted',
-            method: result.method,
+            completed: recoveredComplete,
+            source: recovered.persisted
+              ? 'persisted_assistant'
+              : recovered.body
+                ? 'orphan_snapshot'
+                : 'empty',
           },
         },
-        error: 'Process interrupted before the card reached a terminal state',
+      });
+      if (recoveredComplete) {
+        completeRecoveredChannelTurnRun(claimed.turnRunId);
+      }
+      const final = finalizeStreamingCardRecord(claimed.id, claimed.revision, {
+        status: recoveredComplete ? 'completed' : 'aborted',
+        version: result.version,
+        snapshot: {
+          ...snapshotBase,
+          ...(recovered.body ? { text: recovered.body } : {}),
+          recovery: {
+            reason: recoveredComplete
+              ? 'persisted_reply'
+              : 'process_interrupted',
+            method: result.method,
+            source: recovered.persisted
+              ? 'persisted_assistant'
+              : recovered.body
+                ? 'orphan_snapshot'
+                : 'empty',
+          },
+        },
+        error: recoveredComplete
+          ? null
+          : 'Process interrupted before the card reached a terminal state',
       });
       if (!final) {
         throw new Error('Streaming card recovery fence was lost');
       }
       if (
+        !recoveredComplete &&
         interruptChannelTurnRunById(
           claimed.turnRunId,
           'Process restarted before the streaming card reached a terminal state',

--- a/src/channel-reliability-store.ts
+++ b/src/channel-reliability-store.ts
@@ -1514,6 +1514,30 @@ export function interruptExpiredChannelTurnRuns(
 }
 
 /**
+ * Close a Turn whose reply was already persisted before the process died.
+ * Lease-free on purpose: crash recovery runs after the old owner is gone.
+ * Terminal rows stay immutable.
+ */
+export function completeRecoveredChannelTurnRun(
+  id: string,
+  nowInput?: Date | string,
+): boolean {
+  const now = isoNow(nowInput);
+  const changed = requireDatabase()
+    .prepare(
+      `UPDATE turn_runs
+       SET status = 'completed', completed_at = COALESCE(completed_at, ?),
+           updated_at = ?, error = NULL,
+           lease_owner = NULL, lease_expires_at = NULL,
+           lease_token = lease_token + 1, revision = revision + 1
+       WHERE id = ?
+         AND status IN ('queued','running','finalizing','waiting_user','retry_wait')`,
+    )
+    .run(now, now, id);
+  return changed.changes === 1;
+}
+
+/**
  * Explicitly fence one live conversation Turn (stop button, shutdown, or
  * unrecoverable card/run reconciliation). Terminal rows are immutable, so
  * repeating the same interrupt is a no-op.

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -115,6 +115,41 @@ export interface InterruptedStreamingCardInput {
   reason?: string;
 }
 
+const DEFAULT_INTERRUPT_REASON = '上次服务中断，本次任务未完成';
+
+/** Visible body stored on a leftover streaming-card snapshot. */
+export function streamingCardSnapshotText(snapshot: unknown): string {
+  if (!snapshot || typeof snapshot !== 'object') return '';
+  const text = (snapshot as { text?: unknown }).text;
+  return typeof text === 'string' ? text.trim() : '';
+}
+
+function streamingCardRecoveryCompleted(snapshot: unknown): boolean {
+  if (!snapshot || typeof snapshot !== 'object') return false;
+  const recovery = (snapshot as { recovery?: { completed?: unknown } })
+    .recovery;
+  return recovery?.completed === true;
+}
+
+/**
+ * Crash recovery rewrite: keep a real body as-is. The interrupt banner is
+ * only for cards that have nothing to show.
+ */
+export function resolveInterruptedStreamingCardRewrite(input: {
+  snapshot?: unknown;
+  reason?: string;
+}): { text: string; status: 'done' | 'warning'; hasBody: boolean } {
+  const body = streamingCardSnapshotText(input.snapshot);
+  if (body) {
+    return { text: body, status: 'done', hasBody: true };
+  }
+  if (streamingCardRecoveryCompleted(input.snapshot)) {
+    return { text: '', status: 'done', hasBody: false };
+  }
+  const reason = input.reason?.trim() || DEFAULT_INTERRUPT_REASON;
+  return { text: `> ⚠️ ${reason}`, status: 'warning', hasBody: false };
+}
+
 /** Extract the platform error code from both rejected SDK calls and resolved
  * error envelopes. Lark SDK versions differ in where they expose this field. */
 function feishuErrorCode(value: unknown): number | undefined {
@@ -3776,14 +3811,11 @@ export async function reconcileInterruptedStreamingCard(
   client: lark.Client,
   input: InterruptedStreamingCardInput,
 ): Promise<{ version: number; method: 'cardkit' | 'message_patch' }> {
-  const saved = input.snapshot as
-    | { text?: unknown; thinking?: unknown }
-    | null
-    | undefined;
-  const partial = typeof saved?.text === 'string' ? saved.text.trim() : '';
-  const reason = input.reason?.trim() || '上次服务中断，本次任务未完成';
-  const text = partial ? `${partial}\n\n---\n> ⚠️ ${reason}` : `> ⚠️ ${reason}`;
-  const card = buildAgentReplyCard({ status: 'warning', text });
+  const rewrite = resolveInterruptedStreamingCardRewrite(input);
+  const card = buildAgentReplyCard({
+    status: rewrite.status,
+    text: rewrite.text,
+  });
 
   if (input.cardId) {
     let version = Math.max(0, Math.trunc(input.version));

--- a/tests/channel-turn-runtime.test.ts
+++ b/tests/channel-turn-runtime.test.ts
@@ -26,10 +26,13 @@ const { deliverChannelOutboxItem, DefinitiveChannelDeliveryError } =
 const runtimeScope = await import('../src/channel-outbox-runtime-scope.js');
 const {
   reconcileChannelReliabilityOnStartup,
+  resolveStreamingCardRecoveryBody,
   startChannelReliabilityRecoveryLoop,
 } = await import('../src/channel-reliability-recovery.js');
-const { reconcileInterruptedStreamingCard } =
-  await import('../src/feishu-streaming-card.js');
+const {
+  reconcileInterruptedStreamingCard,
+  resolveInterruptedStreamingCardRewrite,
+} = await import('../src/feishu-streaming-card.js');
 
 const route = {
   provider: 'feishu',
@@ -993,5 +996,187 @@ describe('provider reconciliation', () => {
       }),
     );
     expect(create).not.toHaveBeenCalled();
+    const updated = JSON.stringify(update.mock.calls[0][0]);
+    expect(updated).toContain('保留的部分回答');
+    expect(updated).not.toContain('上次服务中断');
+  });
+
+  test('writes only the interrupt banner when the leftover card has no body', async () => {
+    const patch = vi.fn().mockResolvedValue({ code: 0 });
+    const client = {
+      cardkit: {
+        v1: { card: { settings: vi.fn(), update: vi.fn(), create: vi.fn() } },
+      },
+      im: { v1: { message: { patch, create: vi.fn() } } },
+    } as any;
+
+    await expect(
+      reconcileInterruptedStreamingCard(client, {
+        messageId: 'om_empty',
+        cardId: null,
+        version: 1,
+        snapshot: { text: '' },
+      }),
+    ).resolves.toEqual({ version: 1, method: 'message_patch' });
+    expect(JSON.stringify(patch.mock.calls[0][0])).toContain('上次服务中断');
+  });
+
+  test('prefers a stored assistant reply over the orphan snapshot and skips the banner', () => {
+    expect(
+      resolveInterruptedStreamingCardRewrite({
+        snapshot: { text: '卡片上的半截' },
+        reason: '上次服务中断，本次任务未完成',
+      }),
+    ).toEqual({
+      text: '卡片上的半截',
+      status: 'done',
+      hasBody: true,
+    });
+    expect(
+      resolveInterruptedStreamingCardRewrite({
+        snapshot: { text: '', recovery: { completed: true } },
+      }),
+    ).toEqual({ text: '', status: 'done', hasBody: false });
+    expect(
+      resolveInterruptedStreamingCardRewrite({ snapshot: { text: '  ' } }),
+    ).toMatchObject({ status: 'warning', hasBody: false });
+  });
+});
+
+describe('persisted assistant recovery', () => {
+  test('startup rewrites a leftover card with the stored reply and does not abort', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:00:00.000Z'));
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-persisted#account:bot-runtime#root:root-persisted#thread:thread-persisted',
+      chatId: 'chat-persisted',
+      rootId: 'root-persisted',
+      threadId: 'thread-persisted',
+      externalMessageId: 'msg-persisted-reply',
+      agentId: 'agent-persisted-reply',
+      sessionId: 'sess-persisted-reply',
+      leaseMs: 5_000,
+      heartbeatMs: 2_000,
+    };
+    const first = ChannelTurnRuntime.start(input);
+    first.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_persisted_reply',
+      cardId: 'card_persisted_reply',
+      version: 4,
+      snapshot: { text: '卡片上还停着半截' },
+    });
+    const leftover = reliability
+      .listAllNonterminalStreamingCards()
+      .find((card) => card.turnRunId === first.runId)!;
+    db.ensureChatExists(input.sourceJid);
+    db.storeMessageDirect(
+      'assistant-persisted-reply',
+      input.sourceJid,
+      'happyclaw-agent',
+      'HappyClaw',
+      '已经写进会话的完整回复',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId: input.externalMessageId,
+          sessionId: input.sessionId,
+          sourceKind: 'sdk_final',
+          finalizationReason: 'completed',
+        },
+      },
+    );
+    expect(
+      resolveStreamingCardRecoveryBody(
+        leftover,
+        reliability.getChannelTurnRun(first.runId),
+      ),
+    ).toEqual({
+      body: '已经写进会话的完整回复',
+      persisted: true,
+    });
+    first.dispose();
+    vi.setSystemTime(new Date('2026-08-28T08:00:06.000Z'));
+
+    const reconcile = vi.fn().mockResolvedValue({
+      version: 6,
+      method: 'cardkit' as const,
+    });
+    await expect(
+      reconcileChannelReliabilityOnStartup({
+        reconcileStreamingCard: reconcile,
+      }),
+    ).resolves.toMatchObject({ reconciled: 1 });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 'om_persisted_reply',
+        snapshot: expect.objectContaining({
+          text: '已经写进会话的完整回复',
+          recovery: expect.objectContaining({
+            completed: true,
+            source: 'persisted_assistant',
+          }),
+        }),
+      }),
+    );
+    expect(reliability.getChannelTurnRun(first.runId)?.status).toBe(
+      'completed',
+    );
+    expect(reliability.getStreamingCardRecord(leftover.id)?.status).toBe(
+      'completed',
+    );
+    vi.useRealTimers();
+  });
+
+  test('a leftover card with no stored body still aborts and keeps the banner path', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:10:00.000Z'));
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-empty-recover#account:bot-runtime#root:root-empty#thread:thread-empty',
+      chatId: 'chat-empty-recover',
+      rootId: 'root-empty',
+      threadId: 'thread-empty',
+      externalMessageId: 'msg-empty-recover',
+      agentId: 'agent-empty-recover',
+      leaseMs: 5_000,
+      heartbeatMs: 2_000,
+    };
+    const first = ChannelTurnRuntime.start(input);
+    first.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_empty_recover',
+      cardId: 'card_empty_recover',
+      version: 1,
+      snapshot: { text: '' },
+    });
+    first.dispose();
+    vi.setSystemTime(new Date('2026-08-28T08:10:06.000Z'));
+
+    const reconcile = vi.fn().mockResolvedValue({
+      version: 2,
+      method: 'cardkit' as const,
+    });
+    await reconcileChannelReliabilityOnStartup({
+      reconcileStreamingCard: reconcile,
+    });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          recovery: expect.objectContaining({
+            completed: false,
+            source: 'empty',
+          }),
+        }),
+      }),
+    );
+    expect(reliability.getChannelTurnRun(first.runId)?.status).toBe(
+      'interrupted',
+    );
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Problem

After a crash, leftover Feishu streaming cards were reconciled from `snapshot.text` only, then always appended ⚠️ 上次服务中断. Recovery always finalized the turn as aborted even when the conversation already had a stored assistant reply.

## Change

- Prefer persisted assistant text (or a turn already marked completed).
- Rewrite the leftover card as completed with that body. No interrupt banner when a body exists.
- Banner only when there is no persisted body.
- When a persisted reply or successful turn is found, mark the card/turn completed instead of aborting.

No OAuth, CLI proxy, protocol translation, model routing, or provider gateway changes.
Based on official main (`d02e3a6` / #704). Not stacked on #705.

## Tests

`npx vitest run tests/channel-turn-runtime.test.ts` — 24 passed
