### PR TITLE
Add Claude Fable 5.1 usage pricing

### DIFF
--- a/src/kaboo-pricing.ts
+++ b/src/kaboo-pricing.ts
@@ -197,6 +197,19 @@ export const KABOO_MODEL_PRICING: readonly KabooModelPricing[] = Object.freeze([
     1.25,
     5,
   ),
+  // Claude 5 generation. Fable 5.1 keeps Fable 5's $10/$50 in/out but cuts
+  // cache reads 75% to $0.25/MTok; cache writes follow the 1.25x-input rule
+  // and reasoning is billed as output.
+  price(
+    'claude-fable-5-1%',
+    'Claude Fable 5.1',
+    'anthropic',
+    10,
+    50,
+    0.25,
+    12.5,
+    50,
+  ),
 ]);
 
 const TOKEN_FIELDS: readonly (keyof KabooTokenUsage)[] = [

--- a/tests/kaboo-pricing.test.ts
+++ b/tests/kaboo-pricing.test.ts
@@ -22,6 +22,28 @@ describe('Kaboo-aligned model pricing', () => {
     });
   });
 
+  test('prices Claude Fable 5.1 with its reduced cache-read rate', () => {
+    const pricing = matchKabooModelPricing('claude-fable-5-1-20260901');
+    expect(pricing).toMatchObject({
+      pattern: 'claude-fable-5-1%',
+      inputPricePerMTok: 10,
+      outputPricePerMTok: 50,
+      cacheReadPricePerMTok: 0.25,
+      cacheCreationPricePerMTok: 12.5,
+      reasoningPricePerMTok: 50,
+    });
+
+    expect(
+      estimateKabooModelCostCents('claude-fable-5-1', {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        cacheReadInputTokens: 1_000_000,
+        cacheCreationInputTokens: 1_000_000,
+        reasoningTokens: 1_000_000,
+      }),
+    ).toBe(12_275);
+  });
+
   test('prices all five token categories and rounds to cents once', () => {
     expect(
       estimateKabooModelCostCents('claude-opus-4-5', {


### PR DESCRIPTION
## What

Adds a Kaboo pricing row for **Claude Fable 5.1** (`claude-fable-5-1`).

## Why

happyclaw has no model allowlist — the official-provider selector uses tier aliases (`fable`) that auto-resolve to the latest version, and third-party providers accept a free-text model id, so Fable 5.1 is already *usable*. The one version-specific gap is `src/kaboo-pricing.ts`, whose table stops at the 4.x generation. Without this row, Fable 5.1 usage falls through to the Sonnet-class fallback ($3/$15) and is under-billed.

## Rates

| field | value | source |
|---|---|---|
| input | $10 /MTok | Anthropic (same as Fable 5) |
| output | $50 /MTok | Anthropic (same as Fable 5) |
| cache read | $0.25 /MTok | Anthropic (75% cut vs Fable 5) |
| cache write | $12.50 /MTok | repo convention: 1.25x input |
| reasoning | $50 /MTok | repo convention: billed as output |

## Test

Adds a case in `tests/kaboo-pricing.test.ts` asserting the match pattern and a full five-category cost (12,275 cents for 1M tokens each). `npx vitest run tests/kaboo-pricing.test.ts` → 8 passed; `tsc --noEmit` clean.

## Note

Fable 5, Opus 5, and Sonnet 5 are *also* absent from this table (pre-existing). Scoped this PR to Fable 5.1 as requested; happy to extend to the full Claude 5 family if wanted.