### PR TITLE
feat(providers): add resilient Claude quota telemetry

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -47,7 +47,7 @@ test -z "$(git status --porcelain)" || {
 export HAPPYCLAW_PREVIOUS_SHA="$(git rev-parse HEAD)"
 printf 'Rollback commit: %s\n' "$HAPPYCLAW_PREVIOUS_SHA"
 git fetch --prune origin \
-  "refs/heads/$HAPPYCLAW_DEPLOY_REF:refs/remotes/origin/$HAPPYCLAW_DEPLOY_REF"
+  "refs/heads/${HAPPYCLAW_DEPLOY_REF}:refs/remotes/origin/${HAPPYCLAW_DEPLOY_REF}"
 test "$(git rev-parse "origin/$HAPPYCLAW_DEPLOY_REF")" = "$HAPPYCLAW_EXPECTED_SHA"
 ```
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -121,6 +121,10 @@ import {
   type ProviderFallbackRetryTurn,
 } from './provider-fallback.js';
 import {
+  isTerminalSdkRateLimitRejection,
+  normalizeSdkRateLimitObservation,
+} from './provider-quota-observation.js';
+import {
   runSdkControlWithTimeout,
   SdkFirstResponseWatchdog,
 } from './sdk-control.js';
@@ -1841,6 +1845,19 @@ async function runQueryAttempt(
     }
     if (emitOutput) writeOutput(output);
   };
+  const publishProviderQuotaObservation = (info: SDKRateLimitInfo): void => {
+    // Passive provider observations are host control-plane state, including
+    // internal maintenance queries whose user-visible output is suppressed.
+    writeOutput(
+      outputCorrelation.correlate({
+        status: 'stream',
+        result: null,
+        providerQuotaObservation: normalizeSdkRateLimitObservation(info),
+        turnId: containerInput.turnId,
+        sessionId: newSessionId || sessionId,
+      }),
+    );
+  };
   let providerFailurePublished = false;
   /**
    * Publish one provider failure control signal.
@@ -2880,7 +2897,8 @@ async function runQueryAttempt(
       // the original indefinite "thinking" state.
       if (message.type === 'rate_limit_event') {
         const info: SDKRateLimitInfo = message.rate_limit_info;
-        if (info.status === 'rejected') {
+        publishProviderQuotaObservation(info);
+        if (isTerminalSdkRateLimitRejection(info)) {
           const limitDecision = decideProviderLimitAction({
             structuredRejection: { rateLimitType: info.rateLimitType },
             result: null,

--- a/container/agent-runner/src/provider-quota-observation.ts
+++ b/container/agent-runner/src/provider-quota-observation.ts
@@ -1,0 +1,91 @@
+import type { SDKRateLimitInfo } from '@anthropic-ai/claude-agent-sdk';
+
+import type { ContainerOutput } from './types.js';
+
+export type RunnerProviderQuotaObservation = NonNullable<
+  ContainerOutput['providerQuotaObservation']
+>;
+
+const MAX_SIGNAL_TEXT_LENGTH = 100;
+
+function boundedText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > MAX_SIGNAL_TEXT_LENGTH)
+    return undefined;
+  return normalized;
+}
+
+function finitePositive(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function fraction(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= 1
+    ? value
+    : undefined;
+}
+
+/**
+ * Convert the SDK's normalized event into HappyClaw's bounded control-plane
+ * DTO. The SDK derives utilization from Anthropic's unified headers, whose
+ * unit is a 0..1 fraction. Keeping that unit here prevents accidental mixing
+ * with `/api/oauth/usage`, where utilization is already a 0..100 percentage.
+ */
+export function normalizeSdkRateLimitObservation(
+  info: SDKRateLimitInfo,
+  observedAt = Date.now(),
+): RunnerProviderQuotaObservation {
+  const utilization = fraction(info.utilization);
+  const resetsAt = finitePositive(info.resetsAt);
+  const overageResetsAt = finitePositive(info.overageResetsAt);
+  const surpassedThreshold = fraction(info.surpassedThreshold);
+  const rateLimitType = boundedText(info.rateLimitType);
+  const overageDisabledReason = boundedText(info.overageDisabledReason);
+  const errorCode = boundedText(info.errorCode);
+
+  return {
+    source: 'sdk_rate_limit_event',
+    observedAt:
+      Number.isFinite(observedAt) && observedAt > 0 ? observedAt : Date.now(),
+    status: info.status,
+    ...(rateLimitType ? { rateLimitType } : {}),
+    ...(utilization !== undefined ? { utilization } : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+    ...(info.overageStatus ? { overageStatus: info.overageStatus } : {}),
+    ...(overageResetsAt !== undefined ? { overageResetsAt } : {}),
+    ...(overageDisabledReason ? { overageDisabledReason } : {}),
+    ...(typeof info.isUsingOverage === 'boolean'
+      ? { isUsingOverage: info.isUsingOverage }
+      : {}),
+    ...(typeof info.overageInUse === 'boolean'
+      ? { overageInUse: info.overageInUse }
+      : {}),
+    ...(surpassedThreshold !== undefined ? { surpassedThreshold } : {}),
+    ...(errorCode ? { errorCode } : {}),
+    ...(typeof info.canUserPurchaseCredits === 'boolean'
+      ? { canUserPurchaseCredits: info.canUserPurchaseCredits }
+      : {}),
+    ...(typeof info.hasChargeableSavedPaymentMethod === 'boolean'
+      ? {
+          hasChargeableSavedPaymentMethod: info.hasChargeableSavedPaymentMethod,
+        }
+      : {}),
+  };
+}
+
+/** A rejected subscription claim is still serviceable once overage is active. */
+export function isTerminalSdkRateLimitRejection(
+  info: SDKRateLimitInfo,
+): boolean {
+  return (
+    info.status === 'rejected' &&
+    info.isUsingOverage !== true &&
+    info.overageInUse !== true
+  );
+}

--- a/container/agent-runner/src/types.ts
+++ b/container/agent-runner/src/types.ts
@@ -333,6 +333,30 @@ export interface ContainerOutput {
   error?: string;
   providerFailure?: boolean;
   /**
+   * Passive SDK rate-limit observation. `utilization` is the SDK/header
+   * fraction (0..1), not the OAuth usage endpoint's 0..100 percentage.
+   */
+  providerQuotaObservation?: {
+    source: 'sdk_rate_limit_event';
+    /** Unix epoch milliseconds. */
+    observedAt: number;
+    status: 'allowed' | 'allowed_warning' | 'rejected';
+    rateLimitType?: string;
+    utilization?: number;
+    /** Unix epoch seconds. */
+    resetsAt?: number;
+    overageStatus?: 'allowed' | 'allowed_warning' | 'rejected';
+    /** Unix epoch seconds. */
+    overageResetsAt?: number;
+    overageDisabledReason?: string;
+    isUsingOverage?: boolean;
+    overageInUse?: boolean;
+    surpassedThreshold?: number;
+    errorCode?: string;
+    canUserPurchaseCredits?: boolean;
+    hasChargeableSavedPaymentMethod?: boolean;
+  };
+  /**
    * Upstream `rate_limit_event.resetsAt` for an account-scope rejection. The
    * host quarantines the provider until this instant instead of the flat
    * recovery interval, so a five-hour account limit cannot re-enter rotation

--- a/src/agent-runtime-contracts.ts
+++ b/src/agent-runtime-contracts.ts
@@ -1,5 +1,31 @@
 import type { MessageSourceKind, StreamEvent } from './types.js';
 
+/**
+ * One passive SDK rate-limit observation. SDK `utilization` is a 0..1
+ * fraction; OAuth `/usage` buckets use 0..100 and intentionally live in a
+ * separate response field.
+ */
+export interface ProviderQuotaObservation {
+  source: 'sdk_rate_limit_event';
+  /** Event observation time, Unix epoch milliseconds. */
+  observedAt: number;
+  status: 'allowed' | 'allowed_warning' | 'rejected';
+  rateLimitType?: string;
+  utilization?: number;
+  /** Anthropic unified-header reset time, Unix epoch seconds. */
+  resetsAt?: number;
+  overageStatus?: 'allowed' | 'allowed_warning' | 'rejected';
+  /** Anthropic overage reset time, Unix epoch seconds. */
+  overageResetsAt?: number;
+  overageDisabledReason?: string;
+  isUsingOverage?: boolean;
+  overageInUse?: boolean;
+  surpassedThreshold?: number;
+  errorCode?: string;
+  canUserPurchaseCredits?: boolean;
+  hasChargeableSavedPaymentMethod?: boolean;
+}
+
 /** Framed host/runner output shared without coupling the parser to a launcher. */
 export interface ContainerOutput {
   status: 'success' | 'error' | 'stream' | 'closed';
@@ -8,6 +34,8 @@ export interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   providerFailure?: boolean;
+  /** Control-plane only; consumed by the host and never projected to chat. */
+  providerQuotaObservation?: ProviderQuotaObservation;
   providerRateLimitResetsAt?: number;
   providerFailureNotice?: string;
   providerRateLimitScope?: 'account' | 'model';

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -54,8 +54,10 @@ import {
   shellQuoteEnvLines,
   writeCredentialsFile,
   buildClaudeAiOauthPayload,
+  providerToConfig,
   updateProviderOAuthCredentialsIfCurrent,
 } from './runtime-config.js';
+import { updateProviderSessionCredentials } from './provider-session-credentials.js';
 import {
   removeClaudeKeychainOAuth,
   syncClaudeKeychainOAuth,
@@ -84,7 +86,10 @@ import {
   resolveTerminalProviderFailureNotice,
   resolveTransientRetryKey,
 } from './provider-failure.js';
-import type { ClaudeProviderConfig } from './runtime-config.js';
+import type {
+  ClaudeOAuthCredentials,
+  ClaudeProviderConfig,
+} from './runtime-config.js';
 import {
   loadManagedMcpLayers,
   resolveManagedMcpPolicy,
@@ -122,6 +127,16 @@ import { validateSkillId, validateSkillPath } from './skill-utils.js';
 import type { ClaudeContextAudit } from './stream-event.types.js';
 import type { ContainerOutput } from './agent-runtime-contracts.js';
 export type { ContainerOutput } from './agent-runtime-contracts.js';
+import {
+  captureProviderQuotaObservationEpoch,
+  consumeProviderQuotaControlOutput,
+} from './provider-quota-observation.js';
+import {
+  dockerOAuthCredentialsEqual,
+  readDockerClaudeOAuthCredentials,
+  reconcileDockerOAuthCredentials,
+  type DockerOAuthReconcileOutcome,
+} from './docker-oauth-credentials.js';
 import {
   resolveHostSkillPolicy,
   type HostSkillPolicy,
@@ -1569,11 +1584,17 @@ export function cleanupContainerTaskRuntimeEnvDirs(
   }
 }
 
+export interface DockerOauthLaunchSnapshot {
+  credentialsFilePath: string;
+  launchCredentials: ClaudeOAuthCredentials;
+}
+
 interface PreparedVolumeMounts {
   mounts: VolumeMount[];
   claudeContextPlan: ReturnType<typeof buildClaudeContextPlan>;
   runtimeMcpServers: Record<string, Record<string, unknown>>;
   hostPlugins: SdkPluginConfig[];
+  dockerOauthLaunch: DockerOauthLaunchSnapshot | null;
 }
 
 function prepareVolumeMounts(
@@ -1625,6 +1646,7 @@ function prepareVolumeMounts(
 
   const mounts: VolumeMount[] = [];
   let feishuCliBinding: FeishuCliRuntimeBinding | null = null;
+  let dockerOauthLaunch: PreparedVolumeMounts['dockerOauthLaunch'] = null;
   const projectRoot = process.cwd();
   const ownerId = group.created_by;
 
@@ -1942,6 +1964,13 @@ function prepareVolumeMounts(
   if (mergedConfig.claudeOAuthCredentials) {
     try {
       writeCredentialsFile(groupSessionsDir, mergedConfig);
+      const launchCredentials = buildClaudeAiOauthPayload(mergedConfig);
+      if (launchCredentials) {
+        dockerOauthLaunch = {
+          credentialsFilePath: path.join(groupSessionsDir, '.credentials.json'),
+          launchCredentials,
+        };
+      }
     } catch (err) {
       logger.warn(
         { group: group.name, err },
@@ -2024,6 +2053,7 @@ function prepareVolumeMounts(
     claudeContextPlan,
     runtimeMcpServers,
     hostPlugins: pluginSkills,
+    dockerOauthLaunch,
   };
 }
 
@@ -2280,6 +2310,78 @@ export function buildContainerArgs(
   return args;
 }
 
+/**
+ * Reconcile a Docker SDK credential rotation at a safe output/exit boundary.
+ * The lower-level helper performs the launch-snapshot CAS; on success, fan the
+ * adopted credential out to other persisted sessions so the next runner does
+ * not start from an invalidated refresh token.
+ */
+export function reconcileDockerOAuthAfterExit(
+  providerId: string | null,
+  launch: DockerOauthLaunchSnapshot | null,
+  dependencies: {
+    reconcile?: typeof reconcileDockerOAuthCredentials;
+    fanOutUpdatedCredentials?: (providerId: string) => void;
+  } = {},
+): DockerOAuthReconcileOutcome | 'error' | null {
+  if (!providerId || !launch) return null;
+  try {
+    const outcome = (dependencies.reconcile ?? reconcileDockerOAuthCredentials)(
+      {
+        providerId,
+        credentialsFilePath: launch.credentialsFilePath,
+        launchCredentials: launch.launchCredentials,
+      },
+    );
+    if (outcome === 'updated') {
+      const adopted = readDockerClaudeOAuthCredentials(
+        launch.credentialsFilePath,
+      );
+      if (adopted) launch.launchCredentials = adopted;
+      const fanOut =
+        dependencies.fanOutUpdatedCredentials ??
+        ((updatedProviderId: string) => {
+          const provider = getProviders().find(
+            (candidate) => candidate.id === updatedProviderId,
+          );
+          if (provider) {
+            updateProviderSessionCredentials(
+              updatedProviderId,
+              providerToConfig(provider),
+            );
+          }
+        });
+      fanOut(providerId);
+    } else if (outcome === 'stale') {
+      // A sibling Runner may already have adopted this exact rotation and
+      // fanned it into our mounted file. Advance this warm Runner's CAS base
+      // only when disk and current Provider agree; an administrator change or
+      // unrelated account can never be treated as our credential lineage.
+      const diskCredentials = readDockerClaudeOAuthCredentials(
+        launch.credentialsFilePath,
+      );
+      const currentProvider = getProviders().find(
+        (candidate) => candidate.id === providerId,
+      );
+      const currentCredentials = currentProvider
+        ? buildClaudeAiOauthPayload(providerToConfig(currentProvider))
+        : null;
+      if (
+        diskCredentials &&
+        currentCredentials &&
+        dockerOAuthCredentialsEqual(diskCredentials, currentCredentials)
+      ) {
+        launch.launchCredentials = diskCredentials;
+      }
+    }
+    return outcome;
+  } catch {
+    // Credential reconciliation is post-run best effort. It must never escape
+    // the EventEmitter close callback or prevent the completed turn settling.
+    return 'error';
+  }
+}
+
 export async function runContainerAgent(
   group: RegisteredGroup,
   input: ContainerInput,
@@ -2305,6 +2407,9 @@ export async function runContainerAgent(
     transientRetryProfileForInput(input.turnId),
   );
   const selectedProfileId = poolResult?.profileId ?? null;
+  const selectedProviderQuotaEpoch = selectedProfileId
+    ? captureProviderQuotaObservationEpoch(selectedProfileId)
+    : null;
   const resolvedProvider = poolResult?.resolved;
   const modelSelectionPinned = !!resolvePinnedModelConfigId(
     input.agentProfile?.modelConfigId,
@@ -2492,119 +2597,171 @@ export async function runContainerAgent(
         clearTimeout(timeout);
         timeout = setTimeout(killOnTimeout, timeoutMs);
       };
-      const handleOutput = onOutput
-        ? async (output: ContainerOutput): Promise<void> => {
-            if (
-              !output.providerFailure &&
-              output.inputTurnCompleted !== undefined
-            ) {
-              healthyInputTurnCompleted = output.inputTurnCompleted;
-            }
-            if (output.providerFailureRetrying) {
-              if (output.providerFailure && selectedProfileId) {
-                if (!providerFailureReported) {
-                  providerFailureReported = true;
-                  quarantineFromOutput(selectedProfileId, output);
-                  logger.warn(
-                    {
-                      group: group.name,
-                      containerName,
-                      providerId: selectedProfileId,
-                    },
-                    'Provider failure detected; agent runner is retrying the failed turn with fallback model',
-                  );
-                }
-              }
-              // This is host-control metadata, never a user-visible output.
-              return;
-            }
-            if (output.providerFailure && selectedProfileId) {
-              if (!providerFailureReported) {
-                providerFailureReported = true;
-                quarantineFromOutput(selectedProfileId, output);
-                logger.warn(
-                  {
-                    group: group.name,
-                    containerName,
-                    providerId: selectedProfileId,
-                    result: output.result,
-                  },
-                  'Provider failure detected from streamed output, stopping container',
-                );
-              }
-            }
-            if (
-              output.providerFailureMaintenance &&
-              healthyInputTurnCompleted
-            ) {
-              providerFailureMaintenance = true;
+      const reconcileDockerOAuth = (
+        phase: 'output' | 'exit',
+      ): DockerOAuthReconcileOutcome | 'error' | null => {
+        const outcome = reconcileDockerOAuthAfterExit(
+          selectedProfileId,
+          preparedLaunch.dockerOauthLaunch,
+        );
+        if (outcome === 'updated') {
+          logger.info(
+            { group: group.name, providerId: selectedProfileId, phase },
+            'Persisted Docker SDK-refreshed OAuth credentials',
+          );
+        } else if (outcome === 'invalid' || outcome === 'not_newer') {
+          logger.warn(
+            {
+              group: group.name,
+              providerId: selectedProfileId,
+              outcome,
+              phase,
+            },
+            'Ignored invalid Docker OAuth credential rewrite',
+          );
+        } else if (outcome === 'stale') {
+          logger.info(
+            { group: group.name, providerId: selectedProfileId, phase },
+            'Ignored Docker OAuth refresh after Provider credentials changed',
+          );
+        } else if (outcome === 'error') {
+          logger.warn(
+            { group: group.name, providerId: selectedProfileId, phase },
+            'Docker OAuth credential reconciliation failed',
+          );
+        }
+        return outcome;
+      };
+      const handleOutput = async (output: ContainerOutput): Promise<void> => {
+        if (
+          output.providerQuotaObservation ||
+          output.inputTurnCompleted === true ||
+          output.status === 'success' ||
+          output.status === 'error'
+        ) {
+          reconcileDockerOAuth('output');
+        }
+        if (
+          consumeProviderQuotaControlOutput(
+            selectedProfileId,
+            output,
+            selectedProviderQuotaEpoch,
+          )
+        ) {
+          // Let the caller refresh its warm-runner activity clock, but keep
+          // the frame on the control path (callers return before projection).
+          if (onOutput) await onOutput(output);
+          resetTimeout();
+          return;
+        }
+        if (!onOutput) return;
+        if (
+          !output.providerFailure &&
+          output.inputTurnCompleted !== undefined
+        ) {
+          healthyInputTurnCompleted = output.inputTurnCompleted;
+        }
+        if (output.providerFailureRetrying) {
+          if (output.providerFailure && selectedProfileId) {
+            if (!providerFailureReported) {
+              providerFailureReported = true;
+              quarantineFromOutput(selectedProfileId, output);
               logger.warn(
                 {
                   group: group.name,
                   containerName,
                   providerId: selectedProfileId,
                 },
-                'Provider failed during internal maintenance; quarantining without user projection or replay',
+                'Provider failure detected; agent runner is retrying the failed turn with fallback model',
               );
-              exec(`docker stop ${containerName}`, (err) => {
-                if (err) {
-                  logger.warn(
-                    { group: group.name, containerName, err },
-                    'Failed to stop container after maintenance provider failure',
-                  );
-                  container.kill('SIGTERM');
-                }
-              });
-              return;
-            }
-            if (output.providerFailureMaintenance) {
-              logger.warn(
-                {
-                  group: group.name,
-                  containerName,
-                  providerId: selectedProfileId,
-                },
-                'Maintenance query failed before durable input completion; treating as replayable provider failure',
-              );
-            }
-            if (output.providerFailure) {
-              const terminal = applyProviderFailureDisposition(
-                output,
-                selectedProfileId,
-                !modelSelectionPinned,
-              );
-              providerFailureTerminal = terminal;
-              logger.warn(
-                {
-                  group: group.name,
-                  containerName,
-                  providerId: selectedProfileId,
-                  terminal,
-                },
-                providerFailureDispositionLogMessage(output, terminal),
-              );
-            }
-            // Quarantine and classify before awaiting any IM/card projection so
-            // concurrent sessions cannot keep selecting a provider that just
-            // returned an account-level failure.
-            await onOutput(output);
-            // The foreground projection resets its idle-close timer during
-            // onOutput. Reset the outer watchdog afterwards so graceful idle
-            // reclamation always wins, even when provider delivery was slow.
-            resetTimeout();
-            if (output.providerFailure) {
-              exec(`docker stop ${containerName}`, (err) => {
-                if (err) {
-                  logger.warn(
-                    { group: group.name, containerName, err },
-                    'Failed to stop container after provider failure',
-                  );
-                  container.kill('SIGTERM');
-                }
-              });
             }
           }
-        : undefined;
+          // This is host-control metadata, never a user-visible output.
+          return;
+        }
+        if (output.providerFailure && selectedProfileId) {
+          if (!providerFailureReported) {
+            providerFailureReported = true;
+            quarantineFromOutput(selectedProfileId, output);
+            logger.warn(
+              {
+                group: group.name,
+                containerName,
+                providerId: selectedProfileId,
+                result: output.result,
+              },
+              'Provider failure detected from streamed output, stopping container',
+            );
+          }
+        }
+        if (output.providerFailureMaintenance && healthyInputTurnCompleted) {
+          providerFailureMaintenance = true;
+          logger.warn(
+            {
+              group: group.name,
+              containerName,
+              providerId: selectedProfileId,
+            },
+            'Provider failed during internal maintenance; quarantining without user projection or replay',
+          );
+          exec(`docker stop ${containerName}`, (err) => {
+            if (err) {
+              logger.warn(
+                { group: group.name, containerName, err },
+                'Failed to stop container after maintenance provider failure',
+              );
+              container.kill('SIGTERM');
+            }
+          });
+          return;
+        }
+        if (output.providerFailureMaintenance) {
+          logger.warn(
+            {
+              group: group.name,
+              containerName,
+              providerId: selectedProfileId,
+            },
+            'Maintenance query failed before durable input completion; treating as replayable provider failure',
+          );
+        }
+        if (output.providerFailure) {
+          const terminal = applyProviderFailureDisposition(
+            output,
+            selectedProfileId,
+            !modelSelectionPinned,
+          );
+          providerFailureTerminal = terminal;
+          logger.warn(
+            {
+              group: group.name,
+              containerName,
+              providerId: selectedProfileId,
+              terminal,
+            },
+            providerFailureDispositionLogMessage(output, terminal),
+          );
+        }
+        // Quarantine and classify before awaiting any IM/card projection so
+        // concurrent sessions cannot keep selecting a provider that just
+        // returned an account-level failure.
+        await onOutput(output);
+        // The foreground projection resets its idle-close timer during
+        // onOutput. Reset the outer watchdog afterwards so graceful idle
+        // reclamation always wins, even when provider delivery was slow.
+        resetTimeout();
+        if (output.providerFailure) {
+          exec(`docker stop ${containerName}`, (err) => {
+            if (err) {
+              logger.warn(
+                { group: group.name, containerName, err },
+                'Failed to stop container after provider failure',
+              );
+              container.kill('SIGTERM');
+            }
+          });
+        }
+      };
 
       // Attach stdout/stderr handlers using shared parser
       attachStdoutHandler(container.stdout, stdoutState, {
@@ -2620,6 +2777,7 @@ export async function runContainerAgent(
       container.on('close', (code, signal) => {
         clearTimeout(timeout);
         const duration = Date.now() - startTime;
+        reconcileDockerOAuth('exit');
 
         const closeCtx: CloseHandlerContext = {
           groupName: group.name,
@@ -3365,6 +3523,9 @@ export async function runHostAgent(
     transientRetryProfileForInput(input.turnId),
   );
   const hostSelectedProfileId = hostPoolResult?.profileId ?? null;
+  const hostProviderQuotaEpoch = hostSelectedProfileId
+    ? captureProviderQuotaObservationEpoch(hostSelectedProfileId)
+    : null;
   const hostModelSelectionPinned = !!resolvePinnedModelConfigId(
     input.agentProfile?.modelConfigId,
   );
@@ -3749,101 +3910,111 @@ export async function runHostAgent(
         clearTimeout(timeout);
         timeout = setTimeout(killOnTimeout, timeoutMs);
       };
-      const handleOutput = onOutput
-        ? async (output: ContainerOutput): Promise<void> => {
-            if (
-              !output.providerFailure &&
-              output.inputTurnCompleted !== undefined
-            ) {
-              hostHealthyInputTurnCompleted = output.inputTurnCompleted;
-            }
-            if (output.providerFailureRetrying) {
-              if (output.providerFailure && hostSelectedProfileId) {
-                if (!hostProviderFailureReported) {
-                  hostProviderFailureReported = true;
-                  quarantineFromOutput(hostSelectedProfileId, output);
-                  logger.warn(
-                    {
-                      group: group.name,
-                      processId,
-                      providerId: hostSelectedProfileId,
-                    },
-                    'Provider failure detected; agent runner is retrying the failed turn with fallback model',
-                  );
-                }
-              }
-              // This is host-control metadata, never a user-visible output.
-              return;
-            }
-            if (output.providerFailure && hostSelectedProfileId) {
-              if (!hostProviderFailureReported) {
-                hostProviderFailureReported = true;
-                quarantineFromOutput(hostSelectedProfileId, output);
-                logger.warn(
-                  {
-                    group: group.name,
-                    processId,
-                    providerId: hostSelectedProfileId,
-                    result: output.result,
-                  },
-                  'Provider failure detected from streamed output, stopping host agent',
-                );
-              }
-            }
-            if (
-              output.providerFailureMaintenance &&
-              hostHealthyInputTurnCompleted
-            ) {
-              hostProviderFailureMaintenance = true;
+      const handleOutput = async (output: ContainerOutput): Promise<void> => {
+        if (
+          consumeProviderQuotaControlOutput(
+            hostSelectedProfileId,
+            output,
+            hostProviderQuotaEpoch,
+          )
+        ) {
+          if (onOutput) await onOutput(output);
+          resetTimeout();
+          return;
+        }
+        if (!onOutput) return;
+        if (
+          !output.providerFailure &&
+          output.inputTurnCompleted !== undefined
+        ) {
+          hostHealthyInputTurnCompleted = output.inputTurnCompleted;
+        }
+        if (output.providerFailureRetrying) {
+          if (output.providerFailure && hostSelectedProfileId) {
+            if (!hostProviderFailureReported) {
+              hostProviderFailureReported = true;
+              quarantineFromOutput(hostSelectedProfileId, output);
               logger.warn(
                 {
                   group: group.name,
                   processId,
                   providerId: hostSelectedProfileId,
                 },
-                'Provider failed during internal maintenance; quarantining without user projection or replay',
+                'Provider failure detected; agent runner is retrying the failed turn with fallback model',
               );
-              killProcessTree(proc, 'SIGTERM');
-              return;
-            }
-            if (output.providerFailureMaintenance) {
-              logger.warn(
-                {
-                  group: group.name,
-                  processId,
-                  providerId: hostSelectedProfileId,
-                },
-                'Maintenance query failed before durable input completion; treating as replayable provider failure',
-              );
-            }
-            if (output.providerFailure) {
-              const terminal = applyProviderFailureDisposition(
-                output,
-                hostSelectedProfileId,
-                !hostModelSelectionPinned,
-              );
-              hostProviderFailureTerminal = terminal;
-              logger.warn(
-                {
-                  group: group.name,
-                  processId,
-                  providerId: hostSelectedProfileId,
-                  terminal,
-                },
-                providerFailureDispositionLogMessage(output, terminal),
-              );
-            }
-            // Keep provider selection safe while the user-facing projection is
-            // awaiting a network ACK.
-            await onOutput(output);
-            // See the container path above: start the watchdog after the
-            // foreground projection has reset its graceful idle timer.
-            resetTimeout();
-            if (output.providerFailure) {
-              killProcessTree(proc, 'SIGTERM');
             }
           }
-        : undefined;
+          // This is host-control metadata, never a user-visible output.
+          return;
+        }
+        if (output.providerFailure && hostSelectedProfileId) {
+          if (!hostProviderFailureReported) {
+            hostProviderFailureReported = true;
+            quarantineFromOutput(hostSelectedProfileId, output);
+            logger.warn(
+              {
+                group: group.name,
+                processId,
+                providerId: hostSelectedProfileId,
+                result: output.result,
+              },
+              'Provider failure detected from streamed output, stopping host agent',
+            );
+          }
+        }
+        if (
+          output.providerFailureMaintenance &&
+          hostHealthyInputTurnCompleted
+        ) {
+          hostProviderFailureMaintenance = true;
+          logger.warn(
+            {
+              group: group.name,
+              processId,
+              providerId: hostSelectedProfileId,
+            },
+            'Provider failed during internal maintenance; quarantining without user projection or replay',
+          );
+          killProcessTree(proc, 'SIGTERM');
+          return;
+        }
+        if (output.providerFailureMaintenance) {
+          logger.warn(
+            {
+              group: group.name,
+              processId,
+              providerId: hostSelectedProfileId,
+            },
+            'Maintenance query failed before durable input completion; treating as replayable provider failure',
+          );
+        }
+        if (output.providerFailure) {
+          const terminal = applyProviderFailureDisposition(
+            output,
+            hostSelectedProfileId,
+            !hostModelSelectionPinned,
+          );
+          hostProviderFailureTerminal = terminal;
+          logger.warn(
+            {
+              group: group.name,
+              processId,
+              providerId: hostSelectedProfileId,
+              terminal,
+            },
+            providerFailureDispositionLogMessage(output, terminal),
+          );
+        }
+        // Keep provider selection safe while the user-facing projection is
+        // awaiting a network ACK.
+        await onOutput(output);
+        // See the container path above: start the watchdog after the
+        // foreground projection has reset its graceful idle timer.
+        resetTimeout();
+        if (output.providerFailure) {
+          killProcessTree(proc, 'SIGTERM');
+        }
+      };
 
       // 10. stdout/stderr 解析
       attachStdoutHandler(proc.stdout, stdoutState, {

--- a/src/db.ts
+++ b/src/db.ts
@@ -8507,6 +8507,28 @@ export function setSessionProviderId(
   })();
 }
 
+/** Persisted session namespaces currently bound to one Provider account. */
+export function listSessionNamespacesForProviderId(providerId: string): Array<{
+  groupFolder: string;
+  agentId: string | null;
+}> {
+  if (!isDatabaseInitialized()) return [];
+  const rows = db
+    .prepare(
+      `SELECT group_folder, agent_id
+       FROM sessions
+       WHERE provider_id = ?`,
+    )
+    .all(providerId) as Array<{
+    group_folder: string;
+    agent_id: string | null;
+  }>;
+  return rows.map((row) => ({
+    groupFolder: row.group_folder,
+    agentId: row.agent_id || null,
+  }));
+}
+
 export function deleteAllSessionsForFolder(groupFolder: string): void {
   db.transaction(() => {
     db.prepare('DELETE FROM sessions WHERE group_folder = ?').run(groupFolder);

--- a/src/docker-oauth-credentials.ts
+++ b/src/docker-oauth-credentials.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+
+import {
+  normalizeClaudeAiOauth,
+  type KeychainClaudeAiOauth,
+} from './macos-keychain-credentials.js';
+import {
+  updateProviderOAuthCredentialsIfCurrent,
+  type ClaudeOAuthCredentials,
+} from './runtime-config.js';
+
+const MAX_DOCKER_CREDENTIAL_FILE_BYTES = 64 * 1024;
+
+export type DockerOAuthReconcileOutcome =
+  | 'missing'
+  | 'invalid'
+  | 'unchanged'
+  | 'not_newer'
+  | 'stale'
+  | 'updated';
+
+export interface ReconcileDockerOAuthCredentialsOptions {
+  providerId: string;
+  credentialsFilePath: string;
+  launchCredentials: ClaudeOAuthCredentials;
+  persistRefreshedCredentials?: (
+    expected: ClaudeOAuthCredentials,
+    refreshed: ClaudeOAuthCredentials,
+  ) => boolean;
+}
+
+function canonicalOAuth(credentials: KeychainClaudeAiOauth): string {
+  return JSON.stringify(normalizeClaudeAiOauth(credentials));
+}
+
+export function dockerOAuthCredentialsEqual(
+  left: ClaudeOAuthCredentials,
+  right: ClaudeOAuthCredentials,
+): boolean {
+  try {
+    return canonicalOAuth(left) === canonicalOAuth(right);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the complete Claude OAuth value from a Docker session credential file.
+ * The file is writable by Claude Code, so incomplete or non-regular payloads
+ * are ignored rather than being allowed into Provider configuration.
+ */
+export function readDockerClaudeOAuthCredentials(
+  credentialsFilePath: string,
+): ClaudeOAuthCredentials | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(credentialsFilePath);
+  } catch {
+    return null;
+  }
+  if (
+    !stat.isFile() ||
+    stat.isSymbolicLink() ||
+    stat.size <= 0 ||
+    stat.size > MAX_DOCKER_CREDENTIAL_FILE_BYTES
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(
+      fs.readFileSync(credentialsFilePath, 'utf8'),
+    );
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    const oauth = normalizeClaudeAiOauth(
+      (parsed as Record<string, unknown>).claudeAiOauth,
+    );
+    return { ...oauth };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Adopt a Docker SDK credential rotation only while the selected Provider is
+ * still exactly the credential snapshot used for this launch. A concurrent
+ * administrator update therefore wins the CAS and can never be overwritten by
+ * a runner that exits later.
+ */
+export function reconcileDockerOAuthCredentials(
+  options: ReconcileDockerOAuthCredentialsOptions,
+): DockerOAuthReconcileOutcome {
+  const refreshed = readDockerClaudeOAuthCredentials(
+    options.credentialsFilePath,
+  );
+  if (!refreshed) {
+    return fs.existsSync(options.credentialsFilePath) ? 'invalid' : 'missing';
+  }
+
+  let expected: ClaudeOAuthCredentials;
+  try {
+    expected = { ...normalizeClaudeAiOauth(options.launchCredentials) };
+  } catch {
+    return 'invalid';
+  }
+  if (dockerOAuthCredentialsEqual(expected, refreshed)) {
+    return 'unchanged';
+  }
+  // A token refresh extends the credential lifetime. Do not persist arbitrary
+  // rewrites of the writable session file that do not carry that evidence.
+  if (refreshed.expiresAt <= expected.expiresAt) return 'not_newer';
+
+  const persist =
+    options.persistRefreshedCredentials ??
+    ((launch, next) =>
+      updateProviderOAuthCredentialsIfCurrent(
+        options.providerId,
+        launch,
+        next,
+      ));
+  try {
+    return persist(expected, refreshed) ? 'updated' : 'stale';
+  } catch {
+    // Provider deletion and concurrent configuration changes are both stale
+    // launch outcomes, not runtime failures for the completed user turn.
+    return 'stale';
+  }
+}

--- a/src/group-queue.ts
+++ b/src/group-queue.ts
@@ -2258,6 +2258,33 @@ export class GroupQueue {
   }
 
   /**
+   * Gracefully retire only runners using the refreshed Provider. The drain
+   * sentinel is consumed after the current query, so a read-only usage poll
+   * can rotate credentials without interrupting unrelated or in-flight work.
+   */
+  drainProviderRunnersForCredentialRefresh(providerId: string): number {
+    let drained = 0;
+    for (const [jid, state] of this.groups) {
+      if (
+        !state.active ||
+        !state.groupFolder ||
+        state.selectedProviderId !== providerId ||
+        state.drainSentinelWritten
+      ) {
+        continue;
+      }
+      if (!this.writeDrainSentinel(state as ActiveGroupState)) continue;
+      state.drainSentinelWritten = true;
+      drained++;
+      logger.info(
+        { groupJid: jid, groupFolder: state.groupFolder, providerId },
+        'Sent drain signal after provider credential refresh',
+      );
+    }
+    return drained;
+  }
+
+  /**
    * Interrupt the current query for the same chat only (do not cross-interrupt
    * sibling chats that share a serialized runner/folder).
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ import {
   PROVIDER_FAILURE_USER_NOTICE,
   resolveProviderFailureClass,
 } from './provider-failure.js';
+import { isProviderQuotaControlOutput } from './provider-quota-observation.js';
 import {
   closeDatabase,
   createTask,
@@ -10248,6 +10249,7 @@ async function runAgent(
   // Wrap onOutput to track session ID from streamed results
   const wrappedOnOutput = async (output: ContainerOutput) => {
     queue.markRunnerActivity(chatJid);
+    if (isProviderQuotaControlOutput(output)) return;
     bindRunnerActiveIpcCoverage(chatJid, output.activeIpcReceipts);
     const outputTurnId = output.turnId || output.streamEvent?.turnId;
     const isInterruptStatus =
@@ -16309,6 +16311,7 @@ async function processAgentConversation(
     // #547: warm-lifecycle bookkeeping — mark activity, and flag query-idle on
     // a substantive result / interruption so the runner can be kept warm.
     queue.markRunnerActivity(virtualJid);
+    if (isProviderQuotaControlOutput(output)) return;
     bindRunnerActiveIpcCoverage(virtualJid, output.activeIpcReceipts);
     const isInterruptStatus =
       output.status === 'stream' &&

--- a/src/provider-quota-observation.ts
+++ b/src/provider-quota-observation.ts
@@ -1,0 +1,206 @@
+import type { ProviderQuotaObservation } from './agent-runtime-contracts.js';
+import type { ContainerOutput } from './agent-runtime-contracts.js';
+
+export type ProviderQuotaSnapshot = ProviderQuotaObservation;
+
+export const MAX_PROVIDER_QUOTA_OBSERVATIONS = 64;
+
+const MAX_TEXT_LENGTH = 100;
+const MAX_PROVIDER_QUOTA_EPOCHS = MAX_PROVIDER_QUOTA_OBSERVATIONS * 4;
+const observations = new Map<string, ProviderQuotaSnapshot>();
+const observationEpochs = new Map<string, number>();
+let nextObservationEpoch = 1;
+
+function enforceEpochCapacity(): void {
+  while (observationEpochs.size > MAX_PROVIDER_QUOTA_EPOCHS) {
+    const oldestProviderId = observationEpochs.keys().next().value as
+      | string
+      | undefined;
+    if (oldestProviderId === undefined) break;
+    observationEpochs.delete(oldestProviderId);
+  }
+}
+
+function currentObservationEpoch(providerId: string): number {
+  const normalizedProviderId = providerId.trim();
+  const existing = observationEpochs.get(normalizedProviderId);
+  if (existing !== undefined) return existing;
+  const created = nextObservationEpoch++;
+  observationEpochs.set(normalizedProviderId, created);
+  enforceEpochCapacity();
+  return created;
+}
+
+/** Capture the credential generation that a Runner was launched with. */
+export function captureProviderQuotaObservationEpoch(
+  providerId: string,
+): number {
+  return currentObservationEpoch(providerId);
+}
+
+function boundedText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized && normalized.length <= MAX_TEXT_LENGTH
+    ? normalized
+    : undefined;
+}
+
+function finitePositive(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function fraction(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= 1
+    ? value
+    : undefined;
+}
+
+function enforceCapacity(): void {
+  while (observations.size > MAX_PROVIDER_QUOTA_OBSERVATIONS) {
+    let oldestKey: string | undefined;
+    let oldestObservedAt = Number.POSITIVE_INFINITY;
+    for (const [providerId, snapshot] of observations) {
+      if (snapshot.observedAt < oldestObservedAt) {
+        oldestObservedAt = snapshot.observedAt;
+        oldestKey = providerId;
+      }
+    }
+    if (oldestKey === undefined) break;
+    observations.delete(oldestKey);
+  }
+}
+
+function normalizeObservation(
+  value: ProviderQuotaObservation,
+  now: number,
+): ProviderQuotaObservation | null {
+  if (
+    value?.source !== 'sdk_rate_limit_event' ||
+    !['allowed', 'allowed_warning', 'rejected'].includes(value.status)
+  ) {
+    return null;
+  }
+
+  const reportedAt = finitePositive(value.observedAt);
+  // Docker and host share a clock, but fail closed on a wildly future stamp.
+  const observedAt =
+    reportedAt !== undefined && reportedAt <= now + 60_000 ? reportedAt : now;
+  const rateLimitType = boundedText(value.rateLimitType);
+  const utilization = fraction(value.utilization);
+  const resetsAt = finitePositive(value.resetsAt);
+  const overageResetsAt = finitePositive(value.overageResetsAt);
+  const overageDisabledReason = boundedText(value.overageDisabledReason);
+  const surpassedThreshold = fraction(value.surpassedThreshold);
+  const errorCode = boundedText(value.errorCode);
+  const overageStatus = ['allowed', 'allowed_warning', 'rejected'].includes(
+    String(value.overageStatus),
+  )
+    ? value.overageStatus
+    : undefined;
+
+  return {
+    source: 'sdk_rate_limit_event',
+    observedAt,
+    status: value.status,
+    ...(rateLimitType ? { rateLimitType } : {}),
+    ...(utilization !== undefined ? { utilization } : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+    ...(overageStatus ? { overageStatus } : {}),
+    ...(overageResetsAt !== undefined ? { overageResetsAt } : {}),
+    ...(overageDisabledReason ? { overageDisabledReason } : {}),
+    ...(typeof value.isUsingOverage === 'boolean'
+      ? { isUsingOverage: value.isUsingOverage }
+      : {}),
+    ...(typeof value.overageInUse === 'boolean'
+      ? { overageInUse: value.overageInUse }
+      : {}),
+    ...(surpassedThreshold !== undefined ? { surpassedThreshold } : {}),
+    ...(errorCode ? { errorCode } : {}),
+    ...(typeof value.canUserPurchaseCredits === 'boolean'
+      ? { canUserPurchaseCredits: value.canUserPurchaseCredits }
+      : {}),
+    ...(typeof value.hasChargeableSavedPaymentMethod === 'boolean'
+      ? {
+          hasChargeableSavedPaymentMethod:
+            value.hasChargeableSavedPaymentMethod,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Replace the provider's passive observation with the newest complete event.
+ * Fields from different responses are never unioned, matching CLIProxyAPI's
+ * current-response snapshot semantics.
+ */
+export function observeProviderQuota(
+  providerId: string,
+  value: ProviderQuotaObservation,
+  now = Date.now(),
+): ProviderQuotaSnapshot | null {
+  const normalizedProviderId = providerId.trim();
+  if (!normalizedProviderId || normalizedProviderId.length > 128) return null;
+  const normalized = normalizeObservation(value, now);
+  if (!normalized) return null;
+  const existing = observations.get(normalizedProviderId);
+  if (existing && normalized.observedAt < existing.observedAt) return existing;
+
+  const snapshot: ProviderQuotaSnapshot = { ...normalized };
+  observations.set(normalizedProviderId, snapshot);
+  enforceCapacity();
+  return { ...snapshot };
+}
+
+export function getProviderQuotaObservation(
+  providerId: string,
+): ProviderQuotaSnapshot | null {
+  const snapshot = observations.get(providerId.trim());
+  return snapshot ? { ...snapshot } : null;
+}
+
+export function clearProviderQuotaObservation(providerId: string): boolean {
+  const normalizedProviderId = providerId.trim();
+  const removed = observations.delete(normalizedProviderId);
+  // Rotate even when no snapshot exists: an already-running process may emit
+  // its first event after the credential mutation completes.
+  observationEpochs.delete(normalizedProviderId);
+  observationEpochs.set(normalizedProviderId, nextObservationEpoch++);
+  enforceEpochCapacity();
+  return removed;
+}
+
+/** Test/runtime reset hook; observation state is deliberately not persisted. */
+export function clearAllProviderQuotaObservations(): void {
+  observations.clear();
+  observationEpochs.clear();
+  nextObservationEpoch = 1;
+}
+
+export function isProviderQuotaControlOutput(
+  output: Pick<ContainerOutput, 'providerQuotaObservation'>,
+): boolean {
+  return output.providerQuotaObservation !== undefined;
+}
+
+/** Consume one Runner control frame before any user-facing projection. */
+export function consumeProviderQuotaControlOutput(
+  providerId: string | null,
+  output: Pick<ContainerOutput, 'providerQuotaObservation'>,
+  launchEpoch?: number | null,
+): boolean {
+  if (!output.providerQuotaObservation) return false;
+  if (
+    providerId &&
+    (launchEpoch === undefined ||
+      launchEpoch === currentObservationEpoch(providerId))
+  ) {
+    observeProviderQuota(providerId, output.providerQuotaObservation);
+  }
+  return true;
+}

--- a/src/provider-session-credentials.ts
+++ b/src/provider-session-credentials.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DATA_DIR } from './config.js';
+import { listSessionNamespacesForProviderId } from './db.js';
+import { logger } from './logger.js';
+import {
+  writeCredentialsFile,
+  type ClaudeProviderConfig,
+} from './runtime-config.js';
+import { isValidWorkspaceFolderName } from './workspace-folder.js';
+
+const SESSION_AGENT_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+/**
+ * Fan a Provider credential rotation only into session namespaces that are
+ * durably bound to that Provider. Unbound and other-Provider directories are
+ * deliberately left untouched; their next launch writes the selected config.
+ */
+export function updateProviderSessionCredentials(
+  providerId: string,
+  config: ClaudeProviderConfig,
+): { updated: number; skipped: number } {
+  if (!config.claudeOAuthCredentials) return { updated: 0, skipped: 0 };
+  let updated = 0;
+  let skipped = 0;
+  let namespaces: ReturnType<typeof listSessionNamespacesForProviderId>;
+  try {
+    namespaces = listSessionNamespacesForProviderId(providerId);
+  } catch (err) {
+    logger.warn(
+      { err, providerId },
+      'Failed to list Provider-scoped session credentials',
+    );
+    return { updated: 0, skipped: 0 };
+  }
+  for (const namespace of namespaces) {
+    if (
+      !isValidWorkspaceFolderName(namespace.groupFolder) ||
+      (namespace.agentId !== null &&
+        !SESSION_AGENT_ID_RE.test(namespace.agentId))
+    ) {
+      skipped++;
+      continue;
+    }
+    const claudeDir = namespace.agentId
+      ? path.join(
+          DATA_DIR,
+          'sessions',
+          namespace.groupFolder,
+          'agents',
+          namespace.agentId,
+          '.claude',
+        )
+      : path.join(DATA_DIR, 'sessions', namespace.groupFolder, '.claude');
+    try {
+      if (!fs.existsSync(claudeDir) || !fs.statSync(claudeDir).isDirectory()) {
+        skipped++;
+        continue;
+      }
+      writeCredentialsFile(claudeDir, config);
+      updated++;
+    } catch (err) {
+      skipped++;
+      logger.warn(
+        {
+          err,
+          providerId,
+          groupFolder: namespace.groupFolder,
+          agentId: namespace.agentId,
+        },
+        'Failed to update Provider-scoped session credentials',
+      );
+    }
+  }
+  return { updated, skipped };
+}

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -110,6 +110,8 @@ import {
   getEffectiveExternalDir,
   getContainerEnvConfig,
   saveSystemSettings,
+  buildClaudeAiOauthPayload,
+  updateProviderOAuthCredentialsIfCurrent,
   getUserFeishuConfig,
   saveUserFeishuConfig,
   getUserTelegramConfig,
@@ -124,15 +126,16 @@ import {
   saveUserDiscordConfig,
   getUserWhatsAppConfig,
   saveUserWhatsAppConfig,
-  updateAllSessionCredentials,
   appendImConfigAudit,
 } from '../runtime-config.js';
 import type {
   ClaudeOAuthCredentials,
   CachedOAuthUsage,
-  OAuthUsageResponse,
 } from '../runtime-config.js';
-import { parseOAuthUsageBucket } from '../runtime-config.js';
+import {
+  hasOAuthUsageSignals,
+  parseOAuthUsageResponse,
+} from '../runtime-config.js';
 import type { AudienceMode, AuthUser, RegisteredGroup } from '../types.js';
 import { logger } from '../logger.js';
 import brandAssetRoutes from './brand-assets.js';
@@ -151,6 +154,8 @@ import {
 } from '../channel-mount-service.js';
 import { checkImChannelLimit, isBillingEnabled } from '../billing.js';
 import { providerPool } from '../provider-pool.js';
+import { getProviderQuotaObservation } from '../provider-quota-observation.js';
+import { updateProviderSessionCredentials } from '../provider-session-credentials.js';
 import { getClientIp } from '../utils.js';
 import {
   getWorkspaceRuntimeJids,
@@ -769,23 +774,210 @@ setInterval(() => {
 
 const OAUTH_USAGE_API = 'https://api.anthropic.com/api/oauth/usage';
 const USAGE_CACHE_TTL_MS = 3 * 60 * 1000; // 3 minutes
+const OAUTH_USAGE_TIMEOUT_MS = 5_000;
+const OAUTH_TOKEN_REFRESH_TIMEOUT_MS = 30_000;
 const usageCache = new Map<string, CachedOAuthUsage>();
 const inFlightUsageRequests = new Map<string, Promise<CachedOAuthUsage>>();
+const usageCacheEpochs = new Map<string, number>();
+const MAX_USAGE_CACHE_EPOCHS = 256;
+let nextUsageCacheEpoch = 1;
 
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, entry] of usageCache) {
-    if (now - entry.fetchedAt >= USAGE_CACHE_TTL_MS) {
-      usageCache.delete(key);
+function enforceUsageEpochCapacity(): void {
+  while (usageCacheEpochs.size > MAX_USAGE_CACHE_EPOCHS) {
+    const oldestProviderId = usageCacheEpochs.keys().next().value as
+      | string
+      | undefined;
+    if (oldestProviderId === undefined) break;
+    usageCacheEpochs.delete(oldestProviderId);
+  }
+}
+
+function getProviderUsageEpoch(providerId: string): number {
+  const existing = usageCacheEpochs.get(providerId);
+  if (existing !== undefined) return existing;
+  const epoch = nextUsageCacheEpoch++;
+  usageCacheEpochs.set(providerId, epoch);
+  enforceUsageEpochCapacity();
+  return epoch;
+}
+
+function advanceProviderUsageEpoch(providerId: string): number {
+  const epoch = nextUsageCacheEpoch++;
+  usageCacheEpochs.delete(providerId);
+  usageCacheEpochs.set(providerId, epoch);
+  enforceUsageEpochCapacity();
+  return epoch;
+}
+
+function invalidateProviderUsageCache(providerId: string): void {
+  usageCache.delete(providerId);
+  inFlightUsageRequests.delete(providerId);
+  advanceProviderUsageEpoch(providerId);
+}
+
+async function fetchOAuthEndpoint(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<{ response: Response; release: () => void }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    clearTimeout(timeout);
+  };
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+    // Keep the abort timer alive until the caller finishes consuming the
+    // response body. Receiving headers alone is not a completed request.
+    return { response, release };
+  } catch (err) {
+    release();
+    throw err;
+  }
+}
+
+function usageFailureFallback(
+  providerId: string,
+  cached: CachedOAuthUsage | undefined,
+  error: string,
+): CachedOAuthUsage | null {
+  const observation = getProviderQuotaObservation(providerId);
+  if (cached) return { ...cached, error, observation };
+  if (!observation) return null;
+  return {
+    data: parseOAuthUsageResponse({}),
+    fetchedAt: observation.observedAt,
+    error,
+    observation,
+  };
+}
+
+class ProviderOAuthCredentialsChangedError extends Error {
+  constructor() {
+    super('Provider OAuth credentials changed during refresh');
+    this.name = 'ProviderOAuthCredentialsChangedError';
+  }
+}
+
+async function refreshProviderOAuthCredentials(
+  providerId: string,
+  expected: ClaudeOAuthCredentials,
+): Promise<void> {
+  const endpoint = await fetchOAuthEndpoint(
+    OAUTH_TOKEN_URL,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: expected.refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+        scope: expected.scopes.join(' '),
+      }),
+    },
+    OAUTH_TOKEN_REFRESH_TIMEOUT_MS,
+  );
+  let raw: Record<string, unknown>;
+  try {
+    if (!endpoint.response.ok) {
+      throw new Error(
+        `OAuth token refresh returned ${endpoint.response.status}`,
+      );
+    }
+    raw = (await endpoint.response.json()) as Record<string, unknown>;
+  } finally {
+    endpoint.release();
+  }
+  const accessToken =
+    typeof raw.access_token === 'string' ? raw.access_token.trim() : '';
+  if (!accessToken) {
+    throw new Error('OAuth token refresh returned no access_token');
+  }
+  const refreshToken =
+    typeof raw.refresh_token === 'string' && raw.refresh_token.trim()
+      ? raw.refresh_token.trim()
+      : expected.refreshToken;
+  const expiresIn =
+    typeof raw.expires_in === 'number' &&
+    Number.isFinite(raw.expires_in) &&
+    raw.expires_in > 0
+      ? raw.expires_in
+      : 8 * 60 * 60;
+  const responseScopes =
+    typeof raw.scope === 'string'
+      ? raw.scope.split(/\s+/).filter(Boolean)
+      : expected.scopes;
+  const refreshed: ClaudeOAuthCredentials = {
+    ...expected,
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + expiresIn * 1000,
+    scopes: responseScopes,
+  };
+
+  let persisted = false;
+  try {
+    persisted = updateProviderOAuthCredentialsIfCurrent(
+      providerId,
+      expected,
+      refreshed,
+    );
+  } catch {
+    throw new ProviderOAuthCredentialsChangedError();
+  }
+  if (!persisted) {
+    throw new ProviderOAuthCredentialsChangedError();
+  }
+  invalidateProviderUsageCache(providerId);
+  const updated = getProviders().find((provider) => provider.id === providerId);
+  if (updated) {
+    try {
+      updateProviderSessionCredentials(providerId, providerToConfig(updated));
+    } catch (err) {
+      logger.warn(
+        { err, providerId },
+        'Failed to project refreshed OAuth credentials into sessions',
+      );
+    }
+    // A rotated refresh token may invalidate a credential cached inside a
+    // running SDK process. Drain only this Provider's runners after their
+    // current query; a settings-page GET must never interrupt active work.
+    try {
+      deps?.queue?.drainProviderRunnersForCredentialRefresh?.(providerId);
+    } catch (err) {
+      logger.warn(
+        { err, providerId },
+        'Failed to drain runners after OAuth credential refresh',
+      );
     }
   }
-}, 5 * 60_000);
+}
 
-async function fetchOAuthUsage(providerId: string): Promise<CachedOAuthUsage> {
-  const cached = usageCache.get(providerId);
-  if (cached && Date.now() - cached.fetchedAt < USAGE_CACHE_TTL_MS) {
-    return cached;
+async function fetchOAuthUsage(
+  providerId: string,
+  refreshAttempted = false,
+  inheritedFallback?: CachedOAuthUsage,
+): Promise<CachedOAuthUsage> {
+  const storedCached = usageCache.get(providerId);
+  if (
+    storedCached &&
+    Date.now() - storedCached.fetchedAt < USAGE_CACHE_TTL_MS
+  ) {
+    return {
+      ...storedCached,
+      observation: getProviderQuotaObservation(providerId),
+    };
   }
+  const cached = storedCached ?? inheritedFallback;
 
   // Deduplicate concurrent requests for the same provider
   const inFlight = inFlightUsageRequests.get(providerId);
@@ -796,45 +988,102 @@ async function fetchOAuthUsage(providerId: string): Promise<CachedOAuthUsage> {
   if (!provider) {
     throw new Error('Provider not found');
   }
-  if (!provider.claudeOAuthCredentials) {
-    throw new Error('Provider has no OAuth credentials');
+  const oauthCredentials = buildClaudeAiOauthPayload(
+    providerToConfig(provider),
+  );
+  if (!oauthCredentials) {
+    const observation = getProviderQuotaObservation(providerId);
+    return {
+      data: parseOAuthUsageResponse({}),
+      fetchedAt: observation?.observedAt ?? Date.now(),
+      observation,
+    };
   }
 
-  const requestPromise = (async () => {
-    try {
-      const resp = await fetch(OAUTH_USAGE_API, {
-        headers: {
-          Authorization: `Bearer ${provider.claudeOAuthCredentials!.accessToken}`,
-          'anthropic-beta': 'oauth-2025-04-20',
-        },
-      });
+  const requestEpoch = getProviderUsageEpoch(providerId);
 
-      if (!resp.ok) {
-        // Return stale cache if available, otherwise throw
-        if (cached) {
-          const stale: CachedOAuthUsage = {
-            ...cached,
-            error: `HTTP ${resp.status}`,
-          };
-          usageCache.set(providerId, stale);
-          return stale;
-        }
-        throw new Error(`Usage API returned ${resp.status}`);
+  let requestPromise!: Promise<CachedOAuthUsage>;
+  requestPromise = (async () => {
+    try {
+      if (!refreshAttempted && oauthCredentials.expiresAt <= Date.now()) {
+        await refreshProviderOAuthCredentials(providerId, oauthCredentials);
+        return fetchOAuthUsage(providerId, true, cached);
       }
 
-      const raw = (await resp.json()) as Record<string, unknown>;
-      const data: OAuthUsageResponse = {
-        five_hour: parseOAuthUsageBucket(raw.five_hour),
-        seven_day: parseOAuthUsageBucket(raw.seven_day),
-        seven_day_opus: parseOAuthUsageBucket(raw.seven_day_opus),
-        seven_day_sonnet: parseOAuthUsageBucket(raw.seven_day_sonnet),
-      };
+      const endpoint = await fetchOAuthEndpoint(
+        OAUTH_USAGE_API,
+        {
+          headers: {
+            Authorization: `Bearer ${oauthCredentials.accessToken}`,
+            'anthropic-beta': 'oauth-2025-04-20',
+          },
+        },
+        OAUTH_USAGE_TIMEOUT_MS,
+      );
+      let raw: Record<string, unknown>;
+      try {
+        // A credential update/delete invalidates the request that was started
+        // with the old token. Join (or start) the current epoch's request so
+        // the original caller cannot receive a stale account's usage body.
+        if (getProviderUsageEpoch(providerId) !== requestEpoch) {
+          return fetchOAuthUsage(providerId);
+        }
 
-      const result: CachedOAuthUsage = { data, fetchedAt: Date.now() };
-      usageCache.set(providerId, result);
+        if (endpoint.response.status === 401 && !refreshAttempted) {
+          endpoint.release();
+          await refreshProviderOAuthCredentials(providerId, oauthCredentials);
+          return fetchOAuthUsage(providerId, true, cached);
+        }
+        if (!endpoint.response.ok) {
+          throw new Error(`Usage API returned ${endpoint.response.status}`);
+        }
+        raw = (await endpoint.response.json()) as Record<string, unknown>;
+      } finally {
+        endpoint.release();
+      }
+      if (getProviderUsageEpoch(providerId) !== requestEpoch) {
+        return fetchOAuthUsage(providerId);
+      }
+      if (!hasOAuthUsageSignals(raw)) {
+        throw new Error('Usage API returned no recognized quota data');
+      }
+      const data = parseOAuthUsageResponse(raw);
+
+      const result: CachedOAuthUsage = {
+        data,
+        fetchedAt: Date.now(),
+        observation: getProviderQuotaObservation(providerId),
+      };
+      if (getProviderUsageEpoch(providerId) === requestEpoch) {
+        usageCache.set(providerId, result);
+      }
       return result;
+    } catch (err) {
+      if (getProviderUsageEpoch(providerId) !== requestEpoch) {
+        return fetchOAuthUsage(providerId);
+      }
+      if (err instanceof ProviderOAuthCredentialsChangedError) {
+        // A refresh performed outside this route can change the Provider
+        // without advancing our request epoch. Detach this exact promise
+        // before retrying so fetchOAuthUsage cannot join itself. Preserve the
+        // full snapshot because a token refresh stays within one account.
+        if (inFlightUsageRequests.get(providerId) === requestPromise) {
+          inFlightUsageRequests.delete(providerId);
+          advanceProviderUsageEpoch(providerId);
+        }
+        return fetchOAuthUsage(providerId, false, cached);
+      }
+      const message = err instanceof Error ? err.message : 'Usage API failed';
+      const fallback = usageFailureFallback(providerId, cached, message);
+      if (fallback) {
+        if (cached) usageCache.set(providerId, fallback);
+        return fallback;
+      }
+      throw err;
     } finally {
-      inFlightUsageRequests.delete(providerId);
+      if (inFlightUsageRequests.get(providerId) === requestPromise) {
+        inFlightUsageRequests.delete(providerId);
+      }
     }
   })();
 
@@ -1099,13 +1348,14 @@ configRoutes.put(
 
         const commit = () => {
           const updated = updateProviderSecrets(id, validation.data);
+          invalidateProviderUsageCache(id);
           appendClaudeConfigAuditBestEffort(actor, 'update_provider_secrets', [
             `id:${id}`,
             ...changedFields,
           ]);
           return runAfterProviderPersistence(updated, () => {
             if (validation.data.claudeOAuthCredentials && updated.enabled) {
-              updateAllSessionCredentials(providerToConfig(updated));
+              updateProviderSessionCredentials(id, providerToConfig(updated));
               deps?.queue?.closeAllActiveForCredentialRefresh();
             }
           });
@@ -1195,6 +1445,7 @@ configRoutes.delete(
           () => {
             if (previous) {
               deleteProvider(id);
+              invalidateProviderUsageCache(id);
               appendClaudeConfigAuditBestEffort(actor, 'delete_provider', [
                 `id:${id}`,
               ]);
@@ -1515,6 +1766,7 @@ configRoutes.post(
             : tokenData.access_token,
           clearAnthropicApiKey: true,
         });
+        invalidateProviderUsageCache(flow.targetProviderId);
       } else {
         // Create new official provider
         provider = createProvider({
@@ -1528,7 +1780,10 @@ configRoutes.post(
 
       // Write .credentials.json to all sessions
       if (oauthCredentials) {
-        updateAllSessionCredentials(providerToConfig(provider));
+        updateProviderSessionCredentials(
+          provider.id,
+          providerToConfig(provider),
+        );
         deps?.queue?.closeAllActiveForCredentialRefresh();
       }
 

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -5,6 +5,7 @@ import os from 'os';
 
 import { ASSISTANT_NAME, DATA_DIR } from './config.js';
 import { logger } from './logger.js';
+import { clearProviderQuotaObservation } from './provider-quota-observation.js';
 
 const MAX_FIELD_LENGTH = 2000;
 const DEFAULT_THIRD_PARTY_PROFILE_ID = 'default';
@@ -225,21 +226,43 @@ export interface ClaudeOAuthCredentials {
 }
 
 export interface OAuthUsageBucket {
-  utilization: number; // 0-100
-  resets_at: string; // ISO 8601
+  /** Percentage reported by the OAuth usage endpoint, in the 0..100 unit. */
+  utilization: number | null;
+  resets_at: string | null;
+}
+
+export interface OAuthModelUsageBucket extends OAuthUsageBucket {
+  /** Server-supplied label. Do not infer model buckets from fixed field names. */
+  display_name: string;
+}
+
+export interface OAuthExtraUsage {
+  is_enabled: boolean;
+  monthly_limit: number | null;
+  used_credits: number | null;
+  /** Percentage reported by the OAuth usage endpoint, in the 0..100 unit. */
+  utilization: number | null;
+  currency: string | null;
 }
 
 export interface OAuthUsageResponse {
   five_hour: OAuthUsageBucket | null;
   seven_day: OAuthUsageBucket | null;
+  seven_day_oauth_apps: OAuthUsageBucket | null;
   seven_day_opus: OAuthUsageBucket | null;
   seven_day_sonnet: OAuthUsageBucket | null;
+  model_scoped: OAuthModelUsageBucket[];
+  extra_usage: OAuthExtraUsage | null;
 }
 
 export interface CachedOAuthUsage {
   data: OAuthUsageResponse;
   fetchedAt: number; // Unix timestamp ms
   error?: string;
+  /** Latest bounded SDK rate_limit_event snapshot for this provider. */
+  observation?:
+    | import('./provider-quota-observation.js').ProviderQuotaSnapshot
+    | null;
 }
 
 export interface ClaudeProviderConfig {
@@ -1494,6 +1517,7 @@ export function updateProviderSecrets(
 
   state.providers[idx] = updated;
   writeStoredStateV4(state.providers, state.balancing);
+  clearProviderQuotaObservation(id);
   return updated;
 }
 
@@ -1578,6 +1602,7 @@ export function deleteProvider(id: string): void {
 
   state.providers.splice(idx, 1);
   writeStoredStateV4(state.providers, state.balancing);
+  clearProviderQuotaObservation(id);
 }
 
 /** Convert a UnifiedProvider to the flat ClaudeProviderConfig used by container runner */
@@ -2465,59 +2490,6 @@ export function writeCredentialsFile(
   } catch {
     /* ignore — best effort */
   }
-}
-
-/**
- * Update .credentials.json in all existing session directories + host ~/.claude/
- */
-export function updateAllSessionCredentials(
-  config: ClaudeProviderConfig,
-): void {
-  if (!config.claudeOAuthCredentials) return;
-
-  const sessionsDir = path.join(DATA_DIR, 'sessions');
-  try {
-    if (!fs.existsSync(sessionsDir)) return;
-    for (const folder of fs.readdirSync(sessionsDir)) {
-      const claudeDir = path.join(sessionsDir, folder, '.claude');
-      if (fs.existsSync(claudeDir) && fs.statSync(claudeDir).isDirectory()) {
-        try {
-          writeCredentialsFile(claudeDir, config);
-        } catch (err) {
-          logger.warn(
-            { err, folder },
-            'Failed to write .credentials.json for session',
-          );
-        }
-      }
-      // Also update sub-agent session dirs
-      const agentsDir = path.join(sessionsDir, folder, 'agents');
-      if (fs.existsSync(agentsDir) && fs.statSync(agentsDir).isDirectory()) {
-        for (const agentId of fs.readdirSync(agentsDir)) {
-          const agentClaudeDir = path.join(agentsDir, agentId, '.claude');
-          if (
-            fs.existsSync(agentClaudeDir) &&
-            fs.statSync(agentClaudeDir).isDirectory()
-          ) {
-            try {
-              writeCredentialsFile(agentClaudeDir, config);
-            } catch (err) {
-              logger.warn(
-                { err, folder, agentId },
-                'Failed to write .credentials.json for agent session',
-              );
-            }
-          }
-        }
-      }
-    }
-  } catch (err) {
-    logger.warn({ err }, 'Failed to update session credentials');
-  }
-
-  // Host mode uses CLAUDE_CONFIG_DIR=data/sessions/{folder}/.claude for isolation,
-  // so we must NOT touch ~/.claude/.credentials.json to avoid interfering with
-  // the user's local Claude Code installation.
 }
 
 // ─── Appearance config (plain JSON, no encryption) ────────────────
@@ -3600,9 +3572,25 @@ export function saveSystemSettings(
 
 // ─── OAuth Usage Types ─────────────────────────────────────────────────────
 
-export interface OAuthUsageBucket {
-  utilization: number;
-  resets_at: string;
+const MAX_OAUTH_MODEL_WINDOWS = 32;
+const MAX_OAUTH_MODEL_LABEL_LENGTH = 100;
+
+function parseNullableFiniteNumber(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function parseNullableResetAt(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    const milliseconds = value < 1e11 ? value * 1000 : value;
+    const parsed = new Date(milliseconds);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  return undefined;
 }
 
 /**
@@ -3612,7 +3600,143 @@ export interface OAuthUsageBucket {
 export function parseOAuthUsageBucket(v: unknown): OAuthUsageBucket | null {
   if (!v || typeof v !== 'object') return null;
   const obj = v as Record<string, unknown>;
-  if (typeof obj.utilization !== 'number' || typeof obj.resets_at !== 'string')
+  const utilization = parseNullableFiniteNumber(obj.utilization);
+  const resetsAt = parseNullableResetAt(obj.resets_at);
+  if (utilization === undefined && resetsAt === undefined) return null;
+  return {
+    utilization: utilization === undefined ? null : utilization,
+    resets_at: resetsAt === undefined ? null : resetsAt,
+  };
+}
+
+export function parseOAuthExtraUsage(v: unknown): OAuthExtraUsage | null {
+  if (!v || typeof v !== 'object') return null;
+  const obj = v as Record<string, unknown>;
+  if (typeof obj.is_enabled !== 'boolean') return null;
+  const monthlyLimit = parseNullableFiniteNumber(obj.monthly_limit);
+  const usedCredits = parseNullableFiniteNumber(obj.used_credits);
+  const utilization = parseNullableFiniteNumber(obj.utilization);
+  const currency =
+    obj.currency === null
+      ? null
+      : typeof obj.currency === 'string' && obj.currency.trim().length <= 16
+        ? obj.currency.trim()
+        : null;
+  return {
+    is_enabled: obj.is_enabled,
+    monthly_limit: monthlyLimit === undefined ? null : monthlyLimit,
+    used_credits: usedCredits === undefined ? null : usedCredits,
+    utilization: utilization === undefined ? null : utilization,
+    currency,
+  };
+}
+
+function parseOAuthModelWindow(v: unknown): OAuthModelUsageBucket | null {
+  if (!v || typeof v !== 'object') return null;
+  const obj = v as Record<string, unknown>;
+  const displayName =
+    typeof obj.display_name === 'string' ? obj.display_name.trim() : '';
+  if (!displayName || displayName.length > MAX_OAUTH_MODEL_LABEL_LENGTH)
     return null;
-  return { utilization: obj.utilization, resets_at: obj.resets_at };
+  const bucket = parseOAuthUsageBucket(obj);
+  return bucket ? { display_name: displayName, ...bucket } : null;
+}
+
+/**
+ * Project dynamic weekly model windows from either the current SDK shape
+ * (`model_scoped`) or the raw OAuth endpoint's `limits[]` shape. The endpoint
+ * owns the labels; HappyClaw deliberately does not invent fields such as
+ * `seven_day_sonnet_max`.
+ */
+export function parseOAuthModelWindows(raw: unknown): OAuthModelUsageBucket[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const obj = raw as Record<string, unknown>;
+  const projected: OAuthModelUsageBucket[] = [];
+
+  if (Array.isArray(obj.model_scoped)) {
+    for (const candidate of obj.model_scoped) {
+      const bucket = parseOAuthModelWindow(candidate);
+      if (bucket) projected.push(bucket);
+      if (projected.length >= MAX_OAUTH_MODEL_WINDOWS) break;
+    }
+  } else if (Array.isArray(obj.limits)) {
+    for (const candidate of obj.limits) {
+      if (!candidate || typeof candidate !== 'object') continue;
+      const limit = candidate as Record<string, unknown>;
+      if (limit.kind !== 'weekly_scoped') continue;
+      const scope = limit.scope;
+      if (!scope || typeof scope !== 'object') continue;
+      const model = (scope as Record<string, unknown>).model;
+      if (!model || typeof model !== 'object') continue;
+      const displayName = (model as Record<string, unknown>).display_name;
+      const bucket = parseOAuthModelWindow({
+        display_name: displayName,
+        utilization: limit.percent,
+        resets_at: limit.resets_at,
+      });
+      if (bucket) projected.push(bucket);
+      if (projected.length >= MAX_OAUTH_MODEL_WINDOWS) break;
+    }
+  }
+
+  const unique = new Map<string, OAuthModelUsageBucket>();
+  for (const bucket of projected) {
+    const key = bucket.display_name.toLowerCase();
+    if (!unique.has(key)) unique.set(key, bucket);
+  }
+  return [...unique.values()];
+}
+
+/**
+ * Whether an upstream body contains a recognized usage snapshot. A 200 body
+ * can still be an in-band error (`{ error: ... }`) or an unrelated object;
+ * those responses must not replace the last known snapshot with empty data.
+ */
+export function hasOAuthUsageSignals(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
+  const obj = raw as Record<string, unknown>;
+  for (const key of [
+    'five_hour',
+    'seven_day',
+    'seven_day_oauth_apps',
+    'seven_day_opus',
+    'seven_day_sonnet',
+  ]) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
+    if (obj[key] === null || parseOAuthUsageBucket(obj[key]) !== null) {
+      return true;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(obj, 'extra_usage')) {
+    if (
+      obj.extra_usage === null ||
+      parseOAuthExtraUsage(obj.extra_usage) !== null
+    ) {
+      return true;
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(obj, 'model_scoped') &&
+    Array.isArray(obj.model_scoped)
+  ) {
+    return true;
+  }
+  return (
+    Object.prototype.hasOwnProperty.call(obj, 'limits') &&
+    Array.isArray(obj.limits)
+  );
+}
+
+export function parseOAuthUsageResponse(raw: unknown): OAuthUsageResponse {
+  const obj =
+    raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+  return {
+    five_hour: parseOAuthUsageBucket(obj.five_hour),
+    seven_day: parseOAuthUsageBucket(obj.seven_day),
+    seven_day_oauth_apps: parseOAuthUsageBucket(obj.seven_day_oauth_apps),
+    seven_day_opus: parseOAuthUsageBucket(obj.seven_day_opus),
+    seven_day_sonnet: parseOAuthUsageBucket(obj.seven_day_sonnet),
+    model_scoped: parseOAuthModelWindows(obj),
+    extra_usage: parseOAuthExtraUsage(obj.extra_usage),
+  };
 }

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -21,6 +21,7 @@ import {
   writeTasksSnapshot,
 } from './container-runner.js';
 import { PROVIDER_FAILURE_USER_NOTICE } from './provider-failure.js';
+import { isProviderQuotaControlOutput } from './provider-quota-observation.js';
 import {
   cancelDeliveredGroupTaskRunWithWorkspaceIntent,
   cancelTaskRun,
@@ -1308,6 +1309,11 @@ async function runTaskInner(
           selectedProviderId,
         ),
       async (streamedOutput: ContainerOutput) => {
+        if (isProviderQuotaControlOutput(streamedOutput)) {
+          lastOutputTime = Date.now();
+          resetIdleTimer();
+          return;
+        }
         // Broadcast stream events to WebSocket clients viewing the task workspace
         if (streamedOutput.status === 'stream' && streamedOutput.streamEvent) {
           deps.broadcastStreamEvent?.(effectiveJid, streamedOutput.streamEvent);

--- a/tests/docker-oauth-refresh-reconciliation.test.ts
+++ b/tests/docker-oauth-refresh-reconciliation.test.ts
@@ -1,0 +1,359 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'happyclaw-docker-oauth-refresh-'),
+);
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: root,
+  STORE_DIR: path.join(root, 'db'),
+  GROUPS_DIR: path.join(root, 'groups'),
+}));
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const runtimeConfig = await import('../src/runtime-config.js');
+const db = await import('../src/db.js');
+const dockerOauth = await import('../src/docker-oauth-credentials.js');
+const containerRunner = await import('../src/container-runner.js');
+
+const original = {
+  accessToken: 'docker-access-original',
+  refreshToken: 'docker-refresh-original',
+  expiresAt: 1_800_000_000_000,
+  scopes: ['user:profile', 'user:inference'],
+  subscriptionType: 'max',
+};
+const refreshed = {
+  accessToken: 'docker-access-refreshed',
+  refreshToken: 'docker-refresh-refreshed',
+  expiresAt: 1_800_003_600_000,
+  scopes: ['user:inference', 'user:profile'],
+  subscriptionType: 'max',
+};
+
+function writeCredentialFile(
+  directory: string,
+  claudeAiOauth: unknown,
+): string {
+  fs.mkdirSync(directory, { recursive: true });
+  const file = path.join(directory, '.credentials.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ claudeAiOauth, mcpOAuth: { preserved: true } }),
+  );
+  return file;
+}
+
+beforeAll(() => {
+  db.initDatabase();
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('Docker SDK OAuth credential reconciliation', () => {
+  test('persists a validated rotation with Provider CAS and fans it out', () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Docker refresh provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: original,
+    });
+    const currentSession = path.join(root, 'sessions', 'current', '.claude');
+    const otherSession = path.join(root, 'sessions', 'other', '.claude');
+    const foreignSession = path.join(root, 'sessions', 'foreign', '.claude');
+    const credentialsFilePath = writeCredentialFile(currentSession, refreshed);
+    writeCredentialFile(otherSession, original);
+    const foreignCredentials = {
+      accessToken: 'foreign-access',
+      refreshToken: 'foreign-refresh',
+      expiresAt: 1_900_000_000_000,
+      scopes: ['user:inference'],
+      subscriptionType: 'pro',
+    };
+    const foreignProvider = runtimeConfig.createProvider({
+      name: 'Foreign Docker refresh provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: foreignCredentials,
+    });
+    writeCredentialFile(foreignSession, foreignCredentials);
+    db.setSessionProviderId('current', null, provider.id);
+    db.setSessionProviderId('other', null, provider.id);
+    db.setSessionProviderId('foreign', null, foreignProvider.id);
+
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, {
+        credentialsFilePath,
+        launchCredentials: original,
+      }),
+    ).toBe('updated');
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.claudeOAuthCredentials,
+    ).toEqual({ ...refreshed, scopes: [...refreshed.scopes].sort() });
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(otherSession, '.credentials.json'), 'utf8'),
+      ).claudeAiOauth,
+    ).toEqual({ ...refreshed, scopes: [...refreshed.scopes].sort() });
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(foreignSession, '.credentials.json'), 'utf8'),
+      ).claudeAiOauth,
+    ).toEqual(foreignCredentials);
+  });
+
+  test('advances the launch snapshot so a warm runner can persist another rotation', () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Docker repeated refresh provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: original,
+    });
+    const credentialsFilePath = writeCredentialFile(
+      path.join(root, 'sessions', 'repeated', '.claude'),
+      refreshed,
+    );
+    const launch = { credentialsFilePath, launchCredentials: original };
+
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, launch),
+    ).toBe('updated');
+    expect(launch.launchCredentials).toEqual({
+      ...refreshed,
+      scopes: [...refreshed.scopes].sort(),
+    });
+
+    const refreshedAgain = {
+      ...refreshed,
+      accessToken: 'docker-access-refreshed-again',
+      refreshToken: 'docker-refresh-refreshed-again',
+      expiresAt: refreshed.expiresAt + 3_600_000,
+    };
+    writeCredentialFile(path.dirname(credentialsFilePath), refreshedAgain);
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, launch),
+    ).toBe('updated');
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.claudeOAuthCredentials,
+    ).toEqual({
+      ...refreshedAgain,
+      scopes: [...refreshedAgain.scopes].sort(),
+    });
+  });
+
+  test('advances a sibling warm runner from O to R before it persists R2', () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Docker sibling generation provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: original,
+    });
+    const sessionA = path.join(root, 'sessions', 'generation-a', '.claude');
+    const sessionB = path.join(root, 'sessions', 'generation-b', '.claude');
+    const fileA = writeCredentialFile(sessionA, refreshed);
+    const fileB = writeCredentialFile(sessionB, original);
+    db.setSessionProviderId('generation-a', null, provider.id);
+    db.setSessionProviderId('generation-b', null, provider.id);
+    const launchA = {
+      credentialsFilePath: fileA,
+      launchCredentials: original,
+    };
+    const launchB = {
+      credentialsFilePath: fileB,
+      launchCredentials: original,
+    };
+
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, launchA),
+    ).toBe('updated');
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, launchB),
+    ).toBe('stale');
+    expect(launchB.launchCredentials).toEqual({
+      ...refreshed,
+      scopes: [...refreshed.scopes].sort(),
+    });
+
+    const refreshedAgain = {
+      ...refreshed,
+      accessToken: 'sibling-r2-access',
+      refreshToken: 'sibling-r2-refresh',
+      expiresAt: refreshed.expiresAt + 3_600_000,
+    };
+    writeCredentialFile(sessionB, refreshedAgain);
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, launchB),
+    ).toBe('updated');
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.claudeOAuthCredentials,
+    ).toEqual({
+      ...refreshedAgain,
+      scopes: [...refreshedAgain.scopes].sort(),
+    });
+  });
+
+  test('does not overwrite an administrator credential update made mid-run', () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Docker refresh CAS provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: original,
+    });
+    const credentialsFilePath = writeCredentialFile(
+      path.join(root, 'sessions', 'cas', '.claude'),
+      refreshed,
+    );
+    const administratorUpdate = {
+      accessToken: 'administrator-access',
+      refreshToken: 'administrator-refresh',
+      expiresAt: 1_900_000_000_000,
+      scopes: ['user:inference'],
+      subscriptionType: 'pro',
+    };
+    runtimeConfig.updateProviderSecrets(provider.id, {
+      claudeOAuthCredentials: administratorUpdate,
+    });
+
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit(provider.id, {
+        credentialsFilePath,
+        launchCredentials: original,
+      }),
+    ).toBe('stale');
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.claudeOAuthCredentials,
+    ).toEqual(administratorUpdate);
+  });
+
+  test('rejects malformed, incomplete, non-regular, and oversized files', () => {
+    const directory = path.join(root, 'invalid-files');
+    fs.mkdirSync(directory, { recursive: true });
+    const file = path.join(directory, '.credentials.json');
+
+    fs.writeFileSync(file, '{invalid');
+    expect(dockerOauth.readDockerClaudeOAuthCredentials(file)).toBeNull();
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ claudeAiOauth: { ...original, scopes: [1] } }),
+    );
+    expect(dockerOauth.readDockerClaudeOAuthCredentials(file)).toBeNull();
+    fs.writeFileSync(file, 'x'.repeat(64 * 1024 + 1));
+    expect(dockerOauth.readDockerClaudeOAuthCredentials(file)).toBeNull();
+
+    const target = writeCredentialFile(
+      path.join(root, 'symlink-target'),
+      refreshed,
+    );
+    const link = path.join(directory, 'linked-credentials.json');
+    fs.symlinkSync(target, link);
+    expect(dockerOauth.readDockerClaudeOAuthCredentials(link)).toBeNull();
+    expect(
+      dockerOauth.reconcileDockerOAuthCredentials({
+        providerId: 'unused',
+        credentialsFilePath: path.join(directory, 'missing.json'),
+        launchCredentials: original,
+      }),
+    ).toBe('missing');
+  });
+
+  test('requires evidence of a later expiry before invoking the CAS', () => {
+    const persist = vi.fn(() => true);
+    const directory = path.join(root, 'freshness');
+    const unchangedFile = writeCredentialFile(directory, {
+      ...original,
+      scopes: [...original.scopes].reverse(),
+    });
+    expect(
+      dockerOauth.reconcileDockerOAuthCredentials({
+        providerId: 'unused',
+        credentialsFilePath: unchangedFile,
+        launchCredentials: original,
+        persistRefreshedCredentials: persist,
+      }),
+    ).toBe('unchanged');
+
+    const notNewerFile = writeCredentialFile(directory, {
+      ...refreshed,
+      expiresAt: original.expiresAt,
+    });
+    expect(
+      dockerOauth.reconcileDockerOAuthCredentials({
+        providerId: 'unused',
+        credentialsFilePath: notNewerFile,
+        launchCredentials: original,
+        persistRefreshedCredentials: persist,
+      }),
+    ).toBe('not_newer');
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test('runs reconciliation on Docker output and close without changing the Host path', () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/container-runner.ts'),
+      'utf8',
+    );
+    const dockerClose = source.indexOf("container.on('close'");
+    const outputHandler = source.indexOf(
+      'const handleOutput = async',
+      source.indexOf('export async function runContainerAgent'),
+    );
+    const outputReconcile = source.indexOf(
+      "reconcileDockerOAuth('output')",
+      outputHandler,
+    );
+    const closeReconcile = source.indexOf(
+      "reconcileDockerOAuth('exit')",
+      dockerClose,
+    );
+    const closeHandling = source.indexOf(
+      'const closeCtx: CloseHandlerContext',
+      dockerClose,
+    );
+    const hostStart = source.indexOf('export async function runHostAgent');
+
+    expect(dockerClose).toBeGreaterThanOrEqual(0);
+    expect(outputReconcile).toBeGreaterThan(outputHandler);
+    expect(outputReconcile).toBeLessThan(dockerClose);
+    expect(closeReconcile).toBeGreaterThan(dockerClose);
+    expect(closeReconcile).toBeLessThan(closeHandling);
+    expect(source.slice(hostStart)).not.toContain(
+      'reconcileDockerOAuthAfterExit(',
+    );
+  });
+
+  test('contains reconciliation and fan-out failures after a completed run', () => {
+    const launch = {
+      credentialsFilePath: '/unused/.credentials.json',
+      launchCredentials: original,
+    };
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit('provider', launch, {
+        reconcile: () => {
+          throw new Error('read or CAS failure');
+        },
+      }),
+    ).toBe('error');
+    expect(
+      containerRunner.reconcileDockerOAuthAfterExit('provider', launch, {
+        reconcile: () => 'updated',
+        fanOutUpdatedCredentials: () => {
+          throw new Error('fan-out failure');
+        },
+      }),
+    ).toBe('error');
+  });
+});

--- a/tests/group-queue-query-identity.test.ts
+++ b/tests/group-queue-query-identity.test.ts
@@ -22,6 +22,52 @@ vi.mock('../src/db.js', () => ({ getTaskById: () => undefined }));
 const { GroupQueue } = await import('../src/group-queue.js');
 
 describe('GroupQueue query identity', () => {
+  test('drains only matching Provider runners without interrupting the current query', () => {
+    const queue = new GroupQueue();
+    const matchingJid = 'web:credential-drain-match';
+    const otherJid = 'web:credential-drain-other';
+    const matching = (queue as any).getGroup(matchingJid);
+    matching.active = true;
+    matching.groupFolder = 'credential-drain-match';
+    matching.selectedProviderId = 'provider-refresh';
+    matching.queryInFlight = true;
+    matching.queryId = 'query-in-progress';
+    const other = (queue as any).getGroup(otherJid);
+    other.active = true;
+    other.groupFolder = 'credential-drain-other';
+    other.selectedProviderId = 'provider-other';
+
+    expect(
+      queue.drainProviderRunnersForCredentialRefresh('provider-refresh'),
+    ).toBe(1);
+
+    const matchingInput = path.join(
+      '/tmp/happyclaw-query-identity-test',
+      'ipc',
+      'credential-drain-match',
+      'input',
+    );
+    const otherInput = path.join(
+      '/tmp/happyclaw-query-identity-test',
+      'ipc',
+      'credential-drain-other',
+      'input',
+    );
+    expect(fs.existsSync(path.join(matchingInput, '_drain'))).toBe(true);
+    expect(fs.existsSync(path.join(matchingInput, '_close'))).toBe(false);
+    expect(fs.existsSync(path.join(otherInput, '_drain'))).toBe(false);
+    expect(matching.queryInFlight).toBe(true);
+    expect(matching.pendingMessages).toBe(false);
+    expect(
+      queue.drainProviderRunnersForCredentialRefresh('provider-refresh'),
+    ).toBe(0);
+
+    fs.rmSync(path.join('/tmp/happyclaw-query-identity-test', 'ipc'), {
+      recursive: true,
+      force: true,
+    });
+  });
+
   test('matches coalescing only against physical inputs covered by the active query', () => {
     const queue = new GroupQueue();
     const jid = 'web:query-covered-input';

--- a/tests/oauth-usage-bars-dom.test.tsx
+++ b/tests/oauth-usage-bars-dom.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const apiMock = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('../web/src/api/client', () => ({
+  api: { get: apiMock.get },
+}));
+
+import {
+  UsageBars,
+  clampUsagePercentage,
+  extraUsagePercentage,
+  formatExtraUsageDetail,
+  formatResetTime,
+  isCurrentProviderQuotaObservation,
+  sdkUtilizationPercentage,
+} from '../web/src/components/settings/UsageBars';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  apiMock.get.mockReset();
+  vi.useRealTimers();
+});
+
+describe('Claude provider usage bars', () => {
+  test('normalizes each source in its documented unit', () => {
+    expect(clampUsagePercentage(100.25)).toBe(100);
+    expect(
+      sdkUtilizationPercentage({
+        source: 'sdk_rate_limit_event',
+        observedAt: 1,
+        status: 'allowed_warning',
+        utilization: 0.53,
+      }),
+    ).toBe(53);
+    expect(
+      extraUsagePercentage({
+        is_enabled: true,
+        monthly_limit: 100,
+        used_credits: 25,
+        utilization: null,
+        currency: 'USD',
+      }),
+    ).toBe(25);
+  });
+
+  test('formats extra usage amounts from minor currency units and recognizes unlimited plans', () => {
+    const usd = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    expect(
+      formatExtraUsageDetail({
+        is_enabled: true,
+        monthly_limit: 10_000,
+        used_credits: 2_500,
+        utilization: 25,
+        currency: 'USD',
+      }),
+    ).toBe(`${usd.format(25)} / ${usd.format(100)}`);
+    expect(
+      formatExtraUsageDetail({
+        is_enabled: true,
+        monthly_limit: null,
+        used_credits: 2_500,
+        utilization: null,
+        currency: 'USD',
+      }),
+    ).toBe(`已用 ${usd.format(25)} · 无月度上限`);
+    const jpy = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: 'JPY',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+    expect(
+      formatExtraUsageDetail({
+        is_enabled: true,
+        monthly_limit: 10_000,
+        used_credits: 2_500,
+        utilization: 25,
+        currency: 'JPY',
+      }),
+    ).toBe(`${jpy.format(2_500)} / ${jpy.format(10_000)}`);
+    expect(
+      formatExtraUsageDetail({
+        is_enabled: true,
+        monthly_limit: 10_000,
+        used_credits: 2_500,
+        utilization: 25,
+        currency: null,
+      }),
+    ).toBe(`${usd.format(25)} / ${usd.format(100)}`);
+    expect(
+      extraUsagePercentage({
+        is_enabled: false,
+        monthly_limit: 100,
+        used_credits: 90,
+        utilization: 90,
+        currency: 'USD',
+      }),
+    ).toBeNull();
+  });
+
+  test('downgrades expired or old SDK observations from Live to Last', () => {
+    const now = Date.parse('2026-09-02T08:00:00.000Z');
+    expect(
+      isCurrentProviderQuotaObservation(
+        {
+          source: 'sdk_rate_limit_event',
+          observedAt: now - 60_000,
+          status: 'rejected',
+          resetsAt: now / 1000 + 60,
+        },
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      isCurrentProviderQuotaObservation(
+        {
+          source: 'sdk_rate_limit_event',
+          observedAt: now - 60_000,
+          status: 'rejected',
+          resetsAt: now / 1000 - 1,
+        },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      isCurrentProviderQuotaObservation(
+        {
+          source: 'sdk_rate_limit_event',
+          observedAt: now - 6 * 60_000,
+          status: 'allowed',
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test('formats nullable and invalid reset timestamps safely', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-02T08:00:00.000Z'));
+    expect(formatResetTime(null)).toBeNull();
+    expect(formatResetTime('invalid')).toBeNull();
+    expect(formatResetTime('2026-09-02T10:30:00.000Z')).toBe('2h 30m');
+  });
+
+  test('renders dynamic model windows, Extra fallback, and live status in a wrapping grid', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    apiMock.get.mockResolvedValue({
+      fetchedAt: Date.now(),
+      data: {
+        five_hour: {
+          utilization: 12.5,
+          resets_at: '2099-09-02T10:00:00.000Z',
+        },
+        seven_day: null,
+        seven_day_oauth_apps: null,
+        seven_day_opus: null,
+        seven_day_sonnet: null,
+        model_scoped: [
+          {
+            display_name: 'Fable future window with a long server label',
+            utilization: 61.25,
+            resets_at: null,
+          },
+        ],
+        extra_usage: {
+          is_enabled: true,
+          monthly_limit: 10_000,
+          used_credits: 2_500,
+          utilization: null,
+          currency: 'USD',
+        },
+      },
+      observation: {
+        source: 'sdk_rate_limit_event',
+        observedAt: Date.now(),
+        status: 'allowed_warning',
+        rateLimitType: 'seven_day',
+        utilization: 0.53,
+        resetsAt: 4_102_444_800,
+      },
+    });
+
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(<UsageBars providerId="provider-a" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMock.get).toHaveBeenCalledWith(
+      '/api/config/claude/providers/provider-a/usage',
+    );
+    expect(container.textContent).toContain('Live');
+    expect(container.textContent).toContain('接近限额');
+    expect(container.textContent).toContain('53%');
+    expect(container.textContent).toContain('Fable future window');
+    expect(container.textContent).toContain('Extra');
+    expect(container.textContent).toContain('25%');
+    expect(container.textContent).toContain('100');
+    expect(container.querySelector('.grid.min-w-0.grid-cols-1')).not.toBeNull();
+    expect(
+      container.querySelector('[title^="Fable future window"]'),
+    ).not.toBeNull();
+  });
+
+  test('marks a stale fallback instead of presenting it as freshly fetched', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    apiMock.get.mockResolvedValue({
+      fetchedAt: Date.parse('2026-09-02T08:00:00.000Z'),
+      error: 'Usage API returned 503',
+      data: {
+        five_hour: { utilization: 40, resets_at: null },
+        seven_day: null,
+        seven_day_oauth_apps: null,
+        seven_day_opus: null,
+        seven_day_sonnet: null,
+        model_scoped: [],
+        extra_usage: null,
+      },
+      observation: null,
+    });
+
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        <UsageBars providerId="provider-stale" providerVersion="v1" />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('暂时无法刷新，显示上次数据');
+    expect(container.textContent).toContain('40%');
+    expect(
+      container.querySelector('[title="Usage API returned 503"]'),
+    ).not.toBeNull();
+  });
+});

--- a/tests/oauth-usage-response.test.ts
+++ b/tests/oauth-usage-response.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  hasOAuthUsageSignals,
+  parseOAuthExtraUsage,
+  parseOAuthModelWindows,
+  parseOAuthUsageBucket,
+  parseOAuthUsageResponse,
+} from '../src/runtime-config.js';
+
+describe('Claude OAuth usage response parsing', () => {
+  test('parses the current raw endpoint shape without inventing fixed model fields', () => {
+    const parsed = parseOAuthUsageResponse({
+      five_hour: {
+        utilization: 12.75,
+        resets_at: '2026-09-02T10:00:00.000Z',
+      },
+      seven_day: {
+        utilization: 53.125,
+        resets_at: '2026-09-08T10:00:00.000Z',
+      },
+      seven_day_oauth_apps: {
+        utilization: null,
+        resets_at: null,
+      },
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 250,
+        used_credits: 18.45,
+        utilization: 7.38,
+        currency: 'USD',
+      },
+      limits: [
+        {
+          kind: 'weekly_scoped',
+          group: 'model',
+          percent: 61.25,
+          resets_at: '2026-09-08T11:00:00.000Z',
+          scope: { model: { display_name: 'Fable' } },
+        },
+        {
+          kind: 'weekly_scoped',
+          group: 'surface',
+          percent: 90,
+          resets_at: '2026-09-08T11:00:00.000Z',
+          scope: { surface: { display_name: 'Claude Code' } },
+        },
+      ],
+    });
+
+    expect(parsed).toEqual({
+      five_hour: {
+        utilization: 12.75,
+        resets_at: '2026-09-02T10:00:00.000Z',
+      },
+      seven_day: {
+        utilization: 53.125,
+        resets_at: '2026-09-08T10:00:00.000Z',
+      },
+      seven_day_oauth_apps: { utilization: null, resets_at: null },
+      seven_day_opus: null,
+      seven_day_sonnet: null,
+      model_scoped: [
+        {
+          display_name: 'Fable',
+          utilization: 61.25,
+          resets_at: '2026-09-08T11:00:00.000Z',
+        },
+      ],
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 250,
+        used_credits: 18.45,
+        utilization: 7.38,
+        currency: 'USD',
+      },
+    });
+    expect(parsed).not.toHaveProperty('seven_day_sonnet_max');
+    expect(parsed.extra_usage).not.toHaveProperty('resets_at');
+  });
+
+  test('accepts the SDK control response model_scoped shape with nullable values', () => {
+    expect(
+      parseOAuthModelWindows({
+        model_scoped: [
+          {
+            display_name: 'Future model',
+            utilization: null,
+            resets_at: null,
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        display_name: 'Future model',
+        utilization: null,
+        resets_at: null,
+      },
+    ]);
+  });
+
+  test('keeps OAuth percentages precise and does not clamp or round them', () => {
+    expect(
+      parseOAuthUsageBucket({
+        utilization: 100.125,
+        resets_at: '2026-09-02T10:00:00.000Z',
+      }),
+    ).toEqual({
+      utilization: 100.125,
+      resets_at: '2026-09-02T10:00:00.000Z',
+    });
+  });
+
+  test('requires the real extra_usage discriminator but not a reset timestamp', () => {
+    expect(
+      parseOAuthExtraUsage({
+        is_enabled: false,
+        monthly_limit: null,
+        used_credits: null,
+        utilization: null,
+      }),
+    ).toEqual({
+      is_enabled: false,
+      monthly_limit: null,
+      used_credits: null,
+      utilization: null,
+      currency: null,
+    });
+    expect(parseOAuthExtraUsage({ utilization: 20 })).toBeNull();
+  });
+
+  test('bounds dynamic windows and keeps the first case-insensitive label', () => {
+    const limits = Array.from({ length: 40 }, (_, index) => ({
+      kind: 'weekly_scoped',
+      percent: index,
+      resets_at: null,
+      scope: {
+        model: { display_name: index === 1 ? 'MODEL-0' : `model-${index}` },
+      },
+    }));
+    const parsed = parseOAuthModelWindows({ limits });
+
+    expect(parsed).toHaveLength(31);
+    expect(parsed[0]).toMatchObject({
+      display_name: 'model-0',
+      utilization: 0,
+    });
+    expect(
+      parsed.find((bucket) => bucket.display_name === 'MODEL-0'),
+    ).toBeUndefined();
+    expect(parsed.at(-1)?.display_name).toBe('model-31');
+  });
+
+  test('distinguishes explicit snapshots from fieldless 200 responses', () => {
+    expect(hasOAuthUsageSignals({})).toBe(false);
+    expect(hasOAuthUsageSignals([])).toBe(false);
+    expect(hasOAuthUsageSignals({ error: 'temporarily unavailable' })).toBe(
+      false,
+    );
+    expect(hasOAuthUsageSignals({ five_hour: 'malformed' })).toBe(false);
+    expect(hasOAuthUsageSignals({ five_hour: null })).toBe(true);
+    expect(hasOAuthUsageSignals({ model_scoped: [] })).toBe(true);
+    expect(hasOAuthUsageSignals({ limits: [] })).toBe(true);
+  });
+});

--- a/tests/provider-quota-observation.test.ts
+++ b/tests/provider-quota-observation.test.ts
@@ -1,0 +1,231 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  isTerminalSdkRateLimitRejection,
+  normalizeSdkRateLimitObservation,
+} from '../container/agent-runner/src/provider-quota-observation.js';
+import {
+  captureProviderQuotaObservationEpoch,
+  clearAllProviderQuotaObservations,
+  clearProviderQuotaObservation,
+  consumeProviderQuotaControlOutput,
+  getProviderQuotaObservation,
+  MAX_PROVIDER_QUOTA_OBSERVATIONS,
+  observeProviderQuota,
+} from '../src/provider-quota-observation.js';
+
+afterEach(() => clearAllProviderQuotaObservations());
+
+describe('SDK provider quota observation', () => {
+  test('preserves the SDK/header units and bounded overage signals', () => {
+    const observedAt = Date.parse('2026-09-02T08:00:00.000Z');
+    const observation = normalizeSdkRateLimitObservation(
+      {
+        status: 'allowed_warning',
+        rateLimitType: 'seven_day',
+        utilization: 0.53,
+        resetsAt: 1_788_000_000,
+        overageStatus: 'allowed',
+        overageResetsAt: 1_788_100_000,
+        overageDisabledReason: 'member_zero_credit_limit',
+        isUsingOverage: false,
+        overageInUse: false,
+        surpassedThreshold: 0.5,
+      },
+      observedAt,
+    );
+
+    expect(observation).toMatchObject({
+      source: 'sdk_rate_limit_event',
+      observedAt,
+      status: 'allowed_warning',
+      rateLimitType: 'seven_day',
+      utilization: 0.53,
+      resetsAt: 1_788_000_000,
+      overageStatus: 'allowed',
+      overageResetsAt: 1_788_100_000,
+      surpassedThreshold: 0.5,
+    });
+    // Epoch seconds must not be silently converted into milliseconds.
+    expect(observation.resetsAt).toBe(1_788_000_000);
+  });
+
+  test('omits malformed fractions instead of clamping them into valid data', () => {
+    expect(
+      normalizeSdkRateLimitObservation({
+        status: 'allowed_warning',
+        utilization: 1.7,
+        surpassedThreshold: -0.2,
+      }),
+    ).not.toHaveProperty('utilization');
+  });
+
+  test('does not fail an allowed warning or an active overage transition', () => {
+    expect(isTerminalSdkRateLimitRejection({ status: 'allowed_warning' })).toBe(
+      false,
+    );
+    expect(
+      isTerminalSdkRateLimitRejection({
+        status: 'rejected',
+        rateLimitType: 'seven_day',
+        overageStatus: 'allowed',
+        isUsingOverage: true,
+      }),
+    ).toBe(false);
+    expect(
+      isTerminalSdkRateLimitRejection({
+        status: 'rejected',
+        rateLimitType: 'overage',
+        overageInUse: true,
+      }),
+    ).toBe(false);
+    expect(
+      isTerminalSdkRateLimitRejection({
+        status: 'rejected',
+        rateLimitType: 'seven_day',
+        overageStatus: 'allowed_warning',
+      }),
+    ).toBe(true);
+    expect(
+      isTerminalSdkRateLimitRejection({
+        status: 'rejected',
+        rateLimitType: 'five_hour',
+        isUsingOverage: false,
+      }),
+    ).toBe(true);
+  });
+
+  test('replaces the whole snapshot and never resurrects older fields', () => {
+    observeProviderQuota('provider-a', {
+      source: 'sdk_rate_limit_event',
+      observedAt: 100,
+      status: 'allowed_warning',
+      rateLimitType: 'seven_day',
+      utilization: 0.8,
+      overageStatus: 'rejected',
+      overageDisabledReason: 'out_of_credits',
+    });
+    observeProviderQuota('provider-a', {
+      source: 'sdk_rate_limit_event',
+      observedAt: 200,
+      status: 'allowed',
+      rateLimitType: 'five_hour',
+      utilization: 0.1,
+    });
+
+    expect(getProviderQuotaObservation('provider-a')).toEqual({
+      source: 'sdk_rate_limit_event',
+      observedAt: 200,
+      status: 'allowed',
+      rateLimitType: 'five_hour',
+      utilization: 0.1,
+    });
+    expect(getProviderQuotaObservation('provider-a')).not.toHaveProperty(
+      'overageStatus',
+    );
+  });
+
+  test('ignores an older concurrent observation and bounds provider cardinality', () => {
+    observeProviderQuota('newest', {
+      source: 'sdk_rate_limit_event',
+      observedAt: 300,
+      status: 'rejected',
+    });
+    observeProviderQuota('newest', {
+      source: 'sdk_rate_limit_event',
+      observedAt: 200,
+      status: 'allowed',
+    });
+    expect(getProviderQuotaObservation('newest')?.status).toBe('rejected');
+
+    clearAllProviderQuotaObservations();
+    for (let index = 0; index <= MAX_PROVIDER_QUOTA_OBSERVATIONS; index += 1) {
+      observeProviderQuota(`provider-${index}`, {
+        source: 'sdk_rate_limit_event',
+        observedAt: index + 1,
+        status: 'allowed',
+      });
+    }
+    expect(getProviderQuotaObservation('provider-0')).toBeNull();
+    expect(
+      getProviderQuotaObservation(
+        `provider-${MAX_PROVIDER_QUOTA_OBSERVATIONS}`,
+      ),
+    ).not.toBeNull();
+  });
+
+  test('consumes a control frame without requiring a selected provider', () => {
+    const output = {
+      providerQuotaObservation: {
+        source: 'sdk_rate_limit_event' as const,
+        observedAt: 100,
+        status: 'allowed' as const,
+      },
+    };
+    expect(consumeProviderQuotaControlOutput(null, output)).toBe(true);
+    expect(getProviderQuotaObservation('')).toBeNull();
+    expect(consumeProviderQuotaControlOutput('provider-a', output)).toBe(true);
+    expect(getProviderQuotaObservation('provider-a')?.status).toBe('allowed');
+    expect(consumeProviderQuotaControlOutput('provider-a', {})).toBe(false);
+  });
+
+  test('rejects a late frame from the credential generation that was cleared', () => {
+    const providerId = 'provider-rotated';
+    const oldEpoch = captureProviderQuotaObservationEpoch(providerId);
+    const output = {
+      providerQuotaObservation: {
+        source: 'sdk_rate_limit_event' as const,
+        observedAt: 100,
+        status: 'rejected' as const,
+      },
+    };
+
+    clearProviderQuotaObservation(providerId);
+    expect(
+      consumeProviderQuotaControlOutput(providerId, output, oldEpoch),
+    ).toBe(true);
+    expect(getProviderQuotaObservation(providerId)).toBeNull();
+
+    const newEpoch = captureProviderQuotaObservationEpoch(providerId);
+    expect(newEpoch).not.toBe(oldEpoch);
+    consumeProviderQuotaControlOutput(providerId, output, newEpoch);
+    expect(getProviderQuotaObservation(providerId)?.status).toBe('rejected');
+  });
+
+  test('wires both Host and Container frames through activity before projection', () => {
+    const runner = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/container-runner.ts'),
+      'utf8',
+    );
+    const main = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/index.ts'),
+      'utf8',
+    );
+
+    expect(
+      runner.match(
+        /consumeProviderQuotaControlOutput\([\s\S]*?output,[\s\S]*?QuotaEpoch,[\s\S]*?\)/g,
+      ),
+    ).toHaveLength(2);
+    expect(
+      runner.match(/if \(onOutput\) await onOutput\(output\);/g),
+    ).toHaveLength(2);
+    expect(main).toMatch(
+      /queue\.markRunnerActivity\(chatJid\);\s*if \(isProviderQuotaControlOutput\(output\)\) return;/,
+    );
+    expect(main).toMatch(
+      /queue\.markRunnerActivity\(virtualJid\);\s*if \(isProviderQuotaControlOutput\(output\)\) return;/,
+    );
+
+    const agentRunner = fs.readFileSync(
+      path.resolve(process.cwd(), 'container/agent-runner/src/index.ts'),
+      'utf8',
+    );
+    expect(agentRunner).toMatch(
+      /if \(message\.type === 'rate_limit_event'\) \{\s*const info:[^;]+;\s*publishProviderQuotaObservation\(info\);\s*if \(isTerminalSdkRateLimitRejection\(info\)\)/,
+    );
+  });
+});

--- a/tests/routes-oauth-usage.test.ts
+++ b/tests/routes-oauth-usage.test.ts
@@ -1,0 +1,842 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happyclaw-oauth-usage-'));
+
+vi.mock('../src/config.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DATA_DIR: tmpDir,
+  STORE_DIR: path.join(tmpDir, 'db'),
+  GROUPS_DIR: path.join(tmpDir, 'groups'),
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../src/middleware/auth.ts', async (importOriginal) => {
+  const real =
+    await importOriginal<typeof import('../src/middleware/auth.ts')>();
+  return {
+    ...real,
+    authMiddleware: async (c: any, next: any) => {
+      c.set('user', {
+        id: 'quota-route-admin',
+        username: 'quota-route-admin',
+        display_name: 'Quota Route Admin',
+        role: 'admin',
+        status: 'active',
+        permissions: [],
+        must_change_password: false,
+      });
+      return next();
+    },
+  };
+});
+
+const web = await import('../src/web.js');
+const db = await import('../src/db.js');
+const runtimeConfig = await import('../src/runtime-config.js');
+const quotaObservation = await import('../src/provider-quota-observation.js');
+
+const closeAllActiveForCredentialRefresh = vi.fn(() => 0);
+const drainProviderRunnersForCredentialRefresh = vi.fn(() => 0);
+const app = web.createAppForTest({
+  queue: {
+    stopGroup: vi.fn(async () => {}),
+    listDescendantJids: () => [],
+    pauseGroupsForMutation: () => ({ id: 0 }),
+    resumeGroupsAfterMutation: vi.fn(),
+    closeAllActiveForCredentialRefresh,
+    drainProviderRunnersForCredentialRefresh,
+  },
+  getRegisteredGroups: () => ({}),
+  sessions: {},
+} as any);
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(tmpDir, 'db'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'groups'), { recursive: true });
+  db.initDatabase();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  quotaObservation.clearAllProviderQuotaObservations();
+  closeAllActiveForCredentialRefresh.mockClear();
+  drainProviderRunnersForCredentialRefresh.mockClear();
+});
+
+afterAll(() => {
+  db.closeDatabase();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Claude provider usage route', () => {
+  test('returns full OAuth data and a separate latest SDK observation', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'OAuth fixture provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: {
+        accessToken: 'fixture-access-token',
+        refreshToken: 'fixture-refresh-token',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference', 'user:profile'],
+      },
+    });
+    quotaObservation.observeProviderQuota(provider.id, {
+      source: 'sdk_rate_limit_event',
+      observedAt: 1_788_300_000_000,
+      status: 'allowed_warning',
+      rateLimitType: 'seven_day',
+      utilization: 0.53,
+      resetsAt: 1_788_700_000,
+    });
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      expect(new Headers(init?.headers).get('Authorization')).toBe(
+        'Bearer fixture-access-token',
+      );
+      return new Response(
+        JSON.stringify({
+          five_hour: {
+            utilization: 10.25,
+            resets_at: '2026-09-02T10:00:00.000Z',
+          },
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'model',
+              percent: 44.5,
+              resets_at: '2026-09-08T10:00:00.000Z',
+              scope: { model: { display_name: 'Future model' } },
+            },
+          ],
+          extra_usage: {
+            is_enabled: true,
+            monthly_limit: 100,
+            used_credits: 25,
+            utilization: null,
+            currency: 'USD',
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    const response = await app.request(
+      `/api/config/claude/providers/${provider.id}/usage`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        five_hour: { utilization: 10.25 },
+        model_scoped: [{ display_name: 'Future model', utilization: 44.5 }],
+        extra_usage: {
+          is_enabled: true,
+          monthly_limit: 100,
+          used_credits: 25,
+          utilization: null,
+          currency: 'USD',
+        },
+      },
+      observation: {
+        source: 'sdk_rate_limit_event',
+        status: 'allowed_warning',
+        rateLimitType: 'seven_day',
+        utilization: 0.53,
+        resetsAt: 1_788_700_000,
+      },
+    });
+  });
+
+  test('serves an observation-only response without OAuth credentials', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Passive-only provider',
+      type: 'official',
+      enabled: true,
+      anthropicApiKey: 'api-key-does-not-have-oauth-usage',
+    });
+    quotaObservation.observeProviderQuota(provider.id, {
+      source: 'sdk_rate_limit_event',
+      observedAt: Date.now(),
+      status: 'allowed',
+      rateLimitType: 'five_hour',
+      utilization: 0.1,
+    });
+
+    const response = await app.request(
+      `/api/config/claude/providers/${provider.id}/usage`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        five_hour: null,
+        seven_day: null,
+        model_scoped: [],
+        extra_usage: null,
+      },
+      observation: {
+        status: 'allowed',
+        rateLimitType: 'five_hour',
+        utilization: 0.1,
+      },
+    });
+  });
+
+  test('serves an empty successful response before an API-key provider has an observation', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Passive provider without an event yet',
+      type: 'official',
+      enabled: true,
+      anthropicApiKey: 'api-key-without-observation',
+    });
+    globalThis.fetch = vi.fn();
+
+    const response = await app.request(
+      `/api/config/claude/providers/${provider.id}/usage`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        five_hour: null,
+        seven_day: null,
+        model_scoped: [],
+        extra_usage: null,
+      },
+      observation: null,
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test('clears passive state when the provider credential epoch changes', () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Credential rotation provider',
+      type: 'official',
+      enabled: true,
+      claudeOAuthCredentials: {
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    quotaObservation.observeProviderQuota(provider.id, {
+      source: 'sdk_rate_limit_event',
+      observedAt: Date.now(),
+      status: 'rejected',
+    });
+
+    runtimeConfig.updateProviderSecrets(provider.id, {
+      claudeOAuthCredentials: {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresAt: Date.now() + 120_000,
+        scopes: ['user:inference'],
+      },
+    });
+    expect(
+      quotaObservation.getProviderQuotaObservation(provider.id),
+    ).toBeNull();
+  });
+
+  test('invalidates the three-minute OAuth body cache on credential rotation', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Cached credential provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'cached-old-access',
+        refreshToken: 'cached-old-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    let requestCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      requestCount += 1;
+      return new Response(
+        JSON.stringify({
+          five_hour: {
+            utilization: requestCount === 1 ? 10 : 20,
+            resets_at: '2026-09-02T10:00:00.000Z',
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+    expect(
+      (await (await app.request(usageUrl)).json()).data.five_hour,
+    ).toMatchObject({ utilization: 10 });
+    expect(
+      (await (await app.request(usageUrl)).json()).data.five_hour,
+    ).toMatchObject({ utilization: 10 });
+    expect(requestCount).toBe(1);
+
+    const rotate = await app.request(
+      `/api/config/claude/providers/${provider.id}/secrets`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          claudeOAuthCredentials: {
+            accessToken: 'cached-new-access',
+            refreshToken: 'cached-new-refresh',
+            expiresAt: Date.now() + 120_000,
+            scopes: ['user:inference'],
+          },
+        }),
+      },
+    );
+    expect(rotate.status).toBe(200);
+    expect(
+      (await (await app.request(usageUrl)).json()).data.five_hour,
+    ).toMatchObject({ utilization: 20 });
+    expect(requestCount).toBe(2);
+  });
+
+  test('keeps the last full snapshot when a 200 response has no usage signals', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-02T08:00:00.000Z'));
+    const provider = runtimeConfig.createProvider({
+      name: 'Fieldless response provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'fieldless-access',
+        refreshToken: 'fieldless-refresh',
+        expiresAt: Date.now() + 60 * 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    let requestCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      requestCount += 1;
+      return Response.json(
+        requestCount === 1
+          ? {
+              five_hour: {
+                utilization: 31,
+                resets_at: '2026-09-02T10:00:00.000Z',
+              },
+            }
+          : { error: 'temporarily unavailable' },
+      );
+    });
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const first = await (await app.request(usageUrl)).json();
+    await vi.advanceTimersByTimeAsync(3 * 60_000 + 1);
+    const second = await (await app.request(usageUrl)).json();
+
+    expect(requestCount).toBe(2);
+    expect(second.data.five_hour.utilization).toBe(31);
+    expect(second.fetchedAt).toBe(first.fetchedAt);
+    expect(second.error).toContain('no recognized quota data');
+  });
+
+  test('falls back to a passive observation when the OAuth endpoint fails', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'OAuth failure with passive state',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'passive-fallback-access',
+        refreshToken: 'passive-fallback-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    quotaObservation.observeProviderQuota(provider.id, {
+      source: 'sdk_rate_limit_event',
+      observedAt: Date.now(),
+      status: 'allowed_warning',
+      utilization: 0.8,
+    });
+    globalThis.fetch = vi.fn(async () => new Response(null, { status: 429 }));
+
+    const response = await app.request(
+      `/api/config/claude/providers/${provider.id}/usage`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { five_hour: null, model_scoped: [] },
+      error: 'Usage API returned 429',
+      observation: { status: 'allowed_warning', utilization: 0.8 },
+    });
+  });
+
+  test('times out a hung usage request and releases its in-flight slot', async () => {
+    vi.useFakeTimers();
+    const provider = runtimeConfig.createProvider({
+      name: 'Hung OAuth usage provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'hung-access',
+        refreshToken: 'hung-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    globalThis.fetch = vi.fn(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => reject(new Error('usage request aborted')),
+            { once: true },
+          );
+        }),
+    );
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const hungRequest = app.request(usageUrl);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect((await hungRequest).status).toBe(400);
+
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        five_hour: {
+          utilization: 9,
+          resets_at: '2026-09-02T10:00:00.000Z',
+        },
+      }),
+    );
+    const retried = await app.request(usageUrl);
+    expect(retried.status).toBe(200);
+    expect((await retried.json()).data.five_hour.utilization).toBe(9);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  test('keeps the timeout active while a response body is stalled', async () => {
+    vi.useFakeTimers();
+    const provider = runtimeConfig.createProvider({
+      name: 'Stalled OAuth body provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'stalled-body-access',
+        refreshToken: 'stalled-body-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      const signal = init?.signal;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const abort = () => controller.error(new Error('body aborted'));
+          if (signal?.aborted) abort();
+          else signal?.addEventListener('abort', abort, { once: true });
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const stalledRequest = app.request(usageUrl);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect((await stalledRequest).status).toBe(400);
+
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        five_hour: {
+          utilization: 11,
+          resets_at: '2026-09-02T10:00:00.000Z',
+        },
+      }),
+    );
+    const retried = await app.request(usageUrl);
+    expect(retried.status).toBe(200);
+    expect((await retried.json()).data.five_hour.utilization).toBe(11);
+  });
+
+  test('refreshes an expired OAuth token, persists it, and fetches usage with it', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Expired OAuth provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'expired-access',
+        refreshToken: 'refresh-before-rotation',
+        expiresAt: Date.now() - 1,
+        scopes: ['user:inference', 'user:profile'],
+        subscriptionType: 'max',
+      },
+    });
+    globalThis.fetch = vi.fn(async (url, init) => {
+      if (String(url).endsWith('/v1/oauth/token')) {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          grant_type: 'refresh_token',
+          refresh_token: 'refresh-before-rotation',
+          scope: 'user:inference user:profile',
+        });
+        return Response.json({
+          access_token: 'refreshed-access',
+          refresh_token: 'rotated-refresh',
+          expires_in: 3600,
+          scope: 'user:profile user:inference',
+        });
+      }
+      expect(new Headers(init?.headers).get('Authorization')).toBe(
+        'Bearer refreshed-access',
+      );
+      return Response.json({
+        five_hour: {
+          utilization: 42,
+          resets_at: '2026-09-02T10:00:00.000Z',
+        },
+      });
+    });
+
+    const response = await app.request(
+      `/api/config/claude/providers/${provider.id}/usage`,
+    );
+    expect(response.status).toBe(200);
+    expect((await response.json()).data.five_hour.utilization).toBe(42);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(drainProviderRunnersForCredentialRefresh).toHaveBeenCalledOnce();
+    expect(drainProviderRunnersForCredentialRefresh).toHaveBeenCalledWith(
+      provider.id,
+    );
+    expect(closeAllActiveForCredentialRefresh).not.toHaveBeenCalled();
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.claudeOAuthCredentials,
+    ).toMatchObject({
+      accessToken: 'refreshed-access',
+      refreshToken: 'rotated-refresh',
+      scopes: ['user:inference', 'user:profile'],
+      subscriptionType: 'max',
+    });
+  });
+
+  test('retries one 401 with a refreshed token', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'OAuth 401 provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'rejected-access',
+        refreshToken: '401-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      if (String(url).endsWith('/v1/oauth/token')) {
+        calls.push('refresh');
+        return Response.json({
+          access_token: '401-refreshed-access',
+          expires_in: 3600,
+        });
+      }
+      const auth = new Headers(init?.headers).get('Authorization') ?? '';
+      calls.push(auth);
+      if (auth === 'Bearer rejected-access') {
+        return new Response(null, { status: 401 });
+      }
+      return Response.json({
+        seven_day: {
+          utilization: 17,
+          resets_at: '2026-09-08T10:00:00.000Z',
+        },
+      });
+    });
+
+    const response = await app.request(
+      `/api/config/claude/providers/${provider.id}/usage`,
+    );
+    expect(response.status).toBe(200);
+    expect((await response.json()).data.seven_day.utilization).toBe(17);
+    expect(calls).toEqual([
+      'Bearer rejected-access',
+      'refresh',
+      'Bearer 401-refreshed-access',
+    ]);
+  });
+
+  test('retains the previous full snapshot when refresh succeeds but usage stays unavailable', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-02T08:00:00.000Z'));
+    const provider = runtimeConfig.createProvider({
+      name: 'Refresh fallback provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'soon-expired-access',
+        refreshToken: 'refresh-fallback-token',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    let call = 0;
+    globalThis.fetch = vi.fn(async (url) => {
+      call += 1;
+      if (call === 1) {
+        return Response.json({
+          five_hour: {
+            utilization: 64,
+            resets_at: '2026-09-02T10:00:00.000Z',
+          },
+        });
+      }
+      if (String(url).endsWith('/v1/oauth/token')) {
+        return Response.json({
+          access_token: 'fallback-refreshed-access',
+          expires_in: 3600,
+        });
+      }
+      return new Response(null, { status: 503 });
+    });
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const first = await (await app.request(usageUrl)).json();
+    await vi.advanceTimersByTimeAsync(3 * 60_000 + 1);
+    const secondResponse = await app.request(usageUrl);
+    const second = await secondResponse.json();
+
+    expect(secondResponse.status).toBe(200);
+    expect(call).toBe(3);
+    expect(second.data.five_hour.utilization).toBe(64);
+    expect(second.fetchedAt).toBe(first.fetchedAt);
+    expect(second.error).toBe('Usage API returned 503');
+  });
+
+  test('joins the new credential epoch when an old usage request resolves late', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'In-flight credential provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'in-flight-old-access',
+        refreshToken: 'in-flight-old-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    let resolveOld!: (response: Response) => void;
+    let resolveNew!: (response: Response) => void;
+    const requestedTokens: string[] = [];
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      requestedTokens.push(
+        new Headers(init?.headers).get('Authorization') ?? '',
+      );
+      return new Promise<Response>((resolve) => {
+        if (requestedTokens.length === 1) resolveOld = resolve;
+        else resolveNew = resolve;
+      });
+    });
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const oldCaller = app.request(usageUrl);
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+    const rotate = await app.request(
+      `/api/config/claude/providers/${provider.id}/secrets`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          claudeOAuthCredentials: {
+            accessToken: 'in-flight-new-access',
+            refreshToken: 'in-flight-new-refresh',
+            expiresAt: Date.now() + 120_000,
+            scopes: ['user:inference'],
+          },
+        }),
+      },
+    );
+    expect(rotate.status).toBe(200);
+
+    const newCaller = app.request(usageUrl);
+    const deduplicatedCaller = app.request(usageUrl);
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+    resolveOld(
+      Response.json({
+        five_hour: {
+          utilization: 10,
+          resets_at: '2026-09-02T10:00:00.000Z',
+        },
+      }),
+    );
+    await Promise.resolve();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+
+    resolveNew(
+      Response.json({
+        five_hour: {
+          utilization: 20,
+          resets_at: '2026-09-02T11:00:00.000Z',
+        },
+      }),
+    );
+    const bodies = await Promise.all(
+      [oldCaller, newCaller, deduplicatedCaller].map(async (request) =>
+        (await request).json(),
+      ),
+    );
+
+    expect(requestedTokens).toEqual([
+      'Bearer in-flight-old-access',
+      'Bearer in-flight-new-access',
+    ]);
+    expect(bodies.map((body) => body.data.five_hour.utilization)).toEqual([
+      20, 20, 20,
+    ]);
+    expect(
+      (await (await app.request(usageUrl)).json()).data.five_hour.utilization,
+    ).toBe(20);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not let a late token refresh overwrite an administrator credential rotation', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Refresh CAS race provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'cas-old-access',
+        refreshToken: 'cas-old-refresh',
+        expiresAt: Date.now() - 1,
+        scopes: ['user:inference'],
+      },
+    });
+    let resolveOldRefresh!: (response: Response) => void;
+    globalThis.fetch = vi.fn(async (url, init) => {
+      if (String(url).endsWith('/v1/oauth/token')) {
+        return new Promise<Response>((resolve) => {
+          resolveOldRefresh = resolve;
+        });
+      }
+      expect(new Headers(init?.headers).get('Authorization')).toBe(
+        'Bearer cas-admin-access',
+      );
+      return Response.json({
+        five_hour: {
+          utilization: 22,
+          resets_at: '2026-09-02T10:00:00.000Z',
+        },
+      });
+    });
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const oldCaller = app.request(usageUrl);
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    const rotate = await app.request(
+      `/api/config/claude/providers/${provider.id}/secrets`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          claudeOAuthCredentials: {
+            accessToken: 'cas-admin-access',
+            refreshToken: 'cas-admin-refresh',
+            expiresAt: Date.now() + 60_000,
+            scopes: ['user:inference'],
+          },
+        }),
+      },
+    );
+    expect(rotate.status).toBe(200);
+
+    const currentCaller = app.request(usageUrl);
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+    expect(
+      (await (await currentCaller).json()).data.five_hour.utilization,
+    ).toBe(22);
+    resolveOldRefresh(
+      Response.json({
+        access_token: 'cas-must-not-win-access',
+        refresh_token: 'cas-must-not-win-refresh',
+        expires_in: 3600,
+      }),
+    );
+    expect((await (await oldCaller).json()).data.five_hour.utilization).toBe(
+      22,
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(
+      runtimeConfig.getProviders().find((item) => item.id === provider.id)
+        ?.claudeOAuthCredentials,
+    ).toMatchObject({
+      accessToken: 'cas-admin-access',
+      refreshToken: 'cas-admin-refresh',
+    });
+  });
+
+  test('does not resurrect a deleted provider from an old in-flight response', async () => {
+    const provider = runtimeConfig.createProvider({
+      name: 'Deleted in-flight provider',
+      type: 'official',
+      enabled: false,
+      claudeOAuthCredentials: {
+        accessToken: 'deleted-access',
+        refreshToken: 'deleted-refresh',
+        expiresAt: Date.now() + 60_000,
+        scopes: ['user:inference'],
+      },
+    });
+    quotaObservation.observeProviderQuota(provider.id, {
+      source: 'sdk_rate_limit_event',
+      observedAt: Date.now(),
+      status: 'allowed_warning',
+    });
+    let resolveUsage!: (response: Response) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveUsage = resolve;
+        }),
+    );
+    const usageUrl = `/api/config/claude/providers/${provider.id}/usage`;
+
+    const oldCaller = app.request(usageUrl);
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    const deleted = await app.request(
+      `/api/config/claude/providers/${provider.id}`,
+      { method: 'DELETE' },
+    );
+    expect(deleted.status).toBe(200);
+    expect(
+      quotaObservation.getProviderQuotaObservation(provider.id),
+    ).toBeNull();
+
+    resolveUsage(
+      Response.json({
+        five_hour: {
+          utilization: 99,
+          resets_at: '2026-09-02T10:00:00.000Z',
+        },
+      }),
+    );
+    expect((await oldCaller).status).toBe(400);
+    expect((await app.request(usageUrl)).status).toBe(400);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/task-scheduler-contract.test.ts
+++ b/tests/task-scheduler-contract.test.ts
@@ -821,6 +821,55 @@ describe('scheduled task workspace/session contract', () => {
     expect(runContainerAgentMock).toHaveBeenCalledOnce();
   });
 
+  test('treats Provider quota control frames as activity-only scheduler output', async () => {
+    const taskId = createTask({ id: 'task-provider-quota-control-frame' });
+    const groups = {
+      [GROUP_JID]: db.getRegisteredGroup(GROUP_JID)!,
+    };
+    runContainerAgentMock.mockImplementationOnce(
+      async (_group, input, onProcess, onOutput) => {
+        onProcess?.({} as never, `container-${input.taskRunId}`, null);
+        await onOutput?.({
+          status: 'stream',
+          result: 'must-not-project',
+          streamEvent: { type: 'text', text: 'must-not-broadcast' },
+          providerQuotaObservation: {
+            source: 'sdk_rate_limit_event',
+            observedAt: Date.now(),
+            status: 'allowed_warning',
+            utilization: 0.75,
+          },
+        });
+        return {
+          status: 'success',
+          result: 'task result after quota control',
+          inputTurnCompleted: true,
+        };
+      },
+    );
+    const { deps, waitForRun } = makeDeps(groups);
+
+    const trigger = triggerTaskNow(taskId, deps);
+    await waitForRun();
+
+    expect(trigger.success).toBe(true);
+    expect(deps.broadcastStreamEvent).not.toHaveBeenCalled();
+    expect(db.getTaskRunById(trigger.runId!)).toMatchObject({
+      status: 'success',
+      result: 'task result after quota control',
+    });
+    expect(deps.storeResultAndNotify).toHaveBeenCalledWith(
+      GROUP_JID,
+      expect.stringContaining('task result after quota control'),
+      expect.any(Object),
+    );
+    expect(deps.storeResultAndNotify).not.toHaveBeenCalledWith(
+      GROUP_JID,
+      expect.stringContaining('must-not-project'),
+      expect.any(Object),
+    );
+  });
+
   test('persists and retries a failed canonical workspace result without rerunning isolated Agent work', async () => {
     const taskId = createTask({ id: 'task-workspace-projection-retry' });
     const groups = {

--- a/web/src/components/settings/ProviderList.tsx
+++ b/web/src/components/settings/ProviderList.tsx
@@ -315,8 +315,11 @@ export function ProviderList({
                     )}
 
                   {/* OAuth 用量 */}
-                  {provider.hasClaudeOAuthCredentials && (
-                    <UsageBars providerId={provider.id} />
+                  {provider.type === 'official' && (
+                    <UsageBars
+                      providerId={provider.id}
+                      providerVersion={provider.updatedAt}
+                    />
                   )}
                 </div>
               );

--- a/web/src/components/settings/UsageBars.tsx
+++ b/web/src/components/settings/UsageBars.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '@/api/client';
-import type { CachedOAuthUsage, OAuthUsageBucket } from './types';
+import type {
+  CachedOAuthUsage,
+  OAuthExtraUsage,
+  OAuthUsageBucket,
+  ProviderQuotaObservation,
+} from './types';
 
-const POLL_INTERVAL_MS = 3 * 60 * 1000; // 3 minutes
+const POLL_INTERVAL_MS = 3 * 60 * 1000;
+const LIVE_OBSERVATION_FRESHNESS_MS = 5 * 60 * 1000;
+
+export function clampUsagePercentage(value: number | null): number | null {
+  if (value === null || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, value));
+}
 
 function barColor(utilization: number): string {
   if (utilization >= 80) return 'bg-red-500';
@@ -10,8 +21,11 @@ function barColor(utilization: number): string {
   return 'bg-emerald-500';
 }
 
-function formatResetTime(resetsAt: string): string {
-  const diff = new Date(resetsAt).getTime() - Date.now();
+export function formatResetTime(resetsAt: string | null): string | null {
+  if (!resetsAt) return null;
+  const resetMs = new Date(resetsAt).getTime();
+  if (!Number.isFinite(resetMs)) return null;
+  const diff = resetMs - Date.now();
   if (diff <= 0) return '现在';
 
   const totalMinutes = Math.floor(diff / 60_000);
@@ -29,42 +43,236 @@ function formatResetTime(resetsAt: string): string {
   return `${minutes}m`;
 }
 
+export function sdkUtilizationPercentage(
+  observation: ProviderQuotaObservation,
+): number | null {
+  if (
+    observation.utilization === undefined ||
+    !Number.isFinite(observation.utilization) ||
+    observation.utilization < 0 ||
+    observation.utilization > 1
+  ) {
+    return null;
+  }
+  return observation.utilization * 100;
+}
+
+export function extraUsagePercentage(extra: OAuthExtraUsage): number | null {
+  if (!extra.is_enabled) return null;
+  const reported = clampUsagePercentage(extra.utilization);
+  if (reported !== null) return reported;
+  if (
+    extra.used_credits === null ||
+    extra.monthly_limit === null ||
+    !Number.isFinite(extra.used_credits) ||
+    !Number.isFinite(extra.monthly_limit) ||
+    extra.monthly_limit <= 0
+  ) {
+    return null;
+  }
+  return clampUsagePercentage((extra.used_credits / extra.monthly_limit) * 100);
+}
+
+export function isCurrentProviderQuotaObservation(
+  observation: ProviderQuotaObservation,
+  now = Date.now(),
+): boolean {
+  if (
+    !Number.isFinite(observation.observedAt) ||
+    observation.observedAt <= 0 ||
+    now - observation.observedAt > LIVE_OBSERVATION_FRESHNESS_MS
+  ) {
+    return false;
+  }
+  if (
+    observation.resetsAt !== undefined &&
+    Number.isFinite(observation.resetsAt) &&
+    observation.resetsAt > 0 &&
+    observation.resetsAt * 1000 <= now
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function formatEpochReset(value: number | undefined): string | null {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return null;
+  const milliseconds = value < 1e11 ? value * 1000 : value;
+  return formatResetTime(new Date(milliseconds).toISOString());
+}
+
 function UsageColumn({
   label,
   bucket,
+  detail,
 }: {
   label: string;
   bucket: OAuthUsageBucket;
+  detail?: string | null;
 }) {
-  const pct = Math.round(bucket.utilization);
+  const pct = clampUsagePercentage(bucket.utilization);
+  const reset = formatResetTime(bucket.resets_at);
   return (
-    <div className="flex items-center gap-1.5 flex-1 min-w-0 justify-center">
-      <span className="text-[11px] font-medium text-muted-foreground shrink-0">
-        {label}
-      </span>
-      <div className="w-16 h-1.5 rounded-full bg-muted overflow-hidden shrink-0">
-        <div
-          className={`h-full rounded-full transition-all ${barColor(pct)}`}
-          style={{ width: `${Math.min(pct, 100)}%` }}
-        />
+    <div className="min-w-0 rounded-md bg-muted/35 px-2.5 py-2">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <span
+          className="truncate text-[11px] font-medium text-muted-foreground"
+          title={label}
+        >
+          {label}
+        </span>
+        <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+          {pct === null ? '—' : `${Math.round(pct)}%`}
+        </span>
       </div>
-      <span className="text-[11px] font-mono text-muted-foreground shrink-0">
-        {pct}%
-      </span>
-      <span className="text-[10px] text-muted-foreground/60 shrink-0">
-        {formatResetTime(bucket.resets_at)}
-      </span>
+      <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted">
+        {pct !== null && (
+          <div
+            className={`h-full rounded-full transition-all ${barColor(pct)}`}
+            style={{ width: `${pct}%` }}
+          />
+        )}
+      </div>
+      {(reset || detail) && (
+        <div className="mt-1 truncate text-[10px] text-muted-foreground/60">
+          {detail ?? (reset ? `${reset} 后重置` : null)}
+        </div>
+      )}
     </div>
   );
 }
 
-export function UsageBars({ providerId }: { providerId: string }) {
+function formatMinorCurrency(
+  value: number | null,
+  currency: string | null,
+): string {
+  if (value === null || !Number.isFinite(value)) return '—';
+  const normalizedCurrency =
+    currency && /^[A-Za-z]{3}$/.test(currency) ? currency.toUpperCase() : 'USD';
+  try {
+    const zeroDecimalCurrency = ['JPY', 'KRW', 'VND'].includes(
+      normalizedCurrency,
+    );
+    const formatter = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: normalizedCurrency,
+      minimumFractionDigits: zeroDecimalCurrency ? 0 : 2,
+      maximumFractionDigits: zeroDecimalCurrency ? 0 : 2,
+    });
+    return formatter.format(value / (zeroDecimalCurrency ? 1 : 100));
+  } catch {
+    return `${new Intl.NumberFormat(undefined, {
+      maximumFractionDigits: 2,
+    }).format(value / 100)} ${normalizedCurrency}`;
+  }
+}
+
+export function formatExtraUsageDetail(extra: OAuthExtraUsage): string {
+  if (!extra.is_enabled) return '未启用';
+  if (extra.monthly_limit === null) {
+    return extra.used_credits === null
+      ? '无月度上限'
+      : `已用 ${formatMinorCurrency(extra.used_credits, extra.currency)} · 无月度上限`;
+  }
+  return `${formatMinorCurrency(extra.used_credits, extra.currency)} / ${formatMinorCurrency(extra.monthly_limit, extra.currency)}`;
+}
+
+function ExtraUsageColumn({ extra }: { extra: OAuthExtraUsage }) {
+  return (
+    <UsageColumn
+      label="Extra"
+      bucket={{ utilization: extraUsagePercentage(extra), resets_at: null }}
+      detail={formatExtraUsageDetail(extra)}
+    />
+  );
+}
+
+function displayRateLimitType(type: string | undefined): string {
+  switch (type) {
+    case 'five_hour':
+      return '5h';
+    case 'seven_day':
+      return '7d';
+    case 'seven_day_opus':
+      return 'Opus';
+    case 'seven_day_sonnet':
+      return 'Sonnet';
+    case 'seven_day_overage_included':
+      return '模型周期';
+    case 'overage':
+      return 'Extra';
+    default:
+      return type?.replaceAll('_', ' ') || '整体额度';
+  }
+}
+
+function LiveStatus({
+  observation,
+}: {
+  observation: ProviderQuotaObservation;
+}) {
+  const usingOverage =
+    observation.isUsingOverage === true || observation.overageInUse === true;
+  const current = isCurrentProviderQuotaObservation(observation);
+  const currentStatus = usingOverage
+    ? '正在使用额外用量'
+    : observation.status === 'rejected'
+      ? '已受限'
+      : observation.status === 'allowed_warning'
+        ? '接近限额'
+        : '可用';
+  const status = current ? currentStatus : `上次观测：${currentStatus}`;
+  const color = !current
+    ? 'bg-muted-foreground/50'
+    : usingOverage
+      ? 'bg-blue-500'
+      : observation.status === 'rejected'
+        ? 'bg-red-500'
+        : observation.status === 'allowed_warning'
+          ? 'bg-amber-500'
+          : 'bg-emerald-500';
+  const pct = sdkUtilizationPercentage(observation);
+  const reset = formatEpochReset(observation.resetsAt);
+
+  return (
+    <div
+      className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border/60 px-2.5 py-1.5 text-[11px] text-muted-foreground"
+      title={new Date(observation.observedAt).toLocaleString()}
+    >
+      <span className={`size-1.5 shrink-0 rounded-full ${color}`} />
+      <span className="shrink-0 font-medium">{current ? 'Live' : 'Last'}</span>
+      <span className="min-w-0 truncate">{status}</span>
+      <span className="shrink-0">
+        {displayRateLimitType(observation.rateLimitType)}
+      </span>
+      {pct !== null && (
+        <span className="shrink-0 font-mono">{Math.round(pct)}%</span>
+      )}
+      {current && reset && <span className="shrink-0">{reset} 后重置</span>}
+      {observation.overageStatus && !usingOverage && (
+        <span className="min-w-0 truncate">
+          Extra: {observation.overageStatus}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function UsageBars({
+  providerId,
+  providerVersion,
+}: {
+  providerId: string;
+  providerVersion?: string;
+}) {
   const [usage, setUsage] = useState<CachedOAuthUsage | null>(null);
   const [loading, setLoading] = useState(true);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    setUsage(null);
+    setLoading(true);
 
     const fetchUsage = async () => {
       if (document.visibilityState !== 'visible') return;
@@ -74,7 +282,8 @@ export function UsageBars({ providerId }: { providerId: string }) {
         );
         if (!cancelled) setUsage(data);
       } catch {
-        // Silent — usage is optional
+        // Usage observation is optional and must not disrupt provider settings.
+        if (!cancelled) setUsage(null);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -93,30 +302,60 @@ export function UsageBars({ providerId }: { providerId: string }) {
       document.removeEventListener('visibilitychange', onVisible);
       if (timerRef.current) clearInterval(timerRef.current);
     };
-  }, [providerId]);
+  }, [providerId, providerVersion]);
 
   if (loading || !usage?.data) return null;
 
-  const USAGE_BUCKET_LABELS = {
-    five_hour: '5h',
-    seven_day: '7d',
-    seven_day_opus: '7dO',
-    seven_day_sonnet: '7dS',
-  } as const;
-
   const buckets: { label: string; bucket: OAuthUsageBucket }[] = [];
-  if (usage.data.five_hour) buckets.push({ label: USAGE_BUCKET_LABELS.five_hour, bucket: usage.data.five_hour });
-  if (usage.data.seven_day) buckets.push({ label: USAGE_BUCKET_LABELS.seven_day, bucket: usage.data.seven_day });
-  if (usage.data.seven_day_opus) buckets.push({ label: USAGE_BUCKET_LABELS.seven_day_opus, bucket: usage.data.seven_day_opus });
-  if (usage.data.seven_day_sonnet) buckets.push({ label: USAGE_BUCKET_LABELS.seven_day_sonnet, bucket: usage.data.seven_day_sonnet });
+  if (usage.data.five_hour)
+    buckets.push({ label: '5h', bucket: usage.data.five_hour });
+  if (usage.data.seven_day)
+    buckets.push({ label: '7d', bucket: usage.data.seven_day });
+  if (usage.data.seven_day_oauth_apps)
+    buckets.push({
+      label: 'OAuth apps',
+      bucket: usage.data.seven_day_oauth_apps,
+    });
+  if (usage.data.seven_day_opus)
+    buckets.push({ label: 'Opus', bucket: usage.data.seven_day_opus });
+  if (usage.data.seven_day_sonnet)
+    buckets.push({ label: 'Sonnet', bucket: usage.data.seven_day_sonnet });
+  for (const bucket of usage.data.model_scoped) {
+    buckets.push({ label: bucket.display_name, bucket });
+  }
 
-  if (buckets.length === 0) return null;
+  if (buckets.length === 0 && !usage.data.extra_usage && !usage.observation) {
+    return null;
+  }
 
   return (
-    <div className="mt-1.5 ml-4 flex items-center gap-3">
-      {buckets.map((b) => (
-        <UsageColumn key={b.label} label={b.label} bucket={b.bucket} />
-      ))}
+    <div className="mt-2 ml-4 min-w-0 space-y-2">
+      {usage.error && (
+        <div
+          className="text-[10px] text-amber-600 dark:text-amber-400"
+          title={usage.error}
+        >
+          暂时无法刷新，显示上次数据
+          {Number.isFinite(usage.fetchedAt)
+            ? `（${new Date(usage.fetchedAt).toLocaleString()}）`
+            : ''}
+        </div>
+      )}
+      {usage.observation && <LiveStatus observation={usage.observation} />}
+      {(buckets.length > 0 || usage.data.extra_usage) && (
+        <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
+          {buckets.map(({ label, bucket }, index) => (
+            <UsageColumn
+              key={`${label}-${index}`}
+              label={label}
+              bucket={bucket}
+            />
+          ))}
+          {usage.data.extra_usage && (
+            <ExtraUsageColumn extra={usage.data.extra_usage} />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/settings/types.ts
+++ b/web/src/components/settings/types.ts
@@ -109,21 +109,53 @@ export interface HostIntegrationSettings {
 // ─── OAuth Usage ────────────────────────────────────────────
 
 export interface OAuthUsageBucket {
-  utilization: number;
-  resets_at: string;
+  utilization: number | null;
+  resets_at: string | null;
+}
+
+export interface OAuthModelUsageBucket extends OAuthUsageBucket {
+  display_name: string;
+}
+
+export interface OAuthExtraUsage {
+  is_enabled: boolean;
+  monthly_limit: number | null;
+  used_credits: number | null;
+  utilization: number | null;
+  currency: string | null;
+}
+
+export interface ProviderQuotaObservation {
+  source: 'sdk_rate_limit_event';
+  observedAt: number;
+  status: 'allowed' | 'allowed_warning' | 'rejected';
+  rateLimitType?: string;
+  /** SDK/header fraction in the 0..1 unit, unlike OAuth buckets. */
+  utilization?: number;
+  /** Unix epoch seconds. */
+  resetsAt?: number;
+  overageStatus?: 'allowed' | 'allowed_warning' | 'rejected';
+  overageResetsAt?: number;
+  overageDisabledReason?: string;
+  isUsingOverage?: boolean;
+  overageInUse?: boolean;
 }
 
 export interface OAuthUsageResponse {
   five_hour: OAuthUsageBucket | null;
   seven_day: OAuthUsageBucket | null;
+  seven_day_oauth_apps: OAuthUsageBucket | null;
   seven_day_opus: OAuthUsageBucket | null;
   seven_day_sonnet: OAuthUsageBucket | null;
+  model_scoped: OAuthModelUsageBucket[];
+  extra_usage: OAuthExtraUsage | null;
 }
 
 export interface CachedOAuthUsage {
   data: OAuthUsageResponse;
   fetchedAt: number;
   error?: string;
+  observation?: ProviderQuotaObservation | null;
 }
 
 export type SettingsTab =


### PR DESCRIPTION
## Summary

- replace the closed #713 approach with provider-scoped Claude quota snapshots modeled after CLIProxyAPI's replace-not-merge observation semantics
- keep OAuth usage percentages separate from SDK/header fractions, support dynamic model windows and real extra-usage fields, and render stale/live state explicitly
- harden token refresh, timeout, cache, credential-generation, Host/Container control-frame, and Docker refresh reconciliation paths
- scope credential fan-out and graceful runner drains to the affected Provider so multi-account sessions cannot cross-contaminate

## Verification

- `npm test -- --run` — 441 files, 3867 passed, 23 skipped
- `npm run build:all`
- `npm run self-test:agent-runner`
- `node tests/e2e/provider-failure-upstream.mjs fast` — 2/2
- `npm --prefix web run test:e2e` — 9/9
- `make typecheck`
- `npm run format:check`
- `git diff --check`

Supersedes the implementation proposed in #713.