### PR TITLE
fix(runtime): harden session delivery invariants

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -54,7 +54,9 @@ test "$(git rev-parse "origin/$HAPPYCLAW_DEPLOY_REF")" = "$HAPPYCLAW_EXPECTED_SH
 所有者已明确选择不保留部署备份。部署期间不得运行 `make backup`，不得创建 SQLite
 快照、完整运行数据归档或 `.env` 备份副本，除非所有者在未来明确撤销该策略。禁止运行
 `make reset-init`、`git clean`、`git reset --hard`，也不要用带 `--delete` 的 rsync 同步
-生产目录。
+生产目录。Mac mini 的现有 `.env` 必须原地配置
+`HAPPYCLAW_SKIP_MIGRATION_BACKUP=1`；它只关闭启动时的 schema 迁移快照，其他安装默认仍会
+在迁移前创建并校验快照。
 
 ## 3. 构建与切换
 
@@ -63,6 +65,13 @@ test "$(git rev-parse "origin/$HAPPYCLAW_DEPLOY_REF")" = "$HAPPYCLAW_EXPECTED_SH
 ```bash
 git switch --detach "$HAPPYCLAW_EXPECTED_SHA"
 test "$(git rev-parse HEAD)" = "$HAPPYCLAW_EXPECTED_SHA"
+
+if grep -q '^HAPPYCLAW_SKIP_MIGRATION_BACKUP=' .env 2>/dev/null; then
+  sed -i '' 's/^HAPPYCLAW_SKIP_MIGRATION_BACKUP=.*$/HAPPYCLAW_SKIP_MIGRATION_BACKUP=1/' .env
+else
+  printf '\nHAPPYCLAW_SKIP_MIGRATION_BACKUP=1\n' >> .env
+fi
+chmod 600 .env
 
 /bin/zsh -lic 'make install'
 /bin/zsh -lic 'npm run build:all'

--- a/container/agent-runner/prompts/delivery-contract.proactive.md
+++ b/container/agent-runner/prompts/delivery-contract.proactive.md
@@ -27,9 +27,11 @@ not an identity or personality instruction.
   error with a card tool or raw channel API, and do not sleep and retry. The
   framework owns user-visible delivery-failure notices.
 - Never place user-visible content only in the final SDK text. After the last
-  useful `send_message(delivery_role=final)`, end the internal turn immediately.
-  Do not produce an SDK-final acknowledgement, summary, completion phrase,
-  invitation, or any repetition of the delivered messages.
+  useful `send_message(delivery_role=final)`, end the internal turn immediately
+  with exactly `<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->` as the invisible,
+  non-empty SDK control text. This prevents the CLI from starting a redundant
+  no-visible-output turn. Do not produce an acknowledgement, summary,
+  completion phrase, invitation, or any repetition of the delivered messages.
 - Not calling `send_message` means that this turn stays silent. Ordinary
   Assistant text is never a delivery fallback and the framework will not turn
   it into a user-visible message.

--- a/container/agent-runner/prompts/output.proactive.md
+++ b/container/agent-runner/prompts/output.proactive.md
@@ -24,10 +24,11 @@
   不能作为主动模式的默认回复样式。
 - 最终 SDK Assistant 文本是内部控制面，不会展示给用户。所有用户需要看到的内容必须由成功的
   `send_message` 送达；最后一条有用消息必须使用 `delivery_role=final`，并同时承载结果或明确的失败说明。送达后立即结束内部回合，
-  不要再写“已送达”“任务完成”“如需继续随时说”等总结、完成语或邀请，也不要在 SDK 最终文本里重复。
+  严格按工具成功回执的要求，只输出固定的不可见 SDK 控制标记
+  `<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->`。不要再写“已送达”“任务完成”“如需继续随时说”等总结、完成语或邀请，也不要重复已送达内容。
 - 不调用 `send_message` 表示本轮保持沉默。普通 Assistant 文本绝不是发送失败时的备用回复，
   框架不会把它转换成用户可见消息；需要回复却遗漏工具调用时，用户将看不到这段内容。
-- 若 CLI 在已成功发送后注入
+- 兼容旧 CLI：若它仍在已成功发送后注入
   `[Your previous response had no visible output. Please continue and produce a user-visible response.]`，
   将它视为内部收尾信号：不要重发任何内容，只结束当前内部回合。只有确有新的、不同的信息时才能再次发消息。
 

--- a/container/agent-runner/src/background-task-drain.ts
+++ b/container/agent-runner/src/background-task-drain.ts
@@ -279,6 +279,37 @@ export class QuiescentResultGate {
 }
 
 /**
+ * Hard deadline for a Result withheld solely by protocol completion debt.
+ * Re-observing the same debt never extends the original boundary; otherwise a
+ * stream of unrelated SDK frames could postpone terminal recovery forever.
+ */
+export class BackgroundProtocolDebtWatchdog {
+  private armedAt: number | undefined;
+
+  arm(now: number = Date.now()): number {
+    this.armedAt ??= now;
+    return this.armedAt;
+  }
+
+  clear(): void {
+    this.armedAt = undefined;
+  }
+
+  isExpired(timeoutMs: number, now: number = Date.now()): boolean {
+    return this.armedAt !== undefined && now - this.armedAt >= timeoutMs;
+  }
+
+  remainingMs(timeoutMs: number, now: number = Date.now()): number {
+    if (this.armedAt === undefined) return timeoutMs;
+    return Math.max(0, timeoutMs - (now - this.armedAt));
+  }
+
+  get isArmed(): boolean {
+    return this.armedAt !== undefined;
+  }
+}
+
+/**
  * Tracks whether the input currently owning Runner output has crossed a
  * healthy, durable result boundary.
  *

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -86,6 +86,7 @@ import {
 } from './runtime-mcp-policy.js';
 import {
   IpcTurnDeliveryTracker,
+  ipcReceiptInputIdentity,
   IpcTurnOutputCorrelation,
   isHealthyInputTurnCompletion,
   latestIpcDeliveryId,
@@ -135,6 +136,11 @@ import {
 } from './assistant-usage.js';
 import { buildHappyClawPromptPlan, type PromptPlan } from './prompt-plan.js';
 import { withHappyClawSubagentContract } from './sdk-compat.js';
+import {
+  isCliNoVisibleOutputCompanion,
+  isProactiveFinalDeliveredSentinel,
+  proactiveFinalWasDeliveredForInput,
+} from './proactive-turn-protocol.js';
 import { assessContextBudget } from './context-budget.js';
 import {
   findClaudeMdExcludeLeaks,
@@ -147,10 +153,12 @@ import {
 } from './agent-turn-contract.js';
 import { prepareMessageStreamText } from './message-stream-text.js';
 import {
+  BackgroundProtocolDebtWatchdog,
   DurableInputTurnCompletion,
   QuiescentResultGate,
   shouldFailIncompleteQueryExit,
 } from './background-task-drain.js';
+import { IpcInputClaimStore } from './ipc-input-claims.js';
 
 // 路径解析：优先读取环境变量，降级到容器内默认路径（保持向后兼容）
 const WORKSPACE_GROUP =
@@ -178,6 +186,7 @@ const MODEL_LIMIT_EXHAUSTED_NOTICE =
 const IPC_INPUT_DIR = path.join(WORKSPACE_IPC, 'input');
 const IPC_INPUT_CLOSE_SENTINEL = path.join(IPC_INPUT_DIR, '_close');
 const IPC_FALLBACK_POLL_MS = 5000; // 后备轮询间隔（仅防止 inotify 事件丢失）
+const ipcInputClaims = new IpcInputClaimStore(IPC_INPUT_DIR);
 
 let hadCompaction = false;
 // Module-level session ID so SIGTERM handler can emit it before exit.
@@ -819,6 +828,8 @@ const SDK_CONTEXT_USAGE_TIMEOUT_MS = 5_000;
 const SDK_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
 const SDK_COMPACTION_RESPONSE_TIMEOUT_MS = 10 * 60_000;
 const SDK_PROVIDER_FAILURE_EXIT_GRACE_MS = 250;
+const BACKGROUND_PROTOCOL_DEBT_TIMEOUT_MS = 15_000;
+const BACKGROUND_PROTOCOL_FAILURE_EXIT_GRACE_MS = 1_000;
 
 function writeOutput(output: ContainerOutput): void {
   const correlatedOutput: ContainerOutput = activeOutputInputTurnId
@@ -1238,10 +1249,10 @@ function isWithinInterruptGraceWindow(): boolean {
 
 function isInterruptRelatedError(err: unknown): boolean {
   const errno = err as NodeJS.ErrnoException;
-  const message = err instanceof Error ? err.message : String(err ?? '');
   return (
     errno?.code === 'ABORT_ERR' ||
-    /abort|aborted|interrupt|interrupted|cancelled|canceled/i.test(message)
+    (err instanceof Error &&
+      (err.name === 'AbortError' || err.name === 'CanceledError'))
   );
 }
 
@@ -1303,16 +1314,11 @@ interface IpcDrainResult {
 function drainIpcInput(): IpcDrainResult {
   const result: IpcDrainResult = { messages: [] };
   try {
-    const files = fs
-      .readdirSync(IPC_INPUT_DIR)
-      .filter((f) => f.endsWith('.json'))
-      .sort();
+    const claimPaths = ipcInputClaims.claimAvailable();
 
-    for (const file of files) {
-      const filePath = path.join(IPC_INPUT_DIR, file);
+    for (const claimPath of claimPaths) {
       try {
-        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-        fs.unlinkSync(filePath);
+        const data = JSON.parse(fs.readFileSync(claimPath, 'utf-8'));
         if (data.type === 'message' && data.text) {
           result.messages.push({
             text: data.text,
@@ -1327,24 +1333,65 @@ function drainIpcInput(): IpcDrainResult {
               typeof data.sourceJid === 'string' ? data.sourceJid : undefined,
             ),
             receipt: parseIpcReceipt(data.receipt),
+            ipcClaimPath: claimPath,
           });
+        } else {
+          ipcInputClaims.discard(claimPath);
         }
       } catch (err) {
         log(
-          `Failed to process input file ${file}: ${err instanceof Error ? err.message : String(err)}`,
+          `Failed to process input claim ${path.basename(claimPath)}: ${err instanceof Error ? err.message : String(err)}`,
         );
-        try {
-          fs.unlinkSync(filePath);
-        } catch {
-          /* ignore */
-        }
+        ipcInputClaims.discard(claimPath);
       }
     }
-    result.messages = orderIpcInputMessages(result.messages);
+    const seenInputIdentities = new Set<string>();
+    const duplicateClaims: string[] = [];
+    result.messages = orderIpcInputMessages(
+      result.messages.filter((message) => {
+        const receipt = message.receipt;
+        if (!receipt) return true;
+        const identity = ipcReceiptInputIdentity(receipt);
+        if (!seenInputIdentities.has(identity)) {
+          seenInputIdentities.add(identity);
+          return true;
+        }
+        if (message.ipcClaimPath) duplicateClaims.push(message.ipcClaimPath);
+        return false;
+      }),
+    );
+    // A crash claim and a Host re-emission can coexist briefly. Keep exactly
+    // one durable copy and remove the duplicate claim before prompt assembly.
+    const duplicateClaimFailures = ipcInputClaims.acknowledge(duplicateClaims);
+    if (duplicateClaimFailures.length > 0) {
+      logWarn(
+        `Failed to remove ${duplicateClaimFailures.length} duplicate IPC claim(s); delivery-id deduplication remains active`,
+      );
+    }
   } catch (err) {
     log(`IPC drain error: ${err instanceof Error ? err.message : String(err)}`);
   }
   return result;
+}
+
+/**
+ * Transfer durable file ownership to the in-memory delivery tracker. Failed
+ * unlinks stay claimed and are ignored by this process; a replacement Runner
+ * can recover them after a crash.
+ */
+function acknowledgeRegisteredIpcInputs(
+  messages: readonly IpcInputMessage[],
+): void {
+  const failed = ipcInputClaims.acknowledge(
+    messages
+      .map((message) => message.ipcClaimPath)
+      .filter((claimPath): claimPath is string => !!claimPath),
+  );
+  if (failed.length > 0) {
+    logWarn(
+      `Failed to acknowledge ${failed.length} registered IPC input claim(s); keeping them recoverable on disk`,
+    );
+  }
 }
 
 /**
@@ -1627,6 +1674,9 @@ async function runQueryAttempt(
   // name in the return type, this includes the initial startup/idle-drain batch
   // as well as messages piped while the query is active.
   const ipcDeliveryTracker = new IpcTurnDeliveryTracker(initialIpcMessages);
+  // Registration is synchronous and precedes every await in this query. Only
+  // now may the crash-recoverable disk claims be removed.
+  acknowledgeRegisteredIpcInputs(initialIpcMessages);
   const coldInputTurnId =
     resolveLogicalQueryInputTurnId(
       containerInput.turnId,
@@ -1903,6 +1953,7 @@ async function runQueryAttempt(
   // before force-closing the stream.
   let resultReceivedAt: number | null = null;
   let cancelBackgroundResultCompletion: () => void = () => {};
+  let clearBackgroundProtocolDebtWatchdog: () => void = () => {};
   const POST_RESULT_TIMEOUT_MS = 5_000;
   // queryRef is set just before the for-await loop so pollIpcDuringQuery can call interrupt()
   let queryRef: Pick<Query, 'interrupt'> | null = null;
@@ -2031,6 +2082,7 @@ async function runQueryAttempt(
     if (shouldClose()) {
       log('Close sentinel detected during query, ending stream');
       cancelBackgroundResultCompletion();
+      clearBackgroundProtocolDebtWatchdog();
       closedDuringQuery = true;
       emitResultUsage({}, containerInput.turnId || generateTurnId());
       interruptQueryForShutdown('Close sentinel detected during query');
@@ -2042,6 +2094,7 @@ async function runQueryAttempt(
     if (shouldInterrupt()) {
       log('Interrupt sentinel detected, interrupting current query');
       cancelBackgroundResultCompletion();
+      clearBackgroundProtocolDebtWatchdog();
       interruptedDuringQuery = true;
       const cancelledInputs = ipcDeliveryTracker.cancelCurrentTurn();
       cancelledIpcReceipts = cancelledInputs
@@ -2076,6 +2129,7 @@ async function runQueryAttempt(
     if (resultCount > 0 && shouldDrain()) {
       log('Drain sentinel detected after query result, ending stream');
       cancelBackgroundResultCompletion();
+      clearBackgroundProtocolDebtWatchdog();
       closedDuringQuery = true;
       interruptQueryForShutdown('Drain sentinel detected after query result');
       stream.end();
@@ -2135,12 +2189,16 @@ async function runQueryAttempt(
     }
 
     const { messages } = drainIpcInput();
+    // Claim the entire drained batch in the delivery tracker before the first
+    // Memory/Profile await. Previously each file was deleted by drainIpcInput()
+    // and registered one at a time, so a close/interrupt during the first await
+    // could permanently lose every later file in the batch.
+    const acceptedMessages: IpcInputMessage[] = [];
     for (const msg of messages) {
-      log(
-        `Piping IPC message into active query (${msg.text.length} chars, ${msg.images?.length || 0} images)`,
-      );
       const becomesCurrentTurn = !ipcDeliveryTracker.hasPendingTurns;
-      ipcDeliveryTracker.acceptTurn([msg]);
+      const accepted = ipcDeliveryTracker.acceptTurn([msg]);
+      if (accepted.length === 0) continue;
+      acceptedMessages.push(...accepted);
       if (becomesCurrentTurn) {
         durableInputCompletion.activateInput();
         providerFallbackTurns.acceptCurrentTurn([msg]);
@@ -2148,6 +2206,13 @@ async function runQueryAttempt(
           msg.receipt?.deliveryId || containerInput.turnId || generateTurnId(),
         );
       }
+    }
+    acknowledgeRegisteredIpcInputs(messages);
+
+    for (const msg of acceptedMessages) {
+      log(
+        `Piping IPC message into active query (${msg.text.length} chars, ${msg.images?.length || 0} images)`,
+      );
       // A new user turn arrived after a prior result. Cancel that result's
       // post-timeout so the stream cannot close before this turn completes.
       resultReceivedAt = null;
@@ -2168,7 +2233,7 @@ async function runQueryAttempt(
             loadHappyClawOwnerProfileTurnContext(() =>
               fetchHappyClawOwnerProfileTurn(
                 mcpToolsContext,
-                5_000,
+                8_000,
                 msg.receipt?.deliveryId,
               ),
             ),
@@ -2241,6 +2306,67 @@ async function runQueryAttempt(
   scheduleIpcPoll();
 
   const processor = new StreamEventProcessor(emit, log);
+  const backgroundProtocolDebtWatchdog = new BackgroundProtocolDebtWatchdog();
+  let backgroundProtocolDebtTimer: ReturnType<typeof setTimeout> | undefined;
+  let backgroundProtocolFailureExitTimer:
+    | ReturnType<typeof setTimeout>
+    | undefined;
+  let backgroundProtocolFailure: Error | undefined;
+
+  clearBackgroundProtocolDebtWatchdog = () => {
+    backgroundProtocolDebtWatchdog.clear();
+    if (backgroundProtocolDebtTimer) {
+      clearTimeout(backgroundProtocolDebtTimer);
+      backgroundProtocolDebtTimer = undefined;
+    }
+    if (backgroundProtocolFailureExitTimer) {
+      clearTimeout(backgroundProtocolFailureExitTimer);
+      backgroundProtocolFailureExitTimer = undefined;
+    }
+  };
+
+  const armBackgroundProtocolDebtWatchdog = (
+    blockingDebtCount: number,
+  ): void => {
+    if (blockingDebtCount <= 0 || backgroundProtocolFailure) return;
+    backgroundProtocolDebtWatchdog.arm();
+    if (backgroundProtocolDebtTimer) return;
+    backgroundProtocolDebtTimer = setTimeout(() => {
+      backgroundProtocolDebtTimer = undefined;
+      const unresolved = processor.getBlockingBackgroundProtocolCount();
+      const liveTasks = processor.getBlockingPendingSdkTaskCount();
+      if (unresolved <= 0 || liveTasks > 0) {
+        clearBackgroundProtocolDebtWatchdog();
+        return;
+      }
+      const message =
+        `background_protocol_timeout: ${unresolved} completion obligation(s) ` +
+        `remained unresolved for ${BACKGROUND_PROTOCOL_DEBT_TIMEOUT_MS}ms`;
+      backgroundProtocolFailure = new Error(message);
+      logWarn(
+        `${message}; interrupting the SDK stream so the durable input can recover`,
+      );
+      emitResultUsage({}, containerInput.turnId || generateTurnId());
+      processor.discardPendingTextOutput();
+      interruptQueryForShutdown('Background protocol debt watchdog expired');
+      stream.end();
+      ipcPolling = false;
+      ipcQueryWatcher.close();
+      // query.interrupt() normally unwinds the iterator immediately. Keep a
+      // bounded escape hatch for a wedged transport so this path can never fall
+      // back to the outer 30-minute idle timeout.
+      backgroundProtocolFailureExitTimer = setTimeout(() => {
+        emit({
+          status: 'error',
+          result: null,
+          error: message,
+          newSessionId,
+          finalizationReason: 'error',
+        });
+        forceExitWithSafetyNet(1);
+      }, BACKGROUND_PROTOCOL_FAILURE_EXIT_GRACE_MS);
+    }, backgroundProtocolDebtWatchdog.remainingMs(BACKGROUND_PROTOCOL_DEBT_TIMEOUT_MS));
+  };
 
   const { isHome } = normalizeHomeFlags(containerInput);
   const agentBuilderEnabled = resolveAgentBuilderEnabled(
@@ -2289,6 +2415,9 @@ async function runQueryAttempt(
     candidate: BackgroundResultCandidate,
     inputTurnCompleted: boolean,
   ): void => {
+    if (inputTurnCompleted) {
+      clearBackgroundProtocolDebtWatchdog();
+    }
     const ipcReceipts = inputTurnCompleted
       ? ipcDeliveryTracker.completeNextTurn()
       : undefined;
@@ -2890,6 +3019,11 @@ async function runQueryAttempt(
           // user.origin=task-notification. Never apply it while B is already
           // accepted, or B's assistant activity could repay A's debt.
           processor.observeBackgroundNotificationActivity();
+          // The hard watchdog only bounds arrival of the completion-driven
+          // continuation. Once that continuation has started, normal SDK
+          // response/tool watchdogs own its execution time; a legitimate long
+          // synthesis must not inherit the notification-arrival deadline.
+          clearBackgroundProtocolDebtWatchdog();
         }
         processor.processStreamEvent(message as any);
         continue;
@@ -2991,6 +3125,61 @@ async function runQueryAttempt(
           continue;
         }
       }
+      if (
+        proactiveInteractiveContract &&
+        isCliNoVisibleOutputCompanion(message) &&
+        proactiveFinalWasDeliveredForInput(
+          mcpToolsContext?.proactiveFinalDeliveredInputTurnId,
+          outputCorrelation.currentInputTurnId,
+        )
+      ) {
+        // Older CLIs inject this synthetic user turn after a tool-only response
+        // and immediately start another model call. The native final is already
+        // physically ACKed, so seal the exact input now and interrupt that
+        // redundant companion before it can produce a second final.
+        log(
+          `Suppressing CLI no-visible-output companion after Proactive final ACK for ${outputCorrelation.currentInputTurnId}`,
+        );
+        // resumeSessionAt accepts any chain UUID. Anchor after the synthetic
+        // companion (rather than the earlier assistant tool_use) so the next
+        // warm turn cannot revive a dangling send_message call or replay the
+        // just-completed user input.
+        const companionUuid = (message as { uuid?: string }).uuid;
+        const completionUuid = companionUuid || lastAssistantUuid;
+        if (completionUuid) lastAssistantUuid = completionUuid;
+        cancelBackgroundResultCompletion();
+        emitResultUsage({}, containerInput.turnId || generateTurnId());
+        assistantBatchFlushedSinceLastResult = false;
+        processor.cleanup();
+        assistantTextTracker.reset();
+        canonicalAssistantUuid = undefined;
+        publishResultCandidate(
+          {
+            finalText: null,
+            suspectTruncated: false,
+            pendingBgTasks: 0,
+            sdkMessageUuid: completionUuid,
+            completedAssistantUuid: completionUuid,
+          },
+          true,
+        );
+        stream.end();
+        ipcPolling = false;
+        ipcQueryWatcher.close();
+        q.interrupt().catch((err: unknown) =>
+          log(`No-visible companion interrupt failed: ${err}`),
+        );
+        return {
+          newSessionId,
+          lastAssistantUuid,
+          closedDuringQuery,
+          interruptedDuringQuery,
+          cancelledIpcReceipts,
+          pipedMessagesDuringQuery,
+          durableInputTurnCompleted: true,
+          providerAccountFailure: false,
+        };
+      }
       if (message.type === 'assistant') {
         sawLiveTurnActivity = true;
       } else if (message.type === 'user') {
@@ -3011,9 +3200,11 @@ async function runQueryAttempt(
         if (um.origin?.kind === 'task-notification') {
           if ((message as { shouldQuery?: boolean }).shouldQuery === false) {
             processor.observeBackgroundNotificationWithoutQuery();
+            clearBackgroundProtocolDebtWatchdog();
             scheduleBackgroundResultCompletion();
           } else {
             processor.observeBackgroundNotificationActivity();
+            clearBackgroundProtocolDebtWatchdog();
           }
         }
       }
@@ -3061,9 +3252,13 @@ async function runQueryAttempt(
       if (message.type === 'assistant' && 'uuid' in message) {
         const assistantError = (message as { error?: SDKAssistantMessageError })
           .error;
-        const assistantErrorClass =
-          classifyProviderAssistantError(assistantError);
-        if (assistantError && assistantErrorClass) {
+        if (assistantError) {
+          // Assistant.error is itself a terminal SDK-attempt boundary. The
+          // classifier only selects the host disposition; it must never decide
+          // whether we keep waiting for a Result which compatible endpoints may
+          // never emit.
+          const assistantErrorClass =
+            classifyProviderAssistantError(assistantError) ?? 'transient';
           log(
             `Assistant provider error (${assistantError}); classified as ${assistantErrorClass}`,
           );
@@ -3111,6 +3306,7 @@ async function runQueryAttempt(
             ipcDeliveryTracker.pendingTurnCount <= 1
           ) {
             processor.observeBackgroundNotificationActivity();
+            clearBackgroundProtocolDebtWatchdog();
           }
           const msgContent = (
             assistantMsg.message as Record<string, unknown> | undefined
@@ -3426,7 +3622,16 @@ async function runQueryAttempt(
         // 过程旁白混进最终回复。选择链固定为：非空 SDK Result → 最近一条
         // 完全不含 top-level tool_use 的 AssistantMessage；旁白绝不兜底。
         processor.processResult(textResult);
-        const finalText = assistantTextTracker.pickFinalText(textResult);
+        const pickedFinalText = assistantTextTracker.pickFinalText(textResult);
+        const finalText =
+          proactiveInteractiveContract &&
+          isProactiveFinalDeliveredSentinel(pickedFinalText) &&
+          proactiveFinalWasDeliveredForInput(
+            mcpToolsContext?.proactiveFinalDeliveredInputTurnId,
+            outputCorrelation.currentInputTurnId,
+          )
+            ? null
+            : pickedFinalText;
         // ── emit 前置计算：截断指纹 + 后台任务数 ──
         // finalizationReason / pendingBgTasks 必须随本条 result 一起送达主进程，
         // 主进程据此决定流式卡片是定稿「已完成」还是保持「后台任务运行中/自动续写中」。
@@ -3554,6 +3759,7 @@ async function runQueryAttempt(
               ? candidate
               : undefined;
           resultReceivedAt = null;
+          armBackgroundProtocolDebtWatchdog(blockingBackgroundProtocol);
           log(
             `Result #${resultCount} withheld: ${blockingBackgroundProtocol} background protocol obligation(s) remain`,
           );
@@ -3571,6 +3777,7 @@ async function runQueryAttempt(
         }
 
         if (pendingBgTasks > 0) {
+          clearBackgroundProtocolDebtWatchdog();
           resultReceivedAt = null;
           log(
             `Result #${resultCount} emitted; holding stream open for ${pendingBgTasks} background task(s): ${processor.describePendingSdkTasks().join(' | ')}`,
@@ -3588,6 +3795,10 @@ async function runQueryAttempt(
           });
         }
       }
