### PR TITLE
fix(chat): keep pasted text when clipboard also has images

### DIFF
--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -42,6 +42,7 @@ import {
   FOLLOW_UP_MODE_CHANGED_EVENT,
   getDefaultFollowUpMode,
 } from '../../lib/follow-up-preferences';
+import { planImageClipboardPaste } from '../../lib/mixed-paste';
 
 interface PendingFile {
   /** Display name: relative path for folder uploads, file name otherwise */
@@ -525,43 +526,46 @@ export function MessageInput({
       }
     }
 
-    if (imageItems.length > 0) {
-      e.preventDefault();
-      const pastedText = e.clipboardData.getData('text/plain');
-      if (pastedText) {
-        const textarea = textareaRef.current;
-        const start = textarea?.selectionStart ?? content.length;
-        const end = textarea?.selectionEnd ?? content.length;
-        const next = content.slice(0, start) + pastedText + content.slice(end);
-        setContent(next);
-        debouncedSaveDraft(next);
-        requestAnimationFrame(() => {
-          const el = textareaRef.current;
-          if (!el) return;
-          const pos = start + pastedText.length;
-          el.setSelectionRange(pos, pos);
+    if (imageItems.length === 0) return;
+
+    const textarea = e.currentTarget;
+    const pastePlan = planImageClipboardPaste({
+      value: textarea.value,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+      text: e.clipboardData.getData('text/plain'),
+      imageItemCount: imageItems.length,
+    });
+    e.preventDefault();
+
+    if (pastePlan.value !== textarea.value) {
+      setContent(pastePlan.value);
+      debouncedSaveDraft(pastePlan.value);
+    }
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.setSelectionRange(pastePlan.selectionStart, pastePlan.selectionEnd);
+    });
+
+    const newImages: PendingImage[] = [];
+    for (const item of imageItems) {
+      const file = item.getAsFile();
+      if (!file) continue;
+      try {
+        const base64 = await readFileAsBase64(file);
+        newImages.push({
+          name: file.name || `pasted-${Date.now()}.png`,
+          data: base64,
+          mimeType: file.type,
+          preview: URL.createObjectURL(file),
         });
+      } catch {
+        // Skip failed images
       }
+    }
 
-      const newImages: PendingImage[] = [];
-
-      for (const item of imageItems) {
-        const file = item.getAsFile();
-        if (file) {
-          try {
-            const base64 = await readFileAsBase64(file);
-            newImages.push({
-              name: file.name || `pasted-${Date.now()}.png`,
-              data: base64,
-              mimeType: file.type,
-              preview: URL.createObjectURL(file),
-            });
-          } catch {
-            // Skip failed images
-          }
-        }
-      }
-
+    if (newImages.length > 0) {
       setPendingImages((prev) => [...prev, ...newImages]);
     }
   };

--- a/web/src/components/chat/MessageInput.tsx
+++ b/web/src/components/chat/MessageInput.tsx
@@ -527,6 +527,22 @@ export function MessageInput({
 
     if (imageItems.length > 0) {
       e.preventDefault();
+      const pastedText = e.clipboardData.getData('text/plain');
+      if (pastedText) {
+        const textarea = textareaRef.current;
+        const start = textarea?.selectionStart ?? content.length;
+        const end = textarea?.selectionEnd ?? content.length;
+        const next = content.slice(0, start) + pastedText + content.slice(end);
+        setContent(next);
+        debouncedSaveDraft(next);
+        requestAnimationFrame(() => {
+          const el = textareaRef.current;
+          if (!el) return;
+          const pos = start + pastedText.length;
+          el.setSelectionRange(pos, pos);
+        });
+      }
+
       const newImages: PendingImage[] = [];
 
       for (const item of imageItems) {

--- a/web/src/components/common/BugReportDialog.tsx
+++ b/web/src/components/common/BugReportDialog.tsx
@@ -1,11 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import {
-  Bug,
-  ImagePlus,
-  X,
-  Loader2,
-  Copy,
-} from 'lucide-react';
+import { Bug, ImagePlus, X, Loader2, Copy } from 'lucide-react';
 import { toast } from 'sonner';
 import { api } from '@/api/client';
 import { Button } from '@/components/ui/button';
@@ -19,6 +13,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { showToast } from '@/utils/toast';
+import { planImageClipboardPaste } from '@/lib/mixed-paste';
 
 interface BugReportDialogProps {
   open: boolean;
@@ -44,6 +39,7 @@ interface SubmitResult {
 
 const MAX_SCREENSHOTS = 3;
 const MAX_SCREENSHOT_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_DESCRIPTION_LENGTH = 5000;
 
 export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
   // Capabilities (pre-fetched on open)
@@ -71,9 +67,16 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
   // Pre-fetch capabilities when dialog opens
   useEffect(() => {
     if (open) {
-      api.get<Capabilities>('/api/bug-report/capabilities').then(setCaps).catch(() => {
-        setCaps({ ghAvailable: false, ghUsername: null, claudeAvailable: false });
-      });
+      api
+        .get<Capabilities>('/api/bug-report/capabilities')
+        .then(setCaps)
+        .catch(() => {
+          setCaps({
+            ghAvailable: false,
+            ghUsername: null,
+            claudeAvailable: false,
+          });
+        });
     }
   }, [open]);
 
@@ -103,7 +106,9 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
         toast.error(`最多上传 ${MAX_SCREENSHOTS} 张截图`);
         return;
       }
-      setScreenshots((prev) => [...prev, base64]);
+      setScreenshots((prev) =>
+        prev.length >= MAX_SCREENSHOTS ? prev : [...prev, base64],
+      );
     },
     [screenshots.length],
   );
@@ -136,40 +141,56 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
     (e: React.ClipboardEvent) => {
       const items = e.clipboardData?.items;
       if (!items) return;
-      for (const item of items) {
-        if (item.type.startsWith('image/')) {
-          e.preventDefault();
-          const pastedText = e.clipboardData.getData('text/plain');
-          const target = e.target;
-          if (pastedText && target instanceof HTMLTextAreaElement) {
-            const start = target.selectionStart ?? description.length;
-            const end = target.selectionEnd ?? description.length;
-            const next =
-              description.slice(0, start) + pastedText + description.slice(end);
-            setDescription(next);
-            requestAnimationFrame(() => {
-              const pos = start + pastedText.length;
-              target.setSelectionRange(pos, pos);
-            });
-          }
-          const file = item.getAsFile();
-          if (!file) continue;
-          if (file.size > MAX_SCREENSHOT_SIZE) {
-            toast.error('粘贴的截图不能超过 5MB');
-            return;
-          }
-          const reader = new FileReader();
-          reader.onload = () => {
-            const result = reader.result as string;
-            const base64 = result.includes(',') ? result.split(',')[1] : result;
-            addScreenshot(base64);
-          };
-          reader.readAsDataURL(file);
-          return;
+      const imageItems = Array.from(items).filter((item) =>
+        item.type.startsWith('image/'),
+      );
+      if (imageItems.length === 0) return;
+
+      e.preventDefault();
+      const target = e.target;
+      if (target instanceof HTMLTextAreaElement) {
+        const pastePlan = planImageClipboardPaste({
+          value: target.value,
+          selectionStart: target.selectionStart,
+          selectionEnd: target.selectionEnd,
+          text: e.clipboardData.getData('text/plain'),
+          imageItemCount: imageItems.length,
+          maxLength: MAX_DESCRIPTION_LENGTH,
+        });
+        if (pastePlan.value !== target.value) {
+          setDescription(pastePlan.value);
         }
+        requestAnimationFrame(() => {
+          target.setSelectionRange(
+            pastePlan.selectionStart,
+            pastePlan.selectionEnd,
+          );
+        });
+      }
+
+      const availableSlots = Math.max(0, MAX_SCREENSHOTS - screenshots.length);
+      const files = imageItems
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => file !== null);
+      const validFiles = files.filter((file) => {
+        if (file.size <= MAX_SCREENSHOT_SIZE) return true;
+        toast.error('粘贴的截图不能超过 5MB');
+        return false;
+      });
+      if (validFiles.length > availableSlots) {
+        toast.error(`最多上传 ${MAX_SCREENSHOTS} 张截图`);
+      }
+      for (const file of validFiles.slice(0, availableSlots)) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result as string;
+          const base64 = result.includes(',') ? result.split(',')[1] : result;
+          addScreenshot(base64);
+        };
+        reader.readAsDataURL(file);
       }
     },
-    [addScreenshot, description],
+    [addScreenshot, screenshots.length],
   );
 
   const removeScreenshot = useCallback((index: number) => {
@@ -178,24 +199,25 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
 
   // --- Generate report (Claude analysis) ---
 
-  const generateReport = useCallback(async (): Promise<GenerateResult | null> => {
-    try {
-      return await api.post<GenerateResult>(
-        '/api/bug-report/generate',
-        {
-          description: description.trim(),
-          screenshots: screenshots.length > 0 ? screenshots : undefined,
-        },
-        90000,
-      );
-    } catch (err) {
-      const msg =
-        typeof err === 'object' && err !== null && 'message' in err
-          ? (err as { message: string }).message
-          : '生成报告失败';
-      throw new Error(msg);
-    }
-  }, [description, screenshots]);
+  const generateReport =
+    useCallback(async (): Promise<GenerateResult | null> => {
+      try {
+        return await api.post<GenerateResult>(
+          '/api/bug-report/generate',
+          {
+            description: description.trim(),
+            screenshots: screenshots.length > 0 ? screenshots : undefined,
+          },
+          90000,
+        );
+      } catch (err) {
+        const msg =
+          typeof err === 'object' && err !== null && 'message' in err
+            ? (err as { message: string }).message
+            : '生成报告失败';
+        throw new Error(msg);
+      }
+    }, [description, screenshots]);
 
   // --- Submit flow ---
 
@@ -263,8 +285,7 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
         showToast('已打开 GitHub', '请在新标签页中登录并提交 Issue', 6000);
       }
     } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : '提交失败，请重试';
+      const msg = err instanceof Error ? err.message : '提交失败，请重试';
       showToast('提交失败', msg, 6000);
     }
   }, [generateReport, handleClose]);
