### PR TITLE
fix(oauth): show extra_usage and seven_day_sonnet_max on existing usage bars

### DIFF
--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -828,6 +828,8 @@ async function fetchOAuthUsage(providerId: string): Promise<CachedOAuthUsage> {
         seven_day: parseOAuthUsageBucket(raw.seven_day),
         seven_day_opus: parseOAuthUsageBucket(raw.seven_day_opus),
         seven_day_sonnet: parseOAuthUsageBucket(raw.seven_day_sonnet),
+        seven_day_sonnet_max: parseOAuthUsageBucket(raw.seven_day_sonnet_max),
+        extra_usage: parseOAuthUsageBucket(raw.extra_usage),
       };
 
       const result: CachedOAuthUsage = { data, fetchedAt: Date.now() };

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -234,6 +234,8 @@ export interface OAuthUsageResponse {
   seven_day: OAuthUsageBucket | null;
   seven_day_opus: OAuthUsageBucket | null;
   seven_day_sonnet: OAuthUsageBucket | null;
+  seven_day_sonnet_max: OAuthUsageBucket | null;
+  extra_usage: OAuthUsageBucket | null;
 }
 
 export interface CachedOAuthUsage {
@@ -3605,6 +3607,39 @@ export interface OAuthUsageBucket {
   resets_at: string;
 }
 
+const OAUTH_USAGE_USED_KEYS = [
+  'used',
+  'usage',
+  'credits_used',
+  'used_credits',
+] as const;
+const OAUTH_USAGE_LIMIT_KEYS = [
+  'limit',
+  'credits_limit',
+  'monthly_limit',
+] as const;
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function readFirstFiniteNumber(
+  obj: Record<string, unknown>,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const n = readFiniteNumber(obj[key]);
+    if (n !== undefined) return n;
+  }
+  return undefined;
+}
+
+function clampUtilizationPercent(n: number): number {
+  return Math.round(Math.min(100, Math.max(0, n)));
+}
+
 /**
  * 解析 OAuth usage bucket 对象
  * 运行时类型守卫，验证 API 响应结构
@@ -3612,7 +3647,22 @@ export interface OAuthUsageBucket {
 export function parseOAuthUsageBucket(v: unknown): OAuthUsageBucket | null {
   if (!v || typeof v !== 'object') return null;
   const obj = v as Record<string, unknown>;
-  if (typeof obj.utilization !== 'number' || typeof obj.resets_at !== 'string')
-    return null;
-  return { utilization: obj.utilization, resets_at: obj.resets_at };
+  if (typeof obj.resets_at !== 'string') return null;
+
+  const direct = readFiniteNumber(obj.utilization);
+  if (direct !== undefined) {
+    return {
+      utilization: clampUtilizationPercent(direct),
+      resets_at: obj.resets_at,
+    };
+  }
+
+  const used = readFirstFiniteNumber(obj, OAUTH_USAGE_USED_KEYS);
+  const limit = readFirstFiniteNumber(obj, OAUTH_USAGE_LIMIT_KEYS);
+  if (used === undefined || limit === undefined || limit <= 0) return null;
+
+  return {
+    utilization: clampUtilizationPercent((used / limit) * 100),
+    resets_at: obj.resets_at,
+  };
 }

--- a/tests/oauth-usage-bucket.test.ts
+++ b/tests/oauth-usage-bucket.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  parseOAuthUsageBucket,
+  type OAuthUsageResponse,
+} from '../src/runtime-config.js';
+
+const RESETS_AT = '2026-09-08T00:00:00.000Z';
+
+function parseResponse(raw: Record<string, unknown>): OAuthUsageResponse {
+  return {
+    five_hour: parseOAuthUsageBucket(raw.five_hour),
+    seven_day: parseOAuthUsageBucket(raw.seven_day),
+    seven_day_opus: parseOAuthUsageBucket(raw.seven_day_opus),
+    seven_day_sonnet: parseOAuthUsageBucket(raw.seven_day_sonnet),
+    seven_day_sonnet_max: parseOAuthUsageBucket(raw.seven_day_sonnet_max),
+    extra_usage: parseOAuthUsageBucket(raw.extra_usage),
+  };
+}
+
+describe('parseOAuthUsageBucket', () => {
+  test('clamps utilization to the 0–100 integer percent range', () => {
+    expect(
+      parseOAuthUsageBucket({ utilization: 150, resets_at: RESETS_AT }),
+    ).toEqual({ utilization: 100, resets_at: RESETS_AT });
+    expect(
+      parseOAuthUsageBucket({ utilization: -8, resets_at: RESETS_AT }),
+    ).toEqual({ utilization: 0, resets_at: RESETS_AT });
+    expect(
+      parseOAuthUsageBucket({ utilization: 49.6, resets_at: RESETS_AT }),
+    ).toEqual({ utilization: 50, resets_at: RESETS_AT });
+  });
+
+  test('falls back to used/usage/credits_used over limit/credits_limit', () => {
+    expect(
+      parseOAuthUsageBucket({
+        used: 25,
+        limit: 50,
+        resets_at: RESETS_AT,
+      }),
+    ).toEqual({ utilization: 50, resets_at: RESETS_AT });
+    expect(
+      parseOAuthUsageBucket({
+        usage: 1,
+        credits_limit: 4,
+        resets_at: RESETS_AT,
+      }),
+    ).toEqual({ utilization: 25, resets_at: RESETS_AT });
+    expect(
+      parseOAuthUsageBucket({
+        credits_used: 80,
+        limit: 100,
+        resets_at: RESETS_AT,
+      }),
+    ).toEqual({ utilization: 80, resets_at: RESETS_AT });
+    expect(
+      parseOAuthUsageBucket({
+        used: 200,
+        limit: 100,
+        resets_at: RESETS_AT,
+      }),
+    ).toEqual({ utilization: 100, resets_at: RESETS_AT });
+    expect(
+      parseOAuthUsageBucket({
+        used: 10,
+        limit: 0,
+        resets_at: RESETS_AT,
+      }),
+    ).toBeNull();
+  });
+
+  test('does not invent 0% for an is_enabled-only bucket', () => {
+    expect(parseOAuthUsageBucket({ is_enabled: true })).toBeNull();
+    expect(
+      parseOAuthUsageBucket({ is_enabled: true, resets_at: RESETS_AT }),
+    ).toBeNull();
+    expect(
+      parseOAuthUsageBucket({
+        is_enabled: false,
+        resets_at: RESETS_AT,
+      }),
+    ).toBeNull();
+  });
+
+  test('still requires resets_at', () => {
+    expect(parseOAuthUsageBucket({ utilization: 12 })).toBeNull();
+    expect(parseOAuthUsageBucket({ used: 1, limit: 2 })).toBeNull();
+  });
+
+  test('parses seven_day_sonnet_max and extra_usage keys', () => {
+    const data = parseResponse({
+      seven_day_sonnet_max: {
+        utilization: 41,
+        resets_at: RESETS_AT,
+      },
+      extra_usage: {
+        is_enabled: true,
+        used_credits: 15,
+        monthly_limit: 50,
+        resets_at: RESETS_AT,
+      },
+    });
+
+    expect(data.seven_day_sonnet_max).toEqual({
+      utilization: 41,
+      resets_at: RESETS_AT,
+    });
+    expect(data.extra_usage).toEqual({
+      utilization: 30,
+      resets_at: RESETS_AT,
+    });
+    expect(data.five_hour).toBeNull();
+    expect(data.seven_day).toBeNull();
+    expect(data.seven_day_opus).toBeNull();
+    expect(data.seven_day_sonnet).toBeNull();
+  });
+});

--- a/web/src/components/settings/UsageBars.tsx
+++ b/web/src/components/settings/UsageBars.tsx
@@ -102,13 +102,41 @@ export function UsageBars({ providerId }: { providerId: string }) {
     seven_day: '7d',
     seven_day_opus: '7dO',
     seven_day_sonnet: '7dS',
+    seven_day_sonnet_max: '7dSMax',
+    extra_usage: 'Extra',
   } as const;
 
   const buckets: { label: string; bucket: OAuthUsageBucket }[] = [];
-  if (usage.data.five_hour) buckets.push({ label: USAGE_BUCKET_LABELS.five_hour, bucket: usage.data.five_hour });
-  if (usage.data.seven_day) buckets.push({ label: USAGE_BUCKET_LABELS.seven_day, bucket: usage.data.seven_day });
-  if (usage.data.seven_day_opus) buckets.push({ label: USAGE_BUCKET_LABELS.seven_day_opus, bucket: usage.data.seven_day_opus });
-  if (usage.data.seven_day_sonnet) buckets.push({ label: USAGE_BUCKET_LABELS.seven_day_sonnet, bucket: usage.data.seven_day_sonnet });
+  if (usage.data.five_hour)
+    buckets.push({
+      label: USAGE_BUCKET_LABELS.five_hour,
+      bucket: usage.data.five_hour,
+    });
+  if (usage.data.seven_day)
+    buckets.push({
+      label: USAGE_BUCKET_LABELS.seven_day,
+      bucket: usage.data.seven_day,
+    });
+  if (usage.data.seven_day_opus)
+    buckets.push({
+      label: USAGE_BUCKET_LABELS.seven_day_opus,
+      bucket: usage.data.seven_day_opus,
+    });
+  if (usage.data.seven_day_sonnet)
+    buckets.push({
+      label: USAGE_BUCKET_LABELS.seven_day_sonnet,
+      bucket: usage.data.seven_day_sonnet,
+    });
+  if (usage.data.seven_day_sonnet_max)
+    buckets.push({
+      label: USAGE_BUCKET_LABELS.seven_day_sonnet_max,
+      bucket: usage.data.seven_day_sonnet_max,
+    });
+  if (usage.data.extra_usage)
+    buckets.push({
+      label: USAGE_BUCKET_LABELS.extra_usage,
+      bucket: usage.data.extra_usage,
+    });
 
   if (buckets.length === 0) return null;
 

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -118,6 +118,8 @@ export interface OAuthUsageResponse {
   seven_day: OAuthUsageBucket | null;
   seven_day_opus: OAuthUsageBucket | null;
   seven_day_sonnet: OAuthUsageBucket | null;
+  seven_day_sonnet_max: OAuthUsageBucket | null;
+  extra_usage: OAuthUsageBucket | null;
 }
 
 export interface CachedOAuthUsage {


### PR DESCRIPTION
The existing GET `/api/config/claude/providers/:id/usage` path already talks to Anthropic's oauth/usage API, but it only kept `five_hour` / `seven_day` / `seven_day_opus` / `seven_day_sonnet`. Claude now also sends `seven_day_sonnet_max` and `extra_usage`. Extra usage is the Max overage pool (the one that actually 429s after weekly Sonnet is gone); sonnet_max is the separate 7-day Sonnet Max window. Both were silently dropped, so the settings bars looked fine while those quotas were exhausted.

This wires those two keys through the same `parseOAuthUsageBucket`, clamps percent to 0–100, accepts used/limit-style fields when utilization is absent, and refuses to invent 0% from an `is_enabled`-only object. Bars show as `7dSMax` and `Extra`.

`tests/oauth-usage-bucket.test.ts` covers clamp, used/limit fallback, is_enabled-only → null, and both new keys.

Fork PR: https://github.com/rome-xi/happyclaw-upstream/pull/3