+    }
+
+    if (backgroundProtocolFailure) {
+      throw backgroundProtocolFailure;
     }
 
     if (
@@ -3624,6 +3835,15 @@ async function runQueryAttempt(
     };
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
+
+    // The dedicated protocol watchdog owns this terminal even though it used
+    // query.interrupt() to unwind a stuck SDK iterator. Do not let the generic
+    // post-result interrupt branch downgrade it to a successful warm return.
+    if (backgroundProtocolFailure) {
+      processor.discardPendingTextOutput();
+      processor.cleanup();
+      throw backgroundProtocolFailure;
+    }
 
     // Ending the spent primary stream after a quota notice can make the SDK
     // throw while it tears down. The retry payload is already authoritative;
@@ -3760,6 +3980,7 @@ async function runQueryAttempt(
     throw err;
   } finally {
     firstResponseWatchdog?.clear();
+    clearBackgroundProtocolDebtWatchdog();
     backgroundResultGate.dispose();
     pendingBackgroundResult = undefined;
     // IPC watcher 清理：覆盖 try 块内的正常出口、catch 抛出，以及 try 内所有 early-return
@@ -4032,6 +4253,27 @@ async function main(): Promise<void> {
     prompt = scheduledTaskPrefix + '\n\n' + prompt;
   }
   const pendingDrain = drainIpcInput();
+  const coldBatchMessageIds = new Set(
+    containerInput.currentBatchMessageIds ?? [],
+  );
+  const coldDuplicates = pendingDrain.messages.filter((message) => {
+    const receipt = message.receipt;
+    if (!receipt || coldBatchMessageIds.size === 0) return false;
+    const represented = receipt.coveredCursors ?? [receipt.cursor];
+    return (
+      represented.length > 0 &&
+      represented.every((cursor) => coldBatchMessageIds.has(cursor.id))
+    );
+  });
+  if (coldDuplicates.length > 0) {
+    acknowledgeRegisteredIpcInputs(coldDuplicates);
+    pendingDrain.messages = pendingDrain.messages.filter(
+      (message) => !coldDuplicates.includes(message),
+    );
+    log(
+      `Suppressed ${coldDuplicates.length} stale IPC claim(s) already owned by the cold Host turn`,
+    );
+  }
   // Files replayed after a runner failure may still carry the previous
   // attempt's ID. Startup belongs to the host's newly allocated exact query,
   // so normalize the entire initial batch to ContainerInput.queryRunId.
@@ -4841,7 +5083,7 @@ process.on('unhandledRejection', (reason: unknown) => {
   if (errno?.code === 'EPIPE') {
     process.exit(0);
   }
-  if (isWithinInterruptGraceWindow()) {
+  if (isWithinInterruptGraceWindow() && isInterruptRelatedError(reason)) {
     console.error('Unhandled rejection during interrupt (non-fatal):', reason);
     return;
   }

--- a/container/agent-runner/src/ipc-delivery.ts
+++ b/container/agent-runner/src/ipc-delivery.ts
@@ -17,6 +17,37 @@ export interface IpcInputMessage {
   sourceJid?: string;
   channelContext?: ChannelTurnContext;
   receipt?: IpcDeliveryReceipt;
+  /** Runner-private crash-recovery claim. Never serialized back to Host IPC. */
+  ipcClaimPath?: string;
+}
+
+function compareReceiptCursors(
+  a: { timestamp: string; id: string; sequence?: number },
+  b: { timestamp: string; id: string; sequence?: number },
+): number {
+  if (a.sequence !== undefined && b.sequence !== undefined) {
+    return a.sequence - b.sequence;
+  }
+  if (a.timestamp !== b.timestamp) return a.timestamp < b.timestamp ? -1 : 1;
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? -1 : 1;
+}
+
+function optionalSequence(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+export function ipcReceiptInputIdentity(receipt: IpcDeliveryReceipt): string {
+  const cursors = receipt.coveredCursors ?? [receipt.cursor];
+  return `${receipt.chatJid}\0${cursors
+    .map((cursor) =>
+      cursor.sequence !== undefined
+        ? `s:${cursor.sequence}`
+        : `l:${cursor.timestamp}\0${cursor.id}`,
+    )
+    .join('\u0001')}`;
 }
 
 const SCHEDULED_GROUP_PROMPT_ID_PREFIX = 'scheduled-task-prompt:';
@@ -59,11 +90,7 @@ export function orderIpcInputMessages(
   return [...messages].sort((a, b) => {
     const aCursor = a.receipt!.cursor;
     const bCursor = b.receipt!.cursor;
-    if (aCursor.timestamp !== bCursor.timestamp) {
-      return aCursor.timestamp < bCursor.timestamp ? -1 : 1;
-    }
-    if (aCursor.id === bCursor.id) return 0;
-    return aCursor.id < bCursor.id ? -1 : 1;
+    return compareReceiptCursors(aCursor, bCursor);
   });
 }
 
@@ -83,7 +110,12 @@ export function parseIpcReceipt(
     return undefined;
   }
   let coveredCursors:
-    | Array<{ timestamp: string; id: string; sourceJid?: string }>
+    | Array<{
+        timestamp: string;
+        id: string;
+        sequence?: number;
+        sourceJid?: string;
+      }>
     | undefined;
   if (Object.prototype.hasOwnProperty.call(receipt, 'coveredCursors')) {
     if (
@@ -103,19 +135,23 @@ export function parseIpcReceipt(
       coveredCursors.push({
         timestamp: covered.timestamp,
         id: covered.id,
+        ...(optionalSequence(covered.sequence) !== undefined
+          ? { sequence: optionalSequence(covered.sequence) }
+          : {}),
         ...(typeof covered.sourceJid === 'string'
           ? { sourceJid: covered.sourceJid }
           : {}),
       });
     }
-    const maximum = [...coveredCursors].sort((a, b) => {
-      if (a.timestamp !== b.timestamp) {
-        return a.timestamp < b.timestamp ? -1 : 1;
-      }
-      if (a.id === b.id) return 0;
-      return a.id < b.id ? -1 : 1;
-    })[coveredCursors.length - 1];
-    if (maximum.timestamp !== cursor.timestamp || maximum.id !== cursor.id)
+    const maximum = [...coveredCursors].sort(compareReceiptCursors)[
+      coveredCursors.length - 1
+    ];
+    if (
+      maximum.timestamp !== cursor.timestamp ||
+      maximum.id !== cursor.id ||
+      (maximum.sequence !== undefined &&
+        maximum.sequence !== optionalSequence(cursor.sequence))
+    )
       return undefined;
   }
   return {
@@ -125,6 +161,9 @@ export function parseIpcReceipt(
     cursor: {
       timestamp: cursor.timestamp,
       id: cursor.id,
+      ...(optionalSequence(cursor.sequence) !== undefined
+        ? { sequence: optionalSequence(cursor.sequence) }
+        : {}),
       ...(typeof cursor.sourceJid === 'string'
         ? { sourceJid: cursor.sourceJid }
         : {}),
@@ -159,9 +198,7 @@ export function latestIpcInputMessage(
     if (!receipt) continue;
     if (
       !latest?.receipt ||
-      receipt.cursor.timestamp > latest.receipt.cursor.timestamp ||
-      (receipt.cursor.timestamp === latest.receipt.cursor.timestamp &&
-        receipt.cursor.id > latest.receipt.cursor.id)
+      compareReceiptCursors(receipt.cursor, latest.receipt.cursor) > 0
     ) {
       latest = message;
     }
@@ -175,15 +212,38 @@ export function latestIpcInputMessage(
 export class IpcTurnDeliveryTracker {
   readonly unacknowledgedMessages: IpcInputMessage[];
   private readonly turns: IpcInputMessage[][];
+  private readonly seenInputIdentities = new Set<string>();
 
   constructor(initialMessages: IpcInputMessage[] = []) {
-    this.unacknowledgedMessages = [...initialMessages];
-    this.turns = [[...initialMessages]];
+    const accepted = this.filterUnseen(initialMessages);
+    this.unacknowledgedMessages = [...accepted];
+    // Preserve the explicit cold/non-IPC turn even when it has no receipt.
+    this.turns = [[...accepted]];
   }
 
-  acceptTurn(messages: IpcInputMessage[]): void {
-    this.unacknowledgedMessages.push(...messages);
-    this.turns.push([...messages]);
+  private filterUnseen(
+    messages: readonly IpcInputMessage[],
+  ): IpcInputMessage[] {
+    const accepted: IpcInputMessage[] = [];
+    for (const message of messages) {
+      const receipt = message.receipt;
+      if (receipt) {
+        const identity = ipcReceiptInputIdentity(receipt);
+        if (this.seenInputIdentities.has(identity)) continue;
+        this.seenInputIdentities.add(identity);
+      }
+      accepted.push(message);
+    }
+    return accepted;
+  }
+
+  /** Register one durable turn, dropping stale-claim/re-emission duplicates. */
+  acceptTurn(messages: IpcInputMessage[]): IpcInputMessage[] {
+    const accepted = this.filterUnseen(messages);
+    if (accepted.length === 0) return [];
+    this.unacknowledgedMessages.push(...accepted);
+    this.turns.push([...accepted]);
+    return accepted;
   }
 
   /** Number of accepted user-input turns that have not produced a healthy SDK

--- a/container/agent-runner/src/ipc-input-claims.ts
+++ b/container/agent-runner/src/ipc-input-claims.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const CLAIM_MARKER = '.happyclaw-claimed-';
+const DEFAULT_CLAIM_LEASE_MS = 10_000;
+
+function isInputJsonOrClaim(filename: string): boolean {
+  return (
+    filename.endsWith('.json') || filename.includes(`.json${CLAIM_MARKER}`)
+  );
+}
+
+function claimCreatedAt(filename: string, fallbackMtimeMs: number): number {
+  const markerIndex = filename.indexOf(`.json${CLAIM_MARKER}`);
+  if (markerIndex < 0) return fallbackMtimeMs;
+  const suffix = filename.slice(markerIndex + `.json${CLAIM_MARKER}`.length);
+  const match = suffix.match(/^\d+-(\d+)-/);
+  const encoded = match ? Number(match[1]) : Number.NaN;
+  return Number.isFinite(encoded) ? encoded : fallbackMtimeMs;
+}
+
+/**
+ * Crash-recoverable ownership for Runner IPC inputs.
+ *
+ * A normal input is atomically renamed to a claim before it is read. The claim
+ * stays on disk until the input has been synchronously registered in the
+ * in-memory delivery tracker. If the process dies in between, a new Runner
+ * discovers and reclaims the durable file instead of losing the message.
+ */
+export class IpcInputClaimStore {
+  private readonly activeClaims = new Set<string>();
+
+  constructor(
+    private readonly inputDir: string,
+    private readonly claimLeaseMs: number = DEFAULT_CLAIM_LEASE_MS,
+  ) {}
+
+  claimAvailable(): string[] {
+    fs.mkdirSync(this.inputDir, { recursive: true });
+    const files = fs
+      .readdirSync(this.inputDir)
+      .filter(isInputJsonOrClaim)
+      .sort();
+    const claimed: string[] = [];
+
+    for (const filename of files) {
+      const existingPath = path.join(this.inputDir, filename);
+      if (this.activeClaims.has(existingPath)) continue;
+
+      const jsonEnd = filename.indexOf('.json') + '.json'.length;
+      const alreadyClaimed = filename.includes(`.json${CLAIM_MARKER}`);
+      if (alreadyClaimed) {
+        // Another live Runner may be between claim and synchronous tracker
+        // registration. Never read its claim in place. A crashed owner's lease
+        // becomes recoverable after a short bounded delay and must still be
+        // atomically renamed, so two replacement processes cannot both own it.
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(existingPath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+          throw err;
+        }
+        if (
+          Date.now() - claimCreatedAt(filename, stat.mtimeMs) <
+          this.claimLeaseMs
+        )
+          continue;
+      }
+
+      const originalName = filename.slice(0, jsonEnd);
+      const claimPath = path.join(
+        this.inputDir,
+        `${originalName}${CLAIM_MARKER}${process.pid}-${Date.now()}-${randomUUID()}`,
+      );
+      try {
+        fs.renameSync(existingPath, claimPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw err;
+      }
+
+      this.activeClaims.add(claimPath);
+      claimed.push(claimPath);
+    }
+    return claimed;
+  }
+
+  /** Delete claims only after their messages have a recovery owner. */
+  acknowledge(claimPaths: readonly string[]): string[] {
+    const failed: string[] = [];
+    for (const claimPath of new Set(claimPaths)) {
+      if (!claimPath) continue;
+      try {
+        fs.unlinkSync(claimPath);
+        this.activeClaims.delete(claimPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          this.activeClaims.delete(claimPath);
+          continue;
+        }
+        failed.push(claimPath);
+      }
+    }
+    return failed;
+  }
+
+  /** Invalid/poison files cannot become a message; remove them explicitly. */
+  discard(claimPath: string): boolean {
+    return this.acknowledge([claimPath]).length === 0;
+  }
+}

--- a/container/agent-runner/src/mcp-tools.ts
+++ b/container/agent-runner/src/mcp-tools.ts
@@ -20,6 +20,10 @@ import {
   type ChannelTurnContext,
 } from './types.js';
 import { signWorkspaceMemoryMutation } from './workspace-memory-auth.js';
+import {
+  PROACTIVE_FINAL_DELIVERED_SENTINEL,
+  proactiveFinalWasDeliveredForInput,
+} from './proactive-turn-protocol.js';
 
 /** Context required by MCP tools. Passed at construction time. */
 export interface McpContext {
@@ -46,6 +50,10 @@ export interface McpContext {
    * Cold starts use the triggering message id; IPC turns use the host-issued
    * delivery id from their receipt. */
   currentInputTurnId?: string | null;
+  /** Exact Proactive input whose final native utterance received a physical
+   * Host ACK. This is a per-runner latch used to seal the turn and suppress a
+   * second final if an older CLI injects a no-visible-output companion. */
+  proactiveFinalDeliveredInputTurnId?: string | null;
   /** Current provider session id, used only as server-side provenance. */
   currentSessionId?: string | null;
   /** Runner-private HMAC material. Never expose through a tool schema/result. */
@@ -90,7 +98,7 @@ function writeIpcFile(dir: string, data: object): string {
  * Fixes TOCTOU by directly attempting readFileSync and catching ENOENT.
  * Returns the parsed JSON result, or throws on timeout.
  */
-async function pollIpcResult(
+export async function pollIpcResult(
   dir: string,
   data: Record<string, unknown> & { requestId: string },
   resultFilePrefix: string,
@@ -106,18 +114,37 @@ async function pollIpcResult(
   const pollInterval = 500;
   const deadline = Date.now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  const readResult = (): Record<string, unknown> | undefined => {
     try {
       const raw = fs.readFileSync(resultFilePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
       fs.unlinkSync(resultFilePath);
-      return JSON.parse(raw) as Record<string, unknown>;
+      return parsed;
     } catch (err) {
       // File not ready yet — only swallow ENOENT
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      return undefined;
     }
-    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+  };
+
+  while (Date.now() < deadline) {
+    const result = readResult();
+    if (result) return result;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(pollInterval, remainingMs)),
+    );
   }
-  throw new Error(`Timeout waiting for IPC result (${timeoutMs / 1000}s)`);
+
+  // A Host result can land during the final sleep (especially when its own
+  // fallback poll period equals this timeout). Always perform one deadline
+  // read before declaring the request unavailable.
+  const finalResult = readResult();
+  if (finalResult) return finalResult;
+  throw new Error(
+    `IPC result timeout: requestId=${data.requestId} type=${String(data.type ?? 'unknown')} action=${String(data.action ?? 'unknown')} timeoutMs=${timeoutMs} requestDir=${dir} resultDir=${resultDir} expected=${resultFileName}`,
+  );
 }
 
 function newRequestId(): string {
@@ -350,7 +377,7 @@ export async function acknowledgeHappyClawOwnerProfileFirstWake(
 
 export async function fetchHappyClawOwnerProfileTurn(
   ctx: McpContext,
-  timeoutMs: number = 5_000,
+  timeoutMs: number = 8_000,
   inputTurnId: string | null | undefined = ctx.currentInputTurnId,
 ): Promise<HappyClawOwnerProfileTurnResult | null> {
   if (!ctx.ownerProfileEnabled || !inputTurnId) return null;
@@ -409,10 +436,13 @@ export async function fetchWorkspaceMemorySnapshot(
         limit: Math.min(Math.max(options.limit ?? 8, 1), 20),
         maxChars: Math.min(Math.max(options.maxChars ?? 6000, 500), 12_000),
       },
-      options.timeoutMs ?? 5_000,
+      options.timeoutMs ?? 8_000,
     );
     return parseWorkspaceMemorySnapshot(result.snapshot);
-  } catch {
+  } catch (err) {
+    console.error(
+      `[agent-runner:warn] Workspace memory snapshot unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 }
@@ -770,6 +800,18 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
           : ctx.interactionMode === 'proactive'
             ? (args.delivery_role ?? 'progress')
             : (args.delivery_role ?? 'final');
+        if (
+          usesProactiveInteractiveContract &&
+          deliveryRole === 'final' &&
+          proactiveFinalWasDeliveredForInput(
+            ctx.proactiveFinalDeliveredInputTurnId,
+            ctx.currentInputTurnId,
+          )
+        ) {
+          throw new Error(
+            'This input turn is already sealed by a delivered final message; a second final was rejected.',
+          );
+        }
         const data = buildSendMessageData(ctx, {
           type: 'message',
           text: args.text,
@@ -793,6 +835,14 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
               : 'Message delivery failed.',
           );
         }
+        if (
+          usesProactiveInteractiveContract &&
+          deliveryRole === 'final' &&
+          ctx.currentInputTurnId?.trim()
+        ) {
+          ctx.proactiveFinalDeliveredInputTurnId =
+            ctx.currentInputTurnId.trim();
+        }
         const disposition =
           typeof result.disposition === 'string'
             ? result.disposition
@@ -806,7 +856,7 @@ export function createMcpTools(ctx: McpContext): SdkMcpToolDefinition<any>[] {
                 ? deliveryRole === 'progress'
                   ? 'Progress message delivered. This does not complete the user-visible answer. Continue the work, then call send_message(delivery_role=final) with the last substantive result before ending. Do not put a conclusion, completion phrase, or closing message only in SDK final text.'
                   : deliveryRole === 'final'
-                    ? 'Final message delivered. End the turn now without any user-facing SDK final text. Do not repeat, summarize, acknowledge, or append a closing phrase.'
+                    ? `Final message delivered. End the turn now by returning exactly ${PROACTIVE_FINAL_DELIVERED_SENTINEL} as the non-user-visible SDK control text. Do not repeat, summarize, acknowledge, or append anything else.`
                     : 'Separate message delivered. Continue the work; if this turn needs a final answer, call send_message(delivery_role=final) before ending.'
                 : 'Message sent separately.';
         return {

--- a/container/agent-runner/src/proactive-turn-protocol.ts
+++ b/container/agent-runner/src/proactive-turn-protocol.ts
@@ -1,0 +1,72 @@
+/**
+ * Non-empty SDK Assistant text emitted after a Proactive final delivery.
+ *
+ * Claude Code treats a tool-only turn with no Assistant text as incomplete and
+ * injects a synthetic "no visible output" companion, which starts another API
+ * call. An HTML comment is non-empty to the CLI but invisible when a transient
+ * Web stream happens to render it. The Host suppresses all Proactive SDK-final
+ * text, so this is control-plane data only.
+ */
+export const PROACTIVE_FINAL_DELIVERED_SENTINEL =
+  '<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->';
+
+export const CLI_NO_VISIBLE_OUTPUT_COMPANION =
+  '[Your previous response had no visible output. Please continue and produce a user-visible response.]';
+
+export function isProactiveFinalDeliveredSentinel(
+  value: string | null | undefined,
+): boolean {
+  return value?.trim() === PROACTIVE_FINAL_DELIVERED_SENTINEL;
+}
+
+function userMessageText(message: unknown): string {
+  if (!message || typeof message !== 'object') return '';
+  const envelope = message as Record<string, unknown>;
+  const body = envelope.message;
+  if (!body || typeof body !== 'object') return '';
+  const content = (body as Record<string, unknown>).content;
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter(
+      (block): block is { type: 'text'; text: string } =>
+        !!block &&
+        typeof block === 'object' &&
+        (block as Record<string, unknown>).type === 'text' &&
+        typeof (block as Record<string, unknown>).text === 'string',
+    )
+    .map((block) => block.text)
+    .join('')
+    .trim();
+}
+
+/**
+ * Match only the CLI-owned synthetic companion. A user can legitimately type
+ * the same sentence, so text alone is never sufficient to consume a turn.
+ * `isMeta`/turnCompanion are accepted for forward/backward-compatible CLI
+ * builds; Claude Code 2.1.238 currently exposes `isSynthetic` only.
+ */
+export function isCliNoVisibleOutputCompanion(message: unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const envelope = message as Record<string, unknown>;
+  if (envelope.type !== 'user') return false;
+  const origin = envelope.origin as Record<string, unknown> | undefined;
+  const markedByCli =
+    envelope.isSynthetic === true ||
+    envelope.isMeta === true ||
+    envelope.turnCompanion === true ||
+    envelope.turn_companion === true ||
+    origin?.kind === 'auto-continuation';
+  return (
+    markedByCli && userMessageText(envelope) === CLI_NO_VISIBLE_OUTPUT_COMPANION
+  );
+}
+
+export function proactiveFinalWasDeliveredForInput(
+  deliveredInputTurnId: string | null | undefined,
+  currentInputTurnId: string | null | undefined,
+): boolean {
+  const delivered = deliveredInputTurnId?.trim();
+  const current = currentInputTurnId?.trim();
+  return !!delivered && !!current && delivered === current;
+}

--- a/container/agent-runner/src/provider-fallback.ts
+++ b/container/agent-runner/src/provider-fallback.ts
@@ -168,6 +168,7 @@ export type ProviderFailureClass = 'account' | 'transient' | 'config';
 const ACCOUNT_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
   'authentication_failed',
   'oauth_org_not_allowed',
+  'account_on_hold',
   'billing_error',
   // A bare `rate_limit` assistant error carries no rateLimitType, so its blast
   // radius is unknown. classifyProviderRateLimitType() already fails safe as
@@ -183,6 +184,14 @@ const ACCOUNT_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
 const TRANSIENT_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
   'overloaded',
   'server_error',
+  // The SDK could not attribute the failure more precisely. It is not a
+  // verdict on the OAuth profile, so keep the account healthy and use the
+  // host's bounded same-provider replay budget.
+  'unknown',
+  // This can be emitted by compatible endpoints as an Assistant error rather
+  // than a normal truncated Result. Replaying once is safer than quarantining
+  // the account or waiting forever for a Result which will never arrive.
+  'max_output_tokens',
 ]);
 
 /**
@@ -192,6 +201,7 @@ const TRANSIENT_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
  * it would empty the pool over a typo.
  */
 const CONFIG_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
+  'invalid_request',
   'model_not_found',
 ]);
 
@@ -202,17 +212,26 @@ const CONFIG_PROVIDER_ASSISTANT_ERRORS = new Set<SDKAssistantMessageError>([
  * wait indefinitely for a Result that may never arrive — but only the returned
  * class decides what happens to the account and to the user's input.
  *
- * @returns the failure class, or undefined when the error is not a provider
- * failure at all and normal processing should continue.
+ * @returns the failure class, or undefined only when no error was reported.
+ * Every non-empty Assistant error is a terminal SDK-attempt boundary.
  */
 export function classifyProviderAssistantError(
-  error: SDKAssistantMessageError | undefined,
+  error: SDKAssistantMessageError | (string & {}) | undefined,
 ): ProviderFailureClass | undefined {
   if (!error) return undefined;
-  if (ACCOUNT_PROVIDER_ASSISTANT_ERRORS.has(error)) return 'account';
-  if (TRANSIENT_PROVIDER_ASSISTANT_ERRORS.has(error)) return 'transient';
-  if (CONFIG_PROVIDER_ASSISTANT_ERRORS.has(error)) return 'config';
-  return undefined;
+  if (ACCOUNT_PROVIDER_ASSISTANT_ERRORS.has(error as SDKAssistantMessageError))
+    return 'account';
+  if (
+    TRANSIENT_PROVIDER_ASSISTANT_ERRORS.has(error as SDKAssistantMessageError)
+  )
+    return 'transient';
+  if (CONFIG_PROVIDER_ASSISTANT_ERRORS.has(error as SDKAssistantMessageError))
+    return 'config';
+  // Assistant.error is already a terminal SDK event even when a newer CLI or
+  // compatible endpoint introduces a value this runner does not know yet.
+  // Unknown failures say nothing about account health, so fail safe as a
+  // bounded transient replay instead of parking the stream indefinitely.
+  return 'transient';
 }
 
 /**

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -225,6 +225,8 @@ export interface ContainerInput {
   prompt: string;
   sessionId?: string;
   turnId?: string;
+  /** Persisted message IDs already represented by the cold bootstrap prompt. */
+  currentBatchMessageIds?: readonly string[];
   /** Exact GroupQueue query attempt for Web stream fencing. */
   queryRunId?: string;
   groupFolder: string;
@@ -435,9 +437,15 @@ export interface ContainerOutput {
     coveredCursors?: Array<{
       timestamp: string;
       id: string;
+      sequence?: number;
       sourceJid?: string;
     }>;
-    cursor: { timestamp: string; id: string; sourceJid?: string };
+    cursor: {
+      timestamp: string;
+      id: string;
+      sequence?: number;
+      sourceJid?: string;
+    };
   }>;
   /** Exact durable inputs that became the current SDK turn immediately after
    * this completion. Present only while the same streaming query stays busy.
@@ -449,9 +457,15 @@ export interface ContainerOutput {
     coveredCursors?: Array<{
       timestamp: string;
       id: string;
+      sequence?: number;
       sourceJid?: string;
     }>;
-    cursor: { timestamp: string; id: string; sourceJid?: string };
+    cursor: {
+      timestamp: string;
+      id: string;
+      sequence?: number;
+      sourceJid?: string;
+    };
   }>;
 }
 

--- a/container/agent-runner/tests/background-task-drain.test.ts
+++ b/container/agent-runner/tests/background-task-drain.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  BackgroundProtocolDebtWatchdog,
   BackgroundTaskDrainTracker,
   DurableInputTurnCompletion,
   QuiescentResultGate,
@@ -162,6 +163,26 @@ describe('QuiescentResultGate', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('BackgroundProtocolDebtWatchdog', () => {
+  test('uses a hard first-withheld deadline which later frames cannot extend', () => {
+    const watchdog = new BackgroundProtocolDebtWatchdog();
+    expect(watchdog.arm(1_000)).toBe(1_000);
+    expect(watchdog.arm(9_000)).toBe(1_000);
+    expect(watchdog.remainingMs(10_000, 9_000)).toBe(2_000);
+    expect(watchdog.isExpired(10_000, 10_999)).toBe(false);
+    expect(watchdog.isExpired(10_000, 11_000)).toBe(true);
+  });
+
+  test('clearing a repaid debt permits a fresh later deadline', () => {
+    const watchdog = new BackgroundProtocolDebtWatchdog();
+    watchdog.arm(1_000);
+    watchdog.clear();
+    expect(watchdog.isArmed).toBe(false);
+    expect(watchdog.arm(20_000)).toBe(20_000);
+    expect(watchdog.isExpired(10_000, 25_000)).toBe(false);
   });
 });
 

--- a/src/agent-runtime-contracts.ts
+++ b/src/agent-runtime-contracts.ts
@@ -41,5 +41,6 @@ export interface RuntimeIpcReceipt {
 export interface RuntimeIpcCursor {
   timestamp: string;
   id: string;
+  sequence?: number;
   sourceJid?: string;
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -199,12 +199,15 @@ function stmts() {
          )`,
       ),
       getMessagesSince: db.prepare(
-        `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, channel_context, source_kind, task_id,
-                delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-         FROM messages
-         WHERE chat_jid = ? AND (timestamp > ? OR (timestamp = ? AND id > ?)) AND is_from_me = 0
-           AND COALESCE(delivery_status, '') NOT IN ('queued', 'promoting', 'cancelled', 'awaiting_companion', 'subsumed')
-         ORDER BY timestamp ASC, id ASC`,
+        `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+                m.attachments, m.channel_context, m.source_kind, m.task_id,
+                m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+                m.delivery_updated_at, seq.sequence AS ingest_sequence
+         FROM message_ingest_sequences seq
+         JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+         WHERE m.chat_jid = ? AND seq.sequence > ? AND m.is_from_me = 0
+           AND COALESCE(m.delivery_status, '') NOT IN ('queued', 'promoting', 'cancelled', 'awaiting_companion', 'subsumed')
+         ORDER BY seq.sequence ASC`,
       ),
       getExpiredSessionIds: db.prepare(
         'SELECT id FROM user_sessions WHERE expires_at < ?',
@@ -219,15 +222,18 @@ function getNewMessagesStmt(jidCount: number): any {
   if (!s) {
     const placeholders = Array(jidCount).fill('?').join(',');
     s = db.prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, attachments, channel_context, source_kind, task_id,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE (timestamp > ? OR (timestamp = ? AND id > ?))
-         AND chat_jid IN (${placeholders})
-         AND is_from_me = 0
-         AND COALESCE(source_kind, '') NOT IN ('user_command', 'scheduled_task_prompt')
-         AND COALESCE(delivery_status, '') NOT IN ('queued', 'promoting', 'cancelled', 'awaiting_companion', 'subsumed')
-       ORDER BY timestamp ASC, id ASC`,
+      `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.attachments, m.channel_context, m.source_kind, m.task_id,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE seq.sequence > ?
+         AND m.chat_jid IN (${placeholders})
+         AND m.is_from_me = 0
+         AND COALESCE(m.source_kind, '') NOT IN ('user_command', 'scheduled_task_prompt')
+         AND COALESCE(m.delivery_status, '') NOT IN ('queued', 'promoting', 'cancelled', 'awaiting_companion', 'subsumed')
+       ORDER BY seq.sequence ASC`,
     );
     // Cap cache size to avoid unbounded growth in deployments where the
     // distinct jidCount values shift over time. better-sqlite3 does not
@@ -321,6 +327,50 @@ function tableExists(tableName: string): boolean {
   return !!row;
 }
 
+/**
+ * Give every persisted message an immutable host-side arrival position.
+ *
+ * The sequence lives in a separate table so upgrading an existing installation
+ * never rebuilds the large messages table. The mapping intentionally survives
+ * message deletion and INSERT OR REPLACE: re-observing the same provider
+ * message remains idempotent and cannot jump past a committed cursor.
+ */
+function ensureMessageIngestSequenceSchema(backfill: boolean): void {
+  db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS message_ingest_sequences (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        chat_jid TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        UNIQUE (chat_jid, message_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_message_ingest_sequences_chat_sequence
+        ON message_ingest_sequences(chat_jid, sequence);
+    `);
+
+    if (backfill) {
+      // rowid reflects the host's historical insertion order. ORDER BY makes
+      // the AUTOINCREMENT backfill deterministic for an upgraded database.
+      db.exec(`
+        INSERT OR IGNORE INTO message_ingest_sequences (chat_jid, message_id)
+        SELECT chat_jid, id
+        FROM messages
+        ORDER BY rowid ASC;
+      `);
+    }
+    db.exec(`
+      DROP TRIGGER IF EXISTS messages_assign_ingest_sequence;
+      CREATE TRIGGER messages_assign_ingest_sequence
+      AFTER INSERT ON messages
+      BEGIN
+        INSERT INTO message_ingest_sequences (chat_jid, message_id)
+        VALUES (NEW.chat_jid, NEW.id)
+        ON CONFLICT(chat_jid, message_id) DO NOTHING;
+      END;
+    `);
+  })();
+}
+
 function reportKnownForeignKeyOrphans(): void {
   if (!tableExists('users')) return;
   const specs: Array<{
@@ -393,6 +443,20 @@ function sqliteStringLiteral(value: string): string {
  * or data-reconciliation write; a backup failure aborts startup.
  */
 function createPreMigrationBackup(dbPath: string, schemaVersion: number): void {
+  const skipBackup = ['1', 'true'].includes(
+    (process.env.HAPPYCLAW_SKIP_MIGRATION_BACKUP ?? '').trim().toLowerCase(),
+  );
+  if (skipBackup) {
+    logger.warn(
+      {
+        fromVersion: schemaVersion,
+        toVersion: CURRENT_SCHEMA_VERSION,
+        environmentOverride: 'HAPPYCLAW_SKIP_MIGRATION_BACKUP',
+      },
+      'Skipping pre-migration SQLite backup by explicit operator policy',
+    );
+    return;
+  }
   const configuredDir = process.env.HAPPYCLAW_MIGRATION_BACKUP_DIR;
   const backupDir = configuredDir
     ? path.resolve(configuredDir)
@@ -1305,6 +1369,12 @@ export function initDatabase(
   ensureColumn('registered_groups', 'init_git_url', 'TEXT');
   ensureColumn('messages', 'attachments', 'TEXT');
   ensureColumn('messages', 'source_jid', 'TEXT');
+  // v73 -> v74: provider timestamps and random provider IDs are display and
+  // idempotency fields, not a safe durable consumption order.
+  ensureMessageIngestSequenceSchema(
+    rawSchemaVersionBeforeInit === null ||
+      Number(rawSchemaVersionBeforeInit) < 74,
+  );
   ensureColumn('registered_groups', 'created_by', 'TEXT');
   ensureColumn('registered_groups', 'is_home', 'INTEGER DEFAULT 0');
   // v56 -> v57: cache provider chat avatars so binding lists do not need an
@@ -3331,6 +3401,8 @@ function normalizeQueuedFollowUpRow(
   return {
     id: String(row.id),
     chat_jid: String(row.chat_jid),
+    ingest_sequence:
+      typeof row.ingest_sequence === 'number' ? row.ingest_sequence : undefined,
     source_jid: row.source_jid ? String(row.source_jid) : undefined,
     sender: String(row.sender ?? ''),
     sender_name: String(row.sender_name ?? ''),
@@ -3351,7 +3423,10 @@ function normalizeQueuedFollowUpRow(
 const FOLLOW_UP_SELECT = `
   SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp,
          attachments, channel_context, delivery_mode, delivery_status, delivery_run_id,
-         delivery_priority
+         delivery_priority,
+         (SELECT sequence FROM message_ingest_sequences seq
+          WHERE seq.chat_jid = messages.chat_jid AND seq.message_id = messages.id)
+           AS ingest_sequence
   FROM messages
 `;
 
@@ -3389,7 +3464,7 @@ export function listQueuedFollowUps(chatJid: string): QueuedFollowUp[] {
     .prepare(
       `${FOLLOW_UP_SELECT}
        WHERE chat_jid = ? AND delivery_status IN ('queued', 'promoting')
-       ORDER BY delivery_priority ASC, timestamp ASC, id ASC`,
+       ORDER BY delivery_priority ASC, ingest_sequence ASC`,
     )
     .all(chatJid) as Array<Record<string, unknown>>;
   return rows.map(normalizeQueuedFollowUpRow);
@@ -3505,7 +3580,7 @@ export function moveQueuedFollowUp(
     `${FOLLOW_UP_SELECT}
      WHERE chat_jid = ? AND delivery_status = 'queued'
        AND delivery_mode = 'queue'
-     ORDER BY delivery_priority ASC, timestamp ASC, id ASC`,
+     ORDER BY delivery_priority ASC, ingest_sequence ASC`,
   );
   const update = db.prepare(
     `UPDATE messages
@@ -3588,7 +3663,7 @@ export function claimNextQueuedFollowUp(
   const select = db.prepare(
     `${FOLLOW_UP_SELECT}
      WHERE chat_jid = ? AND delivery_status = 'queued'
-     ORDER BY delivery_priority ASC, timestamp ASC, id ASC
+     ORDER BY delivery_priority ASC, ingest_sequence ASC
      LIMIT 1`,
   );
   const update = db.prepare(
@@ -3627,7 +3702,7 @@ export function claimNextQueuedFollowUpBatch(
   const select = db.prepare(
     `${FOLLOW_UP_SELECT}
      WHERE chat_jid = ? AND delivery_status = 'queued'
-     ORDER BY delivery_priority ASC, timestamp ASC, id ASC`,
+     ORDER BY delivery_priority ASC, ingest_sequence ASC`,
   );
   const update = db.prepare(
     `UPDATE messages
@@ -4520,17 +4595,22 @@ export function getNewMessages(
 ): { messages: NewMessage[]; newCursor: MessageCursor } {
   if (jids.length === 0) return { messages: [], newCursor: cursor };
 
+  const resolvedCursor = resolveMessageCursorSequence(cursor);
   const rawRows = getNewMessagesStmt(jids.length).all(
-    cursor.timestamp,
-    cursor.timestamp,
-    cursor.id,
+    resolvedCursor.sequence,
     ...jids,
   ) as NewMessage[];
   const rows = rawRows.map((r) => normalizeMessageRow(r));
   const last = rows[rows.length - 1];
   return {
     messages: rows,
-    newCursor: last ? { timestamp: last.timestamp, id: last.id } : cursor,
+    newCursor: last
+      ? {
+          timestamp: last.timestamp,
+          id: last.id,
+          sequence: last.ingest_sequence,
+        }
+      : resolvedCursor,
   };
 }
 
@@ -4538,13 +4618,76 @@ export function getMessagesSince(
   chatJid: string,
   cursor: MessageCursor,
 ): NewMessage[] {
+  const resolvedCursor = resolveMessageCursorSequence(cursor, chatJid);
   const rows = stmts().getMessagesSince.all(
     chatJid,
-    cursor.timestamp,
-    cursor.timestamp,
-    cursor.id,
+    resolvedCursor.sequence,
   ) as NewMessage[];
   return rows.map((row) => normalizeMessageRow(row));
+}
+
+/**
+ * Upgrade a legacy `(timestamp,id)` cursor to the immutable host sequence.
+ * Exact message identity is authoritative. If the old anchor was deleted or
+ * malformed, replay from zero rather than guessing from a provider clock and
+ * silently losing work.
+ */
+export function resolveMessageCursorSequence(
+  cursor: MessageCursor,
+  chatJid?: string,
+): MessageCursor & { sequence: number } {
+  if (
+    typeof cursor.sequence === 'number' &&
+    Number.isSafeInteger(cursor.sequence) &&
+    cursor.sequence >= 0
+  ) {
+    return { ...cursor, sequence: cursor.sequence };
+  }
+
+  let row: { sequence: number } | undefined;
+  if (cursor.id) {
+    if (chatJid) {
+      row = db
+        .prepare(
+          `SELECT sequence FROM message_ingest_sequences
+           WHERE chat_jid = ? AND message_id = ?`,
+        )
+        .get(chatJid, cursor.id) as { sequence: number } | undefined;
+    } else {
+      row = db
+        .prepare(
+          `SELECT seq.sequence
+           FROM message_ingest_sequences seq
+           JOIN messages m
+             ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+           WHERE m.id = ? AND m.timestamp = ?
+           ORDER BY seq.sequence DESC
+           LIMIT 1`,
+        )
+        .get(cursor.id, cursor.timestamp) as { sequence: number } | undefined;
+    }
+  }
+  return { ...cursor, sequence: row?.sequence ?? 0 };
+}
+
+/** Exact stable cursor for a persisted message, used by immediate Web paths. */
+export function getMessageCursor(
+  chatJid: string,
+  messageId: string,
+): MessageCursor | null {
+  const row = db
+    .prepare(
+      `SELECT m.timestamp, seq.sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid = ? AND m.id = ?`,
+    )
+    .get(chatJid, messageId) as
+    | { timestamp: string; sequence: number }
+    | undefined;
+  return row
+    ? { timestamp: row.timestamp, id: messageId, sequence: row.sequence }
+    : null;
 }
 
 type CreateTaskInput = Omit<
@@ -12318,28 +12461,60 @@ export function getMessagesPage(
   chatJid: string,
   before?: string,
   limit = 50,
+  beforeSequence?: number,
 ): Array<NewMessage & { is_from_me: boolean }> {
-  const sql = before
-    ? `
-      SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-             turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-             delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-      FROM messages
-      WHERE chat_jid = ? AND timestamp < ?
-      ORDER BY timestamp DESC
+  const stableSequence =
+    typeof beforeSequence === 'number' &&
+    Number.isSafeInteger(beforeSequence) &&
+    beforeSequence >= 0
+      ? beforeSequence
+      : undefined;
+  const sql =
+    stableSequence !== undefined
+      ? `
+      SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+             m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+             m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+             m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+             m.delivery_updated_at, seq.sequence AS ingest_sequence
+      FROM message_ingest_sequences seq
+      JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+      WHERE m.chat_jid = ? AND seq.sequence < ?
+      ORDER BY seq.sequence DESC
       LIMIT ?
     `
-    : `
-      SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-             turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-             delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-      FROM messages
-      WHERE chat_jid = ?
-      ORDER BY timestamp DESC
+      : before
+        ? `
+      SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+             m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+             m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+             m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+             m.delivery_updated_at, seq.sequence AS ingest_sequence
+      FROM message_ingest_sequences seq
+      JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+      WHERE m.chat_jid = ? AND m.timestamp < ?
+      ORDER BY m.timestamp DESC, seq.sequence DESC
+      LIMIT ?
+    `
+        : `
+      SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+             m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+             m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+             m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+             m.delivery_updated_at, seq.sequence AS ingest_sequence
+      FROM message_ingest_sequences seq
+      JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+      WHERE m.chat_jid = ?
+      ORDER BY seq.sequence DESC
       LIMIT ?
     `;
 
-  const params = before ? [chatJid, before, limit] : [chatJid, limit];
+  const params =
+    stableSequence !== undefined
+      ? [chatJid, stableSequence, limit]
+      : before
+        ? [chatJid, before, limit]
+        : [chatJid, limit];
   const rows = db.prepare(sql).all(...params) as Array<
     NewMessage & { is_from_me: number }
   >;
@@ -12356,12 +12531,15 @@ export function getMessagesForTurn(
   if (!normalizedTurnId) return [];
   const rows = db
     .prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE chat_jid = ? AND turn_id = ?
-       ORDER BY timestamp DESC, id DESC`,
+      `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid = ? AND m.turn_id = ?
+       ORDER BY seq.sequence DESC`,
     )
     .all(chatJid, normalizedTurnId) as Array<
     NewMessage & { is_from_me: number }
@@ -12384,13 +12562,16 @@ export function getConversationHistoryMessagesPage(
   const safeLimit = Math.min(200, Math.max(1, Math.floor(limit)));
   const rows = db
     .prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE chat_jid = ? AND history_recovery_allowed = 1
-         AND id NOT IN (SELECT value FROM json_each(?))
-       ORDER BY timestamp DESC, id DESC
+      `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid = ? AND m.history_recovery_allowed = 1
+         AND m.id NOT IN (SELECT value FROM json_each(?))
+       ORDER BY seq.sequence DESC
        LIMIT ?`,
     )
     .all(chatJid, JSON.stringify(excluded), safeLimit) as Array<
@@ -12405,20 +12586,43 @@ export function getConversationHistoryMessagesPage(
  */
 export function getMessagesAfter(
   chatJid: string,
-  after: string,
+  after = '',
   limit = 50,
+  afterSequence?: number,
 ): Array<NewMessage & { is_from_me: boolean }> {
+  const stableSequence =
+    typeof afterSequence === 'number' &&
+    Number.isSafeInteger(afterSequence) &&
+    afterSequence >= 0
+      ? afterSequence
+      : undefined;
+  const sql =
+    stableSequence !== undefined
+      ? `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid = ? AND seq.sequence > ?
+       ORDER BY seq.sequence ASC
+       LIMIT ?`
+      : `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid = ? AND m.timestamp > ?
+       ORDER BY m.timestamp ASC, seq.sequence ASC
+       LIMIT ?`;
   const rows = db
-    .prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE chat_jid = ? AND timestamp > ?
-       ORDER BY timestamp ASC
-       LIMIT ?`,
-    )
-    .all(chatJid, after, limit) as Array<NewMessage & { is_from_me: number }>;
+    .prepare(sql)
+    .all(chatJid, stableSequence ?? after, limit) as Array<
+    NewMessage & { is_from_me: number }
+  >;
 
   return rows.map((row) => normalizeMessageRow(row));
 }
@@ -12469,28 +12673,59 @@ export function getMessagesPageMulti(
   chatJids: string[],
   before?: string,
   limit = 50,
+  beforeSequence?: number,
 ): Array<NewMessage & { is_from_me: boolean }> {
   if (chatJids.length === 0) return [];
-  if (chatJids.length === 1) return getMessagesPage(chatJids[0], before, limit);
+  if (chatJids.length === 1)
+    return getMessagesPage(chatJids[0], before, limit, beforeSequence);
 
   const placeholders = chatJids.map(() => '?').join(',');
-  const sql = before
-    ? `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE chat_jid IN (${placeholders}) AND timestamp < ?
-       ORDER BY timestamp DESC
+  const stableSequence =
+    typeof beforeSequence === 'number' &&
+    Number.isSafeInteger(beforeSequence) &&
+    beforeSequence >= 0
+      ? beforeSequence
+      : undefined;
+  const sql =
+    stableSequence !== undefined
+      ? `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid IN (${placeholders}) AND seq.sequence < ?
+       ORDER BY seq.sequence DESC
        LIMIT ?`
-    : `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE chat_jid IN (${placeholders})
-       ORDER BY timestamp DESC
+      : before
+        ? `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+                m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+                m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+                m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+                m.delivery_updated_at, seq.sequence AS ingest_sequence
+         FROM message_ingest_sequences seq
+         JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+         WHERE m.chat_jid IN (${placeholders}) AND m.timestamp < ?
+         ORDER BY m.timestamp DESC, seq.sequence DESC
+         LIMIT ?`
+        : `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid IN (${placeholders})
+       ORDER BY seq.sequence DESC
        LIMIT ?`;
 
-  const params = before ? [...chatJids, before, limit] : [...chatJids, limit];
+  const params =
+    stableSequence !== undefined
+      ? [...chatJids, stableSequence, limit]
+      : before
+        ? [...chatJids, before, limit]
+        : [...chatJids, limit];
   const rows = db.prepare(sql).all(...params) as Array<
     NewMessage & { is_from_me: number }
   >;
@@ -12503,24 +12738,46 @@ export function getMessagesPageMulti(
  */
 export function getMessagesAfterMulti(
   chatJids: string[],
-  after: string,
+  after = '',
   limit = 50,
+  afterSequence?: number,
 ): Array<NewMessage & { is_from_me: boolean }> {
   if (chatJids.length === 0) return [];
-  if (chatJids.length === 1) return getMessagesAfter(chatJids[0], after, limit);
+  if (chatJids.length === 1)
+    return getMessagesAfter(chatJids[0], after, limit, afterSequence);
 
   const placeholders = chatJids.map(() => '?').join(',');
+  const stableSequence =
+    typeof afterSequence === 'number' &&
+    Number.isSafeInteger(afterSequence) &&
+    afterSequence >= 0
+      ? afterSequence
+      : undefined;
+  const sql =
+    stableSequence !== undefined
+      ? `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid IN (${placeholders}) AND seq.sequence > ?
+       ORDER BY seq.sequence ASC
+       LIMIT ?`
+      : `SELECT m.id, m.chat_jid, m.source_jid, m.sender, m.sender_name, m.content, m.timestamp,
+              m.is_from_me, m.attachments, m.token_usage, m.channel_context,
+              m.turn_id, m.session_id, m.sdk_message_uuid, m.source_kind, m.finalization_reason,
+              m.delivery_mode, m.delivery_status, m.delivery_run_id, m.delivery_priority,
+              m.delivery_updated_at, seq.sequence AS ingest_sequence
+       FROM message_ingest_sequences seq
+       JOIN messages m ON m.chat_jid = seq.chat_jid AND m.id = seq.message_id
+       WHERE m.chat_jid IN (${placeholders}) AND m.timestamp > ?
+       ORDER BY m.timestamp ASC, seq.sequence ASC
+       LIMIT ?`;
   const rows = db
-    .prepare(
-      `SELECT id, chat_jid, source_jid, sender, sender_name, content, timestamp, is_from_me, attachments, token_usage, channel_context,
-              turn_id, session_id, sdk_message_uuid, source_kind, finalization_reason,
-              delivery_mode, delivery_status, delivery_run_id, delivery_priority, delivery_updated_at
-       FROM messages
-       WHERE chat_jid IN (${placeholders}) AND timestamp > ?
-       ORDER BY timestamp ASC
-       LIMIT ?`,
-    )
-    .all(...chatJids, after, limit) as Array<
+    .prepare(sql)
+    .all(...chatJids, stableSequence ?? after, limit) as Array<
     NewMessage & { is_from_me: number }
   >;
 

--- a/src/delivery-cursor.ts
+++ b/src/delivery-cursor.ts
@@ -3,6 +3,24 @@ import type { MessageCursor } from './types.js';
 export interface CursorOrderedMessage {
   timestamp: string;
   id: string;
+  ingest_sequence?: number;
+  sequence?: number;
+}
+
+function compareCursorOrder(
+  message: CursorOrderedMessage,
+  cursor: MessageCursor,
+): number {
+  if (
+    (message.ingest_sequence !== undefined || message.sequence !== undefined) &&
+    cursor.sequence !== undefined
+  ) {
+    return (message.ingest_sequence ?? message.sequence!) - cursor.sequence;
+  }
+  if (message.timestamp !== cursor.timestamp) {
+    return message.timestamp < cursor.timestamp ? -1 : 1;
+  }
+  return message.id.localeCompare(cursor.id);
 }
 
 /** True when DB recovery still contains work ordered before an out-of-band
@@ -12,15 +30,14 @@ export function hasEarlierCursorMessage(
   pending: CursorOrderedMessage[],
   candidate: MessageCursor,
 ): boolean {
-  return pending.some((message) => {
-    if (message.timestamp < candidate.timestamp) return true;
-    return (
-      message.timestamp === candidate.timestamp && message.id < candidate.id
-    );
-  });
+  return pending.some((message) => compareCursorOrder(message, candidate) < 0);
 }
 
 function cursorKey(cursor: CursorOrderedMessage): string {
+  const sequence = cursor.ingest_sequence ?? cursor.sequence;
+  if (sequence !== undefined) {
+    return `sequence:${sequence}`;
+  }
   return `${cursor.timestamp}\u0000${cursor.id}`;
 }
 
@@ -35,9 +52,7 @@ export function hasUncoveredCursorMessageThrough(
 ): boolean {
   const coveredKeys = new Set(covered.map(cursorKey));
   return pending.some((message) => {
-    const isThroughTerminal =
-      message.timestamp < terminal.timestamp ||
-      (message.timestamp === terminal.timestamp && message.id <= terminal.id);
+    const isThroughTerminal = compareCursorOrder(message, terminal) <= 0;
     return isThroughTerminal && !coveredKeys.has(cursorKey(message));
   });
 }
@@ -48,16 +63,21 @@ export class DeferredOutOfBandCursorLedger {
   defer(jid: string, cursor: MessageCursor): void {
     const cursors = this.entries.get(jid) ?? [];
     if (
-      !cursors.some(
-        (item) => item.timestamp === cursor.timestamp && item.id === cursor.id,
+      !cursors.some((item) =>
+        item.sequence !== undefined && cursor.sequence !== undefined
+          ? item.sequence === cursor.sequence
+          : item.timestamp === cursor.timestamp && item.id === cursor.id,
       )
     ) {
       cursors.push(cursor);
-      cursors.sort((a, b) =>
-        a.timestamp === b.timestamp
+      cursors.sort((a, b) => {
+        if (a.sequence !== undefined && b.sequence !== undefined) {
+          return a.sequence - b.sequence;
+        }
+        return a.timestamp === b.timestamp
           ? a.id.localeCompare(b.id)
-          : a.timestamp.localeCompare(b.timestamp),
-      );
+          : a.timestamp.localeCompare(b.timestamp);
+      });
       this.entries.set(jid, cursors);
     }
   }

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -9,6 +9,7 @@ import { getTaskById } from './db.js';
 import { getSystemSettings } from './runtime-config.js';
 import { logger } from './logger.js';
 import { resolveFeishuCliBoundAccountId } from './feishu-cli-runtime.js';
+import { isIpcInputPayloadFilename } from './ipc-delivery-recovery.js';
 import type {
   RunnerRuntime,
   StuckRecoveryCandidate,
@@ -18,6 +19,8 @@ export type SendMessageResult = 'sent' | 'no_active';
 export interface IpcMessageCursor {
   timestamp: string;
   id: string;
+  /** Host-assigned durable arrival order. */
+  sequence?: number;
   /** Immutable provider route that owns this exact original input's side
    * effects. Omitted for Web/legacy inputs. */
   sourceJid?: string;
@@ -91,6 +94,9 @@ function compareIpcMessageCursors(
   a: IpcMessageCursor,
   b: IpcMessageCursor,
 ): number {
+  if (a.sequence !== undefined && b.sequence !== undefined) {
+    return a.sequence - b.sequence;
+  }
   if (a.timestamp !== b.timestamp) return a.timestamp < b.timestamp ? -1 : 1;
   if (a.id === b.id) return 0;
   return a.id < b.id ? -1 : 1;
@@ -1144,8 +1150,14 @@ export class GroupQueue {
         // Fail closed when the host has not installed its DB-backed checker.
         if (!this.isIpcDeliveryCommitEligibleFn?.(first)) break;
 
-        // Commit first. If persistence throws, keep the delivery pending so
-        // exit/startup recovery replays it rather than silently losing it.
+        // Remove every Runner-visible copy before committing the DB cursor.
+        // A failed Runner unlink can otherwise leave a claim that is replayed
+        // after this healthy receipt has already advanced durable state.
+        if (!this.discardDeliveryIpcFiles(state, new Set([first.deliveryId]))) {
+          throw new Error(
+            `Failed to remove acknowledged IPC claim ${first.deliveryId}`,
+          );
+        }
         commit([first]);
         state.pendingIpcDeliveries.delete(first.deliveryId);
         state.acknowledgedIpcDeliveryIds.delete(first.deliveryId);
@@ -1813,10 +1825,23 @@ export class GroupQueue {
         const maximum = [...deliveryTarget.coveredCursors].sort(
           compareIpcMessageCursors,
         )[deliveryTarget.coveredCursors.length - 1];
+        const coveredHaveAnySequence = deliveryTarget.coveredCursors.some(
+          (cursor) => cursor.sequence !== undefined,
+        );
+        const coveredAllHaveSequence = deliveryTarget.coveredCursors.every(
+          (cursor) => cursor.sequence !== undefined,
+        );
+        const sequenceShapeInvalid =
+          coveredHaveAnySequence || deliveryTarget.cursor.sequence !== undefined
+            ? !coveredAllHaveSequence ||
+              deliveryTarget.cursor.sequence === undefined ||
+              maximum?.sequence !== deliveryTarget.cursor.sequence
+            : false;
         if (
           !maximum ||
           maximum.timestamp !== deliveryTarget.cursor.timestamp ||
-          maximum.id !== deliveryTarget.cursor.id
+          maximum.id !== deliveryTarget.cursor.id ||
+          sequenceShapeInvalid
         ) {
           throw new Error(
             'IPC delivery target must end at its maximum covered cursor',
@@ -2052,10 +2077,14 @@ export class GroupQueue {
       // Once the host rewinds to the durable DB cursor, DB is the sole replay
       // source. Remove any still-on-disk copies first so the next runner cannot
       // receive both a stale IPC file and the DB replay.
-      this.discardDeliveryIpcFiles(
-        state,
-        new Set(receipts.map((r) => r.deliveryId)),
-      );
+      if (
+        !this.discardDeliveryIpcFiles(
+          state,
+          new Set(receipts.map((r) => r.deliveryId)),
+        )
+      ) {
+        throw new Error('Failed to remove unacknowledged IPC delivery files');
+      }
       if (!this.onUnacknowledgedIpcDeliveriesFn) {
         throw new Error(
           'unacknowledged IPC delivery recovery callback is not configured',
@@ -2075,17 +2104,21 @@ export class GroupQueue {
   private discardDeliveryIpcFiles(
     state: GroupState,
     deliveryIds: Set<string>,
-  ): void {
-    if (!state.groupFolder || deliveryIds.size === 0) return;
+  ): boolean {
+    if (!state.groupFolder || deliveryIds.size === 0) return true;
     const inputDir = this.resolveIpcInputDir(state as ActiveGroupState);
     let filenames: string[];
     try {
-      filenames = fs
-        .readdirSync(inputDir)
-        .filter((name) => name.endsWith('.json'));
-    } catch {
-      return;
+      filenames = fs.readdirSync(inputDir).filter(isIpcInputPayloadFilename);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return true;
+      logger.warn(
+        { inputDir, err },
+        'Failed to list IPC input directory while discarding delivery files',
+      );
+      return false;
     }
+    let complete = true;
     for (const filename of filenames) {
       const filepath = path.join(inputDir, filename);
       try {
@@ -2097,12 +2130,14 @@ export class GroupQueue {
           fs.unlinkSync(filepath);
         }
       } catch (err) {
+        complete = false;
         logger.warn(
           { filepath, err },
           'Failed to inspect/discard unacknowledged IPC delivery file',
         );
       }
     }
+    return complete;
   }
 
   private abandonUnacknowledgedIpcDeliveries(
@@ -2113,10 +2148,14 @@ export class GroupQueue {
       return;
     state.acknowledgedIpcDeliveryIds ??= new Set();
     const receipts = [...state.pendingIpcDeliveries.values()];
-    this.discardDeliveryIpcFiles(
-      state,
-      new Set(receipts.map((r) => r.deliveryId)),
-    );
+    if (
+      !this.discardDeliveryIpcFiles(
+        state,
+        new Set(receipts.map((r) => r.deliveryId)),
+      )
+    ) {
+      throw new Error('Failed to remove abandoned IPC delivery files');
+    }
     if (!this.onAbandonedIpcDeliveriesFn) {
       logger.error(
         { groupJid, receipts },
@@ -2143,7 +2182,7 @@ export class GroupQueue {
         : path.join(DATA_DIR, 'ipc', groupFolder, 'input');
     try {
       const files = fs.readdirSync(inputDir);
-      return files.some((f) => f.endsWith('.json'));
+      return files.some(isIpcInputPayloadFilename);
     } catch {
       return false;
     }

--- a/src/host-ipc-output-router.ts
+++ b/src/host-ipc-output-router.ts
@@ -73,6 +73,7 @@ export type HostIpcOutputRoute =
       delivered: false;
       staged: false;
       deliveryRole: TurnMessageDeliveryRole | null;
+      reason: 'unauthorized' | 'conflicting_final';
     };
 
 function normalizeDeliveryRole(value: unknown): TurnMessageDeliveryRole | null {
@@ -101,6 +102,7 @@ export function routeHostIpcOutput(
       delivered: false,
       staged: false,
       deliveryRole,
+      reason: 'unauthorized',
     };
   }
   if (
@@ -118,15 +120,31 @@ export function routeHostIpcOutput(
   }
 
   if (input.interactionMode === 'proactive') {
-    const attemptedFinalRecorded =
+    let attemptedFinalRecorded = false;
+    if (
       deliveryRole === 'final' &&
       typeof input.inputTurnId === 'string' &&
-      Boolean(input.inputTurnId) &&
-      activeTurnOutputs.recordAttemptedFinal({
+      input.inputTurnId
+    ) {
+      attemptedFinalRecorded = activeTurnOutputs.recordAttemptedFinal({
         scopeKey: channelTurnScope(input.sourceGroup, input.agentId),
         inputTurnId: input.inputTurnId,
         text: input.text,
       });
+      if (!attemptedFinalRecorded) {
+        // The first explicit final seals the physical provider lane. Returning
+        // a rejected route is essential: merely recording `false` while still
+        // selecting separate_provider allowed a second, different final to be
+        // irreversibly sent.
+        return {
+          path: 'rejected',
+          delivered: false,
+          staged: false,
+          deliveryRole,
+          reason: 'conflicting_final',
+        };
+      }
+    }
     return {
       path: 'separate_provider',
       delivered: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   preAcceptImDeliveryError,
 } from './im-send-retry-policy.js';
 import { createIpcSendDeduplicator } from './ipc-send-dedup.js';
+import { IpcWatcherManager } from './ipc-watcher-manager.js';
 import {
   deliverTextAndLocalImages,
   prepareLocalImages,
@@ -70,7 +71,10 @@ import {
   stripRedundantCompletionPreamble,
 } from './reply-finalization.js';
 export { buildInterruptedReply } from './reply-finalization.js';
-import { resolveTurnOutcome } from './turn-outcome.js';
+import {
+  hasUnfinishedProactiveOutput,
+  resolveTurnOutcome,
+} from './turn-outcome.js';
 import { finalizeChannelCardAfterDelivery } from './channel-card-finalization.js';
 import { persistUncertainStreamingDelivery } from './channel-streaming-uncertainty.js';
 import { resolveContainerOutputInputTurnId } from './channel-output-correlation.js';
@@ -81,7 +85,10 @@ import {
   type ProcessingIndicatorOwner,
 } from './processing-indicator-batch.js';
 import { resolveFollowUpMode } from './follow-up-policy.js';
-import { discardStartupTypedIpcDeliveries } from './ipc-delivery-recovery.js';
+import {
+  discardStartupTypedIpcDeliveries,
+  isIpcInputPayloadFilename,
+} from './ipc-delivery-recovery.js';
 import {
   DeferredOutOfBandCursorLedger,
   hasEarlierCursorMessage,
@@ -137,6 +144,7 @@ import {
   getUserById,
   getMessagesSince,
   getNewMessages,
+  resolveMessageCursorSequence,
   getRouterState,
   getSessionChannelOwner,
   getRouterStateByPrefix,
@@ -891,7 +899,7 @@ export function feedStreamEventToCard(
   }
 }
 
-let globalMessageCursor: MessageCursor = { timestamp: '', id: '' };
+let globalMessageCursor: MessageCursor = { timestamp: '', id: '', sequence: 0 };
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, MessageCursor> = {};
@@ -903,8 +911,9 @@ const startupRecoveredDeliveryJids = new Set<string>();
 
 /** Set both cursors directly (no max-merge) and persist. */
 function setCursors(jid: string, cursor: MessageCursor): void {
-  lastAgentTimestamp[jid] = cursor;
-  lastCommittedCursor[jid] = cursor;
+  const resolved = resolveMessageCursorSequence(cursor, jid);
+  lastAgentTimestamp[jid] = resolved;
+  lastCommittedCursor[jid] = resolved;
   saveState();
 }
 
@@ -919,16 +928,14 @@ function setCursors(jid: string, cursor: MessageCursor): void {
  * reply commit and the agent finishing processing of the earlier
  * messages would lose them (#18 P2-bug-2).
  *
- * Comparison uses lexicographic (timestamp, id) via `isCursorAfter` —
- * `getMessagesSince` sorts by `(timestamp, id)` so two messages with the
- * same timestamp must be ordered by id. Comparing on timestamp alone
- * could regress the cursor to an earlier id when the later id has
- * already been processed (#20 P2-3, #24 round-16 P2-2).
+ * Comparison uses the host-assigned ingest sequence. Legacy cursors retain
+ * the old `(timestamp,id)` fallback only until load/first use upgrades them.
  */
 function advanceNextPullCursorOnly(
   jid: string,
   candidate: MessageCursor,
 ): void {
+  candidate = resolveMessageCursorSequence(candidate, jid);
   const current = lastAgentTimestamp[jid];
   const target =
     current && isCursorAfter(current, candidate) ? current : candidate;
@@ -939,14 +946,14 @@ function advanceNextPullCursorOnly(
 /**
  * Advance cursors to `candidate`, never regressing behind existing position.
  *
- * Comparison uses lexicographic (timestamp, id) via `isCursorAfter` so
- * mixed batches with same-timestamp ids cannot regress the cursor (#24
- * round-16 P2-2). Pre-fix, only timestamps were compared, so a `/cmd`
+ * Comparison uses the host-assigned ingest sequence so provider clocks and
+ * random IDs cannot regress the cursor. Pre-fix, only timestamps were compared, so a `/cmd`
  * reply that ran `setCursors` to (T,m2) followed by the agent processing
  * a plain m1 with the same timestamp T would call `advanceCursors(T,m1)`
  * → cursor regressed to m1 → next poll re-read m2 and reply re-fired.
  */
 function advanceCursors(jid: string, candidate: MessageCursor): void {
+  candidate = resolveMessageCursorSequence(candidate, jid);
   const currentPull = lastAgentTimestamp[jid];
   lastAgentTimestamp[jid] =
     currentPull && isCursorAfter(currentPull, candidate)
@@ -987,6 +994,9 @@ function bindRunnerActiveIpcCoverage(
     .flatMap((receipt) => receipt.coveredCursors ?? [receipt.cursor])
     .map((cursor) => ({ ...cursor }))
     .sort((a, b) => {
+      if (a.sequence !== undefined && b.sequence !== undefined) {
+        return a.sequence - b.sequence;
+      }
       if (a.timestamp !== b.timestamp)
         return a.timestamp < b.timestamp ? -1 : 1;
       if (a.id === b.id) return 0;
@@ -1006,7 +1016,10 @@ function hasEarlierPendingMessage(
   candidate: MessageCursor,
 ): boolean {
   const sinceCursor = lastCommittedCursor[jid] || EMPTY_CURSOR;
-  return hasEarlierCursorMessage(getMessagesSince(jid, sinceCursor), candidate);
+  return hasEarlierCursorMessage(
+    getMessagesSince(jid, sinceCursor),
+    resolveMessageCursorSequence(candidate, jid),
+  );
 }
 
 function createIpcDeliveryTarget(
@@ -1014,6 +1027,7 @@ function createIpcDeliveryTarget(
   messages: Array<{
     timestamp: string;
     id: string;
+    ingest_sequence?: number;
     source_jid?: string;
     chat_jid?: string;
   }>,
@@ -1021,20 +1035,29 @@ function createIpcDeliveryTarget(
   if (messages.length === 0) return undefined;
   const unique = new Map<
     string,
-    { timestamp: string; id: string; sourceJid?: string }
+    { timestamp: string; id: string; sequence?: number; sourceJid?: string }
   >();
   for (const message of messages) {
     const candidateSourceJid = message.source_jid ?? message.chat_jid;
     const cursor = {
       timestamp: message.timestamp,
       id: message.id,
+      sequence: message.ingest_sequence,
       ...(candidateSourceJid && getChannelType(candidateSourceJid)
         ? { sourceJid: candidateSourceJid }
         : {}),
     };
-    unique.set(`${cursor.timestamp}\u0000${cursor.id}`, cursor);
+    unique.set(
+      cursor.sequence !== undefined
+        ? `sequence:${cursor.sequence}`
+        : `${cursor.timestamp}\u0000${cursor.id}`,
+      cursor,
+    );
   }
   const coveredCursors = [...unique.values()].sort((a, b) => {
+    if (a.sequence !== undefined && b.sequence !== undefined) {
+      return a.sequence - b.sequence;
+    }
     if (a.timestamp !== b.timestamp) return a.timestamp < b.timestamp ? -1 : 1;
     if (a.id === b.id) return 0;
     return a.id < b.id ? -1 : 1;
@@ -1054,14 +1077,18 @@ function hasUncoveredPendingMessage(receipt: IpcDeliveryReceipt): boolean {
       : [receipt.cursor];
   return hasUncoveredCursorMessageThrough(
     getMessagesSince(receipt.chatJid, sinceCursor),
-    receipt.cursor,
-    covered,
+    resolveMessageCursorSequence(receipt.cursor, receipt.chatJid),
+    covered.map((cursor) => ({
+      ...cursor,
+      sequence: resolveMessageCursorSequence(cursor, receipt.chatJid).sequence,
+    })),
   );
 }
 
 /** Complete an out-of-band reply/drop without crossing earlier work that an
  * active runner accepted but has not receipted yet. */
 function completeOutOfBandMessage(jid: string, candidate: MessageCursor): void {
+  candidate = resolveMessageCursorSequence(candidate, jid);
   if (hasEarlierPendingMessage(jid, candidate)) {
     advanceNextPullCursorOnly(jid, candidate);
     deferredOutOfBandCursors.defer(jid, candidate);
@@ -1074,17 +1101,21 @@ function completeOutOfBandMessage(jid: string, candidate: MessageCursor): void {
 
 function completeOutOfBandMessages(
   jid: string,
-  messages: Array<{ timestamp: string; id: string }>,
+  messages: Array<{ timestamp: string; id: string; ingest_sequence?: number }>,
 ): void {
-  const ordered = [...messages].sort((a, b) =>
-    a.timestamp === b.timestamp
+  const ordered = [...messages].sort((a, b) => {
+    if (a.ingest_sequence !== undefined && b.ingest_sequence !== undefined) {
+      return a.ingest_sequence - b.ingest_sequence;
+    }
+    return a.timestamp === b.timestamp
       ? a.id.localeCompare(b.id)
-      : a.timestamp.localeCompare(b.timestamp),
-  );
+      : a.timestamp.localeCompare(b.timestamp);
+  });
   for (const message of ordered) {
     completeOutOfBandMessage(jid, {
       timestamp: message.timestamp,
       id: message.id,
+      sequence: message.ingest_sequence,
     });
   }
 }
@@ -1119,7 +1150,7 @@ function clearPersistedIpcDeliveriesForChats(chatJids: Set<string>): number {
         visit(filepath);
         continue;
       }
-      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      if (!entry.isFile() || !isIpcInputPayloadFilename(entry.name)) continue;
       try {
         const payload = JSON.parse(fs.readFileSync(filepath, 'utf8')) as {
           receipt?: { chatJid?: unknown };
@@ -1144,158 +1175,12 @@ let messageLoopRunning = false;
 let ipcWatcherRunning = false;
 let shuttingDown = false;
 
-// ── IPC Watcher Manager (event-driven fs.watch + fallback polling) ──
-
-class IpcWatcherManager {
-  private watchers = new Map<
-    string,
-    { watchers: fs.FSWatcher[]; refCount: number }
-  >();
-  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  private processingFolders = new Set<string>();
-  private pendingReprocess = new Set<string>();
-  private fallbackTimer: ReturnType<typeof setInterval> | null = null;
-  private processGroupFn: ((folder: string) => Promise<void>) | null = null;
-  private processFullFn: (() => Promise<void>) | null = null;
-
-  /** Bind the per-group and full-scan processing functions (set once from startIpcWatcher). */
-  bind(
-    processGroup: (folder: string) => Promise<void>,
-    processFull: () => Promise<void>,
-  ): void {
-    this.processGroupFn = processGroup;
-    this.processFullFn = processFull;
-  }
-
-  /** Start watching a group's IPC directories. Called when a container/process starts. */
-  watchGroup(folder: string): void {
-    const existing = this.watchers.get(folder);
-    if (existing) {
-      existing.refCount++;
-      return;
-    }
-
-    const groupIpcRoot = path.join(DATA_DIR, 'ipc', folder);
-    const dirsToWatch = [
-      path.join(groupIpcRoot, 'messages'),
-      path.join(groupIpcRoot, 'tasks'),
-    ];
-
-    const folderWatchers: fs.FSWatcher[] = [];
-    for (const dir of dirsToWatch) {
-      try {
-        fs.mkdirSync(dir, { recursive: true });
-        // Listen to all event types — 'rename' covers atomic writes on Linux,
-        // but Docker bind mounts (macOS virtiofs) may emit 'change' instead.
-        const w = fs.watch(dir, () => {
-          this.debouncedProcess(folder);
-        });
-        w.on('error', () => {
-          // Watcher error — fallback polling will handle it
-        });
-        folderWatchers.push(w);
-      } catch {
-        // Watch failed — fallback polling will handle it
-      }
-    }
-    this.watchers.set(folder, { watchers: folderWatchers, refCount: 1 });
-  }
-
-  /** Stop watching a group's IPC directories. Called when a container/process stops. */
-  unwatchGroup(folder: string): void {
-    const entry = this.watchers.get(folder);
-    if (!entry) return;
-    entry.refCount--;
-    if (entry.refCount > 0) return;
-
-    for (const w of entry.watchers) {
-      try {
-        w.close();
-      } catch {}
-    }
-    this.watchers.delete(folder);
-    const timer = this.debounceTimers.get(folder);
-    if (timer) {
-      clearTimeout(timer);
-      this.debounceTimers.delete(folder);
-    }
-  }
-
-  private debouncedProcess(folder: string): void {
-    const existing = this.debounceTimers.get(folder);
-    if (existing) clearTimeout(existing);
-    this.debounceTimers.set(
-      folder,
-      setTimeout(() => {
-        this.debounceTimers.delete(folder);
-        // Skip if a previous processGroupIpc call for this folder is still running;
-        // the pending flag ensures we re-process after the current run finishes.
-        if (this.processingFolders.has(folder)) {
-          this.pendingReprocess.add(folder);
-          return;
-        }
-        this.processingFolders.add(folder);
-        this.processGroupFn?.(folder)
-          .catch((err) => {
-            logger.error({ err, folder }, 'Error processing IPC for group');
-          })
-          .finally(() => {
-            this.processingFolders.delete(folder);
-            // Files may have arrived during processing — run once more
-            if (
-              this.pendingReprocess.delete(folder) &&
-              this.watchers.has(folder)
-            ) {
-              this.debouncedProcess(folder);
-            }
-          });
-      }, 100),
-    );
-  }
-
-  /** Trigger processing for a folder through the concurrency guard. */
-  triggerProcess(folder: string): void {
-    this.debouncedProcess(folder);
-  }
-
-  /** Start fallback polling (every 5s) as safety net for inotify failures. */
-  startFallback(): void {
-    this.fallbackTimer = setInterval(() => {
-      if (shuttingDown) return;
-      this.processFullFn?.().catch((err) => {
-        logger.error({ err }, 'Error in IPC fallback scan');
-      });
-    }, 5000);
-    this.fallbackTimer.unref(); // Don't prevent process from naturally exiting
-  }
-
-  /** Close all watchers and timers. */
-  closeAll(): void {
-    for (const [, entry] of this.watchers) {
-      for (const w of entry.watchers) {
-        try {
-          w.close();
-        } catch {}
-      }
-    }
-    this.watchers.clear();
-    for (const [, timer] of this.debounceTimers) {
-      clearTimeout(timer);
-    }
-    this.debounceTimers.clear();
-    if (this.fallbackTimer) {
-      clearInterval(this.fallbackTimer);
-      this.fallbackTimer = null;
-    }
-  }
-}
-
 let ipcWatcherManager: IpcWatcherManager | null = null;
 /** JIDs already persisted by the shutdown handler — prevents finally blocks from duplicating. */
 const shutdownSavedJids = new Set<string>();
 
 const queue = new GroupQueue();
-const EMPTY_CURSOR: MessageCursor = { timestamp: '', id: '' };
+const EMPTY_CURSOR: MessageCursor = { timestamp: '', id: '', sequence: 0 };
 const terminalWarmupInFlight = new Set<string>();
 const STUCK_RUNNER_CHECK_INTERVAL_POLLS = 15;
 const STUCK_RUNNER_IDLE_MS = 3 * 60 * 1000;
@@ -1573,6 +1458,7 @@ async function completeFollowUpReply(
   completeOutOfBandMessage(item.chat_jid, {
     timestamp: item.timestamp,
     id: item.id,
+    sequence: item.ingest_sequence,
   });
   broadcastFollowUpUpdate(item.chat_jid, {
     id: item.id,
@@ -3717,6 +3603,9 @@ async function settleAndRecordTaskIpcDeliveries(
 }
 
 function isCursorAfter(candidate: MessageCursor, base: MessageCursor): boolean {
+  if (candidate.sequence !== undefined && base.sequence !== undefined) {
+    return candidate.sequence > base.sequence;
+  }
   if (candidate.timestamp > base.timestamp) return true;
   if (candidate.timestamp < base.timestamp) return false;
   return candidate.id > base.id;
@@ -3732,9 +3621,15 @@ function normalizeCursor(value: unknown): MessageCursor {
     typeof (value as { timestamp?: unknown }).timestamp === 'string'
   ) {
     const maybeId = (value as { id?: unknown }).id;
+    const maybeSequence = (value as { sequence?: unknown }).sequence;
     return {
       timestamp: (value as { timestamp: string }).timestamp,
       id: typeof maybeId === 'string' ? maybeId : '',
+      ...(typeof maybeSequence === 'number' &&
+      Number.isSafeInteger(maybeSequence) &&
+      maybeSequence >= 0
+        ? { sequence: maybeSequence }
+        : {}),
     };
   }
   return { ...EMPTY_CURSOR };
@@ -5394,17 +5289,21 @@ function loadState(): void {
   // Load from SQLite
   const persistedTimestamp = getRouterState('last_timestamp') || '';
   const lastTimestampId = getRouterState('last_timestamp_id') || '';
-  globalMessageCursor = {
+  const persistedSequence = Number(getRouterState('last_ingest_sequence'));
+  globalMessageCursor = resolveMessageCursorSequence({
     timestamp: persistedTimestamp,
     id: lastTimestampId,
-  };
+    ...(Number.isSafeInteger(persistedSequence) && persistedSequence >= 0
+      ? { sequence: persistedSequence }
+      : {}),
+  });
   const loadCursorMap = (key: string): Record<string, MessageCursor> => {
     const raw = getRouterState(key);
     try {
       const parsed = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
       const normalized: Record<string, MessageCursor> = {};
       for (const [jid, v] of Object.entries(parsed)) {
-        normalized[jid] = normalizeCursor(v);
+        normalized[jid] = resolveMessageCursorSequence(normalizeCursor(v), jid);
       }
       return normalized;
     } catch {
@@ -5569,6 +5468,7 @@ function saveState(): void {
   const entries: Array<[string, string]> = [
     ['last_timestamp', globalMessageCursor.timestamp],
     ['last_timestamp_id', globalMessageCursor.id],
+    ['last_ingest_sequence', String(globalMessageCursor.sequence ?? 0)],
     ['last_agent_timestamp', JSON.stringify(lastAgentTimestamp)],
     ['last_committed_cursor', JSON.stringify(lastCommittedCursor)],
   ];
@@ -6158,6 +6058,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       completeOutOfBandMessage(chatJid, {
         timestamp: message.timestamp,
         id: message.id,
+        sequence: message.ingest_sequence,
       });
     }
     const terminalIds = new Set(
@@ -6317,6 +6218,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         advanceReplyCursor(chatJid, {
           timestamp: r.originalMsg.timestamp,
           id: r.originalMsg.id,
+          sequence: r.originalMsg.ingest_sequence,
         });
       }
       if (!pluginRepliesAcknowledged) return false;
@@ -6607,6 +6509,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const channelPhysicalDeliveryAckByInput = new Map<string, boolean>([
     [lastProcessed.id, false],
   ]);
+  const channelNonTerminalDeliveryAckByInput = new Map<string, boolean>([
+    [lastProcessed.id, false],
+  ]);
   // Cold-start MCP output uses the triggering DB message id. Warm IPC turns
   // replace this with the receipt delivery id through activeRouteUpdaters.
   const ipcReplyTurnTracker: IpcReplyTurnTracker = {
@@ -6663,6 +6568,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let currentInputCursor: MessageCursor = {
     timestamp: lastProcessed.timestamp,
     id: lastProcessed.id,
+    sequence: lastProcessed.ingest_sequence,
   };
 
   // ── Feishu Streaming Card ──
@@ -6693,6 +6599,26 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   if (channelTurnRuntime) {
     channelTurnRuntimes.set(lastProcessed.id, channelTurnRuntime);
   }
+  const markMainOutputSettled = (result: ContainerOutput): void => {
+    const completedInputTurnIds = result.ipcReceipts?.length
+      ? result.ipcReceipts.map((receipt) => receipt.deliveryId)
+      : [result.inputTurnId ?? lastProcessed.id];
+    const completedInputs = result.ipcReceipts?.length
+      ? result.ipcReceipts.flatMap((receipt) =>
+          (receipt.coveredCursors ?? [receipt.cursor]).map((cursor) => ({
+            chatJid: receipt.chatJid,
+            messageId: cursor.id,
+          })),
+        )
+      : [{ chatJid, messageId: lastProcessed.id }];
+    activeAgentBuilderTurns.clearCompleted(
+      effectiveGroup.folder,
+      completedInputs,
+    );
+    for (const inputTurnId of completedInputTurnIds) {
+      healthyCompletedInputTurns.add(inputTurnId);
+    }
+  };
   const completeChannelRuntimesForOutput = async (
     result: ContainerOutput,
   ): Promise<boolean> => {
@@ -6702,9 +6628,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       ? result.ipcReceipts.map((receipt) => receipt.deliveryId)
       : [result.inputTurnId ?? lastProcessed.id];
     for (const inputId of inputIds) {
-      healthyCompletedInputTurns.add(inputId);
       const runtime = channelTurnRuntimes.get(inputId);
+      const unfinishedProactiveOutput = hasUnfinishedProactiveOutput({
+        interactionMode,
+        nonTerminalDelivered:
+          channelNonTerminalDeliveryAckByInput.get(inputId) === true,
+        finalDelivered: channelPhysicalDeliveryAckByInput.get(inputId) === true,
+      });
       if (!runtime) {
+        if (unfinishedProactiveOutput) {
+          allCompleted = false;
+          logger.error(
+            { chatJid, inputTurnId: inputId },
+            'Refusing to settle Proactive input after progress/separate output without final',
+          );
+          continue;
+        }
         await clearProcessingIndicatorForInput(inputId);
         continue;
       }
@@ -6768,6 +6707,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         }
         continue;
       }
+      if (unfinishedProactiveOutput) {
+        allCompleted = false;
+        logger.error(
+          { chatJid, inputTurnId: inputId, runId: runtime.runId },
+          'Refusing to complete Proactive channel input without final delivery ACK',
+        );
+        continue;
+      }
       const utteranceDelivered =
         channelPhysicalDeliveryAckByInput.get(inputId) === true;
       if (publishesFrameworkAnswer(interactionMode) && !utteranceDelivered) {
@@ -6808,6 +6755,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         );
       }
     }
+    if (allCompleted) markMainOutputSettled(result);
     return allCompleted;
   };
   const channelScopeForOutput = (
@@ -6860,6 +6808,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       advanceCursors(chatJid, {
         timestamp: lastProcessed.timestamp,
         id: lastProcessed.id,
+        sequence: lastProcessed.ingest_sequence,
       });
       return true;
     }
@@ -6871,6 +6820,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       advanceCursors(chatJid, {
         timestamp: lastProcessed.timestamp,
         id: lastProcessed.id,
+        sequence: lastProcessed.ingest_sequence,
       });
       return true;
     }
@@ -7126,6 +7076,10 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         channelPhysicalDeliveryAckByInput.set(inputTurnId, true);
         sentReplyByInput.set(inputTurnId, true);
         acknowledgeIpcReplyTurn(ipcReplyTurnTracker, inputTurnId);
+      },
+      onNonTerminalDelivered: () => {
+        if (interactionMode !== 'proactive') return;
+        channelNonTerminalDeliveryAckByInput.set(inputTurnId, true);
       },
     });
     turnOutputCoordinators.set(inputTurnId, coordinator);
@@ -7412,6 +7366,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       if (inputTurnId) sentReplyByInput.set(inputTurnId, false);
       if (inputTurnId) {
         channelPhysicalDeliveryAckByInput.set(inputTurnId, false);
+        channelNonTerminalDeliveryAckByInput.set(inputTurnId, false);
       }
       // Do not rotate the visible provider projection merely because B was
       // published while A is still emitting. The first B-correlated runner
@@ -7610,6 +7565,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     advanceCursors(chatJid, {
       timestamp: lastProcessed.timestamp,
       id: lastProcessed.id,
+      sequence: lastProcessed.ingest_sequence,
     });
     flushAcknowledgedIpcForJid(chatJid);
     cursorCommittedInputTurns.add(inputTurnId);
@@ -7771,28 +7727,6 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           if (!suppressSupersededOutput) {
             await activateMainProjectionForInput(result.inputTurnId);
           }
-          if (result.inputTurnCompleted) {
-            const completedInputTurnIds = result.ipcReceipts?.length
-              ? result.ipcReceipts.map((receipt) => receipt.deliveryId)
-              : [result.inputTurnId ?? lastProcessed.id];
-            for (const inputTurnId of completedInputTurnIds) {
-              healthyCompletedInputTurns.add(inputTurnId);
-            }
-            const completedInputs = result.ipcReceipts?.length
-              ? result.ipcReceipts.flatMap((receipt) =>
-                  (receipt.coveredCursors ?? [receipt.cursor]).map(
-                    (cursor) => ({
-                      chatJid: receipt.chatJid,
-                      messageId: cursor.id,
-                    }),
-                  ),
-                )
-              : [{ chatJid, messageId: lastProcessed.id }];
-            activeAgentBuilderTurns.clearCompleted(
-              effectiveGroup.folder,
-              completedInputs,
-            );
-          }
           if (result.newSessionId && result.status !== 'error') {
             activeSessionId = result.newSessionId;
           }
@@ -7801,6 +7735,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             // physical input even though its assistant projection is hidden.
             // Commit it just like an interrupted terminal so later IPC receipt
             // commits are not fenced behind a permanently pending cold root.
+            if (result.inputTurnCompleted) markMainOutputSettled(result);
             commitCursor(
               resolveContainerOutputInputTurnId(result, lastProcessed.id),
             );
@@ -8471,11 +8406,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               })
             ) {
               if (result.inputTurnCompleted) {
-                if (await completeChannelRuntimesForOutput(result)) {
-                  commitCursor(
-                    resolveContainerOutputInputTurnId(result, lastProcessed.id),
+                if (!(await completeChannelRuntimesForOutput(result))) {
+                  throw new Error(
+                    'host_turn_settlement_failed: Proactive output did not reach a durable terminal state',
                   );
                 }
+                commitCursor(
+                  resolveContainerOutputInputTurnId(result, lastProcessed.id),
+                );
                 finalizeProactiveOutputCoordinators(result);
                 broadcastStreamEvent(chatJid, {
                   eventType: 'status',
@@ -8526,10 +8464,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             });
             if (!projectionDecision.project) {
               result.result = null;
-              if (
-                result.inputTurnCompleted &&
-                (await completeChannelRuntimesForOutput(result))
-              ) {
+              if (result.inputTurnCompleted) {
+                if (!(await completeChannelRuntimesForOutput(result))) {
+                  throw new Error(
+                    'host_turn_settlement_failed: lifecycle-only output did not reach a durable terminal state',
+                  );
+                }
                 commitCursor(resultInputTurnId);
               }
               logger.info(
@@ -9257,18 +9197,23 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                   channelPhysicalDeliveryAckByInput.set(inputId, true);
                 }
               }
-              if (
-                result.inputTurnCompleted &&
-                (replyDeliveryAcknowledged ||
+              if (result.inputTurnCompleted) {
+                if (!(await completeChannelRuntimesForOutput(result))) {
+                  throw new Error(
+                    'host_turn_settlement_failed: primary output did not reach a durable terminal state',
+                  );
+                }
+                if (
+                  replyDeliveryAcknowledged ||
                   Boolean(
                     outputChannelScope.scope &&
                     getFailedChannelOutboxForTurn(
                       outputChannelScope.scope.turnRunId,
                     ),
-                  )) &&
-                (await completeChannelRuntimesForOutput(result))
-              ) {
-                commitCursor(outputChannelScope.inputId);
+                  )
+                ) {
+                  commitCursor(outputChannelScope.inputId);
+                }
               }
             }
             // Only reset idle timer on actual results, not session-update markers (result: null)
@@ -9282,6 +9227,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         } catch (err) {
           logger.error({ group: group.name, err }, 'onOutput callback failed');
           hadError = true;
+          throw err;
         }
       },
       imagesForAgent,
@@ -10316,16 +10262,6 @@ async function runAgent(
       resolveSteeringInterrupt(chatJid, outputTurnId);
     }
     if (
-      output.ipcReceipts?.length &&
-      (!output.providerFailure || output.providerFailureTerminal === true)
-    ) {
-      queue.acknowledgeIpcDeliveries(
-        chatJid,
-        output.ipcReceipts,
-        commitIpcDeliveryReceipts,
-      );
-    }
-    if (
       output.queryIdle === true ||
       (isInterruptStatus && output.queryIdle !== false)
     ) {
@@ -10349,6 +10285,20 @@ async function runAgent(
       });
     }
     await onOutput?.(output);
+    // A runner receipt proves model consumption, not successful Host
+    // persistence/projection. Commit it only after the Host callback resolves;
+    // callback failure leaves the receipt pending for exact-input recovery.
+    if (
+      output.inputTurnCompleted === true &&
+      output.ipcReceipts?.length &&
+      (!output.providerFailure || output.providerFailureTerminal === true)
+    ) {
+      queue.acknowledgeIpcDeliveries(
+        chatJid,
+        output.ipcReceipts,
+        commitIpcDeliveryReceipts,
+      );
+    }
     if (
       closeRunnerAfterRotatingProviderTurn(
         rotateProviderAfterTurn,
@@ -10368,7 +10318,7 @@ async function runAgent(
     }
   };
 
-  ipcWatcherManager?.watchGroup(group.folder);
+  ipcWatcherManager?.watchRuntime(group.folder);
   try {
     const executionMode = group.executionMode || 'container';
     const feishuCliAccountId =
@@ -10532,7 +10482,7 @@ async function runAgent(
     logger.error({ group: group.name, err }, 'Agent error');
     return { status: 'error', error: errorMsg };
   } finally {
-    ipcWatcherManager?.unwatchGroup(group.folder);
+    ipcWatcherManager?.unwatchRuntime(group.folder);
   }
 }
 
@@ -11178,6 +11128,22 @@ function startIpcWatcher(): void {
                 // DB/IM side effect. SDK Result will finalize the same primary
                 // answer; a failed staging attempt must not fall through into
                 // the legacy separate-message path.
+              } else if (hostOutputRoute.path === 'rejected') {
+                messageDeliveryRejected = true;
+                messageDeliveryError =
+                  hostOutputRoute.reason === 'conflicting_final'
+                    ? 'A different final has already sealed this input turn; the second final was not sent.'
+                    : 'Unauthorized message target.';
+                logger.warn(
+                  {
+                    sourceGroup,
+                    agentId: ipcAgentId,
+                    inputTurnId: data.inputTurnId,
+                    deliveryRole: hostOutputRoute.deliveryRole,
+                    reason: hostOutputRoute.reason,
+                  },
+                  'Rejected IPC send_message before provider delivery',
+                );
               } else if (
                 isRetryDuplicateIpcSend(sourceGroup, data.chatJid, data.text)
               ) {
@@ -11709,6 +11675,7 @@ function startIpcWatcher(): void {
                 messageDelivered &&
                 !messageStaged &&
                 isMainUserTurnReply &&
+                hostOutputRoute.deliveryRole === 'final' &&
                 typeof data.inputTurnId === 'string' &&
                 data.inputTurnId
               ) {
@@ -12352,7 +12319,20 @@ function startIpcWatcher(): void {
   };
 
   // Initialize the event-driven IPC watcher manager
-  ipcWatcherManager = new IpcWatcherManager();
+  ipcWatcherManager = new IpcWatcherManager({
+    ipcBaseDir,
+    isShuttingDown: () => shuttingDown,
+    onError: (err, context) => {
+      if (context.phase === 'process_group') {
+        logger.error(
+          { err, folder: context.folder },
+          'Error processing IPC for group',
+        );
+      } else {
+        logger.error({ err }, 'Error in IPC fallback scan');
+      }
+    },
+  });
   ipcWatcherManager.bind(processGroupIpc, processIpcFilesFull);
 
   // Initial full scan
@@ -15144,6 +15124,7 @@ async function processAgentConversation(
         advanceReplyCursor(virtualChatJid, {
           timestamp: r.originalMsg.timestamp,
           id: r.originalMsg.id,
+          sequence: r.originalMsg.ingest_sequence,
         });
       }
       if (!agentPluginRepliesAcknowledged) return false;
@@ -15442,6 +15423,23 @@ async function processAgentConversation(
   if (agentChannelTurnRuntime) {
     agentChannelTurnRuntimes.set(lastProcessed.id, agentChannelTurnRuntime);
   }
+  const markAgentOutputSettled = (result: ContainerOutput): void => {
+    const completedInputTurnIds = result.ipcReceipts?.length
+      ? result.ipcReceipts.map((receipt) => receipt.deliveryId)
+      : [result.inputTurnId ?? lastProcessed.id];
+    const completedInputs = result.ipcReceipts?.length
+      ? result.ipcReceipts.flatMap((receipt) =>
+          (receipt.coveredCursors ?? [receipt.cursor]).map((cursor) => ({
+            chatJid: receipt.chatJid,
+            messageId: cursor.id,
+          })),
+        )
+      : [{ chatJid: virtualChatJid, messageId: lastProcessed.id }];
+    activeAgentBuilderTurns.clearCompleted(agentBuilderScope, completedInputs);
+    for (const inputTurnId of completedInputTurnIds) {
+      healthyAgentCompletedInputTurns.add(inputTurnId);
+    }
+  };
   const completeAgentChannelRuntimesForOutput = async (
     result: ContainerOutput,
   ): Promise<boolean> => {
@@ -15451,9 +15449,22 @@ async function processAgentConversation(
       ? result.ipcReceipts.map((receipt) => receipt.deliveryId)
       : [result.inputTurnId ?? lastProcessed.id];
     for (const inputId of inputIds) {
-      healthyAgentCompletedInputTurns.add(inputId);
       const runtime = agentChannelTurnRuntimes.get(inputId);
+      const unfinishedProactiveOutput = hasUnfinishedProactiveOutput({
+        interactionMode,
+        nonTerminalDelivered:
+          agentNonTerminalDeliveryAckByInput.get(inputId) === true,
+        finalDelivered: agentPhysicalDeliveryAckByInput.get(inputId) === true,
+      });
       if (!runtime) {
+        if (unfinishedProactiveOutput) {
+          allCompleted = false;
+          logger.error(
+            { chatJid, agentId, inputTurnId: inputId },
+            'Refusing to settle Proactive agent input after progress/separate output without final',
+          );
+          continue;
+        }
         await clearAgentProcessingIndicatorForInput(inputId);
         continue;
       }
@@ -15519,6 +15530,14 @@ async function processAgentConversation(
         }
         continue;
       }
+      if (unfinishedProactiveOutput) {
+        allCompleted = false;
+        logger.error(
+          { chatJid, agentId, inputTurnId: inputId, runId: runtime.runId },
+          'Refusing to complete Proactive agent input without final delivery ACK',
+        );
+        continue;
+      }
       const utteranceDelivered =
         agentPhysicalDeliveryAckByInput.get(inputId) === true;
       if (publishesFrameworkAnswer(interactionMode) && !utteranceDelivered) {
@@ -15557,6 +15576,7 @@ async function processAgentConversation(
         );
       }
     }
+    if (allCompleted) markAgentOutputSettled(result);
     return allCompleted;
   };
   const agentScopeForOutput = (
@@ -15611,6 +15631,7 @@ async function processAgentConversation(
       advanceCursors(virtualChatJid, {
         timestamp: lastProcessed.timestamp,
         id: lastProcessed.id,
+        sequence: lastProcessed.ingest_sequence,
       });
       return true;
     }
@@ -15627,6 +15648,7 @@ async function processAgentConversation(
       advanceCursors(virtualChatJid, {
         timestamp: lastProcessed.timestamp,
         id: lastProcessed.id,
+        sequence: lastProcessed.ingest_sequence,
       });
       return true;
     }
@@ -15858,6 +15880,10 @@ async function processAgentConversation(
         agentPhysicalDeliveryAckByInput.set(inputTurnId, true);
         agentReplySentByInput.set(inputTurnId, true);
       },
+      onNonTerminalDelivered: () => {
+        if (interactionMode !== 'proactive') return;
+        agentNonTerminalDeliveryAckByInput.set(inputTurnId, true);
+      },
     });
     agentTurnOutputCoordinators.set(inputTurnId, coordinator);
     return coordinator;
@@ -16052,6 +16078,7 @@ async function processAgentConversation(
       agentReplySentByInput.set(inputTurnId, false);
       agentAnyReplyProjectedByInput.set(inputTurnId, false);
       agentPhysicalDeliveryAckByInput.set(inputTurnId, false);
+      agentNonTerminalDeliveryAckByInput.set(inputTurnId, false);
       const typingTransportJid = targetSourceJid ?? virtualChatJid;
       const typingReady = setTyping(
         virtualChatJid,
@@ -16211,6 +16238,9 @@ async function processAgentConversation(
   const agentPhysicalDeliveryAckByInput = new Map<string, boolean>([
     [lastProcessed.id, false],
   ]);
+  const agentNonTerminalDeliveryAckByInput = new Map<string, boolean>([
+    [lastProcessed.id, false],
+  ]);
   const proactiveAgentTailNoticesDelivered = new Set<string>();
   const notifyProactiveAgentTailInterruption = async (
     inputTurnId: string,
@@ -16257,12 +16287,13 @@ async function processAgentConversation(
     advanceCursors(virtualChatJid, {
       timestamp: lastProcessed.timestamp,
       id: lastProcessed.id,
+      sequence: lastProcessed.ingest_sequence,
     });
     flushAcknowledgedIpcForJid(virtualChatJid);
     cursorCommittedInputTurns.add(inputTurnId);
   };
 
-  const wrappedOnOutput = async (output: ContainerOutput) => {
+  const handleAgentOutput = async (output: ContainerOutput) => {
     // #547: warm-lifecycle bookkeeping — mark activity, and flag query-idle on
     // a substantive result / interruption so the runner can be kept warm.
     queue.markRunnerActivity(virtualJid);
@@ -16301,36 +16332,6 @@ async function processAgentConversation(
     }
     if (!suppressSupersededOutput) {
       await activateAgentProjectionForInput(output.inputTurnId);
-    }
-    if (
-      output.ipcReceipts?.length &&
-      (!output.providerFailure || output.providerFailureTerminal === true)
-    ) {
-      queue.acknowledgeIpcDeliveries(
-        virtualJid,
-        output.ipcReceipts,
-        commitIpcDeliveryReceipts,
-      );
-    }
-    if (output.inputTurnCompleted) {
-      const completedInputTurnIds = output.ipcReceipts?.length
-        ? output.ipcReceipts.map((receipt) => receipt.deliveryId)
-        : [output.inputTurnId ?? lastProcessed.id];
-      for (const inputTurnId of completedInputTurnIds) {
-        healthyAgentCompletedInputTurns.add(inputTurnId);
-      }
-      const completedInputs = output.ipcReceipts?.length
-        ? output.ipcReceipts.flatMap((receipt) =>
-            (receipt.coveredCursors ?? [receipt.cursor]).map((cursor) => ({
-              chatJid: receipt.chatJid,
-              messageId: cursor.id,
-            })),
-          )
-        : [{ chatJid: virtualChatJid, messageId: lastProcessed.id }];
-      activeAgentBuilderTurns.clearCompleted(
-        agentBuilderScope,
-        completedInputs,
-      );
     }
     if (
       output.queryIdle === true ||
@@ -16391,6 +16392,7 @@ async function processAgentConversation(
     }
 
     if (suppressSupersededOutput) {
+      if (output.inputTurnCompleted) markAgentOutputSettled(output);
       commitCursor(output.inputTurnId ?? activeAgentInputTurnId);
       logger.info(
         {
@@ -16718,11 +16720,14 @@ async function processAgentConversation(
         })
       ) {
         if (output.inputTurnCompleted) {
-          if (await completeAgentChannelRuntimesForOutput(output)) {
-            commitCursor(
-              resolveContainerOutputInputTurnId(output, lastProcessed.id),
+          if (!(await completeAgentChannelRuntimesForOutput(output))) {
+            throw new Error(
+              'host_turn_settlement_failed: Proactive agent output did not reach a durable terminal state',
             );
           }
+          commitCursor(
+            resolveContainerOutputInputTurnId(output, lastProcessed.id),
+          );
           finalizeProactiveAgentOutputCoordinators(output);
           broadcastStreamEvent(
             chatJid,
@@ -16803,10 +16808,12 @@ async function processAgentConversation(
       });
       if (!projectionDecision.project) {
         output.result = null;
-        if (
-          output.inputTurnCompleted &&
-          (await completeAgentChannelRuntimesForOutput(output))
-        ) {
+        if (output.inputTurnCompleted) {
+          if (!(await completeAgentChannelRuntimesForOutput(output))) {
+            throw new Error(
+              'host_turn_settlement_failed: lifecycle-only agent output did not reach a durable terminal state',
+            );
+          }
           commitCursor(resultInputTurnId);
         }
         logger.info(
@@ -17310,10 +17317,12 @@ async function processAgentConversation(
           }
         }
 
-        if (
-          output.inputTurnCompleted &&
-          (await completeAgentChannelRuntimesForOutput(output))
-        ) {
+        if (output.inputTurnCompleted) {
+          if (!(await completeAgentChannelRuntimesForOutput(output))) {
+            throw new Error(
+              'host_turn_settlement_failed: primary agent output did not reach a durable terminal state',
+            );
+          }
           commitCursor(
             resolveContainerOutputInputTurnId(output, lastProcessed.id),
           );
@@ -17384,7 +17393,32 @@ async function processAgentConversation(
     }
   };
 
-  ipcWatcherManager?.watchGroup(effectiveGroup.folder);
+  const wrappedOnOutput = async (output: ContainerOutput): Promise<void> => {
+    try {
+      await handleAgentOutput(output);
+    } catch (err) {
+      hadError = true;
+      lastError = err instanceof Error ? err.message : String(err);
+      retryUnfinishedTurn = true;
+      throw err;
+    }
+    // Match the main-runtime contract: IPC consumption becomes durable only
+    // after every Host-side persistence/projection callback above has
+    // completed. A thrown callback leaves these receipts replayable.
+    if (
+      output.inputTurnCompleted === true &&
+      output.ipcReceipts?.length &&
+      (!output.providerFailure || output.providerFailureTerminal === true)
+    ) {
+      queue.acknowledgeIpcDeliveries(
+        virtualJid,
+        output.ipcReceipts,
+        commitIpcDeliveryReceipts,
+      );
+    }
+  };
+
+  ipcWatcherManager?.watchRuntime(effectiveGroup.folder, { agentId });
   try {
     agentChannelOutboxScope =
       agentChannelTurnRuntime &&
@@ -18169,7 +18203,7 @@ async function processAgentConversation(
     }
     activeAgentBuilderTurns.delete(agentBuilderScope);
     activeChannelTurns.delete(channelTurnScope(effectiveGroup.folder, agentId));
-    ipcWatcherManager?.unwatchGroup(effectiveGroup.folder);
+    ipcWatcherManager?.unwatchRuntime(effectiveGroup.folder, { agentId });
   }
 
   return !retryUnfinishedTurn;
@@ -18442,6 +18476,7 @@ async function startMessageLoop(): Promise<void> {
                 advanceReplyCursor(chatJid, {
                   timestamp: r.originalMsg.timestamp,
                   id: r.originalMsg.id,
+                  sequence: r.originalMsg.ingest_sequence,
                 });
               }
               if (!warmPluginRepliesAcknowledged) {
@@ -21836,8 +21871,9 @@ async function main(): Promise<void> {
     advanceNextPullCursorOnly,
     completeOutOfBandMessage,
     advanceGlobalCursor: (cursor: MessageCursor) => {
-      if (isCursorAfter(cursor, globalMessageCursor)) {
-        globalMessageCursor = cursor;
+      const resolved = resolveMessageCursorSequence(cursor);
+      if (isCursorAfter(resolved, globalMessageCursor)) {
+        globalMessageCursor = resolved;
         saveState();
       }
     },
@@ -22292,14 +22328,33 @@ async function main(): Promise<void> {
       displayName,
       taskRunId,
       selectedProviderId,
-    ) =>
-      queue.registerProcess(groupJid, proc, {
-        containerName,
-        groupFolder,
-        displayName,
-        taskRunId,
-        selectedProviderId,
-      }),
+    ) => {
+      let taskWatchReleased = false;
+      const releaseTaskWatch = (): void => {
+        if (taskWatchReleased || !taskRunId) return;
+        taskWatchReleased = true;
+        ipcWatcherManager?.unwatchRuntime(groupFolder, { taskRunId });
+      };
+      if (taskRunId) {
+        ipcWatcherManager?.watchRuntime(groupFolder, { taskRunId });
+        // Isolated-task namespaces are run-scoped. Releasing on child close
+        // keeps fallback/provider process rotations reference-counted without
+        // retaining one watcher pair per historical task run.
+        proc.once('close', releaseTaskWatch);
+      }
+      try {
+        queue.registerProcess(groupJid, proc, {
+          containerName,
+          groupFolder,
+          displayName,
+          taskRunId,
+          selectedProviderId,
+        });
+      } catch (err) {
+        releaseTaskWatch();
+        throw err;
+      }
+    },
     sendMessage: async (jid, text, options) => {
       const outcome = await sendMessageWithOutcome(jid, text, options);
       if (!outcome.targetDelivered) {
@@ -22692,8 +22747,6 @@ async function main(): Promise<void> {
     },
     assistantName: ASSISTANT_NAME,
   };
-  startSchedulerLoop(schedulerDeps);
-
   // Inject triggerTaskRun into WebDeps (schedulerDeps must exist first)
   const webDeps = getWebDeps();
   if (webDeps) {
@@ -22981,10 +23034,18 @@ async function main(): Promise<void> {
   });
   imManager.resumeDeferredInbound();
   streamingBuffer.recover();
+  // The watcher must exist before any recovery or scheduler path can spawn a
+  // main/conversation/isolated Runner. Otherwise the first nested Memory or
+  // Profile request is invisible until fallback polling and can lose the race
+  // with the Runner-side deadline.
+  startIpcWatcher();
   recoverStartupTypedIpcDeliveries();
   recoverPendingMessages();
   recoverConversationAgents();
-  startIpcWatcher();
+  // Start new scheduled work only after every persisted IPC receipt has been
+  // rewound/discarded and conversation recovery has normalized its cursors.
+  // Otherwise an overdue task can race startup recovery with a fresh Runner.
+  startSchedulerLoop(schedulerDeps);
   streamingBuffer.start();
   startMessageLoop();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
   preAcceptImDeliveryError,
 } from './im-send-retry-policy.js';
 import { createIpcSendDeduplicator } from './ipc-send-dedup.js';
-import { IpcWatcherManager } from './ipc-watcher-manager.js';
+import {
+  DEFAULT_IPC_WATCHER_FALLBACK_MS,
+  IpcWatcherManager,
+} from './ipc-watcher-manager.js';
 import {
   deliverTextAndLocalImages,
   prepareLocalImages,
@@ -12318,9 +12321,15 @@ function startIpcWatcher(): void {
     }
   };
 
+  // Keep the recovery poll below the bounded Runner context-IPC deadline.
+  // Pass the value explicitly so runtime behavior and startup telemetry cannot
+  // silently diverge from the manager default.
+  const fallbackMs = DEFAULT_IPC_WATCHER_FALLBACK_MS;
+
   // Initialize the event-driven IPC watcher manager
   ipcWatcherManager = new IpcWatcherManager({
     ipcBaseDir,
+    fallbackMs,
     isShuttingDown: () => shuttingDown,
     onError: (err, context) => {
       if (context.phase === 'process_group') {
@@ -12340,10 +12349,13 @@ function startIpcWatcher(): void {
     logger.error({ err }, 'Error in initial IPC scan');
   });
 
-  // Start fallback polling (5s instead of 1s)
+  // Start bounded fallback polling alongside event-driven watchers.
   ipcWatcherManager.startFallback();
 
-  logger.info('IPC watcher started (event-driven + 5s fallback)');
+  logger.info(
+    { fallbackMs },
+    'IPC watcher started (event-driven + bounded fallback)',
+  );
 }
 
 /** Atomically acknowledge send_message only after the host has completed its

--- a/src/ipc-delivery-recovery.ts
+++ b/src/ipc-delivery-recovery.ts
@@ -3,6 +3,15 @@ import path from 'node:path';
 
 import type { IpcDeliveryReceipt } from './group-queue.js';
 
+const IPC_INPUT_CLAIM_MARKER = '.json.happyclaw-claimed-';
+
+/** Runner-owned claims remain durable IPC payloads until tracker registration. */
+export function isIpcInputPayloadFilename(filename: string): boolean {
+  return (
+    filename.endsWith('.json') || filename.includes(IPC_INPUT_CLAIM_MARKER)
+  );
+}
+
 function parseTypedDeliveryFile(filepath: string): IpcDeliveryReceipt | null {
   try {
     const payload = JSON.parse(fs.readFileSync(filepath, 'utf8')) as {
@@ -13,9 +22,15 @@ function parseTypedDeliveryFile(filepath: string): IpcDeliveryReceipt | null {
         coveredCursors?: Array<{
           timestamp?: unknown;
           id?: unknown;
+          sequence?: unknown;
           sourceJid?: unknown;
         }>;
-        cursor?: { timestamp?: unknown; id?: unknown; sourceJid?: unknown };
+        cursor?: {
+          timestamp?: unknown;
+          id?: unknown;
+          sequence?: unknown;
+          sourceJid?: unknown;
+        };
       };
     };
     const receipt = payload.receipt;
@@ -43,6 +58,11 @@ function parseTypedDeliveryFile(filepath: string): IpcDeliveryReceipt | null {
             coveredCursors: receipt.coveredCursors.map((cursor) => ({
               timestamp: cursor.timestamp as string,
               id: cursor.id as string,
+              ...(typeof cursor.sequence === 'number' &&
+              Number.isSafeInteger(cursor.sequence) &&
+              cursor.sequence >= 0
+                ? { sequence: cursor.sequence }
+                : {}),
               ...(typeof cursor.sourceJid === 'string'
                 ? { sourceJid: cursor.sourceJid }
                 : {}),
@@ -52,6 +72,11 @@ function parseTypedDeliveryFile(filepath: string): IpcDeliveryReceipt | null {
       cursor: {
         timestamp: receipt.cursor.timestamp,
         id: receipt.cursor.id,
+        ...(typeof receipt.cursor.sequence === 'number' &&
+        Number.isSafeInteger(receipt.cursor.sequence) &&
+        receipt.cursor.sequence >= 0
+          ? { sequence: receipt.cursor.sequence }
+          : {}),
         ...(typeof receipt.cursor.sourceJid === 'string'
           ? { sourceJid: receipt.cursor.sourceJid }
           : {}),
@@ -68,9 +93,7 @@ function scanInputDir(
 ): void {
   let filenames: string[];
   try {
-    filenames = fs
-      .readdirSync(inputDir)
-      .filter((name) => name.endsWith('.json'));
+    filenames = fs.readdirSync(inputDir).filter(isIpcInputPayloadFilename);
   } catch {
     return;
   }

--- a/src/ipc-watcher-manager.ts
+++ b/src/ipc-watcher-manager.ts
@@ -1,0 +1,226 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface IpcRuntimeNamespace {
+  agentId?: string | null;
+  taskRunId?: string | null;
+}
+
+export interface IpcWatcherErrorContext {
+  phase: 'process_group' | 'fallback_scan';
+  folder?: string;
+}
+
+export interface IpcWatcherManagerOptions {
+  ipcBaseDir: string;
+  isShuttingDown: () => boolean;
+  onError?: (error: unknown, context: IpcWatcherErrorContext) => void;
+  debounceMs?: number;
+  fallbackMs?: number;
+}
+
+interface RuntimeWatchEntry {
+  folder: string;
+  watchers: fs.FSWatcher[];
+  refCount: number;
+}
+
+/**
+ * Event-driven watcher for every concrete IPC runtime namespace.
+ *
+ * Main, conversation-agent and isolated-task runners mount different roots;
+ * watching only the workspace-level messages/tasks directories leaves nested
+ * requests dependent on the slow full-scan fallback. Entries are reference
+ * counted because provider fallback and overlapping warm turns can briefly
+ * share the same namespace.
+ */
+export class IpcWatcherManager {
+  private readonly watchers = new Map<string, RuntimeWatchEntry>();
+  private readonly debounceTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private readonly processingFolders = new Set<string>();
+  private readonly pendingReprocess = new Set<string>();
+  private fallbackTimer: ReturnType<typeof setInterval> | null = null;
+  private processGroupFn: ((folder: string) => Promise<void>) | null = null;
+  private processFullFn: (() => Promise<void>) | null = null;
+
+  constructor(private readonly options: IpcWatcherManagerOptions) {}
+
+  bind(
+    processGroup: (folder: string) => Promise<void>,
+    processFull: () => Promise<void>,
+  ): void {
+    this.processGroupFn = processGroup;
+    this.processFullFn = processFull;
+  }
+
+  private runtimeKey(folder: string, namespace: IpcRuntimeNamespace): string {
+    const suffix = namespace.agentId
+      ? `agent:${namespace.agentId}`
+      : namespace.taskRunId
+        ? `task:${namespace.taskRunId}`
+        : 'main';
+    return `${folder}\0${suffix}`;
+  }
+
+  private runtimeRoot(folder: string, namespace: IpcRuntimeNamespace): string {
+    if (namespace.agentId && namespace.taskRunId) {
+      throw new Error(
+        'IPC runtime cannot be both an agent and an isolated task',
+      );
+    }
+    const groupRoot = path.join(this.options.ipcBaseDir, folder);
+    if (namespace.agentId) {
+      return path.join(groupRoot, 'agents', namespace.agentId);
+    }
+    if (namespace.taskRunId) {
+      return path.join(groupRoot, 'tasks-run', namespace.taskRunId);
+    }
+    return groupRoot;
+  }
+
+  /** Acquire watchers for the exact root mounted into one runner. */
+  watchRuntime(folder: string, namespace: IpcRuntimeNamespace = {}): void {
+    const key = this.runtimeKey(folder, namespace);
+    const existing = this.watchers.get(key);
+    if (existing) {
+      existing.refCount += 1;
+      return;
+    }
+
+    const root = this.runtimeRoot(folder, namespace);
+    const runtimeWatchers: fs.FSWatcher[] = [];
+    for (const dir of [path.join(root, 'messages'), path.join(root, 'tasks')]) {
+      try {
+        fs.mkdirSync(dir, { recursive: true });
+        const watcher = fs.watch(dir, () => this.debouncedProcess(folder));
+        watcher.on('error', () => {
+          // The periodic full scan remains the recovery path for an invalidated
+          // platform watcher. Avoid throwing from EventEmitter error handlers.
+        });
+        runtimeWatchers.push(watcher);
+      } catch {
+        // The periodic full scan remains the fallback when fs.watch is absent.
+      }
+    }
+    this.watchers.set(key, {
+      folder,
+      watchers: runtimeWatchers,
+      refCount: 1,
+    });
+    // Close the creation race: a freshly spawned child can atomically publish
+    // its first request between mkdir and fs.watch registration. An immediate
+    // guarded drain observes that file without waiting for fallback polling.
+    this.debouncedProcess(folder);
+  }
+
+  /** Release one runtime acquisition and close its leaf watchers at zero. */
+  unwatchRuntime(folder: string, namespace: IpcRuntimeNamespace = {}): void {
+    const key = this.runtimeKey(folder, namespace);
+    const entry = this.watchers.get(key);
+    if (!entry) return;
+    entry.refCount -= 1;
+    if (entry.refCount > 0) return;
+
+    for (const watcher of entry.watchers) {
+      try {
+        watcher.close();
+      } catch {
+        // Already closed by the platform.
+      }
+    }
+    this.watchers.delete(key);
+    if (!this.hasFolderWatchers(folder)) {
+      const timer = this.debounceTimers.get(folder);
+      if (timer) clearTimeout(timer);
+      this.debounceTimers.delete(folder);
+      this.pendingReprocess.delete(folder);
+    }
+  }
+
+  private hasFolderWatchers(folder: string): boolean {
+    for (const entry of this.watchers.values()) {
+      if (entry.folder === folder) return true;
+    }
+    return false;
+  }
+
+  private debouncedProcess(folder: string): void {
+    const existing = this.debounceTimers.get(folder);
+    if (existing) clearTimeout(existing);
+    this.debounceTimers.set(
+      folder,
+      setTimeout(() => {
+        this.debounceTimers.delete(folder);
+        if (this.processingFolders.has(folder)) {
+          this.pendingReprocess.add(folder);
+          return;
+        }
+        this.processingFolders.add(folder);
+        this.processGroupFn?.(folder)
+          .catch((error) => {
+            this.options.onError?.(error, {
+              phase: 'process_group',
+              folder,
+            });
+          })
+          .finally(() => {
+            this.processingFolders.delete(folder);
+            if (
+              this.pendingReprocess.delete(folder) &&
+              this.hasFolderWatchers(folder)
+            ) {
+              this.debouncedProcess(folder);
+            }
+          });
+      }, this.options.debounceMs ?? 100),
+    );
+  }
+
+  triggerProcess(folder: string): void {
+    this.debouncedProcess(folder);
+  }
+
+  startFallback(): void {
+    if (this.fallbackTimer) return;
+    this.fallbackTimer = setInterval(() => {
+      if (this.options.isShuttingDown()) return;
+      this.processFullFn?.().catch((error) => {
+        this.options.onError?.(error, { phase: 'fallback_scan' });
+      });
+      // Keep the recovery poll comfortably below the Runner's bounded context
+      // IPC deadline. A 5s fallback paired with a 5s Runner timeout was a
+      // deterministic race even after adding a final deadline read, because the
+      // Host still debounces the discovered folder before processing it.
+    }, this.options.fallbackMs ?? 2000);
+    this.fallbackTimer.unref();
+  }
+
+  closeAll(): void {
+    for (const entry of this.watchers.values()) {
+      for (const watcher of entry.watchers) {
+        try {
+          watcher.close();
+        } catch {
+          // Already closed by the platform.
+        }
+      }
+    }
+    this.watchers.clear();
+    for (const timer of this.debounceTimers.values()) clearTimeout(timer);
+    this.debounceTimers.clear();
+    this.processingFolders.clear();
+    this.pendingReprocess.clear();
+    if (this.fallbackTimer) {
+      clearInterval(this.fallbackTimer);
+      this.fallbackTimer = null;
+    }
+  }
+
+  /** Test/diagnostic visibility for leak assertions. */
+  get activeRuntimeCount(): number {
+    return this.watchers.size;
+  }
+}

--- a/src/ipc-watcher-manager.ts
+++ b/src/ipc-watcher-manager.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+export const DEFAULT_IPC_WATCHER_FALLBACK_MS = 2000;
+
 export interface IpcRuntimeNamespace {
   agentId?: string | null;
   taskRunId?: string | null;
@@ -194,7 +196,7 @@ export class IpcWatcherManager {
       // IPC deadline. A 5s fallback paired with a 5s Runner timeout was a
       // deterministic race even after adding a final deadline read, because the
       // Host still debounces the discovered folder before processing it.
-    }, this.options.fallbackMs ?? 2000);
+    }, this.options.fallbackMs ?? DEFAULT_IPC_WATCHER_FALLBACK_MS);
     this.fallbackTimer.unref();
   }
 

--- a/src/routes/groups.ts
+++ b/src/routes/groups.ts
@@ -2400,6 +2400,13 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
 
   const before = c.req.query('before');
   const after = c.req.query('after');
+  const parseSequence = (value: string | undefined): number | undefined => {
+    if (value === undefined || !/^\d+$/.test(value)) return undefined;
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : undefined;
+  };
+  const beforeSequence = parseSequence(c.req.query('beforeSequence'));
+  const afterSequence = parseSequence(c.req.query('afterSequence'));
   const agentIdParam = c.req.query('agentId');
   const limitRaw = parseInt(c.req.query('limit') || '50', 10);
   const limit = Math.min(
@@ -2415,14 +2422,14 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
     }
 
     const virtualJid = `${jid}#agent:${agentIdParam}`;
-    if (after) {
+    if (afterSequence !== undefined || after) {
       const messages = attachSessionWorkflowRuns(
-        getMessagesAfter(virtualJid, after, limit),
+        getMessagesAfter(virtualJid, after, limit, afterSequence),
         { groupFolder: group.folder, agentId: agentIdParam },
       );
       return c.json({ messages });
     }
-    const rows = getMessagesPage(virtualJid, before, limit + 1);
+    const rows = getMessagesPage(virtualJid, before, limit + 1, beforeSequence);
     const hasMore = rows.length > limit;
     const messages = attachSessionWorkflowRuns(
       hasMore ? rows.slice(0, limit) : rows,
@@ -2464,14 +2471,14 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
 
   if (queryJids.length === 1) {
     // 单 JID 走原路径
-    if (after) {
+    if (afterSequence !== undefined || after) {
       const messages = attachSessionWorkflowRuns(
-        getMessagesAfter(jid, after, limit),
+        getMessagesAfter(jid, after, limit, afterSequence),
         { groupFolder: group.folder, agentId: null },
       );
       return c.json({ messages });
     }
-    const rows = getMessagesPage(jid, before, limit + 1);
+    const rows = getMessagesPage(jid, before, limit + 1, beforeSequence);
     const hasMore = rows.length > limit;
     const messages = attachSessionWorkflowRuns(
       hasMore ? rows.slice(0, limit) : rows,
@@ -2481,14 +2488,19 @@ groupRoutes.get('/:jid/messages', authMiddleware, async (c) => {
   }
 
   // 多 JID 合并查询
-  if (after) {
+  if (afterSequence !== undefined || after) {
     const messages = attachSessionWorkflowRuns(
-      getMessagesAfterMulti(queryJids, after, limit),
+      getMessagesAfterMulti(queryJids, after, limit, afterSequence),
       { groupFolder: group.folder, agentId: null },
     );
     return c.json({ messages });
   }
-  const rows = getMessagesPageMulti(queryJids, before, limit + 1);
+  const rows = getMessagesPageMulti(
+    queryJids,
+    before,
+    limit + 1,
+    beforeSequence,
+  );
   const hasMore = rows.length > limit;
   const messages = attachSessionWorkflowRuns(
     hasMore ? rows.slice(0, limit) : rows,

--- a/src/schema-version.ts
+++ b/src/schema-version.ts
@@ -2,4 +2,4 @@
  * Side-effect-free schema version constant for maintenance tools that must
  * inspect a database without importing the normal read/write DB bootstrap.
  */
-export const CURRENT_SCHEMA_VERSION = 73;
+export const CURRENT_SCHEMA_VERSION = 74;

--- a/src/turn-outcome.ts
+++ b/src/turn-outcome.ts
@@ -32,9 +32,25 @@ export interface ResolveTurnOutcomeInput {
   status: 'success' | 'error' | 'stream' | 'closed';
   healthyInputTurnCompleted: boolean;
   cursorCommitted: boolean;
+  /** Terminal/final user-answer acknowledgement only. */
   replyDelivered: boolean;
+  /** Observability only: progress can never settle or commit the turn. */
+  progressDelivered?: boolean;
   stopRequested?: boolean;
   deterministicFailure?: boolean;
+}
+
+/** Progress/separate output creates an obligation to produce a terminal final. */
+export function hasUnfinishedProactiveOutput(input: {
+  interactionMode: 'assistant' | 'proactive';
+  nonTerminalDelivered: boolean;
+  finalDelivered: boolean;
+}): boolean {
+  return (
+    input.interactionMode === 'proactive' &&
+    input.nonTerminalDelivered &&
+    !input.finalDelivered
+  );
 }
 
 export function resolveTurnOutcome(

--- a/src/turn-output-coordinator.ts
+++ b/src/turn-output-coordinator.ts
@@ -286,7 +286,14 @@ export class TurnOutputCoordinator {
 export interface ActiveTurnOutputCallbacks {
   onProgress: (text: string) => boolean;
   onFinalCandidate: (text: string) => boolean;
+  /**
+   * Called only for an acknowledged terminal/user-answer utterance. Progress
+   * is still counted by the reply fuse, but must never settle the input turn.
+   */
   onUtteranceDelivered?: () => void;
+  /** Optional observability hook for progress/separate utterances. Unlike
+   * onUtteranceDelivered this never settles or advances a durable input. */
+  onNonTerminalDelivered?: () => void;
 }
 
 interface ActiveTurnOutputBinding {
@@ -407,7 +414,14 @@ export class ActiveTurnOutputRegistry {
     );
     if (!binding) return false;
     if (!this.recordProjectedUtterance(input)) return false;
-    binding.callbacks.onUtteranceDelivered?.();
+    if (input.role === 'final' || input.role === undefined) {
+      // Legacy messages and non-text artifacts omit a role. Preserve their
+      // historical terminal semantics; explicit progress/separate utterances
+      // are never completion signals.
+      binding.callbacks.onUtteranceDelivered?.();
+    } else {
+      binding.callbacks.onNonTerminalDelivered?.();
+    }
     return true;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,6 +424,8 @@ export interface AgentBuilderDraft {
 export interface NewMessage {
   id: string;
   chat_jid: string;
+  /** Host-assigned durable arrival order. Provider clocks never participate. */
+  ingest_sequence?: number;
   source_jid?: string;
   sender: string;
   sender_name: string;
@@ -463,6 +465,7 @@ export type FollowUpStatus =
 export interface QueuedFollowUp {
   id: string;
   chat_jid: string;
+  ingest_sequence?: number;
   source_jid?: string;
   sender: string;
   sender_name: string;
@@ -537,6 +540,8 @@ export interface MessageAttachment {
 export interface MessageCursor {
   timestamp: string;
   id: string;
+  /** Durable host ingest position. Missing only on legacy persisted cursors. */
+  sequence?: number;
 }
 
 export interface ScheduledTask {

--- a/src/web.ts
+++ b/src/web.ts
@@ -76,6 +76,7 @@ import {
   getRegisteredGroup,
   getChannelMount,
   getJidsByFolder,
+  getMessageCursor,
   storeMessageDirect,
   deleteUserSession,
   updateSessionLastActive,
@@ -399,6 +400,7 @@ app.post('/api/messages', authMiddleware, async (c) => {
     success: true,
     messageId: result.messageId,
     timestamp: result.timestamp,
+    ingestSequence: result.ingestSequence,
     disposition: result.disposition,
     runId: result.runId,
   });
@@ -514,6 +516,7 @@ async function handleWebUserMessage(
       ok: true;
       messageId: string;
       timestamp: string;
+      ingestSequence?: number;
       disposition: 'started' | 'queued' | 'steered';
       runId?: string;
     }
@@ -585,6 +588,10 @@ async function handleWebUserMessage(
         : undefined,
     },
   );
+  const messageCursor = getMessageCursor(chatJid, messageId) ?? {
+    timestamp,
+    id: messageId,
+  };
 
   broadcastNewMessage(chatJid, {
     id: messageId,
@@ -649,7 +656,13 @@ async function handleWebUserMessage(
           id: messageId,
         });
         deps.advanceGlobalCursor({ timestamp, id: messageId });
-        return { ok: true, messageId, timestamp, disposition: 'started' };
+        return {
+          ok: true,
+          messageId,
+          timestamp,
+          ingestSequence: messageCursor.sequence,
+          disposition: 'started',
+        };
       }
     }
   }
@@ -667,6 +680,7 @@ async function handleWebUserMessage(
         ok: true,
         messageId,
         timestamp,
+        ingestSequence: messageCursor.sequence,
         disposition: steerResult?.ok ? 'steered' : 'queued',
         runId: activeRunId!,
       };
@@ -675,6 +689,7 @@ async function handleWebUserMessage(
       ok: true,
       messageId,
       timestamp,
+      ingestSequence: messageCursor.sequence,
       disposition: 'queued',
       runId: activeRunId,
     };
@@ -755,6 +770,7 @@ async function handleWebUserMessage(
           ok: true,
           messageId,
           timestamp,
+          ingestSequence: messageCursor.sequence,
           disposition: activeRunId ? 'steered' : 'started',
           runId: activeRunId ?? undefined,
         };
@@ -831,8 +847,8 @@ async function handleWebUserMessage(
     undefined,
     {
       chatJid,
-      coveredCursors: [{ timestamp, id: messageId }],
-      cursor: { timestamp, id: messageId },
+      coveredCursors: [messageCursor],
+      cursor: messageCursor,
     },
     undefined,
     (receipt) => preAdmitRoute?.(group.folder, null, receipt) ?? false,
@@ -873,6 +889,7 @@ async function handleWebUserMessage(
     ok: true,
     messageId,
     timestamp,
+    ingestSequence: messageCursor.sequence,
     disposition: activeRunId ? 'steered' : 'started',
     runId: activeRunId ?? startedRunId ?? undefined,
   };
@@ -911,6 +928,7 @@ async function handleAgentConversationMessage(
       ok: true;
       messageId: string;
       timestamp: string;
+      ingestSequence?: number;
       disposition: 'started' | 'queued' | 'steered';
       runId?: string;
     }
@@ -987,6 +1005,10 @@ async function handleAgentConversationMessage(
         : undefined,
     },
   );
+  const agentMessageCursor = getMessageCursor(virtualChatJid, messageId) ?? {
+    timestamp,
+    id: messageId,
+  };
   updateAgentContextInfo(agentId, { last_active_at: timestamp });
 
   // Auto-title: show a quick placeholder derived from the first user message.
@@ -1039,6 +1061,7 @@ async function handleAgentConversationMessage(
         ok: true,
         messageId,
         timestamp,
+        ingestSequence: agentMessageCursor.sequence,
         disposition: steerResult?.ok ? 'steered' : 'queued',
         runId: activeRunId!,
       };
@@ -1047,6 +1070,7 @@ async function handleAgentConversationMessage(
       ok: true,
       messageId,
       timestamp,
+      ingestSequence: agentMessageCursor.sequence,
       disposition: 'queued',
       runId: activeRunId,
     };
@@ -1121,6 +1145,7 @@ async function handleAgentConversationMessage(
             ok: true,
             messageId,
             timestamp,
+            ingestSequence: agentMessageCursor.sequence,
             disposition: activeRunId ? 'steered' : 'started',
             runId: activeRunId ?? undefined,
           };
@@ -1198,8 +1223,8 @@ async function handleAgentConversationMessage(
     undefined,
     {
       chatJid: virtualChatJid,
-      coveredCursors: [{ timestamp, id: messageId }],
-      cursor: { timestamp, id: messageId },
+      coveredCursors: [agentMessageCursor],
+      cursor: agentMessageCursor,
     },
     undefined,
     (receipt) =>
@@ -1207,10 +1232,7 @@ async function handleAgentConversationMessage(
     { feishuCliAccountId: requiredFeishuCliAccountId },
   );
   if (agentSendResult === 'sent') {
-    deps.advanceNextPullCursorOnly(virtualChatJid, {
-      timestamp,
-      id: messageId,
-    });
+    deps.advanceNextPullCursorOnly(virtualChatJid, agentMessageCursor);
   }
   if (agentSendResult === 'no_active') {
     if (eagerExpandAgentActive && agentSendContent !== content) {
@@ -1246,6 +1268,7 @@ async function handleAgentConversationMessage(
     ok: true,
     messageId,
     timestamp,
+    ingestSequence: agentMessageCursor.sequence,
     disposition: activeRunId ? 'steered' : 'started',
     runId: activeRunId ?? startedRunId ?? undefined,
   };
@@ -2310,6 +2333,18 @@ export function broadcastNewMessage(
   agentId?: string,
   source?: string,
 ): void {
+  // WS delivery must use the same durable host-assigned position as REST
+  // pagination. Hydrate persisted rows centrally so billing, plugin and
+  // system producers cannot accidentally omit the sequence. Ephemeral
+  // messages have no matching row and retain the legacy optional field.
+  const persistedCursor =
+    msg.ingest_sequence === undefined
+      ? getMessageCursor(msg.chat_jid, msg.id)
+      : null;
+  const sequencedMessage =
+    persistedCursor?.sequence !== undefined
+      ? { ...msg, ingest_sequence: persistedCursor.sequence }
+      : msg;
   // For virtual JIDs like "web:xxx#agent:yyy", extract base JID and agentId
   let baseChatJid = chatJid;
   let effectiveAgentId = agentId;
@@ -2323,7 +2358,10 @@ export function broadcastNewMessage(
   const wsMsg: WsMessageOut = {
     type: 'new_message',
     chatJid: jid,
-    message: { ...msg, is_from_me: msg.is_from_me ?? false },
+    message: {
+      ...sequencedMessage,
+      is_from_me: sequencedMessage.is_from_me ?? false,
+    },
     ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
     ...(source ? { source } : {}),
   };

--- a/tests/agent-runner-ipc-delivery.test.ts
+++ b/tests/agent-runner-ipc-delivery.test.ts
@@ -78,6 +78,24 @@ describe('agent-runner IPC delivery turn tracker', () => {
     ]);
   });
 
+  test('uses host ingest sequence when provider clocks and random IDs disagree', () => {
+    const first = message('1');
+    first.receipt!.cursor = {
+      timestamp: '2026-08-31T00:00:00.000Z',
+      id: 'z-random',
+      sequence: 41,
+    };
+    const late = message('2');
+    late.receipt!.cursor = {
+      timestamp: '2020-01-01T00:00:00.000Z',
+      id: 'a-random',
+      sequence: 42,
+    };
+
+    expect(orderIpcInputMessages([late, first])).toEqual([first, late]);
+    expect(latestIpcInputMessage([late, first])).toBe(late);
+  });
+
   test('preserves filesystem order when a mixed batch has no complete durable ordering', () => {
     const newerArrival = message('2');
     const legacyMessage: IpcInputMessage = { text: 'legacy' };
@@ -131,6 +149,24 @@ describe('agent-runner IPC delivery turn tracker', () => {
       '4',
     ]);
     expect(tracker.unacknowledgedMessages).toEqual([]);
+  });
+
+  test('deduplicates a crash claim and Host re-emission by delivery id', () => {
+    const original = message('1');
+    const tracker = new IpcTurnDeliveryTracker([original]);
+    const duplicate = {
+      ...original,
+      text: 'same durable input re-emitted after claim recovery',
+      receipt: {
+        ...original.receipt!,
+        deliveryId: 'replacement-attempt-delivery-id',
+      },
+    };
+
+    expect(tracker.acceptTurn([duplicate])).toEqual([]);
+    expect(tracker.pendingTurnCount).toBe(1);
+    expect(tracker.unacknowledgedMessages).toEqual([original]);
+    expect(tracker.completeNextTurn()).toEqual([original.receipt]);
   });
 
   test('mid-query turns are FIFO and later receipts cannot attach to an earlier result', () => {
@@ -384,17 +420,20 @@ describe('agent-runner IPC delivery turn tracker', () => {
         {
           timestamp: '2026-07-10T00:00:01.000Z',
           id: 'm1',
+          sequence: 81,
           sourceJid: 'feishu:oc_chat#account:account-a',
         },
         {
           timestamp: '2026-07-10T00:00:02.000Z',
           id: 'm2',
+          sequence: 82,
           sourceJid: 'telegram:-100123#account:account-b',
         },
       ],
       cursor: {
         timestamp: '2026-07-10T00:00:02.000Z',
         id: 'm2',
+        sequence: 82,
         sourceJid: 'telegram:-100123#account:account-b',
       },
     });
@@ -408,6 +447,10 @@ describe('agent-runner IPC delivery turn tracker', () => {
       'telegram:-100123#account:account-b',
     ]);
     expect(parsed?.cursor.sourceJid).toBe('telegram:-100123#account:account-b');
+    expect(parsed?.coveredCursors?.map((cursor) => cursor.sequence)).toEqual([
+      81, 82,
+    ]);
+    expect(parsed?.cursor.sequence).toBe(82);
   });
 
   test('malformed or stale receipt payloads are rejected at the runner boundary', () => {

--- a/tests/agent-runner-reply-mode-prompt.test.ts
+++ b/tests/agent-runner-reply-mode-prompt.test.ts
@@ -69,7 +69,13 @@ describe('Agent Runner reply-mode prompt contract', () => {
     expect(proactiveOutput).toContain('在第一个可能明显耗时的工具调用前');
     expect(proactiveOutput).toContain('简单问题直接回答');
     expect(proactive).not.toContain('minimal internal acknowledgement');
-    expect(proactive).toContain('SDK-final acknowledgement');
+    expect(proactive).toContain('<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->');
+    expect(proactiveOutput).toContain(
+      '<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->',
+    );
+    expect(tools).toContain('PROACTIVE_FINAL_DELIVERED_SENTINEL');
+    expect(tools).toContain('proactiveFinalDeliveredInputTurnId');
+    expect(runner).toContain('isCliNoVisibleOutputCompanion(message)');
     expect(proactive).toContain('Assistant text is never a delivery fallback');
     expect(proactiveOutput).toContain(
       '普通 Assistant 文本绝不是发送失败时的备用回复',

--- a/tests/agent-runner-terminal-invariants.test.ts
+++ b/tests/agent-runner-terminal-invariants.test.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const source = fs.readFileSync(
+  path.join(process.cwd(), 'container/agent-runner/src/index.ts'),
+  'utf8',
+);
+
+describe('Agent Runner terminal invariants', () => {
+  test('every non-empty Assistant error terminates independently of classification', () => {
+    expect(source).toMatch(
+      /if \(assistantError\) \{[\s\S]*?classifyProviderAssistantError\(assistantError\) \?\? 'transient'[\s\S]*?stream\.end\(\);[\s\S]*?providerAccountFailure: true/,
+    );
+    expect(source).not.toContain('if (assistantError && assistantErrorClass)');
+  });
+
+  test('protocol-only background debt has a bounded hard failure', () => {
+    expect(source).toContain('BACKGROUND_PROTOCOL_DEBT_TIMEOUT_MS = 15_000');
+    expect(source).toContain(
+      'armBackgroundProtocolDebtWatchdog(blockingBackgroundProtocol)',
+    );
+    expect(source).toContain('background_protocol_timeout:');
+    expect(source).toContain('BACKGROUND_PROTOCOL_FAILURE_EXIT_GRACE_MS');
+    expect(source).toMatch(
+      /if \(backgroundProtocolFailure\) \{[\s\S]*?throw backgroundProtocolFailure/,
+    );
+  });
+
+  test('notification-driven continuation activity leaves the arrival watchdog', () => {
+    const messageStart = source.indexOf(
+      '// Compatibility fallback for CLI builds which omit',
+    );
+    const taskNotification = source.indexOf(
+      "if (um.origin?.kind === 'task-notification')",
+    );
+    const topLevelAssistant = source.indexOf(
+      'processor.getBlockingBackgroundCompletionDebtCount() > 0',
+      taskNotification,
+    );
+
+    for (const start of [messageStart, taskNotification, topLevelAssistant]) {
+      expect(start).toBeGreaterThanOrEqual(0);
+      const branch = source.slice(start, start + 1_100);
+      expect(branch).toContain('observeBackgroundNotification');
+      expect(branch).toContain('clearBackgroundProtocolDebtWatchdog();');
+    }
+  });
+
+  test('warm IPC claims the full batch before asynchronous context loading', () => {
+    const register = source.indexOf(
+      'for (const msg of messages) {\n      const becomesCurrentTurn',
+    );
+    const acknowledge = source.indexOf(
+      'acknowledgeRegisteredIpcInputs(messages)',
+      register,
+    );
+    const contextLoad = source.indexOf(
+      'loadWorkspaceMemoryTurnContext(msg.text',
+      acknowledge,
+    );
+    expect(register).toBeGreaterThanOrEqual(0);
+    expect(acknowledge).toBeGreaterThan(register);
+    expect(contextLoad).toBeGreaterThan(acknowledge);
+  });
+
+  test('deduplicates crash claims before cold prompt and warm stream delivery', () => {
+    const coldFilter = source.indexOf('const coldDuplicates =');
+    const coldPrompt = source.indexOf(
+      "prompt += '\\n' + pendingDrain.messages.map((m) => m.text).join('\\n')",
+    );
+    expect(coldFilter).toBeGreaterThanOrEqual(0);
+    expect(coldPrompt).toBeGreaterThan(coldFilter);
+
+    const acceptedBatch = source.indexOf(
+      'const acceptedMessages: IpcInputMessage[] = []',
+    );
+    const warmPush = source.indexOf(
+      'for (const msg of acceptedMessages)',
+      acceptedBatch,
+    );
+    expect(acceptedBatch).toBeGreaterThanOrEqual(0);
+    expect(warmPush).toBeGreaterThan(acceptedBatch);
+  });
+
+  test('interrupt grace only suppresses correlated abort-like rejections', () => {
+    expect(source).toContain(
+      'isWithinInterruptGraceWindow() && isInterruptRelatedError(reason)',
+    );
+    expect(source).not.toMatch(
+      /if \(isWithinInterruptGraceWindow\(\)\) \{\s*console\.error\('Unhandled rejection during interrupt/,
+    );
+    expect(source).toContain("err.name === 'AbortError'");
+    expect(source).not.toMatch(
+      /abort\|aborted\|interrupt\|interrupted\|cancelled\|canceled/,
+    );
+  });
+});

--- a/tests/db-upgrade-safety.test.ts
+++ b/tests/db-upgrade-safety.test.ts
@@ -151,7 +151,7 @@ describe('database upgrade safety gate', () => {
     process.env.HAPPYCLAW_MIGRATION_BACKUP_DIR = migrationBackups;
     const backupsBeforeCurrentOnlyRefusal = fs.readdirSync(migrationBackups);
     expect(() => db.initDatabase({ requireCurrentSchema: true })).toThrow(
-      'Database must already be schema v73',
+      'Database must already be schema v74',
     );
     expect(fs.readdirSync(migrationBackups)).toEqual(
       backupsBeforeCurrentOnlyRefusal,
@@ -190,10 +190,9 @@ describe('schema version head', () => {
     // one assertion that fails when the head moves, forcing whoever bumps it
     // to confirm the matching migration block — and a test covering it —
     // actually landed. Update the literal in the same commit as the migration.
-    // v73: generalizes the v72 WeCom DM remount to other JID-classifiable
-    // DMs (QQ / DingTalk / Discord / WhatsApp / Telegram / WeChat leftover
-    // target_main_jid collisions). See
-    // tests/schema-v73-classifiable-direct-mount.test.ts. Do not rewrite v72.
-    expect(db.CURRENT_SCHEMA_VERSION).toBe(73);
+    // v74: introduces the host-owned monotonic message ingest sequence used by
+    // durable consumption and stable Web pagination. See
+    // tests/schema-v74-message-ingest-sequence.test.ts.
+    expect(db.CURRENT_SCHEMA_VERSION).toBe(74);
   });
 });

--- a/tests/deployment-doc-contract.test.ts
+++ b/tests/deployment-doc-contract.test.ts
@@ -15,6 +15,7 @@ describe('Mac mini production deployment contract', () => {
     expect(deployment).toContain('com.riba2534.happyclaw');
     expect(agents).toContain('opted out of deployment backups');
     expect(deployment).toContain('不得运行 `make backup`');
+    expect(deployment).toContain('HAPPYCLAW_SKIP_MIGRATION_BACKUP=1');
     expect(deployment).not.toContain(
       'BACKUP_DIR="$HOME/happyclaw-deploy-backups" make backup',
     );

--- a/tests/follow-up-queue-db.test.ts
+++ b/tests/follow-up-queue-db.test.ts
@@ -146,6 +146,28 @@ describe('durable follow-up queue', () => {
     expect(db.claimNextQueuedFollowUpBatch(jid, 'run-empty')).toEqual([]);
   });
 
+  test('keeps durable FIFO when a later arrival carries an older provider timestamp', () => {
+    const jid = 'web:follow-up-late-clock';
+    db.ensureChatExists(jid);
+    for (const [id, timestamp] of [
+      ['first-arrival', '2026-08-31T06:00:00.000Z'],
+      ['late-old-clock', '2020-01-01T00:00:00.000Z'],
+    ]) {
+      db.storeMessageDirect(id, jid, 'user-1', 'User', id, timestamp, false, {
+        meta: { deliveryMode: 'queue', deliveryStatus: 'queued' },
+      });
+    }
+
+    const claimed = db.claimNextQueuedFollowUpBatch(jid, 'run-late-clock');
+    expect(claimed.map((item) => item.id)).toEqual([
+      'first-arrival',
+      'late-old-clock',
+    ]);
+    expect(claimed[0].ingest_sequence).toBeLessThan(
+      claimed[1].ingest_sequence!,
+    );
+  });
+
   test('merges an explicit steer with the Session pending batch', () => {
     const jid = 'web:follow-up-steer-barrier';
     db.ensureChatExists(jid);

--- a/tests/group-queue-ipc-receipts.test.ts
+++ b/tests/group-queue-ipc-receipts.test.ts
@@ -393,6 +393,50 @@ describe('GroupQueue IPC delivery receipts', () => {
     expect(committedId).toBe('m2');
   });
 
+  test('removes a Runner claim before committing its healthy receipt', async () => {
+    await startRunner();
+    const receipt = inject('claim-cleanup');
+    const original = fs
+      .readdirSync(inputDir())
+      .find((name) => name.endsWith('.json'))!;
+    const claim = path.join(
+      inputDir(),
+      `${original}.happyclaw-claimed-123-1-test`,
+    );
+    fs.renameSync(path.join(inputDir(), original), claim);
+    const commit = vi.fn(() => {
+      expect(fs.existsSync(claim)).toBe(false);
+    });
+
+    queue.acknowledgeIpcDeliveries(JID, [receipt], commit);
+
+    expect(commit).toHaveBeenCalledWith([receipt]);
+    expect(fs.existsSync(claim)).toBe(false);
+  });
+
+  test('does not commit a healthy receipt when the IPC directory cannot be listed', async () => {
+    await startRunner();
+    const receipt = inject('claim-list-failure');
+    const commit = vi.fn();
+    const listError = Object.assign(new Error('permission denied'), {
+      code: 'EACCES',
+    });
+    const readdir = vi.spyOn(fs, 'readdirSync').mockImplementationOnce(() => {
+      throw listError;
+    });
+
+    expect(() =>
+      queue.acknowledgeIpcDeliveries(JID, [receipt], commit),
+    ).toThrow(/Failed to remove acknowledged IPC claim/);
+    expect(commit).not.toHaveBeenCalled();
+
+    readdir.mockRestore();
+    expect(queue.flushAcknowledgedIpcDeliveries(JID, commit)).toEqual([
+      receipt,
+    ]);
+    expect(commit).toHaveBeenCalledWith([receipt]);
+  });
+
   test('preserves each covered input provider route across accounts and channels', async () => {
     await startRunner();
     const coveredCursors = [
@@ -431,6 +475,28 @@ describe('GroupQueue IPC delivery receipts', () => {
         chatJid: JID,
         coveredCursors: [cursor('m2')],
         cursor: cursor('m1'),
+      }),
+    ).toBe('no_active');
+    expect(readPayloads()).toEqual([]);
+  });
+
+  test('rejects a mixed or mismatched ingest sequence receipt', async () => {
+    await startRunner();
+    const first = { ...cursor('m1'), sequence: 10 };
+    const second = { ...cursor('m2'), sequence: 11 };
+
+    expect(
+      queue.sendMessage(JID, 'invalid', undefined, undefined, JID, undefined, {
+        chatJid: JID,
+        coveredCursors: [first, second],
+        cursor: { ...second, sequence: 99 },
+      }),
+    ).toBe('no_active');
+    expect(
+      queue.sendMessage(JID, 'mixed', undefined, undefined, JID, undefined, {
+        chatJid: JID,
+        coveredCursors: [first, cursor('m2')],
+        cursor: cursor('m2'),
       }),
     ).toBe('no_active');
     expect(readPayloads()).toEqual([]);

--- a/tests/group-queue-stuck-recovery.test.ts
+++ b/tests/group-queue-stuck-recovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 
@@ -411,6 +411,76 @@ describe('#618: IPC-injected follow-ups are visible to stuck recovery', () => {
     fs.unlinkSync(path.join(inputDir, 'pending.json'));
     q.markRunnerQueryIdle(jid, { preserveIpcDebt: true });
     expect(getState(q, jid).queryInFlight).toBe(false);
+  });
+
+  test('runner claim files preserve IPC debt after a crash', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, {
+      groupFolder: folder,
+      queryInFlight: true,
+      hasIpcInjectedMessages: true,
+      ipcOwedSinceAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+      lastActivityAt: Date.now() - IDLE_THRESHOLD_MS - 1000,
+    });
+    const inputDir = path.join(ipcDir, 'input');
+    fs.mkdirSync(inputDir, { recursive: true });
+    const claim = path.join(
+      inputDir,
+      'pending.json.happyclaw-claimed-123-1-test',
+    );
+    fs.writeFileSync(claim, '{}');
+
+    q.markRunnerQueryIdle(jid, { preserveIpcDebt: true });
+    expect(getState(q, jid).queryInFlight).toBe(true);
+
+    fs.unlinkSync(claim);
+    q.markRunnerQueryIdle(jid, { preserveIpcDebt: true });
+    expect(getState(q, jid).queryInFlight).toBe(false);
+  });
+
+  test('unacknowledged recovery removes the Runner claim before DB replay', () => {
+    const q = new GroupQueue();
+    const jid = `web:${folder}`;
+    seedRunner(q, jid, { groupFolder: folder, queryInFlight: true });
+    const receipt = {
+      deliveryId: 'delivery-claim',
+      chatJid: jid,
+      cursor: {
+        timestamp: '2026-08-31T00:00:00.000Z',
+        id: 'message-claim',
+        sequence: 42,
+      },
+    };
+    const state = getState(q, jid);
+    (state.pendingIpcDeliveries as Map<string, typeof receipt>).set(
+      receipt.deliveryId,
+      receipt,
+    );
+    const inputDir = path.join(ipcDir, 'input');
+    fs.mkdirSync(inputDir, { recursive: true });
+    const claim = path.join(
+      inputDir,
+      'pending.json.happyclaw-claimed-123-1-test',
+    );
+    fs.writeFileSync(
+      claim,
+      JSON.stringify({ type: 'message', text: 'pending', receipt }),
+    );
+    const rewind = vi.fn();
+    q.setOnUnacknowledgedIpcDeliveries(rewind);
+
+    (
+      q as unknown as {
+        recoverUnacknowledgedIpcDeliveries: (
+          groupJid: string,
+          groupState: Record<string, unknown>,
+        ) => void;
+      }
+    ).recoverUnacknowledgedIpcDeliveries(jid, state);
+
+    expect(fs.existsSync(claim)).toBe(false);
+    expect(rewind).toHaveBeenCalledWith(jid, [receipt]);
   });
 
   test('internal-continue preserve hint still closes a query with no real IPC debt', () => {

--- a/tests/host-ipc-output-router.test.ts
+++ b/tests/host-ipc-output-router.test.ts
@@ -281,6 +281,59 @@ describe('host IPC primary output routing', () => {
     expect(coordinator.attemptedFinalText).toBe('准确的完整总结正文');
   });
 
+  test('rejects a second different Proactive final before provider delivery', async () => {
+    const activeTurnOutputs = new ActiveTurnOutputRegistry();
+    const scope = channelTurnScope('workspace', 'conversation-agent');
+    activeTurnOutputs.bind(scope, 'turn-1', {
+      onProgress: () => true,
+      onFinalCandidate: () => true,
+    });
+    const sendImWithRetry = vi.fn(async () => true);
+
+    expect(
+      routeHostIpcOutput(
+        {
+          sourceGroup: 'workspace',
+          agentId: 'conversation-agent',
+          inputTurnId: 'turn-1',
+          text: '第一份 final',
+          deliveryRole: 'final',
+          authorized: true,
+          scheduledTask: false,
+          interactionMode: 'proactive',
+        },
+        activeTurnOutputs,
+      ),
+    ).toMatchObject({
+      path: 'separate_provider',
+      attemptedFinalRecorded: true,
+    });
+
+    const second = routeHostIpcOutput(
+      {
+        sourceGroup: 'workspace',
+        agentId: 'conversation-agent',
+        inputTurnId: 'turn-1',
+        text: '第二份不同 final',
+        deliveryRole: 'final',
+        authorized: true,
+        scheduledTask: false,
+        interactionMode: 'proactive',
+      },
+      activeTurnOutputs,
+    );
+    if (second.path === 'separate_provider') await sendImWithRetry();
+
+    expect(second).toEqual({
+      path: 'rejected',
+      delivered: false,
+      staged: false,
+      deliveryRole: 'final',
+      reason: 'conflicting_final',
+    });
+    expect(sendImWithRetry).not.toHaveBeenCalled();
+  });
+
   test('wires both host execution paths to the live visible answer for interruption persistence', () => {
     const main = fs.readFileSync(
       path.join(process.cwd(), 'src/index.ts'),

--- a/tests/host-turn-settlement-order.test.ts
+++ b/tests/host-turn-settlement-order.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const source = fs.readFileSync(
+  path.join(process.cwd(), 'src/index.ts'),
+  'utf8',
+);
+
+describe('Host turn settlement ordering', () => {
+  test('main warm IPC receipts commit only after output persistence callback resolves', () => {
+    const start = source.indexOf('// Wrap onOutput to track session ID');
+    const end = source.indexOf('interface SendMessageOutcome');
+    const wrapper = source.slice(start, end);
+    const callbackAt = wrapper.indexOf('await onOutput?.(output);');
+    const receiptAt = wrapper.indexOf('queue.acknowledgeIpcDeliveries(');
+
+    expect(callbackAt).toBeGreaterThanOrEqual(0);
+    expect(receiptAt).toBeGreaterThan(callbackAt);
+  });
+
+  test('conversation-agent warm IPC receipts commit only after its handler resolves', () => {
+    const start = source.indexOf(
+      'const wrappedOnOutput = async (output: ContainerOutput): Promise<void>',
+    );
+    const end = source.indexOf(
+      'ipcWatcherManager?.watchRuntime(effectiveGroup.folder, { agentId })',
+      start,
+    );
+    const wrapper = source.slice(start, end);
+
+    expect(
+      wrapper.indexOf('await handleAgentOutput(output);'),
+    ).toBeGreaterThanOrEqual(0);
+    expect(wrapper.indexOf('queue.acknowledgeIpcDeliveries(')).toBeGreaterThan(
+      wrapper.indexOf('await handleAgentOutput(output);'),
+    );
+  });
+
+  test('main callback failures escape instead of leaving an early healthy marker', () => {
+    const start = source.indexOf('output = await runAgent(');
+    const end = source.indexOf('imagesForAgent,', start);
+    const callback = source.slice(start, end);
+
+    expect(callback).toContain("'onOutput callback failed'");
+    expect(callback).toContain('throw err;');
+    expect(callback).not.toContain('healthyCompletedInputTurns.add');
+  });
+
+  test('initializes IPC watching before scheduler and recovery can spawn runners', () => {
+    const watcher = source.lastIndexOf('startIpcWatcher();');
+    const scheduler = source.lastIndexOf('startSchedulerLoop(schedulerDeps);');
+    const pendingRecovery = source.lastIndexOf('recoverPendingMessages();');
+    const conversationRecovery = source.lastIndexOf(
+      'recoverConversationAgents();',
+    );
+
+    expect(watcher).toBeGreaterThanOrEqual(0);
+    expect(watcher).toBeLessThan(scheduler);
+    expect(watcher).toBeLessThan(pendingRecovery);
+    expect(watcher).toBeLessThan(conversationRecovery);
+    expect(pendingRecovery).toBeLessThan(scheduler);
+    expect(conversationRecovery).toBeLessThan(scheduler);
+  });
+});

--- a/tests/ipc-delivery-startup-recovery.test.ts
+++ b/tests/ipc-delivery-startup-recovery.test.ts
@@ -23,11 +23,16 @@ function writeDelivery(
       receipt: {
         deliveryId: `delivery-${id}`,
         chatJid,
-        coveredCursors: coveredIds.map((coveredId) => ({
+        coveredCursors: coveredIds.map((coveredId, index) => ({
           timestamp: '2026-07-10T00:00:01.000Z',
           id: coveredId,
+          sequence: index + 1,
         })),
-        cursor: { timestamp: '2026-07-10T00:00:01.000Z', id },
+        cursor: {
+          timestamp: '2026-07-10T00:00:01.000Z',
+          id,
+          sequence: coveredIds.length,
+        },
       },
     }),
   );
@@ -121,6 +126,28 @@ describe('startup typed IPC delivery recovery', () => {
       'm2',
     ]);
     expect(recovered[0].cursor.id).toBe('m2');
+    expect(recovered[0].cursor.sequence).toBe(2);
     expect(fs.existsSync(deliveryFile)).toBe(false);
+  });
+
+  test('treats a Runner crash claim as the same durable startup delivery', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-startup-claim-'));
+    roots.push(root);
+    const claimedFile = path.join(
+      root,
+      'folder',
+      'agents',
+      'agent-1',
+      'input',
+      'pending.json.happyclaw-claimed-123-1-test',
+    );
+    writeDelivery(claimedFile, 'web:main#agent:agent-1', 'a1');
+
+    const recovered = discardStartupTypedIpcDeliveries(root);
+
+    expect(recovered.map((receipt) => receipt.deliveryId)).toEqual([
+      'delivery-a1',
+    ]);
+    expect(fs.existsSync(claimedFile)).toBe(false);
   });
 });

--- a/tests/ipc-input-claims.test.ts
+++ b/tests/ipc-input-claims.test.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { IpcInputClaimStore } from '../container/agent-runner/src/ipc-input-claims.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-ipc-claim-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('IpcInputClaimStore', () => {
+  test('keeps a claimed input durable until registration acknowledges it', () => {
+    const dir = tempDir();
+    const original = path.join(dir, '001.json');
+    fs.writeFileSync(original, JSON.stringify({ type: 'message', text: 'hi' }));
+
+    const firstRunner = new IpcInputClaimStore(dir);
+    const [claim] = firstRunner.claimAvailable();
+    expect(claim).toBeTruthy();
+    expect(fs.existsSync(original)).toBe(false);
+    expect(fs.existsSync(claim)).toBe(true);
+    expect(firstRunner.claimAvailable()).toEqual([]);
+
+    // A concurrently overlapping Runner must not steal a live claim.
+    const replacementRunner = new IpcInputClaimStore(dir);
+    expect(replacementRunner.claimAvailable()).toEqual([]);
+
+    // Once the short ownership lease expires, a replacement Runner atomically
+    // reclaims the crash residue under its own claim path.
+    const crashedRunnerRecovery = new IpcInputClaimStore(dir, 0);
+    const [recoveredClaim] = crashedRunnerRecovery.claimAvailable();
+    expect(recoveredClaim).toBeTruthy();
+    expect(recoveredClaim).not.toBe(claim);
+    expect(fs.existsSync(claim)).toBe(false);
+    expect(crashedRunnerRecovery.acknowledge([recoveredClaim])).toEqual([]);
+    expect(fs.existsSync(recoveredClaim)).toBe(false);
+  });
+
+  test('acknowledges an entire registered batch without duplicate claims', () => {
+    const dir = tempDir();
+    fs.writeFileSync(path.join(dir, '001.json'), '{}');
+    fs.writeFileSync(path.join(dir, '002.json'), '{}');
+    const store = new IpcInputClaimStore(dir);
+    const claims = store.claimAvailable();
+    expect(claims).toHaveLength(2);
+    expect(store.acknowledge(claims)).toEqual([]);
+    expect(store.claimAvailable()).toEqual([]);
+  });
+
+  test('only one replacement Runner wins an expired claim', () => {
+    const dir = tempDir();
+    const original = path.join(dir, '001.json');
+    fs.writeFileSync(original, '{}');
+    const owner = new IpcInputClaimStore(dir);
+    const [claim] = owner.claimAvailable();
+    const expiredClaim = `${original}.happyclaw-claimed-999-legacy`;
+    fs.renameSync(claim, expiredClaim);
+    const stale = new Date(Date.now() - 60_000);
+    fs.utimesSync(expiredClaim, stale, stale);
+
+    const replacementA = new IpcInputClaimStore(dir);
+    const replacementB = new IpcInputClaimStore(dir);
+    const claimedA = replacementA.claimAvailable();
+    const claimedB = replacementB.claimAvailable();
+    expect(claimedA).toHaveLength(1);
+    expect(claimedB).toEqual([]);
+    replacementA.acknowledge(claimedA);
+  });
+});

--- a/tests/ipc-result-poll.test.ts
+++ b/tests/ipc-result-poll.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  fetchWorkspaceMemorySnapshot,
+  pollIpcResult,
+} from '../container/agent-runner/src/mcp-tools.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-ipc-result-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('pollIpcResult', () => {
+  test('performs a final read for a result that lands during the deadline sleep', async () => {
+    vi.useFakeTimers();
+    const requests = tempDir();
+    const results = tempDir();
+    const requestId = 'deadline-result';
+    const pending = pollIpcResult(
+      requests,
+      { requestId, type: 'workspace_memory', action: 'snapshot' },
+      'workspace_memory_result',
+      100,
+      results,
+    );
+    setTimeout(() => {
+      fs.writeFileSync(
+        path.join(results, `workspace_memory_result_${requestId}.json`),
+        JSON.stringify({ success: true }),
+      );
+    }, 99);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(pending).resolves.toEqual({ success: true });
+  });
+
+  test('logs correlated Memory timeout details while failing open', async () => {
+    const workspaceIpc = tempDir();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await fetchWorkspaceMemorySnapshot(
+      {
+        chatJid: 'web:main',
+        groupFolder: 'main',
+        isHome: true,
+        isAdminHome: true,
+        agentBuilderEnabled: false,
+        ownerProfileEnabled: false,
+        workspaceIpc,
+        workspaceGroup: tempDir(),
+      },
+      'query',
+      { timeoutMs: 1 },
+    );
+    expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('Workspace memory snapshot unavailable:'),
+    );
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('requestId='));
+  });
+});

--- a/tests/ipc-watcher-manager.test.ts
+++ b/tests/ipc-watcher-manager.test.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { IpcWatcherManager } from '../src/ipc-watcher-manager.js';
+
+const temporaryRoots: string[] = [];
+
+function temporaryIpcRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-ipc-watch-'));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('IpcWatcherManager runtime namespaces', () => {
+  test.each([
+    {
+      name: 'conversation agent tasks',
+      namespace: { agentId: 'agent-1' },
+      relativeDir: path.join('agents', 'agent-1', 'tasks'),
+    },
+    {
+      name: 'isolated task messages',
+      namespace: { taskRunId: 'run-1' },
+      relativeDir: path.join('tasks-run', 'run-1', 'messages'),
+    },
+  ])('processes $name without waiting for the full scan', async (fixture) => {
+    const ipcBaseDir = temporaryIpcRoot();
+    const processGroup = vi.fn(async () => {});
+    const processFull = vi.fn(async () => {});
+    const manager = new IpcWatcherManager({
+      ipcBaseDir,
+      isShuttingDown: () => false,
+      debounceMs: 5,
+      // Do not start fallback: this test proves leaf fs.watch delivery.
+      fallbackMs: 60_000,
+    });
+    manager.bind(processGroup, processFull);
+    manager.watchRuntime('workspace', fixture.namespace);
+    // Ignore the intentional registration-race drain. The next call must come
+    // from the nested leaf watcher because fallback is not running.
+    await vi.waitFor(() => expect(processGroup).toHaveBeenCalled());
+    processGroup.mockClear();
+
+    const requestDir = path.join(ipcBaseDir, 'workspace', fixture.relativeDir);
+    fs.writeFileSync(path.join(requestDir, 'request.json'), '{}');
+
+    await vi.waitFor(() => {
+      expect(processGroup).toHaveBeenCalledWith('workspace');
+    });
+    expect(processFull).not.toHaveBeenCalled();
+    manager.closeAll();
+  });
+
+  test('reference counts one namespace and closes it only after the final release', async () => {
+    const ipcBaseDir = temporaryIpcRoot();
+    const processGroup = vi.fn(async () => {});
+    const manager = new IpcWatcherManager({
+      ipcBaseDir,
+      isShuttingDown: () => false,
+      debounceMs: 5,
+    });
+    manager.bind(processGroup, async () => {});
+    const namespace = { agentId: 'agent-refcount' };
+    manager.watchRuntime('workspace', namespace);
+    manager.watchRuntime('workspace', namespace);
+    expect(manager.activeRuntimeCount).toBe(1);
+    await vi.waitFor(() => expect(processGroup).toHaveBeenCalled());
+    processGroup.mockClear();
+
+    manager.unwatchRuntime('workspace', namespace);
+    const requestDir = path.join(
+      ipcBaseDir,
+      'workspace',
+      'agents',
+      'agent-refcount',
+      'tasks',
+    );
+    fs.writeFileSync(path.join(requestDir, 'first.json'), '{}');
+    await vi.waitFor(() => expect(processGroup).toHaveBeenCalledTimes(1));
+
+    manager.unwatchRuntime('workspace', namespace);
+    expect(manager.activeRuntimeCount).toBe(0);
+    fs.writeFileSync(path.join(requestDir, 'after-release.json'), '{}');
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(processGroup).toHaveBeenCalledTimes(1);
+    manager.closeAll();
+  });
+
+  test('immediately drains a request that won the watcher-registration race', async () => {
+    const ipcBaseDir = temporaryIpcRoot();
+    const requestDir = path.join(
+      ipcBaseDir,
+      'workspace',
+      'agents',
+      'agent-race',
+      'tasks',
+    );
+    fs.mkdirSync(requestDir, { recursive: true });
+    fs.writeFileSync(path.join(requestDir, 'already-present.json'), '{}');
+    const processGroup = vi.fn(async () => {});
+    const manager = new IpcWatcherManager({
+      ipcBaseDir,
+      isShuttingDown: () => false,
+      debounceMs: 5,
+    });
+    manager.bind(processGroup, async () => {});
+
+    manager.watchRuntime('workspace', { agentId: 'agent-race' });
+
+    await vi.waitFor(() =>
+      expect(processGroup).toHaveBeenCalledWith('workspace'),
+    );
+    manager.closeAll();
+  });
+
+  test('falls back within the Runner context deadline when fs.watch is unavailable', async () => {
+    const ipcBaseDir = temporaryIpcRoot();
+    const watch = vi.spyOn(fs, 'watch').mockImplementation(() => {
+      throw new Error('watch unavailable');
+    });
+    const processGroup = vi.fn(async () => {});
+    const processFull = vi.fn(async () => {});
+    const manager = new IpcWatcherManager({
+      ipcBaseDir,
+      isShuttingDown: () => false,
+      debounceMs: 5,
+      fallbackMs: 20,
+    });
+    manager.bind(processGroup, processFull);
+    manager.watchRuntime('workspace', { agentId: 'agent-fallback' });
+    await vi.waitFor(() => expect(processGroup).toHaveBeenCalled());
+    processGroup.mockClear();
+
+    const requestDir = path.join(
+      ipcBaseDir,
+      'workspace',
+      'agents',
+      'agent-fallback',
+      'tasks',
+    );
+    fs.writeFileSync(path.join(requestDir, 'request.json'), '{}');
+    manager.startFallback();
+
+    await vi.waitFor(() => expect(processFull).toHaveBeenCalled());
+    expect(processGroup).not.toHaveBeenCalled();
+    manager.closeAll();
+    watch.mockRestore();
+  });
+});

--- a/tests/ipc-watcher-manager.test.ts
+++ b/tests/ipc-watcher-manager.test.ts
@@ -4,7 +4,10 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { IpcWatcherManager } from '../src/ipc-watcher-manager.js';
+import {
+  DEFAULT_IPC_WATCHER_FALLBACK_MS,
+  IpcWatcherManager,
+} from '../src/ipc-watcher-manager.js';
 
 const temporaryRoots: string[] = [];
 
@@ -21,6 +24,10 @@ afterEach(() => {
 });
 
 describe('IpcWatcherManager runtime namespaces', () => {
+  test('keeps the default recovery scan below the Runner IPC deadline', () => {
+    expect(DEFAULT_IPC_WATCHER_FALLBACK_MS).toBe(2000);
+  });
+
   test.each([
     {
       name: 'conversation agent tasks',

--- a/tests/leftover-direct-mount-cli.test.ts
+++ b/tests/leftover-direct-mount-cli.test.ts
@@ -32,6 +32,18 @@ const tsxCli = path.join(
   'dist',
   'cli.mjs',
 );
+const defaultTestWebPort = (() => {
+  for (let offset = 0; offset < 200; offset++) {
+    const candidate = 40_000 + ((process.pid + offset) % 20_000);
+    const probe = spawnSync('lsof', [
+      '-nP',
+      `-iTCP:${candidate}`,
+      '-sTCP:LISTEN',
+    ]);
+    if (probe.status !== 0) return candidate;
+  }
+  throw new Error('Unable to find an unused test WEB_PORT');
+})();
 
 afterAll(() => {
   delete process.env[DATABASE_MAINTENANCE_TOKEN_ENV];
@@ -41,6 +53,10 @@ afterAll(() => {
 function instanceRoot(name: string): string {
   const target = path.join(root, name);
   fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(
+    path.join(target, '.env'),
+    `WEB_PORT=${defaultTestWebPort}\n`,
+  );
   return target;
 }
 

--- a/tests/message-ingest-sequence.test.ts
+++ b/tests/message-ingest-sequence.test.ts
@@ -1,0 +1,160 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'message-ingest-sequence-'));
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const dataDir = path.join(root, 'data');
+
+vi.mock('../src/config.js', () => ({
+  DATA_DIR: dataDir,
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function store(jid: string, id: string, timestamp: string, content = id): void {
+  db.ensureChatExists(jid);
+  db.storeMessageDirect(id, jid, 'user', 'User', content, timestamp, false);
+}
+
+describe('host message ingest sequence', () => {
+  test('paginates 52 same-timestamp rows without gaps or duplicates', () => {
+    db.initDatabase();
+    const jid = 'telegram:same-second#account:test';
+    const timestamp = '2026-08-31T00:00:00.000Z';
+    const inserted = Array.from(
+      { length: 52 },
+      (_, index) => `id-${String(51 - index).padStart(2, '0')}`,
+    );
+    for (const id of inserted) store(jid, id, timestamp);
+
+    const seen: string[] = [];
+    let beforeSequence: number | undefined;
+    do {
+      const page = db.getMessagesPage(jid, undefined, 10, beforeSequence);
+      seen.push(...page.map((message) => message.id));
+      beforeSequence = page.at(-1)?.ingest_sequence;
+      if (page.length < 10) break;
+    } while (beforeSequence !== undefined);
+
+    expect(seen).toEqual([...inserted].reverse());
+    expect(new Set(seen).size).toBe(52);
+    expect(db.getMessagesPage(jid, undefined, 10, 0)).toEqual([]);
+    expect(db.getMessagesPageMulti([jid], undefined, 10, 0)).toEqual([]);
+  });
+
+  test('consumes same-second random IDs and late old timestamps by arrival order', () => {
+    const jid = 'whatsapp:late-clock#account:test';
+    const timestamp = '2026-08-31T01:00:00.000Z';
+    store(jid, 'z-random-id', timestamp);
+    const first = db.getMessageCursor(jid, 'z-random-id')!;
+
+    store(jid, 'a-random-id', timestamp);
+    store(jid, 'late-old-clock', '2020-01-01T00:00:00.000Z');
+
+    expect(
+      db.getMessagesSince(jid, first).map((message) => message.id),
+    ).toEqual(['a-random-id', 'late-old-clock']);
+  });
+
+  test('keeps sequence stable across replace and database restart', () => {
+    const jid = 'web:restart-sequence';
+    const firstTimestamp = '2026-08-31T02:00:00.000Z';
+    store(jid, 'replace-me', firstTimestamp, 'first');
+    const beforeReplace = db.getMessageCursor(jid, 'replace-me')!;
+
+    store(jid, 'replace-me', '2026-08-31T03:00:00.000Z', 'updated');
+    expect(db.getMessageCursor(jid, 'replace-me')?.sequence).toBe(
+      beforeReplace.sequence,
+    );
+
+    db.closeDatabase();
+    db.initDatabase();
+    const restored = db.resolveMessageCursorSequence(
+      { timestamp: firstTimestamp, id: 'replace-me' },
+      jid,
+    );
+    expect(restored.sequence).toBe(beforeReplace.sequence);
+
+    store(jid, 'after-restart', '2019-01-01T00:00:00.000Z');
+    expect(
+      db.getMessagesSince(jid, restored).map((message) => message.id),
+    ).toEqual(['after-restart']);
+  });
+
+  test('uses one stable sequence across multi-JID history and incremental polling', () => {
+    const left = 'web:multi-left';
+    const right = 'feishu:multi-right#account:test';
+    const timestamp = '2026-08-31T04:00:00.000Z';
+    const ids = Array.from({ length: 52 }, (_, index) => `multi-${index}`);
+    ids.forEach((id, index) =>
+      store(index % 2 === 0 ? left : right, id, timestamp),
+    );
+
+    const firstPage = db.getMessagesPageMulti([left, right], undefined, 17);
+    const secondPage = db.getMessagesPageMulti(
+      [left, right],
+      undefined,
+      17,
+      firstPage.at(-1)!.ingest_sequence,
+    );
+    expect([...firstPage, ...secondPage].map((message) => message.id)).toEqual(
+      [...ids].reverse().slice(0, 34),
+    );
+
+    const after = firstPage.at(-1)!.ingest_sequence!;
+    expect(
+      db
+        .getMessagesAfterMulti([left, right], '', 100, after)
+        .map((message) => message.id),
+    ).toEqual(
+      firstPage
+        .slice(0, -1)
+        .reverse()
+        .map((message) => message.id),
+    );
+  });
+
+  test('unknown deleted legacy anchor fails safe by replaying instead of skipping', () => {
+    const jid = 'web:missing-legacy-anchor';
+    store(jid, 'still-present', '2026-08-31T05:00:00.000Z');
+    const legacy = db.resolveMessageCursorSequence(
+      {
+        timestamp: '2026-08-31T04:59:59.000Z',
+        id: 'already-deleted-before-v74',
+      },
+      jid,
+    );
+    expect(legacy.sequence).toBe(0);
+    expect(
+      db.getMessagesSince(jid, legacy).map((message) => message.id),
+    ).toEqual(['still-present']);
+  });
+
+  test('replays fresh-session history by host arrival rather than provider clock', () => {
+    const jid = 'telegram:history-order#account:test';
+    store(jid, 'first-arrival', '2026-08-31T06:00:00.000Z');
+    store(jid, 'late-old-clock', '2020-01-01T00:00:00.000Z');
+
+    // The API is newest-first; buildRecentConversationHistoryContext reverses
+    // this page and therefore presents first-arrival before late-old-clock.
+    expect(
+      db
+        .getConversationHistoryMessagesPage(jid, new Set(), 30)
+        .map((message) => message.id),
+    ).toEqual(['late-old-clock', 'first-arrival']);
+  });
+});

--- a/tests/proactive-turn-protocol.test.ts
+++ b/tests/proactive-turn-protocol.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CLI_NO_VISIBLE_OUTPUT_COMPANION,
+  PROACTIVE_FINAL_DELIVERED_SENTINEL,
+  isCliNoVisibleOutputCompanion,
+  isProactiveFinalDeliveredSentinel,
+  proactiveFinalWasDeliveredForInput,
+} from '../container/agent-runner/src/proactive-turn-protocol.js';
+import {
+  createMcpTools,
+  type McpContext,
+} from '../container/agent-runner/src/mcp-tools.js';
+
+function companion(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'user',
+    parent_tool_use_id: null,
+    isSynthetic: true,
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text: CLI_NO_VISIBLE_OUTPUT_COMPANION }],
+    },
+    ...overrides,
+  };
+}
+
+describe('Proactive terminal control protocol', () => {
+  test('recognizes only the exact invisible final sentinel', () => {
+    expect(
+      isProactiveFinalDeliveredSentinel(
+        `  ${PROACTIVE_FINAL_DELIVERED_SENTINEL}\n`,
+      ),
+    ).toBe(true);
+    expect(isProactiveFinalDeliveredSentinel('final delivered')).toBe(false);
+  });
+
+  test('recognizes the exact synthetic Claude CLI companion', () => {
+    expect(isCliNoVisibleOutputCompanion(companion())).toBe(true);
+    expect(
+      isCliNoVisibleOutputCompanion(
+        companion({ isSynthetic: false, isMeta: true }),
+      ),
+    ).toBe(true);
+    expect(
+      isCliNoVisibleOutputCompanion(
+        companion({ isSynthetic: false, turnCompanion: true }),
+      ),
+    ).toBe(true);
+  });
+
+  test('never consumes user-authored or merely similar text', () => {
+    expect(
+      isCliNoVisibleOutputCompanion(companion({ isSynthetic: false })),
+    ).toBe(false);
+    expect(
+      isCliNoVisibleOutputCompanion(
+        companion({
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: 'no visible output' }],
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('requires the final ACK to belong to the exact current input', () => {
+    expect(proactiveFinalWasDeliveredForInput('turn-a', 'turn-a')).toBe(true);
+    expect(proactiveFinalWasDeliveredForInput('turn-a', 'turn-b')).toBe(false);
+    expect(proactiveFinalWasDeliveredForInput(undefined, 'turn-a')).toBe(false);
+  });
+
+  test('rejects a second Proactive final before creating another IPC request', async () => {
+    const ctx: McpContext = {
+      chatJid: 'web:main',
+      groupFolder: 'main',
+      isHome: true,
+      isAdminHome: true,
+      agentBuilderEnabled: false,
+      ownerProfileEnabled: false,
+      interactionMode: 'proactive',
+      currentInputTurnId: 'turn-a',
+      proactiveFinalDeliveredInputTurnId: 'turn-a',
+      workspaceIpc: '/tmp/unused-happyclaw-ipc',
+      workspaceGroup: '/tmp/unused-happyclaw-group',
+    };
+    const sendMessage = createMcpTools(ctx).find(
+      (definition) => definition.name === 'send_message',
+    );
+    expect(sendMessage).toBeDefined();
+    await expect(
+      sendMessage!.handler({ text: 'duplicate', delivery_role: 'final' }, {}),
+    ).rejects.toThrow('already sealed');
+  });
+});

--- a/tests/prompt-loader.test.ts
+++ b/tests/prompt-loader.test.ts
@@ -164,6 +164,10 @@ describe('prompts/ files', () => {
     );
     expect(proactiveOutput).toContain('在第一个可能明显耗时的工具调用前');
     expect(proactive).not.toContain('minimal internal acknowledgement');
+    expect(proactive).toContain('<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->');
+    expect(proactiveOutput).toContain(
+      '<!--HAPPYCLAW_PROACTIVE_FINAL_DELIVERED-->',
+    );
     expect(proactiveOutput).not.toContain('最终回复必须自包含');
     expect(taskOutput).toContain(
       '最终 SDK Assistant 文本会自动作为正式任务结果归档',

--- a/tests/provider-model-fallback.test.ts
+++ b/tests/provider-model-fallback.test.ts
@@ -150,14 +150,16 @@ describe('provider model fallback lifecycle', () => {
       'billing_error',
       'authentication_failed',
       'oauth_org_not_allowed',
+      'account_on_hold',
       'overloaded',
       'server_error',
+      'unknown',
+      'max_output_tokens',
+      'invalid_request',
       'model_not_found',
     ] as const) {
       expect(classifyProviderAssistantError(error)).toBeDefined();
     }
-    expect(classifyProviderAssistantError('invalid_request')).toBeUndefined();
-    expect(classifyProviderAssistantError('max_output_tokens')).toBeUndefined();
     expect(classifyProviderAssistantError(undefined)).toBeUndefined();
   });
 
@@ -168,6 +170,7 @@ describe('provider model fallback lifecycle', () => {
     expect(classifyProviderAssistantError('oauth_org_not_allowed')).toBe(
       'account',
     );
+    expect(classifyProviderAssistantError('account_on_hold')).toBe('account');
     expect(classifyProviderAssistantError('billing_error')).toBe('account');
     // A bare rate_limit carries no rateLimitType, so it fails safe as
     // account-wide — matching classifyProviderRateLimitType's unknown default.
@@ -180,12 +183,20 @@ describe('provider model fallback lifecycle', () => {
     // only profile of a single-account install and retired the user's input.
     expect(classifyProviderAssistantError('overloaded')).toBe('transient');
     expect(classifyProviderAssistantError('server_error')).toBe('transient');
+    expect(classifyProviderAssistantError('unknown')).toBe('transient');
+    expect(classifyProviderAssistantError('max_output_tokens')).toBe(
+      'transient',
+    );
+    expect(classifyProviderAssistantError('future_sdk_error' as never)).toBe(
+      'transient',
+    );
   });
 
   test('an unservable model name is a config failure, not a quota one', () => {
     // Every account would be asked for the same model, so quarantining on this
     // would drain the whole pool over one bad model name.
     expect(classifyProviderAssistantError('model_not_found')).toBe('config');
+    expect(classifyProviderAssistantError('invalid_request')).toBe('config');
   });
 
   test('structured rejection wins over text and preserves model-only errors without fallback', () => {

--- a/tests/routes-messages-acl.test.ts
+++ b/tests/routes-messages-acl.test.ts
@@ -243,6 +243,67 @@ describe('POST /api/messages — validation & lookup', () => {
   });
 });
 
+describe('GET /api/groups/:jid/messages — stable sequence cursor', () => {
+  test('paginates same-timestamp messages and polls late arrivals', async () => {
+    seedTestGroup();
+    asUser(OWNER_ID);
+    const timestamp = '2026-08-31T00:00:00.000Z';
+    for (let index = 0; index < 52; index++) {
+      db.ensureChatExists(GROUP_JID);
+      db.storeMessageDirect(
+        `same-ts-${String(51 - index).padStart(2, '0')}`,
+        GROUP_JID,
+        OWNER_ID,
+        'Alice',
+        `message ${index}`,
+        timestamp,
+        false,
+      );
+    }
+
+    const firstResponse = await app.request(
+      `/api/groups/${encodeURIComponent(GROUP_JID)}/messages?limit=20`,
+    );
+    expect(firstResponse.status).toBe(200);
+    const first = (await firstResponse.json()) as {
+      messages: Array<{ id: string; ingest_sequence: number }>;
+      hasMore: boolean;
+    };
+    expect(first.messages).toHaveLength(20);
+    expect(first.hasMore).toBe(true);
+
+    const boundary = first.messages.at(-1)!.ingest_sequence;
+    const secondResponse = await app.request(
+      `/api/groups/${encodeURIComponent(GROUP_JID)}/messages?limit=20&beforeSequence=${boundary}`,
+    );
+    const second = (await secondResponse.json()) as typeof first;
+    expect(second.messages).toHaveLength(20);
+    expect(
+      new Set(
+        [...first.messages, ...second.messages].map((message) => message.id),
+      ).size,
+    ).toBe(40);
+
+    const newestSequence = first.messages[0].ingest_sequence;
+    db.storeMessageDirect(
+      'late-old-provider-clock',
+      GROUP_JID,
+      OWNER_ID,
+      'Alice',
+      'late arrival',
+      '2020-01-01T00:00:00.000Z',
+      false,
+    );
+    const pollResponse = await app.request(
+      `/api/groups/${encodeURIComponent(GROUP_JID)}/messages?limit=20&afterSequence=${newestSequence}`,
+    );
+    const poll = (await pollResponse.json()) as typeof first;
+    expect(poll.messages.map((message) => message.id)).toEqual([
+      'late-old-provider-clock',
+    ]);
+  });
+});
+
 describe('POST /api/messages — /clear interception ACL', () => {
   test('non-owner is denied (403 Access denied)', async () => {
     seedTestGroup();
@@ -304,6 +365,9 @@ describe('POST /api/messages — active-run steering', () => {
       disposition: 'steered',
       runId: 'run-active',
     });
+    const cursor = db.getMessageCursor(GROUP_JID, body.messageId);
+    expect(body.ingestSequence).toBe(cursor?.sequence);
+    expect(body.ingestSequence).toBeGreaterThan(0);
     expect(promoteFollowUpCalls).toEqual([
       {
         chatJid: GROUP_JID,

--- a/tests/schema-v74-message-ingest-sequence.test.ts
+++ b/tests/schema-v74-message-ingest-sequence.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-v74-ingest-'));
+const storeDir = path.join(root, 'store');
+const groupsDir = path.join(root, 'groups');
+const dataDir = path.join(root, 'data');
+const databasePath = path.join(storeDir, 'messages.db');
+fs.mkdirSync(storeDir, { recursive: true });
+fs.mkdirSync(groupsDir, { recursive: true });
+fs.mkdirSync(dataDir, { recursive: true });
+
+const legacy = new Database(databasePath);
+legacy.exec(`
+  CREATE TABLE router_state (key TEXT PRIMARY KEY, value TEXT);
+  INSERT INTO router_state VALUES ('schema_version', '73');
+  CREATE TABLE chats (jid TEXT PRIMARY KEY, name TEXT, last_message_time TEXT);
+  CREATE TABLE messages (
+    id TEXT,
+    chat_jid TEXT,
+    source_jid TEXT,
+    sender TEXT,
+    sender_name TEXT,
+    content TEXT,
+    timestamp TEXT,
+    is_from_me INTEGER,
+    attachments TEXT,
+    token_usage TEXT,
+    channel_context TEXT,
+    turn_id TEXT,
+    session_id TEXT,
+    sdk_message_uuid TEXT,
+    source_kind TEXT,
+    finalization_reason TEXT,
+    task_id TEXT,
+    delivery_mode TEXT,
+    delivery_status TEXT,
+    delivery_run_id TEXT,
+    delivery_priority INTEGER NOT NULL DEFAULT 0,
+    delivery_updated_at TEXT,
+    history_recovery_allowed INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (id, chat_jid)
+  );
+  INSERT INTO chats VALUES ('telegram:migrated', 'Migrated', '2026-08-31T00:00:00Z');
+  INSERT INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me)
+    VALUES ('z-first', 'telegram:migrated', 'u', 'U', 'first', '2026-08-31T00:00:00Z', 0);
+  INSERT INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me)
+    VALUES ('a-second', 'telegram:migrated', 'u', 'U', 'second', '2026-08-31T00:00:00Z', 0);
+  INSERT INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me)
+    VALUES ('late-third', 'telegram:migrated', 'u', 'U', 'third', '2020-01-01T00:00:00Z', 0);
+`);
+legacy.close();
+
+vi.mock('../src/config.js', () => ({
+  DATA_DIR: dataDir,
+  STORE_DIR: storeDir,
+  GROUPS_DIR: groupsDir,
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const db = await import('../src/db.js');
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('schema v74 message ingest sequence migration', () => {
+  test('backfills rowid order without a snapshot when explicitly opted out', () => {
+    process.env.HAPPYCLAW_SKIP_MIGRATION_BACKUP = 'true';
+    try {
+      db.initDatabase();
+    } finally {
+      delete process.env.HAPPYCLAW_SKIP_MIGRATION_BACKUP;
+    }
+    expect(fs.existsSync(path.join(storeDir, 'migration-backups'))).toBe(false);
+    expect(db.getRouterState('schema_version')).toBe(
+      String(db.CURRENT_SCHEMA_VERSION),
+    );
+
+    const all = db.getMessagesSince('telegram:migrated', {
+      timestamp: '',
+      id: '',
+      sequence: 0,
+    });
+    expect(all.map((message) => message.id)).toEqual([
+      'z-first',
+      'a-second',
+      'late-third',
+    ]);
+    expect(all.map((message) => message.ingest_sequence)).toEqual([1, 2, 3]);
+
+    const upgraded = db.resolveMessageCursorSequence(
+      {
+        timestamp: '2026-08-31T00:00:00Z',
+        id: 'a-second',
+      },
+      'telegram:migrated',
+    );
+    expect(upgraded.sequence).toBe(2);
+    expect(
+      db
+        .getMessagesSince('telegram:migrated', upgraded)
+        .map((message) => message.id),
+    ).toEqual(['late-third']);
+  });
+});

--- a/tests/turn-outcome.test.ts
+++ b/tests/turn-outcome.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { resolveTurnOutcome } from '../src/turn-outcome.js';
+import {
+  hasUnfinishedProactiveOutput,
+  resolveTurnOutcome,
+} from '../src/turn-outcome.js';
 import { resolveStreamingCardReplyAcknowledgement } from '../src/reply-delivery.js';
 
 describe('resolveStreamingCardReplyAcknowledgement', () => {
@@ -57,6 +60,29 @@ describe('resolveStreamingCardReplyAcknowledgement', () => {
 });
 
 describe('resolveTurnOutcome', () => {
+  test('requires a final after progress or separate Proactive output', () => {
+    expect(
+      hasUnfinishedProactiveOutput({
+        interactionMode: 'proactive',
+        nonTerminalDelivered: true,
+        finalDelivered: false,
+      }),
+    ).toBe(true);
+    expect(
+      hasUnfinishedProactiveOutput({
+        interactionMode: 'proactive',
+        nonTerminalDelivered: false,
+        finalDelivered: false,
+      }),
+    ).toBe(false);
+    expect(
+      hasUnfinishedProactiveOutput({
+        interactionMode: 'proactive',
+        nonTerminalDelivered: true,
+        finalDelivered: true,
+      }),
+    ).toBe(false);
+  });
   test('retries an in-flight close with no reply or healthy completion', () => {
     expect(
       resolveTurnOutcome({
@@ -69,6 +95,22 @@ describe('resolveTurnOutcome', () => {
       kind: 'retryable',
       cursor: 'keep',
       reason: 'runner_closed_in_flight',
+    });
+  });
+
+  test('retries after an acknowledged progress update followed by runner error', () => {
+    expect(
+      resolveTurnOutcome({
+        status: 'error',
+        healthyInputTurnCompleted: false,
+        cursorCommitted: false,
+        replyDelivered: false,
+        progressDelivered: true,
+      }),
+    ).toEqual({
+      kind: 'retryable',
+      cursor: 'keep',
+      reason: 'runner_failed_in_flight',
     });
   });
 
@@ -221,9 +263,12 @@ describe('resolveTurnOutcome', () => {
     expect(deliveryBranch).toContain(
       'replyDeliveryAcknowledged &&\n                isGenuineReplyResult',
     );
-    expect(deliveryBranch).toContain('result.inputTurnCompleted &&');
+    expect(deliveryBranch).toContain('if (result.inputTurnCompleted) {');
     expect(deliveryBranch).toContain(
-      '(replyDeliveryAcknowledged ||\n                  Boolean(',
+      'if (!(await completeChannelRuntimesForOutput(result)))',
+    );
+    expect(deliveryBranch).toContain(
+      'replyDeliveryAcknowledged ||\n                  Boolean(',
     );
     expect(deliveryBranch).toContain('getFailedChannelOutboxForTurn(');
     expect(deliveryBranch).not.toContain(

--- a/tests/turn-output-coordinator.test.ts
+++ b/tests/turn-output-coordinator.test.ts
@@ -385,6 +385,63 @@ describe('ActiveTurnOutputRegistry exactly-one staging', () => {
     expect(agentDelivered).toHaveBeenCalledOnce();
   });
 
+  test('counts progress delivery without turning it into a terminal reply ACK', () => {
+    const registry = new ActiveTurnOutputRegistry();
+    const terminalDelivered = vi.fn();
+    const progressDelivered = vi.fn();
+    const coordinator = registry.bind('workspace:main', 'turn-1', {
+      onProgress: () => true,
+      onFinalCandidate: () => true,
+      onUtteranceDelivered: terminalDelivered,
+      onNonTerminalDelivered: progressDelivered,
+    });
+
+    expect(
+      registry.recordDeliveredUtterance({
+        scopeKey: 'workspace:main',
+        inputTurnId: 'turn-1',
+        role: 'progress',
+        text: '仍在处理',
+      }),
+    ).toBe(true);
+    expect(coordinator.deliveredUtterances).toBe(1);
+    expect(progressDelivered).toHaveBeenCalledOnce();
+    expect(terminalDelivered).not.toHaveBeenCalled();
+
+    expect(
+      registry.recordDeliveredUtterance({
+        scopeKey: 'workspace:main',
+        inputTurnId: 'turn-1',
+        role: 'final',
+        text: '完成',
+      }),
+    ).toBe(true);
+    expect(terminalDelivered).toHaveBeenCalledOnce();
+  });
+
+  test('treats a separate utterance as non-terminal', () => {
+    const registry = new ActiveTurnOutputRegistry();
+    const terminalDelivered = vi.fn();
+    const nonTerminalDelivered = vi.fn();
+    registry.bind('workspace:main', 'turn-1', {
+      onProgress: () => true,
+      onFinalCandidate: () => true,
+      onUtteranceDelivered: terminalDelivered,
+      onNonTerminalDelivered: nonTerminalDelivered,
+    });
+
+    expect(
+      registry.recordDeliveredUtterance({
+        scopeKey: 'workspace:main',
+        inputTurnId: 'turn-1',
+        role: 'separate',
+        text: '旁路信息',
+      }),
+    ).toBe(true);
+    expect(nonTerminalDelivered).toHaveBeenCalledOnce();
+    expect(terminalDelivered).not.toHaveBeenCalled();
+  });
+
   test('projection failure does not poison dedupe or staged-final state', () => {
     const registry = new ActiveTurnOutputRegistry();
     const final = vi

--- a/web/src/stores/chat-source.test.ts
+++ b/web/src/stores/chat-source.test.ts
@@ -6,7 +6,7 @@ describe('chat store source encoding', () => {
     const source = readFileSync(new URL('./chat.ts', import.meta.url));
     expect(source.includes(0)).toBe(false);
     expect(source.toString('utf8')).toContain(
-      "const inFlightKey = `${jid}\\0${before ?? 'first'}`;",
+      "const inFlightKey = `${jid}\\0${beforeSequence ?? before ?? 'first'}`;",
     );
   });
 });

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -45,6 +45,8 @@ export type { GroupInfo, AgentInfo };
 export interface Message {
   id: string;
   chat_jid: string;
+  /** Stable host arrival order used by history and polling cursors. */
+  ingest_sequence?: number;
   source_jid?: string;
   sender: string;
   sender_name: string;
@@ -230,7 +232,7 @@ export interface StreamingState {
   interrupted?: boolean;
 }
 
-function mergeMessagesChronologically(
+export function mergeMessagesChronologically(
   existing: Message[],
   incoming: Message[],
 ): Message[] {
@@ -239,24 +241,33 @@ function mergeMessagesChronologically(
   // Incoming messages are authoritative, but preserve reference if content unchanged
   for (const m of incoming) {
     const old = byId.get(m.id);
+    // WebSocket/stream projections can update a canonical row before their
+    // payload has been enriched with the REST-only ingest cursor. Never erase
+    // an already-authoritative sequence or pagination can silently fall back
+    // to the provider timestamp boundary.
+    const next =
+      old?.ingest_sequence !== undefined && m.ingest_sequence === undefined
+        ? { ...m, ingest_sequence: old.ingest_sequence }
+        : m;
     if (
       !old ||
-      old.content !== m.content ||
-      old.timestamp !== m.timestamp ||
-      old.token_usage !== m.token_usage ||
+      old.content !== next.content ||
+      old.timestamp !== next.timestamp ||
+      old.ingest_sequence !== next.ingest_sequence ||
+      old.token_usage !== next.token_usage ||
       JSON.stringify(old.workflow_runs ?? []) !==
-        JSON.stringify(m.workflow_runs ?? []) ||
-      old.turn_id !== m.turn_id ||
-      old.session_id !== m.session_id ||
-      old.sdk_message_uuid !== m.sdk_message_uuid ||
-      old.source_kind !== m.source_kind ||
-      old.finalization_reason !== m.finalization_reason ||
-      old.delivery_mode !== m.delivery_mode ||
-      old.delivery_status !== m.delivery_status ||
-      old.delivery_run_id !== m.delivery_run_id ||
-      old.delivery_updated_at !== m.delivery_updated_at
+        JSON.stringify(next.workflow_runs ?? []) ||
+      old.turn_id !== next.turn_id ||
+      old.session_id !== next.session_id ||
+      old.sdk_message_uuid !== next.sdk_message_uuid ||
+      old.source_kind !== next.source_kind ||
+      old.finalization_reason !== next.finalization_reason ||
+      old.delivery_mode !== next.delivery_mode ||
+      old.delivery_status !== next.delivery_status ||
+      old.delivery_run_id !== next.delivery_run_id ||
+      old.delivery_updated_at !== next.delivery_updated_at
     ) {
-      byId.set(m.id, m);
+      byId.set(next.id, next);
     }
   }
   const result = Array.from(byId.values()).sort((a, b) => {
@@ -274,6 +285,24 @@ function mergeMessagesChronologically(
     });
   }
   return result;
+}
+
+function messageSequenceBoundary(
+  messages: Message[],
+  direction: 'min' | 'max',
+): number | undefined {
+  let boundary: number | undefined;
+  for (const message of messages) {
+    const sequence = message.ingest_sequence;
+    if (!Number.isSafeInteger(sequence) || sequence === undefined) continue;
+    boundary =
+      boundary === undefined
+        ? sequence
+        : direction === 'min'
+          ? Math.min(boundary, sequence)
+          : Math.max(boundary, sequence);
+  }
+  return boundary;
 }
 
 const MAX_THINKING_CACHE_SIZE = 500;
@@ -1725,19 +1754,28 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadMessages: async (jid: string, loadMore = false) => {
     const state = get();
     const existing = state.messages[jid] || [];
+    const beforeSequence = loadMore
+      ? messageSequenceBoundary(existing, 'min')
+      : undefined;
     const before =
-      loadMore && existing.length > 0 ? existing[0].timestamp : undefined;
+      loadMore && beforeSequence === undefined && existing.length > 0
+        ? existing[0].timestamp
+        : undefined;
 
     // 首屏有两个入口（ChatPage 路由解析 + ChatView 挂载）会各发一次同参请求；
     // 同一目标的首页加载在途时直接复用，避免重复拉 50 条。
-    const inFlightKey = `${jid}\0${before ?? 'first'}`;
+    const inFlightKey = `${jid}\0${beforeSequence ?? before ?? 'first'}`;
     const inFlight = loadMessagesInFlight.get(inFlightKey);
     if (inFlight) return inFlight;
     const request = (async () => {
       try {
         const data = await api.get<{ messages: Message[]; hasMore: boolean }>(
           `/api/groups/${encodeURIComponent(jid)}/messages?${new URLSearchParams(
-            before ? { before: String(before), limit: '50' } : { limit: '50' },
+            beforeSequence !== undefined
+              ? { beforeSequence: String(beforeSequence), limit: '50' }
+              : before
+                ? { before: String(before), limit: '50' }
+                : { limit: '50' },
           )}`,
         );
         // Messages come in DESC order from API, reverse to chronological for display
@@ -1780,13 +1818,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     const state = get();
     const existing = state.messages[jid] || [];
+    const lastSequence = messageSequenceBoundary(existing, 'max');
     const lastTs =
-      existing.length > 0 ? existing[existing.length - 1].timestamp : undefined;
+      lastSequence === undefined && existing.length > 0
+        ? existing[existing.length - 1].timestamp
+        : undefined;
 
     try {
       // Fetch messages newer than the last one we have
       const params = new URLSearchParams({ limit: '50' });
-      if (lastTs) params.set('after', lastTs);
+      if (lastSequence !== undefined) {
+        params.set('afterSequence', String(lastSequence));
+      } else if (lastTs) {
+        params.set('after', lastTs);
+      }
 
       const data = await api.get<{ messages: Message[] }>(
         `/api/groups/${encodeURIComponent(jid)}/messages?${params}`,
@@ -1910,6 +1955,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             success: true;
             messageId: string;
             timestamp: string;
+            ingestSequence?: number;
             disposition: 'started' | 'queued' | 'steered';
             runId?: string;
           }
@@ -1946,6 +1992,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         content,
         // Use server timestamp so incremental polling cursor stays monotonic with backend data.
         timestamp: data.timestamp,
+        ingest_sequence: data.ingestSequence,
         // is_from_me is from the bot's perspective: true = bot sent it, false = human sent it
         is_from_me: false,
         attachments: body.attachments
@@ -3783,14 +3830,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   loadAgentMessages: async (jid, agentId, loadMore = false) => {
     const existing = get().agentMessages[agentId] || [];
+    const beforeSequence = loadMore
+      ? messageSequenceBoundary(existing, 'min')
+      : undefined;
     const before =
-      loadMore && existing.length > 0 ? existing[0].timestamp : undefined;
+      loadMore && beforeSequence === undefined && existing.length > 0
+        ? existing[0].timestamp
+        : undefined;
 
     try {
       const params = new URLSearchParams(
-        before
-          ? { before: String(before), limit: '50', agentId }
-          : { limit: '50', agentId },
+        beforeSequence !== undefined
+          ? {
+              beforeSequence: String(beforeSequence),
+              limit: '50',
+              agentId,
+            }
+          : before
+            ? { before: String(before), limit: '50', agentId }
+            : { limit: '50', agentId },
       );
       const data = await api.get<{ messages: Message[]; hasMore: boolean }>(
         `/api/groups/${encodeURIComponent(jid)}/messages?${params}`,
@@ -3891,12 +3949,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   refreshAgentMessages: async (jid, agentId) => {
     const existing = get().agentMessages[agentId] || [];
+    const lastSequence = messageSequenceBoundary(existing, 'max');
     const lastTs =
-      existing.length > 0 ? existing[existing.length - 1].timestamp : undefined;
+      lastSequence === undefined && existing.length > 0
+        ? existing[existing.length - 1].timestamp
+        : undefined;
 
     try {
       const params = new URLSearchParams({ limit: '50', agentId });
-      if (lastTs) params.set('after', lastTs);
+      if (lastSequence !== undefined) {
+        params.set('afterSequence', String(lastSequence));
+      } else if (lastTs) {
+        params.set('after', lastTs);
+      }
 
       const data = await api.get<{ messages: Message[] }>(
         `/api/groups/${encodeURIComponent(jid)}/messages?${params}`,

--- a/web/tests/ChatMessageCursor.test.ts
+++ b/web/tests/ChatMessageCursor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeMessagesChronologically, type Message } from '../src/stores/chat';
+
+function message(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'message-1',
+    chat_jid: 'web:main',
+    sender: 'user',
+    sender_name: 'User',
+    content: 'before',
+    timestamp: '2026-08-31T00:00:00.000Z',
+    is_from_me: false,
+    ...overrides,
+  };
+}
+
+describe('chat message cursor preservation', () => {
+  test('keeps a REST ingest sequence across a WebSocket update without one', () => {
+    const merged = mergeMessagesChronologically(
+      [message({ ingest_sequence: 10 })],
+      [message({ content: 'updated over ws' })],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      content: 'updated over ws',
+      ingest_sequence: 10,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- enforce exactly-once terminal delivery and proactive final settlement
- make IPC input claims, acknowledgements, recovery, and watcher fallback crash-safe
- introduce schema v74 host ingest sequences for message ordering and Web pagination
- preserve the owner deployment backup opt-out for schema migration

## Verification

- make typecheck
- npm test -- --run (3814 passed, 23 skipped)
- npm run build:all
- npm run self-test:agent-runner
- provider-failure-upstream fast (2/2)
- web Playwright mobile suite (9/9)