### PR TITLE
fix(im): authorize IPC replies from channel-bound Runtime Sessions

### DIFF
--- a/src/cross-group-acl.ts
+++ b/src/cross-group-acl.ts
@@ -9,6 +9,13 @@ import type { RegisteredGroup } from './types.js';
  *   from that workspace — without this, after agent-runner started rewriting
  *   ctx.chatJid to the IM source, send_file/send_image/send_message from
  *   non-home sub-workspaces got rejected.
+ * - IM channels bound to a Runtime Session (target_agent_id) resolve through
+ *   that session's workspace folder. Workspace binds record target_main_jid,
+ *   but direct-chat session binds only record target_agent_id and leave the
+ *   channel row's own `folder` at the channel account's default workspace, so
+ *   the folder and target_main_jid branches both miss and every reply from a
+ *   session living outside that default workspace was rejected — the runner
+ *   completed the turn while the channel stayed silent.
  */
 export function canSendCrossGroupMessage(
   isAdminHome: boolean,
@@ -17,6 +24,11 @@ export function canSendCrossGroupMessage(
   sourceGroupEntry: RegisteredGroup | undefined,
   targetGroup: RegisteredGroup | undefined,
   lookupGroup: (jid: string) => RegisteredGroup | undefined,
+  /**
+   * Resolve a Runtime Session id to the workspace folder it lives in.
+   * Returns undefined for unknown sessions, which denies the branch.
+   */
+  lookupAgentFolder: (agentId: string) => string | undefined,
 ): boolean {
   if (isAdminHome) return true;
   if (targetGroup && targetGroup.folder === sourceFolder) return true;
@@ -30,6 +42,11 @@ export function canSendCrossGroupMessage(
   if (targetGroup?.target_main_jid) {
     const bound = lookupGroup(targetGroup.target_main_jid);
     if (bound?.folder === sourceFolder) return true;
+  }
+  if (targetGroup?.target_agent_id) {
+    // An unknown session yields undefined, which never equals a folder string.
+    if (lookupAgentFolder(targetGroup.target_agent_id) === sourceFolder)
+      return true;
   }
   return false;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10770,6 +10770,7 @@ function canSendCrossGroupMessage(
     sourceGroupEntry,
     targetGroup,
     (jid) => registeredGroups[jid] ?? getRegisteredGroup(jid),
+    (agentId) => getAgent(agentId)?.group_folder,
   );
 }
 

--- a/tests/can-send-cross-group-message.test.ts
+++ b/tests/can-send-cross-group-message.test.ts
@@ -7,7 +7,7 @@ import type { RegisteredGroup } from '../src/types.js';
 /**
  * Regression tests for the cross-group ACL helper in src/cross-group-acl.ts.
  *
- * The 4 branches:
+ * The 5 branches:
  *  1. admin home → always allowed
  *  2. target.folder === sourceFolder (same workspace)
  *  3. member home + same created_by (cross-workspace, same user)
@@ -15,10 +15,17 @@ import type { RegisteredGroup } from '../src/types.js';
  *     (added in f93d922 — without this, agent in non-home sub-workspaces
  *      could not reply to its IM channel after agent-runner started
  *      rewriting ctx.chatJid to the IM source jid)
+ *  5. target.target_agent_id → bound Runtime Session's workspace folder
+ *     === sourceFolder. Direct-chat session binds record only
+ *     target_agent_id and leave the channel row's own `folder` at the
+ *     channel account's default workspace, so branches 2 and 4 both miss
+ *     and the session's replies were rejected while the turn itself
+ *     completed — a silent channel, not a visible failure.
  *
  * Mutation checks (run by QA): removing branch 4 should turn the
  * "bound IM jid" cases red. Flipping `bound?.folder === sourceFolder`
- * to `===` against anything else should also fail.
+ * to `===` against anything else should also fail. Removing branch 5
+ * should turn the "bound Runtime Session" case red.
  */
 
 function makeGroup(partial: Partial<RegisteredGroup>): RegisteredGroup {
@@ -41,6 +48,7 @@ describe('canSendCrossGroupMessage', () => {
         undefined,
         target,
         () => undefined,
+        () => undefined,
       ),
     ).toBe(true);
   });
@@ -55,6 +63,7 @@ describe('canSendCrossGroupMessage', () => {
         'flow-x',
         source,
         target,
+        () => undefined,
         () => undefined,
       ),
     ).toBe(true);
@@ -71,6 +80,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         target,
         () => undefined,
+        () => undefined,
       ),
     ).toBe(true);
   });
@@ -85,6 +95,7 @@ describe('canSendCrossGroupMessage', () => {
         'flow-x',
         source,
         target,
+        () => undefined,
         () => undefined,
       ),
     ).toBe(false);
@@ -114,6 +125,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         imTarget,
         lookupGroup,
+        () => undefined,
       ),
     ).toBe(true);
     expect(lookupGroup).toHaveBeenCalledWith('web:flow-x');
@@ -147,6 +159,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         resolvedTarget,
         lookupGroup,
+        () => undefined,
       ),
     ).toBe(true);
     expect(lookupGroup).toHaveBeenCalledWith('feishu:oc_topic');