@@ -340,10 +361,10 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="请描述你遇到的问题..."
                 rows={4}
-                maxLength={5000}
+                maxLength={MAX_DESCRIPTION_LENGTH}
               />
               <p className="text-xs text-muted-foreground mt-1">
-                {description.length}/5000
+                {description.length}/{MAX_DESCRIPTION_LENGTH}
               </p>
             </div>
 
@@ -396,7 +417,11 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
         {step === 1 && showConfirm && (
           <div className="text-center py-4 space-y-3">
             <p className="text-sm text-foreground">
-              将以 <span className="font-semibold text-foreground">{caps?.ghUsername || 'GitHub'}</span> 的身份提交 Issue 到
+              将以{' '}
+              <span className="font-semibold text-foreground">
+                {caps?.ghUsername || 'GitHub'}
+              </span>{' '}
+              的身份提交 Issue 到
             </p>
             <p className="text-sm text-muted-foreground">riba2534/happyclaw</p>
           </div>
@@ -466,12 +491,16 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
               <Button variant="outline" onClick={() => setShowConfirm(false)}>
                 取消
               </Button>
-              <Button variant="outline" onClick={() => { setShowConfirm(false); handleGenerateForPreview(); }}>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowConfirm(false);
+                  handleGenerateForPreview();
+                }}
+              >
                 手动编辑
               </Button>
