### PR TITLE
fix(chat): SDK stopped/aborted 终态 + 清掉粘滞的 API 重试状态

### DIFF
--- a/container/agent-runner/src/stream-processor.ts
+++ b/container/agent-runner/src/stream-processor.ts
@@ -27,7 +27,13 @@ import { BackgroundTaskDrainTracker } from './background-task-drain.js';
 // SDK 任务终态（task_updated.patch.status 语义下"不会再有后续信号"的状态）。
 // web/src/stores/chat.ts、src/web.ts、src/index.ts 各有等价映射——SDK 新增
 // 终态时需同步检查；此处漏判的代价是 pendingSdkTasks 泄漏导致关流被永久推迟。
-const SDK_TERMINAL_TASK_STATUSES = new Set(['completed', 'failed', 'killed']);
+const SDK_TERMINAL_TASK_STATUSES = new Set([
+  'completed',
+  'failed',
+  'killed',
+  'stopped',
+  'aborted',
+]);
 
 /** Tools with specialized input_json_delta handling — generic accumulation is skipped for these. */
 const SPECIAL_TOOLS = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -806,7 +806,10 @@ export function feedStreamEventToCard(
           status:
             patchStatus === 'completed'
               ? 'completed'
-              : patchStatus === 'failed' || patchStatus === 'killed'
+              : patchStatus === 'failed' ||
+                  patchStatus === 'killed' ||
+                  patchStatus === 'stopped' ||
+                  patchStatus === 'aborted'
                 ? 'error'
                 : se.taskPatch?.is_backgrounded
                   ? 'backgrounded'

--- a/src/web.ts
+++ b/src/web.ts
@@ -2708,7 +2708,12 @@ function updateSnapshotTask(
   } else if (event.eventType === 'task_updated') {
     const patch = event.taskPatch;
     if (patch?.status === 'completed') task.status = 'completed';
-    else if (patch?.status === 'failed' || patch?.status === 'killed')
+    else if (
+      patch?.status === 'failed' ||
+      patch?.status === 'killed' ||
+      patch?.status === 'stopped' ||
+      patch?.status === 'aborted'
+    )
       task.status = 'error';
     else if (patch?.is_backgrounded) task.status = 'backgrounded';
     task.latestSummary =

--- a/tests/chat-agent-messages.test.ts
+++ b/tests/chat-agent-messages.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Message } from '../web/src/stores/chat';
 
@@ -822,5 +822,169 @@ describe('held Workflow acknowledgements', () => {
       { status: 'running', phases: runningWorkflow.phases },
     );
     expect(state.messages[jid][0].workflow_runs).toBeUndefined();
+  });
+});
+
+describe('SDK task terminal status and sticky API retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChatStore();
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const baseStreaming = {
+    partialText: '',
+    thinkingText: '',
+    isThinking: false,
+    activeTools: [] as [],
+    activeHook: null,
+    systemStatus: null as string | null,
+    recentEvents: [] as [],
+    traceEvents: [] as [],
+    taskStates: {},
+  };
+
+  it('finalizes stopped and aborted task_updated so they leave running counts', () => {
+    const jid = 'web:main';
+    const runId = 'run-terminal-tasks';
+    useChatStore.setState({
+      activeRuns: {
+        [jid]: {
+          chatJid: jid,
+          runId,
+          startedAt: '2026-07-25T00:00:00.000Z',
+          phase: 'running',
+        },
+      },
+      waiting: { [jid]: true },
+      streaming: { [jid]: { ...baseStreaming } },
+      sdkTasks: {
+        'task-stopped': {
+          chatJid: jid,
+          description: 'stopped task',
+          status: 'running',
+        },
+        'task-aborted': {
+          chatJid: jid,
+          description: 'aborted task',
+          status: 'running',
+        },
+      },
+    });
+
+    useChatStore.getState().handleStreamEvent(
+      jid,
+      {
+        eventType: 'task_updated',
+        toolUseId: 'task-stopped',
+        taskId: 'task-stopped',
+        taskPatch: { status: 'stopped' },
+      },
+      undefined,
+      runId,
+    );
+    useChatStore.getState().handleStreamEvent(
+      jid,
+      {
+        eventType: 'task_updated',
+        toolUseId: 'task-aborted',
+        taskId: 'task-aborted',
+        taskPatch: { status: 'aborted' },
+      },
+      undefined,
+      runId,
+    );
+
+    const state = useChatStore.getState();
+    expect(state.sdkTasks['task-stopped']?.status).toBe('error');
+    expect(state.sdkTasks['task-aborted']?.status).toBe('error');
+    expect(state.streaming[jid]?.taskStates['task-stopped']?.status).toBe(
+      'error',
+    );
+    expect(state.streaming[jid]?.taskStates['task-aborted']?.status).toBe(
+      'error',
+    );
+    expect(
+      Object.values(state.sdkTasks).filter((task) => task.status === 'running'),
+    ).toHaveLength(0);
+  });
+
+  it('clears sticky API retry status when generation resumes', () => {
+    const jid = 'web:main';
+    const runId = 'run-retry-clear';
+    useChatStore.setState({
+      activeRuns: {
+        [jid]: {
+          chatJid: jid,
+          runId,
+          startedAt: '2026-07-25T00:00:00.000Z',
+          phase: 'running',
+        },
+      },
+      waiting: { [jid]: true },
+      streaming: {
+        [jid]: {
+          ...baseStreaming,
+          systemStatus: 'API 重试中 (1/3)，2s 后重试',
+        },
+      },
+    });
+
+    useChatStore.getState().handleStreamEvent(
+      jid,
+      {
+        eventType: 'text_delta',
+        text: 'hello',
+      },
+      undefined,
+      runId,
+    );
+
+    expect(useChatStore.getState().streaming[jid]?.systemStatus).toBeNull();
+    expect(useChatStore.getState().streaming[jid]?.partialText).toBe('hello');
+  });
+
+  it('does not clear unrelated system status on text_delta', () => {
+    const jid = 'web:main';
+    const runId = 'run-keep-status';
+    useChatStore.setState({
+      activeRuns: {
+        [jid]: {
+          chatJid: jid,
+          runId,
+          startedAt: '2026-07-25T00:00:00.000Z',
+          phase: 'running',
+        },
+      },
+      waiting: { [jid]: true },
+      streaming: {
+        [jid]: {
+          ...baseStreaming,
+          systemStatus: '正在整理上下文…',
+        },
+      },
+    });
+
+    useChatStore.getState().handleStreamEvent(
+      jid,
+      {
+        eventType: 'text_delta',
+        text: 'still compacting context note',
+      },
+      undefined,
+      runId,
+    );
+
+    expect(useChatStore.getState().streaming[jid]?.systemStatus).toBe(
+      '正在整理上下文…',
+    );
   });
 });