@@ -171,6 +184,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         imTarget,
         lookupGroup,
+        () => undefined,
       ),
     ).toBe(false);
   });
@@ -190,6 +204,91 @@ describe('canSendCrossGroupMessage', () => {
         source,
         imTarget,
         lookupGroup,
+        () => undefined,
+      ),
+    ).toBe(false);
+  });
+
+  // Branch 5: a direct chat bound to a Runtime Session. The channel row keeps
+  // `folder` at the channel account's default workspace ('main') and records
+  // only target_agent_id, so branches 2 and 4 both miss.
+  test('direct chat bound to a Runtime Session in the source workspace → allowed', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-1',
+    });
+    const lookupAgentFolder = vi.fn((agentId: string) =>
+      agentId === 'session-1' ? 'flow-x' : undefined,
+    );
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        'flow-x',
+        source,
+        imTarget,
+        () => undefined,
+        lookupAgentFolder,
+      ),
+    ).toBe(true);
+    expect(lookupAgentFolder).toHaveBeenCalledWith('session-1');
+  });
+
+  test('direct chat bound to a Runtime Session in ANOTHER workspace → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-2',
+    });
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        'flow-x',
+        source,
+        imTarget,
+        () => undefined,
+        (agentId) => (agentId === 'session-2' ? 'flow-y' : undefined),
+      ),
+    ).toBe(false);
+  });
+
+  test('target_agent_id points to an unknown session → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-gone',
+    });
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        'flow-x',
+        source,
+        imTarget,
+        () => undefined,
+        () => undefined,
+      ),
+    ).toBe(false);
+  });
+
+  // An unknown session must not be rescued by an empty sourceFolder: both
+  // sides would read as "" and a missing session would silently authorize.
+  test('unknown session + empty sourceFolder → still denied', () => {
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-gone',
+    });
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        '',
+        makeGroup({ folder: '', created_by: 'u1' }),
+        imTarget,
+        () => undefined,
+        () => undefined,
       ),
     ).toBe(false);
   });
@@ -202,6 +301,7 @@ describe('canSendCrossGroupMessage', () => {
         'flow-x',
         undefined,
         undefined,
+        () => undefined,
         () => undefined,
       ),
     ).toBe(false);


### PR DESCRIPTION
## Problem

A direct chat bound to a Runtime Session records only `target_agent_id` on its
`registered_groups` row, and leaves that row's own `folder` at the channel
account's default workspace. `canSendCrossGroupMessage` had no branch for
`target_agent_id`:

1. admin home
2. `target.folder === sourceFolder`
3. member home + same `created_by`
4. `target.target_main_jid` → bound workspace folder === `sourceFolder`

Workspace binds are covered by (4), but direct-chat **session** binds never set
`target_main_jid`. So whenever the bound session lives in a workspace other than
the channel account's default one, (2) and (4) both miss and every
`send_message` / `send_image` / `send_file` from that session is rejected:

```
WARN  Unauthorized IPC message attempt blocked
WARN  Suppressed Proactive agent SDK final without send_message delivery
```

The two lines are paired, and the failure is silent rather than loud. The runner
completes the turn normally; in Proactive mode the SDK final is then correctly
suppressed because no `send_message` succeeded, so the turn lands as
`{"replyDelivered": false, "silent": true}` and the channel simply never
answers. Nothing surfaces to the user and nothing retries.

Sessions that happen to live in the default workspace keep working, which is why
the gap can sit unnoticed.

## Fix

Add a fifth branch resolving `target_agent_id` to its session's workspace folder:

```ts
if (targetGroup?.target_agent_id) {
  // An unknown session yields undefined, which never equals a folder string.
  if (lookupAgentFolder(targetGroup.target_agent_id) === sourceFolder)
    return true;
}
```

The production wrapper in `src/index.ts` injects
`(agentId) => getAgent(agentId)?.group_folder`. `send_message`, `send_image` and
`send_file` all route through that one wrapper, so a single branch covers the
three IPC entry points.

A deleted or unknown session resolves to `undefined`, which never equals a folder
string, so it stays denied.

## Tests

`tests/can-send-cross-group-message.test.ts`: 9 → 13 cases. The four new ones
cover both directions of the new branch:

| Case | Expected |
| --- | --- |
| Bound session lives in the source workspace | allowed |
| Bound session lives in another workspace | denied |
| `target_agent_id` points at an unknown session | denied |
| Unknown session + empty `sourceFolder` | denied |

The last one pins the comparison against a future refactor such as
`boundFolder ?? sourceFolder`, where two empty strings would otherwise
authorize. The file-header mutation notes are updated to 5 branches.

## Verification

- `npx vitest run tests/can-send-cross-group-message.test.ts` — 13 passed
- `make typecheck` — pass
- `npm run docs:check` — pass
- `make test` — 3769 passed / 426 files
- `make build` — pass
- `git diff --check` — clean

`tests/container-session-permissions.test.ts` fails locally with
`MODULE_NOT_FOUND` inside the agent image. It fails identically on a clean tree
with these changes stashed, so it is a pre-existing local image staleness issue
and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