-              <Button onClick={handleConfirmSubmit}>
-                确认提交
-              </Button>
+              <Button onClick={handleConfirmSubmit}>确认提交</Button>
             </>
           )}
           {step === 2 && (

--- a/web/src/components/common/BugReportDialog.tsx
+++ b/web/src/components/common/BugReportDialog.tsx
@@ -139,6 +139,19 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
       for (const item of items) {
         if (item.type.startsWith('image/')) {
           e.preventDefault();
+          const pastedText = e.clipboardData.getData('text/plain');
+          const target = e.target;
+          if (pastedText && target instanceof HTMLTextAreaElement) {
+            const start = target.selectionStart ?? description.length;
+            const end = target.selectionEnd ?? description.length;
+            const next =
+              description.slice(0, start) + pastedText + description.slice(end);
+            setDescription(next);
+            requestAnimationFrame(() => {
+              const pos = start + pastedText.length;
+              target.setSelectionRange(pos, pos);
+            });
+          }
           const file = item.getAsFile();
           if (!file) continue;
           if (file.size > MAX_SCREENSHOT_SIZE) {
@@ -156,7 +169,7 @@ export function BugReportDialog({ open, onClose }: BugReportDialogProps) {
         }
       }
     },
-    [addScreenshot],
+    [addScreenshot, description],
   );
 
   const removeScreenshot = useCallback((index: number) => {

--- a/web/src/lib/mixed-paste.test.ts
+++ b/web/src/lib/mixed-paste.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'vitest';
+import { planImageClipboardPaste } from './mixed-paste';
+
+describe('planImageClipboardPaste', () => {
+  test('inserts mixed-paste text exactly once even with multiple image items', () => {
+    expect(
+      planImageClipboardPaste({
+        value: 'before',
+        selectionStart: 6,
+        selectionEnd: 6,
+        text: ' after',
+        imageItemCount: 3,
+      }),
+    ).toEqual({
+      preventDefault: true,
+      value: 'before after',
+      selectionStart: 12,
+      selectionEnd: 12,
+      insertedText: ' after',
+    });
+  });
+
+  test('replaces the current textarea selection', () => {
+    expect(
+      planImageClipboardPaste({
+        value: 'hello world',
+        selectionStart: 6,
+        selectionEnd: 11,
+        text: 'HappyClaw',
+        imageItemCount: 1,
+      }),
+    ).toMatchObject({
+      value: 'hello HappyClaw',
+      selectionStart: 15,
+      selectionEnd: 15,
+      insertedText: 'HappyClaw',
+    });
+  });
+
+  test('leaves text-only paste to the browser', () => {
+    expect(
+      planImageClipboardPaste({
+        value: 'existing',
+        selectionStart: 2,
+        selectionEnd: 4,
+        text: 'text',
+        imageItemCount: 0,
+      }),
+    ).toEqual({
+      preventDefault: false,
+      value: 'existing',
+      selectionStart: 2,
+      selectionEnd: 4,
+      insertedText: '',
+    });
+  });
+
+  test('handles image-only paste without changing textarea text', () => {
+    expect(
+      planImageClipboardPaste({
+        value: 'existing',
+        selectionStart: 3,
+        selectionEnd: 6,
+        text: '',
+        imageItemCount: 1,
+      }),
+    ).toEqual({
+      preventDefault: true,
+      value: 'existing',
+      selectionStart: 3,
+      selectionEnd: 6,
+      insertedText: '',
+    });
+  });
+
+  test('truncates inserted text after accounting for the replaced selection', () => {
+    expect(
+      planImageClipboardPaste({
+        value: 'abcdef',
+        selectionStart: 2,
+        selectionEnd: 4,
+        text: 'WXYZ',
+        imageItemCount: 1,
+        maxLength: 7,
+      }),
+    ).toEqual({
+      preventDefault: true,
+      value: 'abWXYef',
+      selectionStart: 5,
+      selectionEnd: 5,
+      insertedText: 'WXY',
+    });
+  });
+
+  test('does not insert text when no capacity remains', () => {
+    expect(
+      planImageClipboardPaste({
+        value: '12345',
+        selectionStart: 5,
+        selectionEnd: 5,
+        text: 'extra',
+        imageItemCount: 2,
+        maxLength: 5,
+      }),
+    ).toEqual({
+      preventDefault: true,
+      value: '12345',
+      selectionStart: 5,
+      selectionEnd: 5,
+      insertedText: '',
+    });
+  });
+
+  test('does not delete a selection when max-length capacity is zero', () => {
+    expect(
+      planImageClipboardPaste({
+        value: '123456',
+        selectionStart: 0,
+        selectionEnd: 1,
+        text: 'extra',
+        imageItemCount: 1,
+        maxLength: 5,
+      }),
+    ).toEqual({
+      preventDefault: true,
+      value: '123456',
+      selectionStart: 0,
+      selectionEnd: 1,
+      insertedText: '',
+    });
+  });
+});

--- a/web/src/lib/mixed-paste.ts
+++ b/web/src/lib/mixed-paste.ts
@@ -1,0 +1,87 @@
+export interface ImageClipboardPasteInput {
+  value: string;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+  text: string;
+  imageItemCount: number;
+  maxLength?: number;
+}
+
+export interface ImageClipboardPastePlan {
+  preventDefault: boolean;
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  insertedText: string;
+}
+
+function clampSelection(value: string, position: number | null): number {
+  if (position === null || !Number.isFinite(position)) return value.length;
+  return Math.max(0, Math.min(value.length, Math.trunc(position)));
+}
+
+/**
+ * Plan the text side of a clipboard paste that also contains one or more
+ * images. Browsers insert plain text for us when there is no image; once we
+ * prevent that default to collect images, the same insertion must be applied
+ * exactly once by the application.
+ */
+export function planImageClipboardPaste({
+  value,
+  selectionStart,
+  selectionEnd,
+  text,
+  imageItemCount,
+  maxLength,
+}: ImageClipboardPasteInput): ImageClipboardPastePlan {
+  const rawStart = clampSelection(value, selectionStart);
+  const rawEnd = clampSelection(value, selectionEnd);
+  const start = Math.min(rawStart, rawEnd);
+  const end = Math.max(rawStart, rawEnd);
+
+  if (imageItemCount <= 0) {
+    return {
+      preventDefault: false,
+      value,
+      selectionStart: start,
+      selectionEnd: end,
+      insertedText: '',
+    };
+  }
+
+  if (text.length === 0) {
+    return {
+      preventDefault: true,
+      value,
+      selectionStart: start,
+      selectionEnd: end,
+      insertedText: '',
+    };
+  }
+
+  const retainedLength = value.length - (end - start);
+  const insertionCapacity =
+    maxLength === undefined
+      ? text.length
+      : Math.max(0, Math.trunc(maxLength) - retainedLength);
+  const insertedText = text.slice(0, insertionCapacity);
+  if (insertedText.length === 0) {
+    return {
+      preventDefault: true,
+      value,
+      selectionStart: start,
+      selectionEnd: end,
+      insertedText: '',
+    };
+  }
+  const nextValue = value.slice(0, start) + insertedText + value.slice(end);
+  const cursor = start + insertedText.length;
+
+  return {
+    preventDefault: true,
+    value: nextValue,
+    selectionStart: cursor,
+    selectionEnd: cursor,
+    insertedText,
+  };
+}


### PR DESCRIPTION
When a paste contains both an image and text, `handlePaste` called `preventDefault()` to take over image attachments and never read `clipboardData.getData('text/plain')`, so the accompanying text disappeared.

Keep the existing image intake. If that same clipboard also has non-empty `text/plain`, insert it at the caret so the controlled textarea, autosize, and draft save follow the new `content`. Text-only paste is unchanged (browser default).

The bug-report dialog has the same listener on a wrapper that includes the description textarea, so it gets the same fix.

Inspired by rome-xi/aster#316 mixed-paste keep text/plain.

Fork PR: https://github.com/rome-xi/happyclaw-upstream/pull/4