--- a/tests/chat-agent-messages.test.ts
+++ b/tests/chat-agent-messages.test.ts
@@ -826,19 +826,29 @@ describe('held Workflow acknowledgements', () => {
 });
 
 describe('SDK task terminal status and sticky API retry', () => {
+  const rafCbs: FrameRequestCallback[] = [];
+
   beforeEach(() => {
     vi.clearAllMocks();
     resetChatStore();
+    rafCbs.length = 0;
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-      cb(0);
-      return 1;
+      rafCbs.push(cb);
+      return rafCbs.length;
     });
-    vi.stubGlobal('cancelAnimationFrame', () => {});
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      rafCbs[id - 1] = () => {};
+    });
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
+
+  function flushRaf(): void {
+    const pending = rafCbs.splice(0);
+    for (const cb of pending) cb(0);
+  }
 
   const baseStreaming = {
     partialText: '',
@@ -947,9 +957,45 @@ describe('SDK task terminal status and sticky API retry', () => {
       undefined,
       runId,
     );
+    flushRaf();
 
     expect(useChatStore.getState().streaming[jid]?.systemStatus).toBeNull();
     expect(useChatStore.getState().streaming[jid]?.partialText).toBe('hello');
+  });
+
+  it('clears sticky API retry status on tool_use_start without waiting for rAF', () => {
+    const jid = 'web:main';
+    const runId = 'run-retry-tool';
+    useChatStore.setState({
+      activeRuns: {
+        [jid]: {
+          chatJid: jid,
+          runId,
+          startedAt: '2026-07-25T00:00:00.000Z',
+          phase: 'running',
+        },
+      },
+      waiting: { [jid]: true },
+      streaming: {
+        [jid]: {
+          ...baseStreaming,
+          systemStatus: 'API retry in progress (2/5)',
+        },
+      },
+    });
+
+    useChatStore.getState().handleStreamEvent(
+      jid,
+      {
+        eventType: 'tool_use_start',
+        toolName: 'Read',
+        toolUseId: 'tool-1',
+      },
+      undefined,
+      runId,
+    );
+
+    expect(useChatStore.getState().streaming[jid]?.systemStatus).toBeNull();
   });
 
   it('does not clear unrelated system status on text_delta', () => {
@@ -982,9 +1028,13 @@ describe('SDK task terminal status and sticky API retry', () => {
       undefined,
       runId,
     );
+    flushRaf();
 
     expect(useChatStore.getState().streaming[jid]?.systemStatus).toBe(
       '正在整理上下文…',
+    );
+    expect(useChatStore.getState().streaming[jid]?.partialText).toBe(
+      'still compacting context note',
     );
   });
 });

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -158,6 +158,45 @@ describe('StreamEventProcessor observability mapping', () => {
     expect(processor.getBlockingPendingSdkTaskCount()).toBe(0);
   });
 
