### PR TITLE
fix: integrate reliable session replies and Feishu recovery

### DIFF
--- a/src/channel-reliability-recovery.ts
+++ b/src/channel-reliability-recovery.ts
@@ -14,7 +14,7 @@ import {
   type ChannelTurnRun,
   type StreamingCardRecord,
 } from './channel-reliability-store.js';
-import { getMessagesPage } from './db.js';
+import { getAgent, getMessagesForTurn } from './db.js';
 import { streamingCardSnapshotText } from './feishu-streaming-card.js';
 import { logger } from './logger.js';
 
@@ -42,19 +42,6 @@ function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
   ];
 }
 
-function turnResultText(result: unknown): string {
-  if (typeof result === 'string') return result.trim();
-  if (!result || typeof result !== 'object') return '';
-  const record = result as { text?: unknown; content?: unknown };
-  if (typeof record.text === 'string' && record.text.trim()) {
-    return record.text.trim();
-  }
-  if (typeof record.content === 'string' && record.content.trim()) {
-    return record.content.trim();
-  }
-  return '';
-}
-
 /**
  * Prefer the conversation's stored assistant reply over the leftover card
  * snapshot. The snapshot is only an orphan copy of what the dead process
@@ -64,40 +51,30 @@ export function resolveStreamingCardRecoveryBody(
   card: Pick<StreamingCardRecord, 'sourceJid' | 'createdAt' | 'snapshot'>,
   turn: ChannelTurnRun | undefined,
 ): { body: string; persisted: boolean } {
-  const sessionId = turn?.sessionId?.trim() || '';
   const turnId = turn?.correlationId?.trim() || '';
-  const since = turn?.startedAt || turn?.createdAt || card.createdAt;
+  const agent = turn?.agentId ? getAgent(turn.agentId) : undefined;
   const chatJids = uniqueNonEmpty([
+    agent ? `${agent.chat_jid}#agent:${agent.id}` : undefined,
     card.sourceJid,
     channelConversationJid(card.sourceJid),
   ]);
 
-  for (const chatJid of chatJids) {
-    const recent = getMessagesPage(chatJid, undefined, 40);
-    const matched = recent.find((message) => {
-      if (!message.is_from_me || !message.content.trim()) return false;
-      if (sessionId && message.session_id === sessionId) return true;
-      if (turnId && message.turn_id === turnId) return true;
-      return false;
-    });
-    if (matched) {
-      return { body: matched.content.trim(), persisted: true };
-    }
-  }
-
-  const fromTurn = turnResultText(turn?.result);
-  if (fromTurn) {
-    return { body: fromTurn, persisted: true };
-  }
-
-  if (since) {
+  if (turnId) {
     for (const chatJid of chatJids) {
-      const recent = getMessagesPage(chatJid, undefined, 20);
-      const matched = recent.find(
+      const matched = getMessagesForTurn(chatJid, turnId).find(
         (message) =>
           message.is_from_me &&
+          message.sender === 'happyclaw-agent' &&
           message.content.trim().length > 0 &&
-          message.timestamp >= since,
+          message.turn_id === turnId &&
+          message.finalization_reason === 'completed' &&
+          ![
+            'interrupt_partial',
+            'overflow_partial',
+            'compact_partial',
+            'input_rejection_warning',
+            'provider_fallback_notice',
+          ].includes(message.source_kind ?? ''),
       );
       if (matched) {
         return { body: matched.content.trim(), persisted: true };
@@ -205,8 +182,23 @@ async function reconcileChannelReliabilityPass(
     }
     try {
       const recovered = resolveStreamingCardRecoveryBody(claimed, turn);
-      const recoveredComplete =
-        recovered.persisted || turn?.status === 'completed';
+      let recoveredComplete = recovered.persisted;
+      if (recoveredComplete) {
+        const turnCompleted =
+          completeRecoveredChannelTurnRun(claimed.turnRunId) ||
+          getChannelTurnRun(claimed.turnRunId)?.status === 'completed';
+        if (!turnCompleted) {
+          recoveredComplete = false;
+          logger.error(
+            {
+              cardId: claimed.id,
+              turnRunId: claimed.turnRunId,
+              turnStatus: getChannelTurnRun(claimed.turnRunId)?.status,
+            },
+            'Refused to mark a recovered card completed because its Turn could not be completed',
+          );
+        }
+      }
       const snapshotBase =
         claimed.snapshot && typeof claimed.snapshot === 'object'
           ? (claimed.snapshot as Record<string, unknown>)
@@ -226,9 +218,6 @@ async function reconcileChannelReliabilityPass(
           },
         },
       });
-      if (recoveredComplete) {
-        completeRecoveredChannelTurnRun(claimed.turnRunId);
-      }
       const final = finalizeStreamingCardRecord(claimed.id, claimed.revision, {
         status: recoveredComplete ? 'completed' : 'aborted',
         version: result.version,
@@ -236,9 +225,12 @@ async function reconcileChannelReliabilityPass(
           ...snapshotBase,
           ...(recovered.body ? { text: recovered.body } : {}),
           recovery: {
+            completed: recoveredComplete,
             reason: recoveredComplete
               ? 'persisted_reply'
-              : 'process_interrupted',
+              : recovered.persisted
+                ? 'turn_completion_conflict'
+                : 'process_interrupted',
             method: result.method,
             source: recovered.persisted
               ? 'persisted_assistant'

--- a/src/channel-reliability-recovery.ts
+++ b/src/channel-reliability-recovery.ts
@@ -1,5 +1,7 @@
+import { channelConversationJid } from './channel-address.js';
 import {
   claimStreamingCardRecovery,
+  completeRecoveredChannelTurnRun,
   finalizeStreamingCardRecord,
   getChannelTurnRun,
   getStreamingCardRecord,
@@ -9,8 +11,11 @@ import {
   interruptExpiredChannelTurnRuns,
   listAllNonterminalStreamingCards,
   releaseStreamingCardRecovery,
+  type ChannelTurnRun,
   type StreamingCardRecord,
 } from './channel-reliability-store.js';
+import { getMessagesPage } from './db.js';
+import { streamingCardSnapshotText } from './feishu-streaming-card.js';
 import { logger } from './logger.js';
 
 export interface StreamingCardReconciler {
@@ -30,6 +35,78 @@ interface ReconciliationPassOptions {
 const MISSING_PROVIDER_IDENTITY_ERROR = manualReconciliationError(
   'Streaming card creation was interrupted before provider identity was persisted; manual reconciliation required',
 );
+
+function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+  return [
+    ...new Set(values.map((value) => value?.trim() ?? '').filter(Boolean)),
+  ];
+}
+
+function turnResultText(result: unknown): string {
+  if (typeof result === 'string') return result.trim();
+  if (!result || typeof result !== 'object') return '';
+  const record = result as { text?: unknown; content?: unknown };
+  if (typeof record.text === 'string' && record.text.trim()) {
+    return record.text.trim();
+  }
+  if (typeof record.content === 'string' && record.content.trim()) {
+    return record.content.trim();
+  }
+  return '';
+}
+
+/**
+ * Prefer the conversation's stored assistant reply over the leftover card
+ * snapshot. The snapshot is only an orphan copy of what the dead process
+ * last flushed.
+ */
+export function resolveStreamingCardRecoveryBody(
+  card: Pick<StreamingCardRecord, 'sourceJid' | 'createdAt' | 'snapshot'>,
+  turn: ChannelTurnRun | undefined,
+): { body: string; persisted: boolean } {
+  const sessionId = turn?.sessionId?.trim() || '';
+  const turnId = turn?.correlationId?.trim() || '';
+  const since = turn?.startedAt || turn?.createdAt || card.createdAt;
+  const chatJids = uniqueNonEmpty([
+    card.sourceJid,
+    channelConversationJid(card.sourceJid),
+  ]);
+
+  for (const chatJid of chatJids) {
+    const recent = getMessagesPage(chatJid, undefined, 40);
+    const matched = recent.find((message) => {
+      if (!message.is_from_me || !message.content.trim()) return false;
+      if (sessionId && message.session_id === sessionId) return true;
+      if (turnId && message.turn_id === turnId) return true;
+      return false;
+    });
+    if (matched) {
+      return { body: matched.content.trim(), persisted: true };
+    }
+  }
+
+  const fromTurn = turnResultText(turn?.result);
+  if (fromTurn) {
+    return { body: fromTurn, persisted: true };
+  }
+
+  if (since) {
+    for (const chatJid of chatJids) {
+      const recent = getMessagesPage(chatJid, undefined, 20);
+      const matched = recent.find(
+        (message) =>
+          message.is_from_me &&
+          message.content.trim().length > 0 &&
+          message.timestamp >= since,
+      );
+      if (matched) {
+        return { body: matched.content.trim(), persisted: true };
+      }
+    }
+  }
+
+  return { body: streamingCardSnapshotText(card.snapshot), persisted: false };
+}
 
 async function reconcileChannelReliabilityPass(
   reconciler: StreamingCardReconciler,
@@ -127,25 +204,58 @@ async function reconcileChannelReliabilityPass(
       continue;
     }
     try {
-      const result = await reconciler.reconcileStreamingCard(claimed);
-      const final = finalizeStreamingCardRecord(claimed.id, claimed.revision, {
-        status: 'aborted',
-        version: result.version,
+      const recovered = resolveStreamingCardRecoveryBody(claimed, turn);
+      const recoveredComplete =
+        recovered.persisted || turn?.status === 'completed';
+      const snapshotBase =
+        claimed.snapshot && typeof claimed.snapshot === 'object'
+          ? (claimed.snapshot as Record<string, unknown>)
+          : {};
+      const result = await reconciler.reconcileStreamingCard({
+        ...claimed,
         snapshot: {
-          ...(claimed.snapshot && typeof claimed.snapshot === 'object'
-            ? claimed.snapshot
-            : {}),
+          ...snapshotBase,
+          ...(recovered.body ? { text: recovered.body } : {}),
           recovery: {
-            reason: 'process_interrupted',
-            method: result.method,
+            completed: recoveredComplete,
+            source: recovered.persisted
+              ? 'persisted_assistant'
+              : recovered.body
+                ? 'orphan_snapshot'
+                : 'empty',
           },
         },
-        error: 'Process interrupted before the card reached a terminal state',
+      });
+      if (recoveredComplete) {
+        completeRecoveredChannelTurnRun(claimed.turnRunId);
+      }
+      const final = finalizeStreamingCardRecord(claimed.id, claimed.revision, {
+        status: recoveredComplete ? 'completed' : 'aborted',
+        version: result.version,
+        snapshot: {
+          ...snapshotBase,
+          ...(recovered.body ? { text: recovered.body } : {}),
+          recovery: {
+            reason: recoveredComplete
+              ? 'persisted_reply'
+              : 'process_interrupted',
+            method: result.method,
+            source: recovered.persisted
+              ? 'persisted_assistant'
+              : recovered.body
+                ? 'orphan_snapshot'
+                : 'empty',
+          },
+        },
+        error: recoveredComplete
+          ? null
+          : 'Process interrupted before the card reached a terminal state',
       });
       if (!final) {
         throw new Error('Streaming card recovery fence was lost');
       }
       if (
+        !recoveredComplete &&
         interruptChannelTurnRunById(
           claimed.turnRunId,
           'Process restarted before the streaming card reached a terminal state',

--- a/src/channel-reliability-store.ts
+++ b/src/channel-reliability-store.ts
@@ -1514,6 +1514,30 @@ export function interruptExpiredChannelTurnRuns(
 }
 
 /**
+ * Close a Turn whose reply was already persisted before the process died.
+ * Lease-free on purpose: crash recovery runs after the old owner is gone.
+ * Terminal rows stay immutable.
+ */
+export function completeRecoveredChannelTurnRun(
+  id: string,
+  nowInput?: Date | string,
+): boolean {
+  const now = isoNow(nowInput);
+  const changed = requireDatabase()
+    .prepare(
+      `UPDATE turn_runs
+       SET status = 'completed', completed_at = COALESCE(completed_at, ?),
+           updated_at = ?, error = NULL,
+           lease_owner = NULL, lease_expires_at = NULL,
+           lease_token = lease_token + 1, revision = revision + 1
+       WHERE id = ?
+         AND status IN ('queued','running','finalizing','waiting_user','retry_wait')`,
+    )
+    .run(now, now, id);
+  return changed.changes === 1;
+}
+
+/**
  * Explicitly fence one live conversation Turn (stop button, shutdown, or
  * unrecoverable card/run reconciliation). Terminal rows are immutable, so
  * repeating the same interrupt is a no-op.

--- a/src/cross-group-acl.ts
+++ b/src/cross-group-acl.ts
@@ -9,6 +9,13 @@ import type { RegisteredGroup } from './types.js';
  *   from that workspace — without this, after agent-runner started rewriting
  *   ctx.chatJid to the IM source, send_file/send_image/send_message from
  *   non-home sub-workspaces got rejected.
+ * - IM channels bound to a Runtime Session (target_agent_id) resolve through
+ *   that session's workspace folder. Workspace binds record target_main_jid,
+ *   but direct-chat session binds only record target_agent_id and leave the
+ *   channel row's own `folder` at the channel account's default workspace, so
+ *   the folder and target_main_jid branches both miss and every reply from a
+ *   session living outside that default workspace was rejected — the runner
+ *   completed the turn while the channel stayed silent.
  */
 export function canSendCrossGroupMessage(
   isAdminHome: boolean,
@@ -17,6 +24,11 @@ export function canSendCrossGroupMessage(
   sourceGroupEntry: RegisteredGroup | undefined,
   targetGroup: RegisteredGroup | undefined,
   lookupGroup: (jid: string) => RegisteredGroup | undefined,
+  /**
+   * Resolve a Runtime Session id to the workspace folder it lives in.
+   * Returns undefined for unknown sessions, which denies the branch.
+   */
+  lookupAgentFolder: (agentId: string) => string | undefined,
 ): boolean {
   if (isAdminHome) return true;
   if (targetGroup && targetGroup.folder === sourceFolder) return true;
@@ -30,6 +42,11 @@ export function canSendCrossGroupMessage(
   if (targetGroup?.target_main_jid) {
     const bound = lookupGroup(targetGroup.target_main_jid);
     if (bound?.folder === sourceFolder) return true;
+  }
+  if (targetGroup?.target_agent_id) {
+    // An unknown session yields undefined, which never equals a folder string.
+    if (lookupAgentFolder(targetGroup.target_agent_id) === sourceFolder)
+      return true;
   }
   return false;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -12347,6 +12347,28 @@ export function getMessagesPage(
   return rows.map((row) => normalizeMessageRow(row));
 }
 
+/** Exact persisted rows for one logical input turn, newest first. */
+export function getMessagesForTurn(
+  chatJid: string,
+  turnId: string,
+): Array<NewMessage & { is_from_me: boolean }> {
+  const normalizedTurnId = turnId.trim();
+  if (!normalizedTurnId) return [];
+  const rows = db
+    .prepare(
+      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
+              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
+              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
+       FROM messages
+       WHERE chat_jid = ? AND turn_id = ?
+       ORDER BY timestamp DESC, id DESC`,
+    )
+    .all(chatJid, normalizedTurnId) as Array<
+    NewMessage & { is_from_me: number }
+  >;
+  return rows.map((row) => normalizeMessageRow(row));
+}
+
 /**
  * Recent persisted messages that are safe to replay into a fresh model
  * session. Privacy migrations leave the Web transcript untouched and fence

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -115,6 +115,41 @@ export interface InterruptedStreamingCardInput {
   reason?: string;
 }
 
+const DEFAULT_INTERRUPT_REASON = '上次服务中断，本次任务未完成';
+
+/** Visible body stored on a leftover streaming-card snapshot. */
+export function streamingCardSnapshotText(snapshot: unknown): string {
+  if (!snapshot || typeof snapshot !== 'object') return '';
+  const text = (snapshot as { text?: unknown }).text;
+  return typeof text === 'string' ? text.trim() : '';
+}
+
+function streamingCardRecoveryCompleted(snapshot: unknown): boolean {
+  if (!snapshot || typeof snapshot !== 'object') return false;
+  const recovery = (snapshot as { recovery?: { completed?: unknown } })
+    .recovery;
+  return recovery?.completed === true;
+}
+
+/**
+ * Crash recovery rewrite: keep a real body as-is. The interrupt banner is
+ * only for cards that have nothing to show.
+ */
+export function resolveInterruptedStreamingCardRewrite(input: {
+  snapshot?: unknown;
+  reason?: string;
+}): { text: string; status: 'done' | 'warning'; hasBody: boolean } {
+  const body = streamingCardSnapshotText(input.snapshot);
+  if (body) {
+    return { text: body, status: 'done', hasBody: true };
+  }
+  if (streamingCardRecoveryCompleted(input.snapshot)) {
+    return { text: '', status: 'done', hasBody: false };
+  }
+  const reason = input.reason?.trim() || DEFAULT_INTERRUPT_REASON;
+  return { text: `> ⚠️ ${reason}`, status: 'warning', hasBody: false };
+}
+
 /** Extract the platform error code from both rejected SDK calls and resolved
  * error envelopes. Lark SDK versions differ in where they expose this field. */
 function feishuErrorCode(value: unknown): number | undefined {
@@ -3776,14 +3811,11 @@ export async function reconcileInterruptedStreamingCard(
   client: lark.Client,
   input: InterruptedStreamingCardInput,
 ): Promise<{ version: number; method: 'cardkit' | 'message_patch' }> {
-  const saved = input.snapshot as
-    | { text?: unknown; thinking?: unknown }
-    | null
-    | undefined;
-  const partial = typeof saved?.text === 'string' ? saved.text.trim() : '';
-  const reason = input.reason?.trim() || '上次服务中断，本次任务未完成';
-  const text = partial ? `${partial}\n\n---\n> ⚠️ ${reason}` : `> ⚠️ ${reason}`;
-  const card = buildAgentReplyCard({ status: 'warning', text });
+  const rewrite = resolveInterruptedStreamingCardRewrite(input);
+  const card = buildAgentReplyCard({
+    status: rewrite.status,
+    text: rewrite.text,
+  });
 
   if (input.cardId) {
     let version = Math.max(0, Math.trunc(input.version));

--- a/src/feishu-streaming-card.ts
+++ b/src/feishu-streaming-card.ts
@@ -131,23 +131,21 @@ function streamingCardRecoveryCompleted(snapshot: unknown): boolean {
   return recovery?.completed === true;
 }
 
-/**
- * Crash recovery rewrite: keep a real body as-is. The interrupt banner is
- * only for cards that have nothing to show.
- */
+/** Crash recovery rewrite: only an explicitly completed recovery looks done. */
 export function resolveInterruptedStreamingCardRewrite(input: {
   snapshot?: unknown;
   reason?: string;
 }): { text: string; status: 'done' | 'warning'; hasBody: boolean } {
   const body = streamingCardSnapshotText(input.snapshot);
-  if (body) {
-    return { text: body, status: 'done', hasBody: true };
-  }
   if (streamingCardRecoveryCompleted(input.snapshot)) {
-    return { text: '', status: 'done', hasBody: false };
+    return { text: body, status: 'done', hasBody: body.length > 0 };
   }
   const reason = input.reason?.trim() || DEFAULT_INTERRUPT_REASON;
-  return { text: `> ⚠️ ${reason}`, status: 'warning', hasBody: false };
+  return {
+    text: body ? `${body}\n\n> ⚠️ ${reason}` : `> ⚠️ ${reason}`,
+    status: 'warning',
+    hasBody: body.length > 0,
+  };
 }
 
 /** Extract the platform error code from both rejected SDK calls and resolved

--- a/src/index.ts
+++ b/src/index.ts
@@ -10770,6 +10770,7 @@ function canSendCrossGroupMessage(
     sourceGroupEntry,
     targetGroup,
     (jid) => registeredGroups[jid] ?? getRegisteredGroup(jid),
+    (agentId) => getAgent(agentId)?.group_folder,
   );
 }
 

--- a/tests/can-send-cross-group-message.test.ts
+++ b/tests/can-send-cross-group-message.test.ts
@@ -7,7 +7,7 @@ import type { RegisteredGroup } from '../src/types.js';
 /**
  * Regression tests for the cross-group ACL helper in src/cross-group-acl.ts.
  *
- * The 4 branches:
+ * The 5 branches:
  *  1. admin home → always allowed
  *  2. target.folder === sourceFolder (same workspace)
  *  3. member home + same created_by (cross-workspace, same user)
@@ -15,10 +15,17 @@ import type { RegisteredGroup } from '../src/types.js';
  *     (added in f93d922 — without this, agent in non-home sub-workspaces
  *      could not reply to its IM channel after agent-runner started
  *      rewriting ctx.chatJid to the IM source jid)
+ *  5. target.target_agent_id → bound Runtime Session's workspace folder
+ *     === sourceFolder. Direct-chat session binds record only
+ *     target_agent_id and leave the channel row's own `folder` at the
+ *     channel account's default workspace, so branches 2 and 4 both miss
+ *     and the session's replies were rejected while the turn itself
+ *     completed — a silent channel, not a visible failure.
  *
  * Mutation checks (run by QA): removing branch 4 should turn the
  * "bound IM jid" cases red. Flipping `bound?.folder === sourceFolder`
- * to `===` against anything else should also fail.
+ * to `===` against anything else should also fail. Removing branch 5
+ * should turn the "bound Runtime Session" case red.
  */
 
 function makeGroup(partial: Partial<RegisteredGroup>): RegisteredGroup {
@@ -41,6 +48,7 @@ describe('canSendCrossGroupMessage', () => {
         undefined,
         target,
         () => undefined,
+        () => undefined,
       ),
     ).toBe(true);
   });
@@ -55,6 +63,7 @@ describe('canSendCrossGroupMessage', () => {
         'flow-x',
         source,
         target,
+        () => undefined,
         () => undefined,
       ),
     ).toBe(true);
@@ -71,6 +80,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         target,
         () => undefined,
+        () => undefined,
       ),
     ).toBe(true);
   });
@@ -85,6 +95,7 @@ describe('canSendCrossGroupMessage', () => {
         'flow-x',
         source,
         target,
+        () => undefined,
         () => undefined,
       ),
     ).toBe(false);
@@ -114,6 +125,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         imTarget,
         lookupGroup,
+        () => undefined,
       ),
     ).toBe(true);
     expect(lookupGroup).toHaveBeenCalledWith('web:flow-x');
@@ -147,6 +159,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         resolvedTarget,
         lookupGroup,
+        () => undefined,
       ),
     ).toBe(true);
     expect(lookupGroup).toHaveBeenCalledWith('feishu:oc_topic');
@@ -171,6 +184,7 @@ describe('canSendCrossGroupMessage', () => {
         source,
         imTarget,
         lookupGroup,
+        () => undefined,
       ),
     ).toBe(false);
   });
@@ -190,6 +204,91 @@ describe('canSendCrossGroupMessage', () => {
         source,
         imTarget,
         lookupGroup,
+        () => undefined,
+      ),
+    ).toBe(false);
+  });
+
+  // Branch 5: a direct chat bound to a Runtime Session. The channel row keeps
+  // `folder` at the channel account's default workspace ('main') and records
+  // only target_agent_id, so branches 2 and 4 both miss.
+  test('direct chat bound to a Runtime Session in the source workspace → allowed', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-1',
+    });
+    const lookupAgentFolder = vi.fn((agentId: string) =>
+      agentId === 'session-1' ? 'flow-x' : undefined,
+    );
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        'flow-x',
+        source,
+        imTarget,
+        () => undefined,
+        lookupAgentFolder,
+      ),
+    ).toBe(true);
+    expect(lookupAgentFolder).toHaveBeenCalledWith('session-1');
+  });
+
+  test('direct chat bound to a Runtime Session in ANOTHER workspace → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-2',
+    });
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        'flow-x',
+        source,
+        imTarget,
+        () => undefined,
+        (agentId) => (agentId === 'session-2' ? 'flow-y' : undefined),
+      ),
+    ).toBe(false);
+  });
+
+  test('target_agent_id points to an unknown session → denied', () => {
+    const source = makeGroup({ folder: 'flow-x', created_by: 'u1' });
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-gone',
+    });
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        'flow-x',
+        source,
+        imTarget,
+        () => undefined,
+        () => undefined,
+      ),
+    ).toBe(false);
+  });
+
+  // An unknown session must not be rescued by an empty sourceFolder: both
+  // sides would read as "" and a missing session would silently authorize.
+  test('unknown session + empty sourceFolder → still denied', () => {
+    const imTarget = makeGroup({
+      folder: 'main',
+      target_agent_id: 'session-gone',
+    });
+    expect(
+      canSendCrossGroupMessage(
+        false,
+        false,
+        '',
+        makeGroup({ folder: '', created_by: 'u1' }),
+        imTarget,
+        () => undefined,
+        () => undefined,
       ),
     ).toBe(false);
   });
@@ -202,6 +301,7 @@ describe('canSendCrossGroupMessage', () => {
         'flow-x',
         undefined,
         undefined,
+        () => undefined,
         () => undefined,
       ),
     ).toBe(false);

--- a/tests/channel-turn-runtime.test.ts
+++ b/tests/channel-turn-runtime.test.ts
@@ -969,7 +969,7 @@ describe('durable channel turn runtime', () => {
 });
 
 describe('provider reconciliation', () => {
-  test('updates the original CardKit card instead of creating a replacement', async () => {
+  test('updates the original CardKit card and marks an orphan body interrupted', async () => {
     const settings = vi.fn().mockResolvedValue({ code: 0 });
     const update = vi.fn().mockResolvedValue({ code: 0 });
     const create = vi.fn();
@@ -998,7 +998,7 @@ describe('provider reconciliation', () => {
     expect(create).not.toHaveBeenCalled();
     const updated = JSON.stringify(update.mock.calls[0][0]);
     expect(updated).toContain('保留的部分回答');
-    expect(updated).not.toContain('上次服务中断');
+    expect(updated).toContain('上次服务中断');
   });
 
   test('writes only the interrupt banner when the leftover card has no body', async () => {
@@ -1021,17 +1021,25 @@ describe('provider reconciliation', () => {
     expect(JSON.stringify(patch.mock.calls[0][0])).toContain('上次服务中断');
   });
 
-  test('prefers a stored assistant reply over the orphan snapshot and skips the banner', () => {
+  test('shows done only for an explicitly completed recovered body', () => {
     expect(
       resolveInterruptedStreamingCardRewrite({
         snapshot: { text: '卡片上的半截' },
         reason: '上次服务中断，本次任务未完成',
       }),
     ).toEqual({
-      text: '卡片上的半截',
-      status: 'done',
+      text: '卡片上的半截\n\n> ⚠️ 上次服务中断，本次任务未完成',
+      status: 'warning',
       hasBody: true,
     });
+    expect(
+      resolveInterruptedStreamingCardRewrite({
+        snapshot: {
+          text: '持久化的完整回答',
+          recovery: { completed: true },
+        },
+      }),
+    ).toEqual({ text: '持久化的完整回答', status: 'done', hasBody: true });
     expect(
       resolveInterruptedStreamingCardRewrite({
         snapshot: { text: '', recovery: { completed: true } },
@@ -1044,6 +1052,143 @@ describe('provider reconciliation', () => {
 });
 
 describe('persisted assistant recovery', () => {
+  test('requires the exact turn id and an explicitly completed terminal', () => {
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-strict-recovery#account:bot-runtime#root:root-strict#thread:thread-strict',
+      chatId: 'chat-strict-recovery',
+      rootId: 'root-strict',
+      threadId: 'thread-strict',
+      externalMessageId: 'msg-strict-recovery',
+      agentId: 'agent-strict-recovery',
+      sessionId: 'long-lived-session',
+    };
+    const runtime = ChannelTurnRuntime.start(input);
+    runtime.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_strict_recovery',
+      cardId: 'card_strict_recovery',
+      version: 1,
+      snapshot: { text: '当前卡片的半截内容' },
+    });
+    const leftover = reliability
+      .listAllNonterminalStreamingCards()
+      .find((card) => card.turnRunId === runtime.runId)!;
+    db.ensureChatExists(input.sourceJid);
+    db.storeMessageDirect(
+      'assistant-same-session-wrong-turn',
+      input.sourceJid,
+      'happyclaw-agent',
+      'HappyClaw',
+      '同一个长期 session 里另一轮的完整回答',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId: 'another-turn',
+          sessionId: input.sessionId,
+          sourceKind: 'sdk_final',
+          finalizationReason: 'completed',
+        },
+      },
+    );
+    db.storeMessageDirect(
+      'assistant-exact-turn-interrupted',
+      input.sourceJid,
+      'happyclaw-agent',
+      'HappyClaw',
+      '当前 turn 的中断片段',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId: input.externalMessageId,
+          sessionId: input.sessionId,
+          sourceKind: 'interrupt_partial',
+          finalizationReason: 'interrupted',
+        },
+      },
+    );
+
+    expect(
+      resolveStreamingCardRecoveryBody(
+        leftover,
+        reliability.getChannelTurnRun(runtime.runId),
+      ),
+    ).toEqual({ body: '当前卡片的半截内容', persisted: false });
+    runtime.dispose();
+  });
+
+  test('finds the exact completed reply in a conversation-agent transcript', () => {
+    const agentId = 'conversation-agent-recovery';
+    const workspaceJid = 'web:conversation-agent-workspace';
+    db.createAgent({
+      id: agentId,
+      group_folder: 'conversation-agent-workspace',
+      chat_jid: workspaceJid,
+      name: 'Conversation Agent',
+      prompt: '',
+      status: 'idle',
+      kind: 'conversation',
+      created_by: 'owner-conversation-agent',
+      created_at: new Date().toISOString(),
+      completed_at: null,
+      result_summary: null,
+      last_im_jid: null,
+      spawned_from_jid: null,
+    });
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-agent-recovery#account:bot-runtime#root:root-agent#thread:thread-agent',
+      chatId: 'chat-agent-recovery',
+      rootId: 'root-agent',
+      threadId: 'thread-agent',
+      externalMessageId: 'msg-agent-recovery',
+      agentId,
+      sessionId: 'session-agent-recovery',
+    };
+    const runtime = ChannelTurnRuntime.start(input);
+    runtime.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_agent_recovery',
+      cardId: 'card_agent_recovery',
+      version: 2,
+      snapshot: { text: '卡片半截' },
+    });
+    const leftover = reliability
+      .listAllNonterminalStreamingCards()
+      .find((card) => card.turnRunId === runtime.runId)!;
+    const transcriptJid = `${workspaceJid}#agent:${agentId}`;
+    db.ensureChatExists(transcriptJid);
+    db.storeMessageDirect(
+      'assistant-agent-persisted',
+      transcriptJid,
+      'happyclaw-agent',
+      'HappyClaw',
+      '会话 Agent 的完整回答',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId: input.externalMessageId,
+          sessionId: input.sessionId,
+          sourceKind: 'sdk_final',
+          finalizationReason: 'completed',
+        },
+      },
+    );
+
+    expect(
+      resolveStreamingCardRecoveryBody(
+        leftover,
+        reliability.getChannelTurnRun(runtime.runId),
+      ),
+    ).toEqual({ body: '会话 Agent 的完整回答', persisted: true });
+    runtime.dispose();
+  });
+
   test('startup rewrites a leftover card with the stored reply and does not abort', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-28T08:00:00.000Z'));
@@ -1129,6 +1274,73 @@ describe('persisted assistant recovery', () => {
       'completed',
     );
     vi.useRealTimers();
+  });
+
+  test('does not show success when the exact persisted reply conflicts with a failed turn', async () => {
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-failed-turn#account:bot-runtime#root:root-failed#thread:thread-failed',
+      chatId: 'chat-failed-turn',
+      rootId: 'root-failed',
+      threadId: 'thread-failed',
+      externalMessageId: 'msg-failed-turn',
+      agentId: 'agent-failed-turn',
+      sessionId: 'session-failed-turn',
+    };
+    const runtime = ChannelTurnRuntime.start(input);
+    runtime.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_failed_turn',
+      cardId: 'card_failed_turn',
+      version: 3,
+      snapshot: { text: '卡片半截' },
+    });
+    const leftover = reliability
+      .listAllNonterminalStreamingCards()
+      .find((card) => card.turnRunId === runtime.runId)!;
+    db.ensureChatExists(input.sourceJid);
+    db.storeMessageDirect(
+      'assistant-failed-turn-conflict',
+      input.sourceJid,
+      'happyclaw-agent',
+      'HappyClaw',
+      '虽然持久化但不能覆盖失败围栏的回答',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId: input.externalMessageId,
+          sessionId: input.sessionId,
+          sourceKind: 'sdk_final',
+          finalizationReason: 'completed',
+        },
+      },
+    );
+    expect(runtime.fail('provider delivery failed')).toBe(true);
+    runtime.dispose();
+
+    const reconcile = vi.fn().mockResolvedValue({
+      version: 5,
+      method: 'cardkit' as const,
+    });
+    await expect(
+      reconcileChannelReliabilityOnStartup({
+        reconcileStreamingCard: reconcile,
+      }),
+    ).resolves.toMatchObject({ reconciled: 1 });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          text: '虽然持久化但不能覆盖失败围栏的回答',
+          recovery: expect.objectContaining({ completed: false }),
+        }),
+      }),
+    );
+    expect(reliability.getChannelTurnRun(runtime.runId)?.status).toBe('failed');
+    expect(reliability.getStreamingCardRecord(leftover.id)?.status).toBe(
+      'aborted',
+    );
   });
 
   test('a leftover card with no stored body still aborts and keeps the banner path', async () => {

--- a/tests/channel-turn-runtime.test.ts
+++ b/tests/channel-turn-runtime.test.ts
@@ -26,10 +26,13 @@ const { deliverChannelOutboxItem, DefinitiveChannelDeliveryError } =
 const runtimeScope = await import('../src/channel-outbox-runtime-scope.js');
 const {
   reconcileChannelReliabilityOnStartup,
+  resolveStreamingCardRecoveryBody,
   startChannelReliabilityRecoveryLoop,
 } = await import('../src/channel-reliability-recovery.js');
-const { reconcileInterruptedStreamingCard } =
-  await import('../src/feishu-streaming-card.js');
+const {
+  reconcileInterruptedStreamingCard,
+  resolveInterruptedStreamingCardRewrite,
+} = await import('../src/feishu-streaming-card.js');
 
 const route = {
   provider: 'feishu',
@@ -993,5 +996,187 @@ describe('provider reconciliation', () => {
       }),
     );
     expect(create).not.toHaveBeenCalled();
+    const updated = JSON.stringify(update.mock.calls[0][0]);
+    expect(updated).toContain('保留的部分回答');
+    expect(updated).not.toContain('上次服务中断');
+  });
+
+  test('writes only the interrupt banner when the leftover card has no body', async () => {
+    const patch = vi.fn().mockResolvedValue({ code: 0 });
+    const client = {
+      cardkit: {
+        v1: { card: { settings: vi.fn(), update: vi.fn(), create: vi.fn() } },
+      },
+      im: { v1: { message: { patch, create: vi.fn() } } },
+    } as any;
+
+    await expect(
+      reconcileInterruptedStreamingCard(client, {
+        messageId: 'om_empty',
+        cardId: null,
+        version: 1,
+        snapshot: { text: '' },
+      }),
+    ).resolves.toEqual({ version: 1, method: 'message_patch' });
+    expect(JSON.stringify(patch.mock.calls[0][0])).toContain('上次服务中断');
+  });
+
+  test('prefers a stored assistant reply over the orphan snapshot and skips the banner', () => {
+    expect(
+      resolveInterruptedStreamingCardRewrite({
+        snapshot: { text: '卡片上的半截' },
+        reason: '上次服务中断，本次任务未完成',
+      }),
+    ).toEqual({
+      text: '卡片上的半截',
+      status: 'done',
+      hasBody: true,
+    });
+    expect(
+      resolveInterruptedStreamingCardRewrite({
+        snapshot: { text: '', recovery: { completed: true } },
+      }),
+    ).toEqual({ text: '', status: 'done', hasBody: false });
+    expect(
+      resolveInterruptedStreamingCardRewrite({ snapshot: { text: '  ' } }),
+    ).toMatchObject({ status: 'warning', hasBody: false });
+  });
+});
+
+describe('persisted assistant recovery', () => {
+  test('startup rewrites a leftover card with the stored reply and does not abort', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:00:00.000Z'));
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-persisted#account:bot-runtime#root:root-persisted#thread:thread-persisted',
+      chatId: 'chat-persisted',
+      rootId: 'root-persisted',
+      threadId: 'thread-persisted',
+      externalMessageId: 'msg-persisted-reply',
+      agentId: 'agent-persisted-reply',
+      sessionId: 'sess-persisted-reply',
+      leaseMs: 5_000,
+      heartbeatMs: 2_000,
+    };
+    const first = ChannelTurnRuntime.start(input);
+    first.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_persisted_reply',
+      cardId: 'card_persisted_reply',
+      version: 4,
+      snapshot: { text: '卡片上还停着半截' },
+    });
+    const leftover = reliability
+      .listAllNonterminalStreamingCards()
+      .find((card) => card.turnRunId === first.runId)!;
+    db.ensureChatExists(input.sourceJid);
+    db.storeMessageDirect(
+      'assistant-persisted-reply',
+      input.sourceJid,
+      'happyclaw-agent',
+      'HappyClaw',
+      '已经写进会话的完整回复',
+      new Date().toISOString(),
+      true,
+      {
+        meta: {
+          turnId: input.externalMessageId,
+          sessionId: input.sessionId,
+          sourceKind: 'sdk_final',
+          finalizationReason: 'completed',
+        },
+      },
+    );
+    expect(
+      resolveStreamingCardRecoveryBody(
+        leftover,
+        reliability.getChannelTurnRun(first.runId),
+      ),
+    ).toEqual({
+      body: '已经写进会话的完整回复',
+      persisted: true,
+    });
+    first.dispose();
+    vi.setSystemTime(new Date('2026-08-28T08:00:06.000Z'));
+
+    const reconcile = vi.fn().mockResolvedValue({
+      version: 6,
+      method: 'cardkit' as const,
+    });
+    await expect(
+      reconcileChannelReliabilityOnStartup({
+        reconcileStreamingCard: reconcile,
+      }),
+    ).resolves.toMatchObject({ reconciled: 1 });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 'om_persisted_reply',
+        snapshot: expect.objectContaining({
+          text: '已经写进会话的完整回复',
+          recovery: expect.objectContaining({
+            completed: true,
+            source: 'persisted_assistant',
+          }),
+        }),
+      }),
+    );
+    expect(reliability.getChannelTurnRun(first.runId)?.status).toBe(
+      'completed',
+    );
+    expect(reliability.getStreamingCardRecord(leftover.id)?.status).toBe(
+      'completed',
+    );
+    vi.useRealTimers();
+  });
+
+  test('a leftover card with no stored body still aborts and keeps the banner path', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-28T08:10:00.000Z'));
+    const input = {
+      ...route,
+      sourceJid:
+        'feishu:chat-empty-recover#account:bot-runtime#root:root-empty#thread:thread-empty',
+      chatId: 'chat-empty-recover',
+      rootId: 'root-empty',
+      threadId: 'thread-empty',
+      externalMessageId: 'msg-empty-recover',
+      agentId: 'agent-empty-recover',
+      leaseMs: 5_000,
+      heartbeatMs: 2_000,
+    };
+    const first = ChannelTurnRuntime.start(input);
+    first.reserveStreamingCard()!.onEvent({
+      status: 'streaming',
+      messageId: 'om_empty_recover',
+      cardId: 'card_empty_recover',
+      version: 1,
+      snapshot: { text: '' },
+    });
+    first.dispose();
+    vi.setSystemTime(new Date('2026-08-28T08:10:06.000Z'));
+
+    const reconcile = vi.fn().mockResolvedValue({
+      version: 2,
+      method: 'cardkit' as const,
+    });
+    await reconcileChannelReliabilityOnStartup({
+      reconcileStreamingCard: reconcile,
+    });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          recovery: expect.objectContaining({
+            completed: false,
+            source: 'empty',
+          }),
+        }),
+      }),
+    );
+    expect(reliability.getChannelTurnRun(first.runId)?.status).toBe(
+      'interrupted',
+    );
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

- integrate #708 so Runtime Session-bound IM chats can reply from their actual workspace
- integrate #707 so leftover Feishu cards recover exact persisted assistant replies
- harden #707 recovery to require exact turn correlation and successful terminal content
- preserve warning state for orphan partial cards and cover conversation-agent transcripts

## Local verification

- targeted ACL and channel recovery tests
- full Vitest suite (port-sensitive maintenance tests additionally rerun in an isolated network)
- format check, production dependency audit, full typecheck, docs check
- backend/web/agent-runner production build
- provider failure upstream smoke
- mobile Playwright E2E
- agent-runner self-test

Mac mini deployment and production verification will be completed on this exact remote commit before merge.