+  test('treats stopped and aborted task_updated as terminal SDK statuses', () => {
+    const { processor } = makeProcessor();
+
+    processor.processSystemMessage({
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 'stopped-1',
+      description: 'user stopped this task',
+      task_type: 'local_agent',
+    });
+    processor.processSystemMessage({
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 'aborted-1',
+      description: 'user aborted this task',
+      task_type: 'local_agent',
+    });
+    expect(processor.getPendingSdkTaskCount()).toBe(2);
+    expect(processor.getBlockingPendingSdkTaskCount()).toBe(2);
+
+    processor.processSystemMessage({
+      type: 'system',
+      subtype: 'task_updated',
+      task_id: 'stopped-1',
+      patch: { status: 'stopped' },
+    });
+    expect(processor.getPendingSdkTaskCount()).toBe(1);
+    expect(processor.getBlockingPendingSdkTaskCount()).toBe(1);
+
+    processor.processSystemMessage({
+      type: 'system',
+      subtype: 'task_updated',
+      task_id: 'aborted-1',
+      patch: { status: 'aborted' },
+    });
+    expect(processor.getPendingSdkTaskCount()).toBe(0);
+    expect(processor.getBlockingPendingSdkTaskCount()).toBe(0);
+  });
+
   test('maps SDK task_progress to structured task_progress event', () => {
     const { processor, outputs } = makeProcessor();
 

--- a/web/src/components/chat/StreamingDisplay.tsx
+++ b/web/src/components/chat/StreamingDisplay.tsx
@@ -79,6 +79,8 @@ const TASK_STATUS_LABELS: Record<string, string> = {
   running: '执行中',
   completed: '已完成',
   error: '出错',
+  stopped: '已停止',
+  aborted: '已停止',
 };
 
 function formatSystemStatus(status: string): string {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -815,6 +815,19 @@ interface PendingDelta {
 }
 const pendingDeltas = new Map<string, PendingDelta>();
 
+const STICKY_API_RETRY_STATUS_RE = /API\s*重试|retry/i;
+
+function clearStickyApiRetryStatus(
+  state: Pick<StreamingState, 'systemStatus'>,
+): void {
+  if (
+    state.systemStatus &&
+    STICKY_API_RETRY_STATUS_RE.test(state.systemStatus)
+  ) {
+    state.systemStatus = null;
+  }
+}
+
 function cancelPendingDelta(key: string): void {
   const entry = pendingDeltas.get(key);
   if (!entry) return;
@@ -856,6 +869,7 @@ function flushPendingDelta(
         return s;
       const prev = s.agentStreaming[agentId] || { ...DEFAULT_STREAMING_STATE };
       const next = { ...prev };
+      clearStickyApiRetryStatus(next);
       if (mergedText) {
         const combined = prev.partialText + mergedText;
         next.partialText =
@@ -891,6 +905,7 @@ function flushPendingDelta(
       if (s.streaming[chatJid]?.interrupted) return s;
       const prev = s.streaming[chatJid] || { ...DEFAULT_STREAMING_STATE };
       const next = { ...prev };
+      clearStickyApiRetryStatus(next);
       if (mergedText) {
         const combined = prev.partialText + mergedText;
         next.partialText =
@@ -1299,7 +1314,12 @@ function updateTaskRuntime(
   } else if (event.eventType === 'task_updated') {
     const patch = event.taskPatch;
     if (patch?.status === 'completed') task.status = 'completed';
-    else if (patch?.status === 'failed' || patch?.status === 'killed')
+    else if (
+      patch?.status === 'failed' ||
+      patch?.status === 'killed' ||
+      patch?.status === 'stopped' ||
+      patch?.status === 'aborted'
+    )
       task.status = 'error';
     else if (patch?.is_backgrounded) task.status = 'backgrounded';
     else if (patch?.status === 'running' || patch?.status === 'pending')
@@ -1378,6 +1398,13 @@ function applyStreamEvent(
   if (event.turnId) next.turnId = event.turnId;
   if (event.sessionId) next.sessionId = event.sessionId;
   next.traceEvents = pushTrace(prev.traceEvents || [], event);
+  if (
+    event.eventType === 'text_delta' ||
+    event.eventType === 'thinking_delta' ||
+    event.eventType === 'tool_use_start'
+  ) {
+    clearStickyApiRetryStatus(next);
+  }
   switch (event.eventType) {
     case 'text_delta': {
       if (event.parentToolUseId) {
@@ -2912,7 +2939,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       if (
         patchStatus === 'completed' ||
         patchStatus === 'failed' ||
-        patchStatus === 'killed'
+        patchStatus === 'killed' ||
+        patchStatus === 'stopped' ||
+        patchStatus === 'aborted'
       ) {
         finalizeSdkTask(
           resolvedTaskId,


### PR DESCRIPTION
从 [rome-xi/aster#318](https://github.com/rome-xi/aster/pull/318) 只裁了 sticky 状态条和子任务终态漏判。

## 问题

1. **stopped/aborted 仍被当成运行中**
   `task_updated:stopped` 可以在 runner 评论路径 settle，但 `SDK_TERMINAL_TASK_STATUSES` 只有 `completed` / `failed` / `killed`。Web store 也没把 stopped/aborted 当终态 finalize，任务会占着「运行中」计数。
2. **API 重试成功后状态条贴住**
   `api_retry` 把 `systemStatus` 设成「API 重试中 (...)」，但 `text_delta` / `thinking_delta` / `flushPendingDelta` 不清，重试成功后横幅还在。

## 修复

- Runner：`stopped` / `aborted` 进 `SDK_TERMINAL_TASK_STATUSES`，跟 `completed` / `failed` / `killed` 一起 settle pending SDK task。
- Web / snapshot / IM 映射：`stopped` / `aborted` 按 failed/killed 走终态 `error`，并 `finalizeSdkTask`，离开 running 计数。
- `applyStreamEvent`（`text_delta` / `thinking_delta` / `tool_use_start`）和 `flushPendingDelta`：只清掉匹配 `/API\s*重试|retry/i` 的 `systemStatus`，不动其它状态。

## 故意没搬的

aster#318 里这几块 HappyClaw 不用移：resume compact / ToolFailBreaker / OAuth / CLI proxy / 协议翻译 / 混贴 MessageInput。

Fork PR: https://github.com/rome-xi/happyclaw-upstream/pull/5
